### PR TITLE
fix switching Large video on Safari

### DIFF
--- a/modules/UI/videolayout/LargeVideo.js
+++ b/modules/UI/videolayout/LargeVideo.js
@@ -165,7 +165,6 @@ class VideoContainer extends LargeContainer {
 
     get id () {
         return getStreamOwnerId(this.stream);
-        return getStreamId(this.stream);
     }
 
     constructor (onPlay) {
@@ -275,7 +274,27 @@ class VideoContainer extends LargeContainer {
         this.stream = stream;
         this.videoType = videoType;
 
-        stream.attach(this.$video);
+        if (RTCBrowserType.isTemasysPluginUsed()) {
+            // when Temasys plugin is in use stream.attach fails
+            // if element is not visible
+            // so we need to make it visible, but opaque
+
+            this.$wrapper.show().css({
+                opacity: 0
+            });
+
+            try {
+                stream.attach(this.$video);
+            } catch (e) {
+                console.error('failed to attach stream', e);
+            }
+
+            this.$wrapper.hide().css({
+                opacity: ''
+            });
+        } else {
+            stream.attach(this.$video);
+        }
 
         let flipX = stream.isLocal() && !this.isScreenSharing();
         this.$video.css({


### PR DESCRIPTION
Currently in `jitsi-meet-new` branch Large video is black on Safari, because DOM element must be visible when we change attached stream.