### PR TITLE
Add QoS marking configuration

### DIFF
--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -41,6 +41,12 @@ function connect(jid, password, uiCredentials) {
             connection.jingle.pc_constraints.optional = [];
         connection.jingle.pc_constraints.optional.push({googIPv6: true});
     }
+    if (config.useDSCP) {
+        // https://code.google.com/p/webrtc/source/detail?r=7669
+        if (!connection.jingle.pc_constraints.optional)
+            connection.jingle.pc_constraints.optional = [];
+        connection.jingle.pc_constraints.optional.push({googDSCP: true});
+    }
 
     if(!password)
         password = uiCredentials.password;


### PR DESCRIPTION
IP DSCP marking is available in Chrome (https://code.google.com/p/webrtc/source/detail?r=7669)
It seems important to me to make it available to Jitsi-meet users.