### PR TITLE
Fixes the error: Cannot read property 'nextSibling' of null

### DIFF
--- a/contact_list.js
+++ b/contact_list.js
@@ -57,7 +57,7 @@ var ContactList = (function (my) {
         var clElement = contactlist.get(0);
 
         if (resourceJid === Strophe.getResourceFromJid(connection.emuc.myroomjid)
-            && $('#contactlist>ul .title')[0].nextSibling.nextSibling)
+            && $('#contactlist>ul .title')[0].nextSibling && $('#contactlist>ul .title')[0].nextSibling.nextSibling)
         {
             clElement.insertBefore(newContact,
                     $('#contactlist>ul .title')[0].nextSibling.nextSibling);


### PR DESCRIPTION
When enter an existing room without participants, it gives the error: Cannot read property 'nextSibling' of null. As a result first, script execution is stopped, and the first user cannot be connected. This condition fixes the issue.
