### PR TITLE
Fix screensharing mute on safari

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -2,10 +2,3 @@ node_modules
 libs
 debian
 analytics.js
-lib-jitsi-meet.js
-
-modules/xmpp/strophe.emuc.js
-modules/UI/prezi/Prezi.js
-modules/RTC/adapter.screenshare.js
-modules/statistics/*
-modules/UI/videolayout/*

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -620,8 +620,8 @@ UI.getRemoteVideoType = function (jid) {
     return VideoLayout.getRemoteVideoType(jid);
 };
 
-UI.connectionIndicatorShowMore = function(jid) {
-    return VideoLayout.showMore(jid);
+UI.connectionIndicatorShowMore = function(id) {
+    VideoLayout.showMore(id);
 };
 
 // FIXME check if someone user this

--- a/modules/UI/videolayout/LargeVideo.js
+++ b/modules/UI/videolayout/LargeVideo.js
@@ -307,9 +307,9 @@ class VideoContainer extends LargeContainer {
     show () {
         let $wrapper = this.$wrapper;
         return new Promise(function(resolve) {
-            $wrapper.css({visibility: 'visible'});
+            $wrapper.css('visibility', 'visible');
             $wrapper.fadeTo(FADE_DURATION_MS, 1, function () {
-                $('.watermark').css({visibility: 'visible'});
+                $('.watermark').css('visibility', 'visible');
                 resolve();
             });
         });
@@ -317,12 +317,15 @@ class VideoContainer extends LargeContainer {
 
     hide () {
         let $wrapper = this.$wrapper;
-
         let id = this.id;
         return new Promise(function(resolve) {
+            // There is no id on initial render
+            // so first time we hide wrapper immediately
+            // instead of slowly fading it out.
+            // This improves startup time.
             $wrapper.fadeTo(id ? FADE_DURATION_MS : 1, 0, function () {
-                $wrapper.css({visibility: 'hidden'});
-                $('.watermark').css({visibility: 'hidden'});
+                $wrapper.css('visibility', 'hidden');
+                $('.watermark').css('visibility', 'hidden');
                 resolve();
             });
         });
@@ -512,14 +515,6 @@ export default class LargeVideoManager {
      */
     updateAvatar (avatarUrl) {
         $("#dominantSpeakerAvatar").attr('src', avatarUrl);
-    }
-
-    /**
-     * Show avatar on Large video container or not.
-     * @param {boolean} show
-     */
-    showAvatar (show) {
-        this.videoContainer.showAvatar(show);
     }
 
     /**

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -1,4 +1,4 @@
-/* global $, interfaceConfig, APP */
+/* global $, interfaceConfig, APP, JitsiMeetJS */
 import ConnectionIndicator from "./ConnectionIndicator";
 import UIUtil from "../util/UIUtil";
 import UIEvents from "../../../service/UI/UIEvents";

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -253,7 +253,8 @@ RemoteVideo.prototype.addRemoteStreamElement = function (stream) {
     // calling attach will show it back
     $(streamElement).hide();
 
-    // If the container is currently visible we attach the stream to the element.
+    // If the container is currently visible
+    // we attach the stream to the element.
     if (!isVideo || (this.container.offsetParent !== null && isVideo)) {
         this.waitForPlayback(streamElement, stream);
 

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -1,4 +1,4 @@
-/* global $, APP, require */
+/* global $, APP, JitsiMeetJS */
 /* jshint -W101 */
 import Avatar from "../avatar/Avatar";
 import UIUtil from "../util/UIUtil";

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -1,4 +1,4 @@
-/* global config, APP, $, interfaceConfig */
+/* global config, APP, $, interfaceConfig, JitsiMeetJS */
 /* jshint -W101 */
 
 import AudioLevels from "../audio_levels/AudioLevels";
@@ -504,8 +504,10 @@ var VideoLayout = {
             remoteVideo.setMutedView(value);
         }
 
-        if(this.isCurrentlyOnLarge(id))
-            largeVideo.showAvatar(value);
+        if (this.isCurrentlyOnLarge(id)) {
+            // large video will show avatar instead of muted stream
+            this.updateLargeVideo(id, true);
+        }
     },
 
     /**

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -819,15 +819,15 @@ var VideoLayout = {
         }
     },
 
-    showMore (jid) {
-        if (jid === 'local') {
+    showMore (id) {
+        if (id === 'local') {
             localVideoThumbnail.connectionIndicator.showMore();
         } else {
-            var remoteVideo = remoteVideos[Strophe.getResourceFromJid(jid)];
+            let remoteVideo = remoteVideos[id];
             if (remoteVideo) {
                 remoteVideo.connectionIndicator.showMore();
             } else {
-                console.info("Error - no remote video for jid: " + jid);
+                console.info("Error - no remote video for id: " + id);
             }
         }
     },


### PR DESCRIPTION
This PR ensures that we hide large video if stream is muted.
 It fixes issue on Safari when after muting desktop stream there is desktop image covered by avatar instead of avatar on black background.

Also it fixes remaining jshint errors.