### PR TITLE
Icetransports relay

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,7 @@ function connect(jid, password) {
         // for chrome, add multistream cap
     }
     connection.jingle.pc_constraints = RTC.pc_constraints;
+    connection.jingle.ice_config.iceTransports = 'relay';
     if (config.useIPv6) {
         // https://code.google.com/p/webrtc/issues/detail?id=2828
         if (!connection.jingle.pc_constraints.optional) connection.jingle.pc_constraints.optional = [];

--- a/libs/strophe/strophe.jingle.js
+++ b/libs/strophe/strophe.jingle.js
@@ -3,7 +3,7 @@ Strophe.addConnectionPlugin('jingle', {
     connection: null,
     sessions: {},
     jid2session: {},
-    ice_config: {iceServers: [], iceTransports: 'relay'},
+    ice_config: {iceServers: [], iceTransports: 'all'},
     pc_constraints: {},
     media_constraints: {
         mandatory: {


### PR DESCRIPTION
@emcho this is the way to go if you only want to send relay candidates. Implemented in chrome 39+ I think.
