### PR TITLE
do not pin participant if moderator clicked item in remote user menu

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -111,7 +111,7 @@ class ConferenceConnector {
         this._reject(err);
     }
     _onConferenceFailed(err, ...params) {
-        console.error('CONFERENCE FAILED:', err, params);
+        console.error('CONFERENCE FAILED:', err, ...params);
         switch (err) {
             // room is locked by the password
         case ConferenceErrors.PASSWORD_REQUIRED:

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -86,13 +86,12 @@ if (!interfaceConfig.filmStripOnly) {
             muteLinkItem.className = 'mutelink disabled';
         }
 
-        var self = this;
-        muteLinkItem.onclick = function(){
+        muteLinkItem.onclick = (event) => {
             if ($(this).attr('disabled')) {
                 event.preventDefault();
             }
-            var isMute = !!self.isMuted;
-            self.emitter.emit(UIEvents.REMOTE_AUDIO_MUTED, self.id);
+            var isMute = !!this.isMuted;
+            this.emitter.emit(UIEvents.REMOTE_AUDIO_MUTED, this.id);
 
             popupmenuElement.setAttribute('style', 'display:none;');
 
@@ -120,8 +119,8 @@ if (!interfaceConfig.filmStripOnly) {
         var ejectText = "<div style='width: 90px;margin-left: 20px;' " +
             "data-i18n='videothumbnail.kick'>&nbsp;</div>";
         ejectLinkItem.innerHTML = ejectIndicator + ' ' + ejectText;
-        ejectLinkItem.onclick = function(){
-            self.emitter.emit(UIEvents.USER_KICKED, self.id);
+        ejectLinkItem.onclick = (event) => {
+            this.emitter.emit(UIEvents.USER_KICKED, this.id);
             popupmenuElement.setAttribute('style', 'display:none;');
         };
 
@@ -225,8 +224,12 @@ RemoteVideo.prototype.addRemoteStreamElement = function (stream) {
 
     // Add click handler.
     let onClickHandler = (event) => {
+        let source = event.target || event.srcElement;
 
-        this.VideoLayout.handleVideoThumbClicked(false, this.id);
+        // ignore click if it was done in popup menu
+        if ($(source).parents('.popupmenu').length === 0) {
+            this.VideoLayout.handleVideoThumbClicked(false, this.id);
+        }
 
         // On IE we need to populate this handler on video <object>
         // and it does not give event instance as an argument,


### PR DESCRIPTION
When we click on small video of remote user then user should be pinned.

Currently when moderator clicks on popup menu of remote user, that user also becomes pinned (even if moderator just want to mute him).

PR fixes this issue.