### PR TITLE
use only a single GUM call

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,7 +162,8 @@ function obtainAudioAndVideoPermissions(callback) {
         },
         function (error) {
             console.error('failed to obtain audio/video stream - stop', error);
-        });
+        },
+        config.resolution || '360');
 }
 
 function maybeDoJoin() {


### PR DESCRIPTION
@paweldomas can you take a look? 
I still think we don't need to have separate streams and could do screensharing with addTrack etc but maybe we can do that later :-)

next step: move GUM to body.onload
