### PR TITLE
specify constraints in a way which doesnt define the AR

### DIFF
--- a/libs/strophe/strophe.jingle.adapter.js
+++ b/libs/strophe/strophe.jingle.adapter.js
@@ -613,8 +613,10 @@ function getUserMediaWithConstraints(um, success_callback, failure_callback, res
             }
             break;
     }
-    if (constraints.video.minWidth) constraints.video.maxWidth = constraints.video.minWidth;
-    if (constraints.video.minHeight) constraints.video.maxHeight = constraints.video.minHeight;
+    if (constraints.video.mandatory.minWidth)
+        constraints.video.mandatory.maxWidth = constraints.video.mandatory.minWidth;
+    if (constraints.video.mandatory.minHeight)
+        constraints.video.mandatory.maxHeight = constraints.video.mandatory.minHeight;
 
     if (bandwidth) { // doesn't work currently, see webrtc issue 1846
         if (!constraints.video) constraints.video = {mandatory: {}, optional: []};//same behaviour as true


### PR DESCRIPTION
Noticed chrome gives me a weird resolution of 640x362 (which turns out to be 640 / 1.77)

@bgrozev: might be related to https://github.com/jitsi/jipopro/commit/dd73a0aa22af170133ac630eb8e343d29b863f79 according to irc.
