### PR TITLE
Tries to enable FEC for opus.

### DIFF
--- a/libs/colibri/colibri.focus.js
+++ b/libs/colibri/colibri.focus.js
@@ -431,7 +431,7 @@ ColibriFocus.prototype.createdConference = function (result) {
         'a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n' +
         'a=sendrecv\r\n' +
         'a=rtpmap:111 opus/48000/2\r\n' +
-        'a=fmtp:111 minptime=10\r\n' +
+        'a=fmtp:111 minptime=10; useinbandfec=true\r\n' +
         'a=rtpmap:103 ISAC/16000\r\n' +
         'a=rtpmap:104 ISAC/32000\r\n' +
         'a=rtpmap:0 PCMU/8000\r\n' +


### PR DESCRIPTION
Sets useinbandfec=1 in everyone's remoteDescription, which should be
enough to enable the use of FEC with chrome versions which support it
and when there is packet loss.

See:
https://code.google.com/p/webrtc/issues/detail?id=3986
https://code.google.com/p/webrtc/issues/detail?id=2419#c27

I don't know of an easy way to verify that this works, but I think it's a safe thing to do (apprtc seems to do the same if the opusfec=true parameter is given).
