### PR TITLE
Enable adaptive simulcast by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -54,7 +54,7 @@ var config = {
     disableAudioLevels: false,
     channelLastN: -1, // The default value of the channel attribute last-n.
     adaptiveLastN: false,
-    adaptiveSimulcast: false,
+    //disableAdaptiveSimulcast: false,
     enableRecording: false,
     enableWelcomePage: true,
     disableSimulcast: false,


### PR DESCRIPTION
In conjunction with corresponding commits in lib-jitsi-meet and jicofo
this enables adaptive simulcast whenever simulcast is enabled.