### PR TITLE
use msid instead of mslabel since mslabel is obsolete

### DIFF
--- a/libs/colibri/colibri.focus.js
+++ b/libs/colibri/colibri.focus.js
@@ -140,7 +140,7 @@ ColibriFocus.prototype.makeConference = function (peers, errorCallback) {
     this.peerconnection.onaddstream = function (event) {
         // search the jid associated with this stream
         Object.keys(self.remotessrc).forEach(function (jid) {
-            if (self.remotessrc[jid].join('\r\n').indexOf('mslabel:' + event.stream.id) != -1) {
+            if (self.remotessrc[jid].join('\r\n').indexOf('msid:' + event.stream.id) != -1) {
                 event.peerjid = jid;
             }
         });


### PR DESCRIPTION
Basically https://github.com/jitsi/jitsi-meet/pull/75 minus the parts @gpolitis fixed in the meantime.