### PR TITLE
Update RTC.js

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -30,9 +30,9 @@ var RTC = {
 
         eventEmitter.removeListener(eventType, listener);
     },
-    createLocalStream: function (stream, type, change) {
+    createLocalStream: function (stream, type, change, videoType) {
 
-        var localStream =  new LocalStream(stream, type, eventEmitter);
+        var localStream =  new LocalStream(stream, type, eventEmitter, videoType);
         //in firefox we have only one stream object
         if(this.localStreams.length == 0 ||
             this.localStreams[0].getOriginalStream() != stream)


### PR DESCRIPTION
fix for screensharing screen ratio on receiver side - jid instead of full peerjid in RTC.js in jitsi-meet commit 6c4a5bd tag 340