### PR TITLE
Load 3rd party JavaScript if config.enableThirdPartyRequests true

### DIFF
--- a/config.js
+++ b/config.js
@@ -69,4 +69,5 @@ var config = {
     /*noticeMessage: 'Service update is scheduled for 16th March 2015. ' +
     'During that time service will not be available. ' +
     'Apologise for inconvenience.'*/
+    enableThirdPartyRequests: true
 };

--- a/css/contact_list.css
+++ b/css/contact_list.css
@@ -44,6 +44,8 @@
     vertical-align: middle;
     font-size: 22pt;
     border-radius: 20px;
+    max-height: 30px;
+    max-width: 30px;
 }
 
 #contactlist .clickable {

--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
         </div>
         <div id="settingsmenu" class="right-panel">
             <div class="icon-settings" data-i18n="settings.title"></div>
-            <img id="avatar" src="https://www.gravatar.com/avatar/87291c37c25be69a072a4514931b1749?d=wavatar&size=30"/>
+            <img id="avatar" src="images/avatar2.png"/>
             <div class="arrow-up"></div>
             <input type="text" id="setDisplayName" data-i18n="[placeholder]settings.name" placeholder="Name">
             <input type="text" id="setEmail" placeholder="E-Mail">

--- a/index.html
+++ b/index.html
@@ -11,11 +11,9 @@
     <meta itemprop="image" content="/images/jitsilogo.png?v=1"/>
       <link rel="stylesheet" href="css/all.css"/>
     <script>console.log("(TIME) index.html loaded:\t", window.performance.now());</script>
-    <script src="https://api.callstats.io/static/callstats.min.js"></script>
     <script src="config.js?v=15"></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
     <script src="interface_config.js?v=6"></script>
     <script src="libs/app.bundle.min.js?v=139"></script>
-    <script src="analytics.js?v=1"></script><!-- google analytics plugin -->
     <!--
         Link used for inline installation of chrome desktop streaming extension,
         is updated automatically from the code with the value defined in config.js -->
@@ -224,5 +222,20 @@
             <a id="feedbackButton" data-container="body" data-toggle="popover" data-placement="right" data-i18n="[data-content]feedback"><i class="fa fa-heart"></i></a>
         </div>
     </div>
+    <script type="text/javascript">
+      if (config.enableThirdPartyRequests === true)
+      { 
+        [
+          'https://api.callstats.io/static/callstats.min.js',
+          'analytics.js?v=1'
+        ].forEach(function(extSrc) 
+        {
+          var extScript = document.createElement('script');
+          extScript.src = extSrc;
+          extScript.async = false;
+          document.head.appendChild(extScript);
+        });
+      }
+    </script>
   </body>
 </html>

--- a/modules/UI/avatar/Avatar.js
+++ b/modules/UI/avatar/Avatar.js
@@ -1,4 +1,4 @@
-/* global Strophe, APP, MD5 */
+/* global Strophe, APP, MD5, config */
 var Settings = require("../../settings/Settings");
 
 var users = {};
@@ -57,9 +57,13 @@ var Avatar = {
                 "No avatar stored yet for " + jid + " - using JID as ID");
             id = jid;
         }
-        return 'https://www.gravatar.com/avatar/' +
-            MD5.hexdigest(id.trim().toLowerCase()) +
-            "?d=wavatar&size=" + (size || "30");
+        if (config.enableThirdPartyRequests === true) {
+            return 'https://www.gravatar.com/avatar/' +
+                MD5.hexdigest(id.trim().toLowerCase()) +
+                "?d=wavatar&size=" + (size || "30");
+        } else {
+            return 'images/avatar2.png';
+        }
     }
 
 };


### PR DESCRIPTION
A step toward making third party javascript able to be disabled with a config entry.
It does not address the gravatar requests which are still present. [EDIT: commit 895bb3f helps remove these requests]

The approach in this request seems to work for the callstats requests, I am unsure if it is working exactly correctly for GA.