### PR TITLE
Accumulate erorrs unitl connected to callstats

### DIFF
--- a/modules/statistics/statistics.js
+++ b/modules/statistics/statistics.js
@@ -113,25 +113,30 @@ var statistics = {
         APP.RTC.addListener(RTCEvents.GET_USER_MEDIA_FAILED, function (e) {
             CallStats.sendGetUserMediaFailed(e);
         });
-        APP.xmpp.addListener(RTCEvents.CREATE_OFFER_FAILED, function (e) {
-            CallStats.sendCreateOfferFailed(e);
+        APP.xmpp.addListener(RTCEvents.CREATE_OFFER_FAILED, function (e, pc) {
+            CallStats.sendCreateOfferFailed(e, pc);
         });
-        APP.xmpp.addListener(RTCEvents.CREATE_ANSWER_FAILED, function (e) {
-            CallStats.sendCreateAnswerFailed(e);
+        APP.xmpp.addListener(RTCEvents.CREATE_ANSWER_FAILED, function (e, pc) {
+            CallStats.sendCreateAnswerFailed(e, pc);
         });
         APP.xmpp.addListener(
             RTCEvents.SET_LOCAL_DESCRIPTION_FAILED,
-            function (e) {
-                CallStats.sendSetLocalDescFailed(e);
-        });
+            function (e, pc) {
+                CallStats.sendSetLocalDescFailed(e, pc);
+            }
+        );
         APP.xmpp.addListener(
             RTCEvents.SET_REMOTE_DESCRIPTION_FAILED,
-            function (e) {
-                CallStats.sendSetRemoteDescFailed(e);
-        });
-        APP.xmpp.addListener(RTCEvents.ADD_ICE_CANDIDATE_FAILED, function (e) {
-            CallStats.sendAddIceCandidateFailed(e);
-        });
+            function (e, pc) {
+                CallStats.sendSetRemoteDescFailed(e, pc);
+            }
+        );
+        APP.xmpp.addListener(
+            RTCEvents.ADD_ICE_CANDIDATE_FAILED,
+            function (e, pc) {
+                CallStats.sendAddIceCandidateFailed(e, pc);
+            }
+        );
     }
 };
 

--- a/modules/xmpp/JingleSessionPC.js
+++ b/modules/xmpp/JingleSessionPC.js
@@ -720,7 +720,7 @@ JingleSessionPC.prototype.addIceCandidate = function (elem) {
                 self.peerconnection.addIceCandidate(candidate);
             } catch (e) {
                 console.error('addIceCandidate failed', e.toString(), line);
-                self.eventEmitter.emit(RTCEvents.ADD_ICE_CANDIDATE_FAILED, err);
+                self.eventEmitter.emit(RTCEvents.ADD_ICE_CANDIDATE_FAILED, err, self.peerconnection);
             }
         });
     });

--- a/modules/xmpp/TraceablePeerConnection.js
+++ b/modules/xmpp/TraceablePeerConnection.js
@@ -293,7 +293,7 @@ TraceablePeerConnection.prototype.setLocalDescription
         },
         function (err) {
             self.trace('setLocalDescriptionOnFailure', err);
-            self.eventEmitter.emit(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED, err);
+            self.eventEmitter.emit(RTCEvents.SET_LOCAL_DESCRIPTION_FAILED, err, self.peerconnection);
             failureCallback(err);
         }
     );
@@ -329,7 +329,7 @@ TraceablePeerConnection.prototype.setRemoteDescription
         },
         function (err) {
             self.trace('setRemoteDescriptionOnFailure', err);
-            self.eventEmitter.emit(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED, err);
+            self.eventEmitter.emit(RTCEvents.SET_REMOTE_DESCRIPTION_FAILED, err, self.peerconnection);
             failureCallback(err);
         }
     );
@@ -375,7 +375,7 @@ TraceablePeerConnection.prototype.createOffer
         },
         function(err) {
             self.trace('createOfferOnFailure', err);
-            self.eventEmitter.emit(RTCEvents.CREATE_OFFER_FAILED, err);
+            self.eventEmitter.emit(RTCEvents.CREATE_OFFER_FAILED, err, self.peerconnection);
             failureCallback(err);
         },
         constraints
@@ -406,7 +406,7 @@ TraceablePeerConnection.prototype.createAnswer
         },
         function(err) {
             self.trace('createAnswerOnFailure', err);
-            self.eventEmitter.emit(RTCEvents.CREATE_ANSWER_FAILED, err);
+            self.eventEmitter.emit(RTCEvents.CREATE_ANSWER_FAILED, err, self.peerconnection);
             failureCallback(err);
         },
         constraints


### PR DESCRIPTION
Some errors may happen before we're connected to callstats.io, so now we store them in the array until connection acquired.