### PR TITLE
Add QoS marking configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,7 +10,8 @@ var config = {
     },
 //  getroomnode: function (path) { return 'someprefixpossiblybasedonpath'; },
 //  useStunTurn: true, // use XEP-0215 to fetch STUN and TURN server
-//  useIPv6: true, // ipv6 support. use at your own risk
+//  useIPv6: true, // IPv6 support .Is Chrome only
+//  useDSCP: true, // IP QoS marking support. Is Chrome only
     useNicks: false,
     bosh: '//jitsi-meet.example.com/http-bind', // FIXME: use xep-0156 for that
     clientNode: 'http://jitsi.org/jitsimeet', // The name of client node advertised in XEP-0115 'c' stanza

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -41,6 +41,12 @@ function connect(jid, password, uiCredentials) {
             connection.jingle.pc_constraints.optional = [];
         connection.jingle.pc_constraints.optional.push({googIPv6: true});
     }
+    if (config.useDSCP) {
+        // https://code.google.com/p/webrtc/source/detail?r=7669
+        if (!connection.jingle.pc_constraints.optional)
+            connection.jingle.pc_constraints.optional = [];
+        connection.jingle.pc_constraints.optional.push({googDSCP: true});
+    }
 
     if(!password)
         password = uiCredentials.password;


### PR DESCRIPTION
Add QoS marking configuration.
IP DSCP marking is available in Chrome (https://code.google.com/p/webrtc/source/detail?r=7669)
It seems important to me to make it available to Jitsi-meet users.
