### PR TITLE
Prevent TypeError when API.processMessage can't parse event.data.

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -107,7 +107,10 @@ function processMessage(event) {
     var message;
     try {
         message = JSON.parse(event.data);
-    } catch (e) {}
+    } catch (e) {
+        console.error("Could not parse event data.");
+        return;
+    }
 
     if(!message.type)
         return;


### PR DESCRIPTION
API.processMessage checks whether message.type is not set, but if the event.data could not be parsed, message will be undefined and the check will throw a TypeError since it tries to access a property of undefined.
