### PR TITLE
escape username after reading it from localstorage

### DIFF
--- a/modules/UI/side_pannels/SidePanelToggler.js
+++ b/modules/UI/side_pannels/SidePanelToggler.js
@@ -143,7 +143,7 @@ var PanelToggler = (function(my) {
             null,
             function() {
                 var settings = Settings.getSettings();
-                $('#setDisplayName').get(0).value = settings.displayName;
+                $('#setDisplayName').get(0).value = UIUtil.unescapeHtml(settings.displayName);
                 $('#setEmail').get(0).value = settings.email;
             },
             null);

--- a/modules/UI/side_pannels/settings/SettingsMenu.js
+++ b/modules/UI/side_pannels/settings/SettingsMenu.js
@@ -91,7 +91,7 @@ var SettingsMenu = {
 
     setDisplayName: function(newDisplayName) {
         var displayName = Settings.setDisplayName(newDisplayName);
-        $('#setDisplayName').get(0).value = displayName;
+        $('#setDisplayName').get(0).value = UIUtil.unescapeHtml(displayName);
     },
 
     onDisplayNameChange: function(peerJid, newDisplayName) {

--- a/modules/UI/util/NicknameHandler.js
+++ b/modules/UI/util/NicknameHandler.js
@@ -1,4 +1,5 @@
 var UIEvents = require("../../../service/UI/UIEvents");
+var UIUtil = require('./UIUtil');
 
 var nickname = null;
 var eventEmitter = null;
@@ -8,7 +9,7 @@ var NicknameHandler = {
         eventEmitter = emitter;
         var storedDisplayName = window.localStorage.displayname;
         if (storedDisplayName) {
-            nickname = storedDisplayName;
+           nickname = UIUtil.escapeHtml(storedDisplayName);
         }
     },
     setNickname: function (newNickname) {
@@ -16,7 +17,7 @@ var NicknameHandler = {
             return;
 
         nickname = newNickname;
-        window.localStorage.displayname = nickname;
+        window.localStorage.displayname = UIUtil.unescapeHtml(nickname);
         eventEmitter.emit(UIEvents.NICKNAME_CHANGED, newNickname);
     },
     getNickname: function () {

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -55,6 +55,16 @@ var UIUtil = module.exports = {
         return $('<div/>').text(unsafeText).html();
     },
 
+    /**
+     * Unescapes the given text.
+     *
+     * @param {string} safe string which contains escaped html
+     * @returns string unescaped html string.
+     */
+    unescapeHtml: function (safe) {
+        return $('<div />').html(safe).text();
+    },
+
     imageToGrayScale: function (canvas) {
         var context = canvas.getContext('2d');
         var imgData = context.getImageData(0, 0, canvas.width, canvas.height);

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -143,7 +143,7 @@ LocalVideo.prototype.inputDisplayNameHandler = function (name) {
         } else {
             var defaultHTML = APP.translation.generateTranslationHTML(
                 interfaceConfig.DEFAULT_LOCAL_DISPLAY_NAME);
-            localDisplayName .html(defaultHTML);
+            localDisplayName.html(defaultHTML);
         }
         localDisplayName.show();
     }

--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -1,4 +1,5 @@
 var UsernameGenerator = require('../util/UsernameGenerator');
+var UIUtil = require('../UI/util/UIUtil')
 
 var email = '';
 var displayName = '';
@@ -40,7 +41,7 @@ if (supportsLocalStorage()) {
     userId = window.localStorage.jitsiMeetId || '';
     callStatsUserName = window.localStorage.callStatsUserName;
     email = window.localStorage.email || '';
-    displayName = window.localStorage.displayname || '';
+    displayName = UIUtil.escapeHtml(window.localStorage.displayname || '');
     language = window.localStorage.language;
 } else {
     console.log("local storage is not supported");
@@ -58,7 +59,7 @@ var Settings = {
      */
     setDisplayName: function (newDisplayName) {
         displayName = newDisplayName;
-        window.localStorage.displayname = displayName;
+        window.localStorage.displayname = UIUtil.unescapeHtml(displayName);
         return displayName;
     },
 


### PR DESCRIPTION
Currently user can manually edit `displayname` property in localStorage to set unescaped html and use it for XSS.
To fix this we can escape `displayname` received from localStorage and unescape it before writing to localStorage.