### PR TITLE
Improve token error reporting in Prosody JWT plugin

### DIFF
--- a/prosody-plugins/mod_auth_token.lua
+++ b/prosody-plugins/mod_auth_token.lua
@@ -80,6 +80,9 @@ function provider.get_sasl_handler(session)
 		-- here we check if 'room' claim exists
 		local room, roomErr = token_util.get_room_name(token, appSecret);
 		if room == nil then
+            if roomErr == nil then
+                roomErr = "'room' claim is missing";
+            end
 			return false, "not-allowed", roomErr;
 		end
 

--- a/prosody-plugins/token/util.lib.lua
+++ b/prosody-plugins/token/util.lib.lua
@@ -23,7 +23,7 @@ local function _verify_token(token, appId, appSecret, roomName)
 
 	local issClaim = claims["iss"];
 	if issClaim == nil then
-		return nil, "Issuer field is missing";
+		return nil, "'iss' claim is missing";
 	end
 	if issClaim ~= appId then
 		return nil, "Invalid application ID('iss' claim)";
@@ -31,7 +31,7 @@ local function _verify_token(token, appId, appSecret, roomName)
 
 	local roomClaim = claims["room"];
 	if roomClaim == nil then
-		return nil, "Room field is missing";
+		return nil, "'room' claim is missing";
 	end
 	if roomName ~= nil and roomName ~= roomClaim then
 		return nil, "Invalid room name('room' claim)";


### PR DESCRIPTION
Adjusts log messages and informs about missing 'room' claim.