### PR TITLE
add nack pli

### DIFF
--- a/libs/colibri/colibri.focus.js
+++ b/libs/colibri/colibri.focus.js
@@ -440,6 +440,7 @@ ColibriFocus.prototype.createdConference = function (result) {
         'a=rtpmap:100 VP8/90000\r\n' +
         'a=rtcp-fb:100 ccm fir\r\n' +
         'a=rtcp-fb:100 nack\r\n' +
+        'a=rtcp-fb:100 nack pli\r\n' +
         'a=rtcp-fb:100 goog-remb\r\n' +
         'a=rtpmap:116 red/90000\r\n' +
         'a=rtpmap:117 ulpfec/90000\r\n' +


### PR DESCRIPTION
This adds nack pli to the SDP. It seems that doing a SRD/SLD cycle as we're doing in sendKeyframe (which might be obsolete now). See also issue #51 

Maybe someone can take a look at the rtcp level? Doesn't seem to break anything though.
