### PR TITLE
Tsareg handle create local tracks errors better

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -222,7 +222,21 @@
         "stopStreamingWarning": "Are you sure you would like to stop the live streaming?",
         "stopRecordingWarning": "Are you sure you would like to stop the recording?",
         "stopLiveStreaming": "Stop live streaming",
-        "stopRecording": "Stop recording"
+        "stopRecording": "Stop recording",
+        "doNotShowWarningAgain": "Don't show this warning again",
+        "permissionDenied": "Permission Denied",
+        "screenSharingPermissionDeniedError": "You have not granted permission to share your screen.",
+        "micErrorPresent": "There was an error connecting to your microphone.",
+        "cameraErrorPresent": "There was an error connecting to your camera.",
+        "cameraUnsupportedResolutionError": "Your camera does not support required video resolution.",
+        "cameraUnknownError": "Cannot use camera for a unknown reason.",
+        "cameraPermissionDeniedError": "You have not granted permission to use your camera.",
+        "cameraNotFoundError": "Requested camera was not found.",
+        "cameraConstraintFailedError": "Yor camera does not satisfy some of required constraints.",
+        "micUnknownError": "Cannot use microphone for a unknown reason.",
+        "micPermissionDeniedError": "You have not granted permission to use your microphone.",
+        "micNotFoundError": "Requested microphone was not found.",
+        "micConstraintFailedError": "Yor microphone does not satisfy some of required constraints."
     },
     "email":
     {

--- a/modules/UI/side_pannels/settings/SettingsMenu.js
+++ b/modules/UI/side_pannels/settings/SettingsMenu.js
@@ -204,6 +204,28 @@ export default {
     },
 
     /**
+     * Sets microphone's <select> element to select microphone ID from settings.
+     */
+    setSelectedMicFromSettings () {
+        $('#selectMic').val(Settings.getMicDeviceId());
+    },
+
+    /**
+     * Sets camera's <select> element to select camera ID from settings.
+     */
+    setSelectedCameraFromSettings () {
+        $('#selectCamera').val(Settings.getCameraDeviceId());
+    },
+
+    /**
+     * Sets audio outputs's <select> element to select audio output ID from
+     * settings.
+     */
+    setSelectedAudioOutputFromSettings () {
+        $('#selectAudioOutput').val(Settings.getAudioOutputDeviceId());
+    },
+
+    /**
      * Change available cameras/microphones or hide selects completely if
      * no devices available.
      * @param {{ deviceId, label, kind }[]} devices list of available devices

--- a/nwjs-integration/index.html
+++ b/nwjs-integration/index.html
@@ -36,7 +36,10 @@
                         };
                         navigator.webkitGetUserMedia({
                             audio: false, video: vid_constraint
-                        }, callback, errorCallback);
+                        }, callback, function (error) {
+                            errorCallback &&
+                                errorCallback(error, vid_constraint);
+                        });
                     }
                 );
             }


### PR DESCRIPTION
This PR is a 'clone' of https://github.com/jitsi/jitsi-meet/pull/661 into the jitsi organization repository where I have (1) push access and (2) automatic PR testing.

@tsareg wrote:
Show dialog with error when GUM calls fail, also fix some minor bugs related to enabling webcam icon or restoring correct <select> state when failed to change camera/mic/audio output.