### PR TITLE
Make the difference between jitsimeet and jitsivideo bridge + Conclusion

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,7 +135,7 @@ Or autostart it by adding the line in `/etc/rc.local`:
 ```sh
 /bin/bash /root/jitsi-videobridge-linux-{arch-buildnum}/jvb.sh --host=localhost --domain=jitmeet.example.com --port=5347 --secret=YOURSECRET1 </dev/null >> /var/log/jvb.log 2>&1
 ```
-
+## Install Jitmeet
 Checkout and configure jitmeet:
 ```sh
 cd /srv
@@ -228,3 +228,6 @@ org.jitsi.impl.neomedia.transform.srtp.SRTPCryptoContext.checkReplay=false
 org.jitsi.videobridge.NAT_HARVESTER_LOCAL_ADDRESS=<Local.IP.Address>
 org.jitsi.videobridge.NAT_HARVESTER_PUBLIC_ADDRESS=<Public.IP.Address>
 ```
+
+## Test it
+Now to access your jitsi.meet webclient conference page go to: jitmeet.example.com.


### PR DESCRIPTION
Add a clear difference between jitsimeet and jitsivideo bridge. This difference appears to be not really clear like in the following video shows: http://twit.tv/show/floss-weekly/293
Jitsi videobridge is a rtp relay bridge.
Jitsi.meet is "just" a javascript webserver that will connects the client to the videobridge that will relay to the others webclient connected.
In a simple word, jitsi meet is the UI and videobridge the engine.

Without any experience in XMPP and nginx etc it is nice just to say "where you can finally test it"
