### PR TITLE
Removes the useBundle and useRtcpMux options from config.js. These are

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,8 +26,6 @@ var config = {
     channelLastN: -1, // The default value of the channel attribute last-n.
     adaptiveLastN: false,
     adaptiveSimulcast: false,
-    useRtcpMux: true, // required for FF support
-    useBundle: true, // required for FF support
     enableRecording: false,
     enableWelcomePage: true,
     enableSimulcast: false, // blocks FF support

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -146,7 +146,7 @@ function RTCUtils(RTCService, onTemasysPluginReady)
     this.service = RTCService;
     if (RTCBrowserType.isFirefox()) {
         var FFversion = RTCBrowserType.getFirefoxVersion();
-        if (FFversion >= 40 && config.useBundle && config.useRtcpMux) {
+        if (FFversion >= 40) {
             this.peerconnection = mozRTCPeerConnection;
             this.getUserMedia = navigator.mozGetUserMedia.bind(navigator);
             this.pc_constraints = {};
@@ -188,9 +188,7 @@ function RTCUtils(RTCService, onTemasysPluginReady)
             RTCIceCandidate = mozRTCIceCandidate;
         } else {
             console.error(
-                "Firefox requirements not met, ver: " + FFversion +
-                ", bundle: " + config.useBundle +
-                ", rtcp-mux: " + config.useRtcpMux);
+                "Firefox version too old: " + FFversion + ". Required >= 40.");
             window.location.href = 'unsupported_browser.html';
             return;
         }

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -27,9 +27,7 @@ var CallStats = {
             this.userID,
             initCallback);
 
-        var usage = callStats.fabricUsage.unbundled;
-        if(config.useBundle)
-            usage = callStats.fabricUsage.multiplex;
+        var usage = callStats.fabricUsage.multiplex;
 
         callStats.addNewFabric(this.peerconnection,
             Strophe.getResourceFromJid(jingleSession.peerjid),

--- a/modules/xmpp/strophe.jingle.js
+++ b/modules/xmpp/strophe.jingle.js
@@ -55,15 +55,13 @@ module.exports = function(XMPP, eventEmitter)
                     this.connection.disco.addFeature('urn:ietf:rfc:4588');
                 }
 
-                // this is dealt with by SDP O/A so we don't need to annouce this
+                // this is dealt with by SDP O/A so we don't need to announce this
                 //this.connection.disco.addFeature('urn:xmpp:jingle:apps:rtp:rtcp-fb:0'); // XEP-0293
                 //this.connection.disco.addFeature('urn:xmpp:jingle:apps:rtp:rtp-hdrext:0'); // XEP-0294
-                if (config.useRtcpMux) {
-                    this.connection.disco.addFeature('urn:ietf:rfc:5761'); // rtcp-mux
-                }
-                if (config.useBundle) {
-                    this.connection.disco.addFeature('urn:ietf:rfc:5888'); // a=group, e.g. bundle
-                }
+
+                this.connection.disco.addFeature('urn:ietf:rfc:5761'); // rtcp-mux
+                this.connection.disco.addFeature('urn:ietf:rfc:5888'); // a=group, e.g. bundle
+
                 //this.connection.disco.addFeature('urn:ietf:rfc:5576'); // a=ssrc
             }
             this.connection.addHandler(this.onJingle.bind(this), 'urn:xmpp:jingle:1', 'iq', 'set', null, null);


### PR DESCRIPTION
now fully supported by jitsi-videobridge and all browsers which we
support (and if we need to enable them conditionally because of browser
compatibility in the future, we should do it based on run-time browser
detection.)

I'll merge this in a few days unless there are objections.