### PR TITLE
example NW.js app

### DIFF
--- a/nwjs-integration/index.html
+++ b/nwjs-integration/index.html
@@ -1,0 +1,68 @@
+<html>
+    <head>
+
+        <style>
+            body {
+                margin: 0;
+            }
+
+            iframe {
+                width: 100%;
+                height: 100%;
+                border: 0 none;
+            }
+        </style>
+    </head>
+    <body>
+        <script>
+            var gui = require('nw.gui');
+            var screenInitialized = false;
+            function obtainDesktopStream (callback, errorCallback) {
+                if (!screenInitialized) {
+                    gui.Screen.Init();
+                    screenInitialized = true;
+                }
+                gui.Screen.chooseDesktopMedia(
+                    ["window","screen"],
+                    function(streamId) {
+                        var vid_constraint = {
+                            mandatory: {
+                                chromeMediaSource: 'desktop',
+                                chromeMediaSourceId: streamId,
+                                maxWidth: 1920,
+                                maxHeight: 1080
+                            },
+                            optional: []
+                        };
+                        navigator.webkitGetUserMedia({
+                            audio: false, video: vid_constraint
+                        }, callback, errorCallback);
+                    }
+                );
+            }
+
+            // use Esc to leave fullscreen mode
+            nw.App.registerGlobalHotKey(new nw.Shortcut({
+                key: "Escape",
+                active: function () {
+                    var win = nw.Window.get();
+                    if (win.isFullscreen) {
+                        win.leaveFullscreen();
+                    }
+                }
+            }));
+
+            // create iframe with jitsi-meet
+            var iframe = document.createElement('iframe');
+            iframe.src = nw.App.manifest['jitsi-url'];
+            iframe.allowFullscreen = true;
+            iframe.onload = function () {
+                iframe.contentWindow.JitsiMeetNW = {
+                    obtainDesktopStream: obtainDesktopStream
+                };
+            };
+
+            document.body.appendChild(iframe);
+        </script>
+    </body>
+</html>

--- a/nwjs-integration/package.json
+++ b/nwjs-integration/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "JitsiMeetNW!",
+    "version": "0.0.1",
+    "jitsi-url": "https://ivan.jitsi.net/",
+    "main": "index.html",
+    "chromium-args": "--ignore-certificate-errors",
+    "user-agent": "Chrome/%webkit_ver JitsiMeetNW/%ver"
+}


### PR DESCRIPTION
example NW.js app with user agent and desktop sharing function expected by lib-jitsi-meet

depends on https://github.com/jitsi/lib-jitsi-meet/pull/33