### PR TITLE
Callstats error reporting

### DIFF
--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -166,7 +166,7 @@ var RTC = {
                 null, null, getMediaStreamUsage());
         };
 
-        this.rtcUtils = new RTCUtils(this, onReady);
+        this.rtcUtils = new RTCUtils(this, eventEmitter, onReady);
 
         // Call onReady() if Temasys plugin is not used
         if (!RTCBrowserType.isTemasysPluginUsed()) {
@@ -199,7 +199,7 @@ var RTC = {
                 APP.xmpp.setVideoMute(false, function(mute) {
                     eventEmitter.emit(RTCEvents.VIDEO_MUTE, mute);
                 });
-                
+
                 callback();
             };
         }

--- a/modules/RTC/RTCUtils.js
+++ b/modules/RTC/RTCUtils.js
@@ -4,6 +4,7 @@
 /* jshint -W101 */
 var RTCBrowserType = require("./RTCBrowserType");
 var Resolutions = require("../../service/RTC/Resolutions");
+var RTCEvents = require("../../service/RTC/RTCEvents");
 var AdapterJS = require("./adapter.screenshare");
 
 var currentResolution = null;
@@ -152,10 +153,11 @@ function getConstraints(um, resolution, bandwidth, fps, desktopStream) {
 }
 
 
-function RTCUtils(RTCService, onTemasysPluginReady)
+function RTCUtils(RTCService, eventEmitter, onTemasysPluginReady)
 {
     var self = this;
     this.service = RTCService;
+    this.eventEmitter = eventEmitter;
     if (RTCBrowserType.isFirefox()) {
         var FFversion = RTCBrowserType.getFirefoxVersion();
         if (FFversion >= 40) {
@@ -321,12 +323,14 @@ RTCUtils.prototype.getUserMediaWithConstraints = function(
                 self.setAvailableDevices(um, false);
                 console.warn('Failed to get access to local media. Error ',
                     error, constraints);
+                self.eventEmitter.emit(RTCEvents.GET_USER_MEDIA_FAILED, error);
                 if (failure_callback) {
                     failure_callback(error);
                 }
             });
     } catch (e) {
         console.error('GUM failed: ', e);
+        self.eventEmitter.emit(RTCEvents.GET_USER_MEDIA_FAILED, e);
         if(failure_callback) {
             failure_callback(e);
         }

--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -108,11 +108,16 @@ var CallStats = {
                                 ', "comment": "' + detailedFeedback + '"}';
 
         var feedbackJSON = JSON.parse(feedbackString);
-        
+
         callStats.sendUserFeedback(
             this.confID, feedbackJSON);
     },
 
+    /**
+     * Notifies CallStats that getUserMedia failed.
+     *
+     * @param {Error} e error to send
+     */
     sendGetUserMediaFailed: function (e) {
         if(!callStats) {
             pendingUserMediaErrors.push(e);
@@ -122,6 +127,11 @@ var CallStats = {
                               callStats.webRTCFunctions.getUserMedia, e);
     },
 
+    /**
+     * Notifies CallStats that peer connection failed to create offer.
+     *
+     * @param {Error} e error to send
+     */
     sendCreateOfferFailed: function (e) {
         if(!callStats) {
             return;
@@ -130,6 +140,11 @@ var CallStats = {
                               callStats.webRTCFunctions.createOffer, e);
     },
 
+    /**
+     * Notifies CallStats that peer connection failed to create answer.
+     *
+     * @param {Error} e error to send
+     */
     sendCreateAnswerFailed: function (e) {
         if(!callStats) {
             return;
@@ -138,6 +153,11 @@ var CallStats = {
                               callStats.webRTCFunctions.createAnswer, e);
     },
 
+    /**
+     * Notifies CallStats that peer connection failed to set local description.
+     *
+     * @param {Error} e error to send
+     */
     sendSetLocalDescFailed: function (e) {
         if(!callStats) {
             return;
@@ -146,21 +166,31 @@ var CallStats = {
                               callStats.webRTCFunctions.setLocalDescription, e);
     },
 
+    /**
+     * Notifies CallStats that peer connection failed to set remote description.
+     *
+     * @param {Error} e error to send
+     */
     sendSetRemoteDescFailed: function (e) {
         if(!callStats) {
             return;
         }
-        callStats.reportError(this.peerconnection, this.confID,
-                              callStats.webRTCFunctions.setRemoteDescription, e);
+        callStats.reportError(
+            this.peerconnection, this.confID,
+            callStats.webRTCFunctions.setRemoteDescription, e);
     },
 
+    /**
+     * Notifies CallStats that peer connection failed to add ICE candidate.
+     *
+     * @param {Error} e error to send
+     */
     sendAddIceCandidateFailed: function (e) {
         if(!callStats) {
             return;
         }
         callStats.reportError(this.peerconnection, this.confID,
                               callStats.webRTCFunctions.addIceCandidate, e);
-    },
-
+    }
 };
 module.exports = CallStats;

--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -109,6 +109,25 @@ var statistics = {
         APP.RTC.addListener(RTCEvents.VIDEO_MUTE, function (mute) {
             CallStats.sendMuteEvent(mute, "video");
         });
+
+        APP.RTC.addListener(RTCEvents.GET_USER_MEDIA_FAILED, function (e) {
+            CallStats.sendGetUserMediaFailed(e);
+        });
+        APP.xmpp.addListener(RTCEvents.CREATE_OFFER_FAILED, function (e) {
+            CallStats.sendCreateOfferFailed(e);
+        });
+        APP.xmpp.addListener(RTCEvents.CREATE_ANSWER_FAILED, function (e) {
+            CallStats.sendCreateAnswerFailed(e);
+        });
+        APP.xmpp.addListener(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED, function (e) {
+            CallStats.sendSetLocalDescFailed(e);
+        });
+        APP.xmpp.addListener(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED, function (e) {
+            CallStats.sendSetRemoteDescFailed(e);
+        });
+        APP.xmpp.addListener(RTCEvents.ADD_ICE_CANDIDATE_FAILED, function (e) {
+            CallStats.sendAddIceCandidateFailed(e);
+        });
     }
 };
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -8,6 +8,7 @@ var SDP = require("./SDP");
 var async = require("async");
 var transform = require("sdp-transform");
 var XMPPEvents = require("../../service/xmpp/XMPPEvents");
+var RTCEvents = require("../../service/RTC/RTCEvents");
 var RTCBrowserType = require("../RTC/RTCBrowserType");
 var SSRCReplacement = require("./LocalSSRCReplacement");
 
@@ -720,6 +721,7 @@ JingleSessionPC.prototype.addIceCandidate = function (elem) {
                 self.peerconnection.addIceCandidate(candidate);
             } catch (e) {
                 console.error('addIceCandidate failed', e.toString(), line);
+                self.eventEmitter.emit(RTCEvents.ADD_ICE_CANDIDATE_FAILED, err);
             }
         });
     });

--- a/service/RTC/RTCEvents.js
+++ b/service/RTC/RTCEvents.js
@@ -1,6 +1,12 @@
 var RTCEvents = {
     RTC_READY: "rtc.ready",
     DATA_CHANNEL_OPEN: "rtc.data_channel_open",
+    CREATE_OFFER_FAILED: "rtc.create_offer_failed",
+    CREATE_ANSWER_FAILED: "rtc.create_answer_failed",
+    SET_LOCAL_DESCRIPTION_FAILED: "rtc.set_local_description_failed",
+    SET_REMOTE_DESCRIPTION_FAILED: "rtc.set_remote_description_failed",
+    ADD_ICE_CANDIDATE_FAILED: "rtc.add_ice_candidate_failed",
+    GET_USER_MEDIA_FAILED: "rtc.get_user_media_failed",
     LASTN_CHANGED: "rtc.lastn_changed",
     DOMINANTSPEAKER_CHANGED: "rtc.dominantspeaker_changed",
     LASTN_ENDPOINT_CHANGED: "rtc.lastn_endpoint_changed",


### PR DESCRIPTION
Use CallStats to report errors in `getUserMedia`, `addIceCandidate` and [others.](http://www.callstats.io/api/#enumeration-of-wrtcfuncnames)