### PR TITLE
Explicitly mention debian version (ie 8) in Quick Install

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -1,6 +1,6 @@
 # Jitsi Meet quick install
 
-This document describes the required steps for a quick Jitsi Meet installation on a Debian based GNU/Linux system.
+This document describes the required steps for a quick Jitsi Meet installation on a Debian 8 (Jessie) based GNU/Linux system.
 
 Note: Some of the components of Jitsi-Meet will not run out-of-the-box on Debian Wheezy systems because of its libc version being too old. [See here](http://lists.jitsi.org/pipermail/users/2015-September/010064.html) for a possible solution.
 


### PR DESCRIPTION
After much troubleshooting on Debian 7, I discovered that the quick install Just Works on deb 8.  Hopefully adding this detail will save others time in future.