### PR TITLE
Adds roomjid as conference id

### DIFF
--- a/modules/statistics/CallStats.js
+++ b/modules/statistics/CallStats.js
@@ -42,8 +42,7 @@ var CallStats = {
 
         this.userID = Settings.getCallStatsUserName();
 
-        var location = window.location;
-        this.confID = location.hostname + location.pathname;
+        this.confID = APP.xmpp.getRoomJid();
 
         //userID is generated or given by the origin server
         callStats.initialize(config.callStatsID,

--- a/modules/xmpp/xmpp.js
+++ b/modules/xmpp/xmpp.js
@@ -560,6 +560,9 @@ var XMPP = {
     getPrezi: function () {
         return connection.emuc.getPrezi(this.myJid());
     },
+    getRoomJid: function () {
+      return connection.emuc.roomjid;
+    },
     removePreziFromPresence: function () {
         connection.emuc.removePreziFromPresence();
         connection.emuc.sendPresence();


### PR DESCRIPTION
Proposing to use the roomjid as the call stats conference id so that it works for all platforms (atom shell/ionic etc) instead of just the web.
