### PR TITLE
lock to jquery-ui 1.10.x for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jquery": "~2.1.1",
     "jQuery-Impromptu": "git+https://github.com/trentrichardson/jQuery-Impromptu.git#v6.0.0",
     "lib-jitsi-meet": "jitsi/lib-jitsi-meet",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "~1.10.5",
     "jssha": "1.5.0",
     "retry": "0.6.1",
     "strophe": "^1.2.2",


### PR DESCRIPTION
1.11.x has breaking changes that need to be figured out.

See #544 and https://jqueryui.com/upgrade-guide/1.11/

Even with the fix provided in #544 jquery UI throws an undefined error for the jQuery object. rolling back to 1.10.x fixes this.