### PR TITLE
Nukes the pre-configured bridge from the config file.

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,7 +6,6 @@ var config = {
         //anonymousdomain: 'guest.example.com',
         //authdomain: 'jitsi-meet.example.com',  // defaults to <domain>
         muc: 'conference.jitsi-meet.example.com', // FIXME: use XEP-0030
-        bridge: 'jitsi-videobridge.jitsi-meet.example.com', // FIXME: use XEP-0030
         //jirecon: 'jirecon.jitsi-meet.example.com',
         //call_control: 'callcontrol.jitsi-meet.example.com',
         //focus: 'focus.jitsi-meet.example.com', // defaults to 'focus.jitsi-meet.example.com'


### PR DESCRIPTION
Jicofo uses pubsub and discoinfo to configure the bridge.