### PR TITLE
Lipsync

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -557,6 +557,9 @@ export default {
                 this.useAudioStream(track);
             } else if (track.isVideoTrack()) {
                 this.useVideoStream(track);
+            } else {
+                console.error(
+                    "Ignored not an audio nor a video track: ", track);
             }
         });
         roomLocker = createRoomLocker(room);

--- a/modules/UI/videolayout/LargeVideo.js
+++ b/modules/UI/videolayout/LargeVideo.js
@@ -446,7 +446,15 @@ export default class LargeVideoManager {
 
         let container = this.getContainer(this.state);
 
-        container.hide().then(() => {
+        // Include hide()/fadeOut only if we're switching between users
+        let preUpdate;
+        if (this.newStreamData.id != this.id) {
+            preUpdate = container.hide();
+        } else {
+            preUpdate = Promise.resolve();
+        }
+        
+        preUpdate.then(() => {
             let {id, stream, videoType, resolve} = this.newStreamData;
             this.newStreamData = null;
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -404,7 +404,11 @@ var VideoLayout = {
             this.isLargeContainerTypeVisible(VIDEO_CONTAINER_TYPE)) ||
             pinnedId === resourceJid ||
             (!pinnedId && resourceJid &&
-                currentDominantSpeaker === resourceJid)) {
+                currentDominantSpeaker === resourceJid) ||
+            /* Playback started while we're on the stage - may need to update
+               video source with the new stream */
+            this.isCurrentlyOnLarge(resourceJid)) {
+
             this.updateLargeVideo(resourceJid, true);
         }
     },


### PR DESCRIPTION
This PR fixes issues discovered while working on lipsync. The problem was that we were not updating "large video" source when we the participant was "on stage" and there was a switch between "camera" and "screen" videos. It happens only when he's not pinned and we're an active speaker. To reproduce need to start conference of 2 and make sure we are an active speaker, then switch to desktop from second participant. The large video will be black.

It also removes the hide() animation for the case described above which was introducing unnecessary flickering.