### PR TITLE
[bugfix] login prompt doesn't show up when login is needed

### DIFF
--- a/modules/UI/util/MessageHandler.js
+++ b/modules/UI/util/MessageHandler.js
@@ -77,9 +77,9 @@ var messageHandler = (function(my) {
             buttons: buttons,
             defaultButton: defaultButton,
             focus: focus,
-            loaded: loadedFunction,
-            submit: submitFunction,
-            close: closeFunction
+            loaded: loadedFunction || function(){},
+            submit: submitFunction || function(){},
+            close: closeFunction || function(){}
         });
     };
 


### PR DESCRIPTION
Login dialog is broken. It doesn't show up because script is stopped on JavaScript errors. Errors are  caused by passing nulls instead of functions to `$.prompt` function.
