### PR TITLE
Skip animation steps

### DIFF
--- a/prezi.js
+++ b/prezi.js
@@ -324,6 +324,11 @@ var Prezi = (function (my) {
     $(document).bind('gotoslide.muc', function (event, jid, presUrl, current) {
         if (preziPlayer) {
             preziPlayer.flyToStep(current);
+            // 
+            var animationStepsArray = preziPlayer.getAnimationCountOnSteps();
+            for (var i = 0; i <= animationStepsArray[current]; i++) {
+                preziPlayer.flyToNextStep();
+            }
         }
     });
 


### PR DESCRIPTION
Current prezi API does not support flying to certain animation steps.
So in case a prezi would have animation steps, the slide would be empty for the viewer.
With this patch we can at least show entire slide content to viewers if the slide has animations steps.

see also http://prezi.github.io/prezi-player/lib/PreziPlayer/
