### PR TITLE
Add `deviceId` used to create `JitsiLocalTrack` to the track object

### DIFF
--- a/modules/RTC/JitsiLocalTrack.js
+++ b/modules/RTC/JitsiLocalTrack.js
@@ -8,11 +8,12 @@ var RTCUtils = require("./RTCUtils");
  * @constructor
  */
 function JitsiLocalTrack(stream, videoType,
-  resolution)
+  resolution, deviceId)
 {
     this.videoType = videoType;
     this.dontFireRemoveEvent = false;
     this.resolution = resolution;
+    this.deviceId = deviceId;
     this.startMuted = false;
     var self = this;
     JitsiTrack.call(this, null, stream,
@@ -71,9 +72,16 @@ JitsiLocalTrack.prototype._setMute = function (mute) {
             //FIXME: Maybe here we should set the SRC for the containers to something
         } else {
             var self = this;
-            RTCUtils.obtainAudioAndVideoPermissions({
+            var streamOptions = {
                 devices: (isAudio ? ["audio"] : ["video"]),
-                resolution: self.resolution})
+                resolution: self.resolution
+            };
+            if (isAudio) {
+              streamOptions['micDeviceId'] = self.deviceId;
+            } else {self.videoType === 'camera'} {
+              streamOptions['cameraDeviceId'] = self.deviceId;
+            }
+            RTCUtils.obtainAudioAndVideoPermissions(streamOptions)
                 .then(function (streams) {
                     var stream = null;
                     for(var i = 0; i < streams.length; i++) {

--- a/modules/RTC/RTC.js
+++ b/modules/RTC/RTC.js
@@ -11,11 +11,17 @@ var DesktopSharingEventTypes
 var MediaStreamType = require("../../service/RTC/MediaStreamTypes");
 var RTCEvents = require("../../service/RTC/RTCEvents.js");
 
-function createLocalTracks(streams) {
+function createLocalTracks(streams, options) {
     var newStreams = []
+    var deviceId = null;
     for (var i = 0; i < streams.length; i++) {
+        if (streams[i].type === 'audio') {
+          deviceId = options.micDeviceId;
+        } else if (streams[i].videoType === 'camera'){
+          deviceId = options.cameraDeviceId;
+        }
         var localStream = new JitsiLocalTrack(streams[i].stream,
-            streams[i].videoType, streams[i].resolution);
+            streams[i].videoType, streams[i].resolution, deviceId);
         newStreams.push(localStream);
         if (streams[i].isMuted === true)
             localStream.setMute(true);
@@ -73,8 +79,11 @@ function RTC(room, options) {
  * @param {string} options.micDeviceId
  * @returns {*} Promise object that will receive the new JitsiTracks
  */
+
 RTC.obtainAudioAndVideoPermissions = function (options) {
-    return RTCUtils.obtainAudioAndVideoPermissions(options).then(createLocalTracks);
+    return RTCUtils.obtainAudioAndVideoPermissions(options).then(function (streams) {
+        return createLocalTracks(streams, options);
+    });
 }
 
 RTC.prototype.onIncommingCall = function(event) {


### PR DESCRIPTION
Add `deviceId` which was used to create `JitsiLocalTrack` to the object to re-use it when unmuting the track

Fixes the issue that when creating local tracks with specific devices after unmuting the new tracks were created with default devices again.