### PR TITLE
Allowing iFrame Content to be clickable on top

### DIFF
--- a/css/videolayout_default.css
+++ b/css/videolayout_default.css
@@ -232,6 +232,7 @@
     left:0;
     right:0;
     z-index:10;
+    height: 0px;
 }
 
 #toolbar {


### PR DESCRIPTION
In order to make the top bar of etherpad clickable
