### PR TITLE
Switch to https on iframe creation

### DIFF
--- a/external_api.js
+++ b/external_api.js
@@ -50,7 +50,7 @@ var JitsiMeetExternalAPI = (function()
         if(height)
             this.iframeHolder.style.height = height + "px";
         this.frameName = "jitsiConferenceFrame" + JitsiMeetExternalAPI.id;
-        this.url = "//" + domain + "/";
+        this.url = "https://" + domain + "/";
         if(room_name)
             this.url += room_name;
         this.url += "#external=true";

--- a/external_api.js
+++ b/external_api.js
@@ -25,10 +25,11 @@ var JitsiMeetExternalAPI = (function()
      * @param parent_node the node that will contain the iframe
      * @param filmStripOnly if the value is true only the small videos will be
      * visible.
+     * @param ssl if the value is true https will be used on the iframe
      * @constructor
      */
     function JitsiMeetExternalAPI(domain, room_name, width, height, parentNode,
-        configOverwrite, interfaceConfigOverwrite) {
+        configOverwrite, interfaceConfigOverwrite, ssl) {
         if (!width || width < MIN_WIDTH)
             width = MIN_WIDTH;
         if (!height || height < MIN_HEIGHT)
@@ -50,7 +51,7 @@ var JitsiMeetExternalAPI = (function()
         if(height)
             this.iframeHolder.style.height = height + "px";
         this.frameName = "jitsiConferenceFrame" + JitsiMeetExternalAPI.id;
-        this.url = "https://" + domain + "/";
+        this.url = (ssl) ? "https:" : "" +"//" + domain + "/";
         if(room_name)
             this.url += room_name;
         this.url += "#external=true";

--- a/external_api.js
+++ b/external_api.js
@@ -25,11 +25,11 @@ var JitsiMeetExternalAPI = (function()
      * @param parent_node the node that will contain the iframe
      * @param filmStripOnly if the value is true only the small videos will be
      * visible.
-     * @param ssl if the value is true https will be used on the iframe
+     * @param noSsl if the value is true https won't be used
      * @constructor
      */
     function JitsiMeetExternalAPI(domain, room_name, width, height, parentNode,
-        configOverwrite, interfaceConfigOverwrite, ssl) {
+        configOverwrite, interfaceConfigOverwrite, noSsl) {
         if (!width || width < MIN_WIDTH)
             width = MIN_WIDTH;
         if (!height || height < MIN_HEIGHT)
@@ -51,7 +51,7 @@ var JitsiMeetExternalAPI = (function()
         if(height)
             this.iframeHolder.style.height = height + "px";
         this.frameName = "jitsiConferenceFrame" + JitsiMeetExternalAPI.id;
-        this.url = (ssl) ? "https:" : "" +"//" + domain + "/";
+        this.url = (noSsl) ? "http" : "https" +"://" + domain + "/";
         if(room_name)
             this.url += room_name;
         this.url += "#external=true";


### PR DESCRIPTION
When accessing via `http://` when the url is prefix is `//` you get this error.
![pasted1](https://cloud.githubusercontent.com/assets/51996/15845572/e97727a2-2c39-11e6-880b-d44a8a041a42.png)

So it needs to be set to `https://` to prevent this error.  

```
JitsiMeetExternalAPI(domain, room_name, width, height, parentNode,
        configOverwrite, interfaceConfigOverwrite, ssl)
```

ssl optional param to force the url to https