### PR TITLE
Stop using the polyfill when assigning it anyway

### DIFF
--- a/JitsiMeetJS.js
+++ b/JitsiMeetJS.js
@@ -121,7 +121,6 @@ var LibJitsiMeet = {
     }
 };
 
-require("es6-promise").polyfill()
 //Setups the promise object.
 window.Promise = window.Promise || require("es6-promise").Promise;
 


### PR DESCRIPTION
Stop using the polyfill when you are assign the es6-promise after that anyway

The es6-promise.polyfill() is broken for Chrome atm and replaces the native Promise and swallows unhandled errors. https://github.com/jakearchibald/es6-promise/issues/70