### PR TITLE
Use valid SPDX license identifier for Jitsi-Meet NPM package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
       "precommit-hook": "3.0.0"
   },
-  "license": "Apache",
+  "license": "Apache-2.0",
   "scripts": {
     "lint": "jshint ."
   },


### PR DESCRIPTION
 .. to avoid warnings during installing npm dependencies