### PR TITLE
include link to desktopSharing extension when install fails

### DIFF
--- a/desktopsharing.js
+++ b/desktopsharing.js
@@ -169,7 +169,7 @@ function obtainScreenFromExtension(streamCallback, failCallback) {
                         console.log("Failed to install the extension", arg);
                         failCallback(arg);
                         messageHandler.showError('Error',
-                            'Failed to install desktop sharing extension');
+                            'Failed to install desktop sharing extension. Try installing through <a href="' + getWebStoreInstallUrl() + '" target="_blank">this link</a>.');
                     }
                 );
             }


### PR DESCRIPTION
When jitsi-meet is running in another webserver/url, it can't automatically install the extension, since the website isn't a verified webstore site for the extension (and never should be).

The original error message on the install button doesn't provide a resolution to the user. This very simple patch adds a link to the message, providing a way to the user install the extension directly through the webstore.
