### PR TITLE
Fix xmpp.createRoom params in lib-jitsi-meet

### DIFF
--- a/JitsiConference.js
+++ b/JitsiConference.js
@@ -31,7 +31,8 @@ function JitsiConference(options) {
     this.connection = this.options.connection;
     this.xmpp = this.connection.xmpp;
     this.eventEmitter = new EventEmitter();
-    this.room = this.xmpp.createRoom(this.options.name, null, null, this.options.config);
+    this.room = this.xmpp.createRoom(this.options.name, this.options.config,
+        this.options.config.useNicks, this.options.config.nick);
     this.room.updateDeviceAvailability(RTC.getDeviceAvailability());
     this.rtc = new RTC(this.room, options);
     if(!RTC.options.disableAudioLevels)


### PR DESCRIPTION
The params being passed into `xmpp.createRoom` from `JitsiConference.js` are incorrectly ordered.

This stops us from using nicks.