### PR TITLE
Don't try to access runtime after determining it is null

### DIFF
--- a/desktopsharing.js
+++ b/desktopsharing.js
@@ -207,6 +207,7 @@ function checkExtInstalled(isInstalledCallback) {
     if(!chrome.runtime) {
         // No API, so no extension for sure
         isInstalledCallback(false);
+        return;
     }
     chrome.runtime.sendMessage(
         config.chromeExtensionId,


### PR DESCRIPTION
A tiny fix - if the runtime is null in the extension check return straight away.
