### PR TITLE
Use member.isFocus to decide whether a given member is the focus user

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -339,13 +339,13 @@ var VideoLayout = (function (my) {
 
         Object.keys(members).forEach(function (jid) {
 
-            if (Strophe.getResourceFromJid(jid) === 'focus') {
+            var resourceJid = Strophe.getResourceFromJid(jid);
+            var member = members[jid];
+
+            if (member.isFocus) {
                 // Skip server side focus
                 return;
             }
-
-            var resourceJid = Strophe.getResourceFromJid(jid);
-            var member = members[jid];
 
             if (member.role === 'moderator') {
                 remoteVideos[resourceJid].removeRemoteVideoMenu();


### PR DESCRIPTION
Fixes issues in the client when the focus user has been renamed from "focus" on the jitsi-meet server.

In client console one may see:

    function ()  - error -  TypeError: remoteVideos[resourceJid] is undefined

Other issues possibly solved include the focus user not granting the first web client user moderator privileges and the video not coming back to the first web client in the large video window.