### PR TITLE
fix typos - syntax errors in config.js example

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -154,8 +154,8 @@ var config = {
         bridge: 'jitsi-videobridge.jitsi.example.com'
     },
     useNicks: false,
-    bosh: '//jitsi.example.com/http-bind' // FIXME: use xep-0156 for that
-    desktopSharing: 'false', // Desktop sharing method. Can be set to 'ext', 'webrtc' or false to disable.
+    bosh: '//jitsi.example.com/http-bind', // FIXME: use xep-0156 for that
+    desktopSharing: 'false' // Desktop sharing method. Can be set to 'ext', 'webrtc' or false to disable.
     //chromeExtensionId: 'diibjkoicjeejcmhdnailmkgecihlobk', // Id of desktop streamer Chrome extension
     //minChromeExtVersion: '0.1' // Required version of Chrome extension
 };


### PR DESCRIPTION
- in the example code for config.js in INSTALL.md
  contains three key-value-pairs not present in the example file
  'config.js.example' - these were appended without inserting a comma
  and the last two of these were commented out without removing
  the trailing comma - the example file 'config.js.example' is correct
  but using the INSTALL.md version causes the page render to halt prematurely
  making login impossible
