### PR TITLE
update sdp-transform to 1.5.2 from 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "retry": "0.6.1",
     "sdp-interop": "0.1.10",
     "sdp-simulcast": "0.1.2",
-    "sdp-transform": "1.4.1",
+    "sdp-transform": "1.5.2",
     "socket.io-client": "1.3.6",
     "strophe": "^1.2.2",
     "strophejs-plugins": "^0.0.6",


### PR DESCRIPTION
The tcptype of candidates is not correctly parsed in sdp-transform 1.4.1; its value is ignored after a parse(). This can lead to problems when manipulating the sdp through sdp-transform, such as by turning a raw sdp into an sdp-transform object and traversing that object to set streams to inactive and back to active. In that case, attempting to set the sdp will fail because tcptype is not declared.