### PR TITLE
Add stopTracks helper to LocalStream to replace deprecated stream.stop()

### DIFF
--- a/modules/RTC/LocalStream.js
+++ b/modules/RTC/LocalStream.js
@@ -78,7 +78,7 @@ LocalStream.prototype.setMute = function (mute)
     } else {
         if (mute) {
             APP.xmpp.removeStream(this.stream);
-            this.stream.stop();
+            this.stopTracks();
             this.eventEmitter.emit(eventType, true);
         } else {
             var self = this;
@@ -119,6 +119,13 @@ LocalStream.prototype.isMuted = function () {
 
 LocalStream.prototype.getId = function () {
     return this.stream.getTracks()[0].id;
+};
+
+LocalStream.prototype.stopTracks = function() {
+  var originalStream = this.getOriginalStream();
+  originalStream && originalStream.getTracks().forEach(function(track) {
+    track.stop();
+  })
 };
 
 module.exports = LocalStream;

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -214,7 +214,7 @@ var RTC = {
         this.localStreams.push(this.localVideo);
     },
     changeLocalVideo: function (stream, isUsingScreenStream, callback) {
-        var oldStream = this.localVideo.getOriginalStream();
+        var oldStream = this.localVideo;
         var type = (isUsingScreenStream ? "screen" : "camera");
         var localCallback = callback;
         if(this.localVideo.isMuted() && this.localVideo.videoType !== type) {
@@ -230,23 +230,23 @@ var RTC = {
         if (stream && stream.videoStream) {
             stream = stream.videoStream;
         }
-        var videoStream = this.rtcUtils.createStream(stream, true);
+        var newOriginalVideoStream = this.rtcUtils.createStream(stream, true);
         this.localVideo =
-            this.createLocalStream(videoStream, "video", true, type);
+            this.createLocalStream(newOriginalVideoStream, "video", true, type);
         // Stop the stream to trigger onended event for old stream
-        oldStream.stop();
+        oldStream.stopTracks();
 
-        this.switchVideoStreams(videoStream);
+        this.switchVideoStreams(newOriginalVideoStream);
 
-        APP.xmpp.switchStreams(videoStream, oldStream,localCallback);
+        APP.xmpp.switchStreams(newOriginalVideoStream, oldStream.getOriginalStream(), localCallback);
     },
     changeLocalAudio: function (stream, callback) {
-        var oldStream = this.localAudio.getOriginalStream();
-        var newStream = this.rtcUtils.createStream(stream);
-        this.localAudio = this.createLocalStream(newStream, "audio", true);
+        var oldStream = this.localAudio;
+        var newOriginalStream = this.rtcUtils.createStream(stream);
+        this.localAudio = this.createLocalStream(newOriginalStream, "audio", true);
         // Stop the stream to trigger onended event for old stream
-        oldStream.stop();
-        APP.xmpp.switchStreams(newStream, oldStream, callback, true);
+        oldStream.stopTracks();
+        APP.xmpp.switchStreams(newOriginalStream, oldStream.getOriginalStream(), callback, true);
     },
     isVideoMuted: function (jid) {
         if (jid === APP.xmpp.myJid()) {

--- a/modules/xmpp/TraceablePeerConnection.js
+++ b/modules/xmpp/TraceablePeerConnection.js
@@ -258,21 +258,7 @@ TraceablePeerConnection.prototype.addStream = function (stream) {
 TraceablePeerConnection.prototype.removeStream = function (stream, stopStreams) {
     this.trace('removeStream', stream.id);
     if(stopStreams) {
-        stream.getAudioTracks().forEach(function (track) {
-            // stop() not supported with IE
-            if (track.stop) {
-                track.stop();
-            }
-        });
-        stream.getVideoTracks().forEach(function (track) {
-            // stop() not supported with IE
-            if (track.stop) {
-                track.stop();
-            }
-        });
-        if (stream.stop) {
-            stream.stop();
-        }
+        stream.stopTracks();
     }
 
     try {


### PR DESCRIPTION
Chrome 47 is deprecating MediaStream.stop(), to be replaced with MediaStreamTrack.stop()

See https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en