### PR TITLE
make the chatArrow image reference relative

### DIFF
--- a/modules/UI/side_pannels/chat/Chat.js
+++ b/modules/UI/side_pannels/chat/Chat.js
@@ -245,7 +245,7 @@ var Chat = {
 
         var messageContainer =
             '<div class="chatmessage">'+
-                '<img src="../images/chatArrow.svg" class="chatArrow">' +
+                '<img src="images/chatArrow.svg" class="chatArrow">' +
                 '<div class="username ' + divClassName +'">' + escDisplayName +
                 '</div>' + '<div class="timestamp">' + getCurrentTime(stamp) +
                 '</div>' + '<div class="usermessage">' + message + '</div>' +


### PR DESCRIPTION
allows for better override using base href, otherwise the image fails to load when base href is overridden