### PR TITLE
Fix room locking with MongooseIM/Ejabberd

### DIFF
--- a/modules/xmpp/strophe.emuc.js
+++ b/modules/xmpp/strophe.emuc.js
@@ -426,10 +426,11 @@ module.exports = function(XMPP, eventEmitter) {
                         var formsubmit = $iq({to: ob.roomjid, type: 'set'}).c('query', {xmlns: 'http://jabber.org/protocol/muc#owner'});
                         formsubmit.c('x', {xmlns: 'jabber:x:data', type: 'submit'});
                         formsubmit.c('field', {'var': 'FORM_TYPE'}).c('value').t('http://jabber.org/protocol/muc#roomconfig').up().up();
-                        formsubmit.c('field', {'var': 'muc#roomconfig_roomsecret'}).c('value').t(key).up().up();
-                        // Fixes a bug in prosody 0.9.+ https://code.google.com/p/lxmppd/issues/detail?id=373
-                        formsubmit.c('field', {'var': 'muc#roomconfig_whois'}).c('value').t('anyone').up().up();
-                        // FIXME: is muc#roomconfig_passwordprotectedroom required?
+                        if (key != '') {
+                            // MongooseIM (maybe Ejabberd) rejects roomsecret when we set passwordprotectedroom to false
+                            formsubmit.c('field', {'var': 'muc#roomconfig_roomsecret'}).c('value').t(key).up().up();
+                        }
+                        formsubmit.c('field', {'var': 'muc#roomconfig_passwordprotectedroom'}).c('value').t(key != '').up().up();
                         ob.connection.sendIQ(formsubmit,
                             onSuccess,
                             onError);


### PR DESCRIPTION
roomconfig_passwordprotectedroom is required with MongooseIM/Ejabberd
Not tested with Prosody nor OpenFire
while at it remove a 3 years old Prosody workaround