### PR TITLE
Fix German language typo.

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -67,7 +67,7 @@
     },
     "bottomtoolbar": {
         "chat": "Chat öffnen / schließen",
-        "filmstrip": "Videovorschauen anzeigen / verstecken",
+        "filmstrip": "Videovorschau anzeigen / verstecken",
         "contactlist": "Kontaktliste öffnen / schließen"
     },
     "chat": {

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -53,7 +53,7 @@
         "record": "Aufnehmen",
         "lock": "Raum schützen / Schutz aufheben",
         "invite": "Andere einladen",
-        "chat": "Chat öffnen / schliessen",
+        "chat": "Chat öffnen / schließen",
         "prezi": "Prezi freigeben",
         "etherpad": "Geteiltes Dokument",
         "sharescreen": "Bildschirm freigeben",
@@ -66,9 +66,9 @@
         "dialpad": "Tastenblock anzeigen"
     },
     "bottomtoolbar": {
-        "chat": "Chat öffnen / schliessen",
+        "chat": "Chat öffnen / schließen",
         "filmstrip": "Videovorschauen anzeigen / verstecken",
-        "contactlist": "Kontaktliste öffnen / schliessen"
+        "contactlist": "Kontaktliste öffnen / schließen"
     },
     "chat": {
         "nickname": {


### PR DESCRIPTION
There was a typo in the German language file. The word close is called "schließen". See the (un-)official spelling: http://www.duden.de/rechtschreibung/schlieszen.
