### PR TITLE
Uses more meaningful names and adds documentation.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -447,12 +447,17 @@ export default {
     sendFeedback (overallFeedback, detailedFeedback) {
         return room.sendFeedback (overallFeedback, detailedFeedback);
     },
-    // used by torture currently
-    isJoined () {
+    /**
+     * Checks whether the MUC is joined.
+     */
+    isMucJoined () {
         return this._room
             && this._room.isJoined();
     },
-    getConnectionState () {
+    /**
+     * Returns the ICE connection state of the PeerConnection.
+     */
+    getIceConnectionState () {
         return this._room
             && this._room.getConnectionState();
     },


### PR DESCRIPTION
conference.isJoined() is confusing, as is conference.getConnectionState()