### PR TITLE
Add https support for API

### DIFF
--- a/external_api.js
+++ b/external_api.js
@@ -48,7 +48,7 @@ var JitsiMeetExternalAPI = (function()
         this.iframeHolder.style.width = width + "px";
         this.iframeHolder.style.height = height + "px";
         this.frameName = "jitsiConferenceFrame" + JitsiMeetExternalAPI.id;
-        this.url = "http://" + domain + "/";
+        this.url = "//" + domain + "/";
         if(room_name)
             this.url += room_name;
         this.url += "#external";


### PR DESCRIPTION
By omitting the protocol, the api will use the parent's protocol. This allows us to embed the iframe in https environments. Otherwise you get this exception:

```
[blocked] The page at 'https://jitsi-meet.example.com:8081/api_example.html' was loaded over HTTPS, 
but ran insecure content from 'http://jitsi-meet.example.com:8081/JitsiMeetAPIExample3#external': 
this content should also be loaded over HTTPS.
```
