### PR TITLE
Fix videoType of video streams coming undefined

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -30,9 +30,9 @@ var RTC = {
 
         eventEmitter.removeListener(eventType, listener);
     },
-    createLocalStream: function (stream, type, change) {
+    createLocalStream: function (stream, type, change, videoType) {
 
-        var localStream =  new LocalStream(stream, type, eventEmitter);
+        var localStream =  new LocalStream(stream, type, eventEmitter, videoType);
         //in firefox we have only one stream object
         if(this.localStreams.length == 0 ||
             this.localStreams[0].getOriginalStream() != stream)

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -346,7 +346,7 @@ RTCUtils.prototype.handleLocalStream = function(stream)
         }
 
 
-        this.service.createLocalStream(videoStream, "video");
+        this.service.createLocalStream(videoStream, "video", false, "video");
     }
     else
     {//firefox


### PR DESCRIPTION
The videoType is coming undefined right now and the only way to check whether current stream is screen/video is through track label as far as I could see.

This is my first PR to jitsi-meet. Please point me to any contributors guidelines I should be aware of.