### PR TITLE
callstats AppID/AppSecret name alignment in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -64,8 +64,8 @@ var config = {
 //    startVideoMuted: 10, //every participant after the Nth will start video muted
 //    defaultLanguage: "en",
 // To enable sending statistics to callstats.io you should provide Applicaiton ID and Secret.
-//    callStatsID: "",//Application ID for callstats.io API
-//    callStatsSecret: ""//Secret for callstats.io API
+//    callStatsID: "",//AppID for callstats.io API
+//    callStatsSecret: ""//AppSecret for callstats.io API
     /*noticeMessage: 'Service update is scheduled for 16th March 2015. ' +
     'During that time service will not be available. ' +
     'Apologise for inconvenience.'*/

--- a/config.js
+++ b/config.js
@@ -65,7 +65,7 @@ var config = {
 //    defaultLanguage: "en",
 // To enable sending statistics to callstats.io you should provide Applicaiton ID and Secret.
 //    callStatsID: "",//AppID for callstats.io API
-//    callStatsSecret: ""//AppSecret for callstats.io API
+//    callStatsSecret: "",//AppSecret for callstats.io API
     /*noticeMessage: 'Service update is scheduled for 16th March 2015. ' +
     'During that time service will not be available. ' +
     'Apologise for inconvenience.'*/


### PR DESCRIPTION
We noticed some irregularity in the config file comments for callStatsID and callStatsSecret with our API terminology, so we fixed the same in this PR. 
