### PR TITLE
Removes hoverIn/Out detection for shared video that shows/hides displ…

### DIFF
--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -336,7 +336,6 @@ function SharedVideoThumb (url)
     this.videoSpanId = "sharedVideoContainer";
     this.container = this.createContainer(this.videoSpanId);
     this.container.onclick = this.videoClick.bind(this);
-    this.bindHoverHandler();
 
     SmallVideo.call(this, VideoLayout);
     this.isVideoMuted = true;


### PR DESCRIPTION
…ayname, as we always display the name of the video when there is no thumb shown. And we do not want the name over the thumb.