### PR TITLE
Preserve full source of javascript application during build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 
 deploy:
 	mkdir -p $(DEPLOY_DIR) && \
-	cp $(OUTPUT_DIR)/app.bundle.min.js $(OUTPUT_DIR)/app.bundle.min.map $(DEPLOY_DIR) && \
+	cp $(OUTPUT_DIR)/app.bundle.min.js $(OUTPUT_DIR)/app.bundle.min.map $(OUTPUT_DIR)/app.bundle.js $(OUTPUT_DIR)/app.bundle.js.map $(DEPLOY_DIR) && \
 	(cd css; cat $(CSS_FILES)) | $(CLEANCSS) > css/all.css && \
 	([ ! -x deploy-local.sh ] || ./deploy-local.sh)
 


### PR DESCRIPTION
It is sometimes nice to have the full source loaded by the browser to do troubleshooting and learn how the client application works.

This merge request simply preserves the full javascript and map files so that they can be easily included and therefore inspected using browser tools.