### PR TITLE
Defines the document encoding.

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
     <script src="libs/app.bundle.min.js?v=139"></script>
     <link rel="icon" type="image/png" href="/images/favicon.ico?v=1"/>
+    <meta charset="utf-8" />
+    <meta http-equiv="content-type" content="text/html;charset=utf-8">
     <meta property="og:title" content="Jitsi Meet"/>
     <meta property="og:image" content="/images/jitsilogo.png?v=1"/>
     <meta property="og:description" content="Join a WebRTC video conference powered by the Jitsi Videobridge"/>


### PR DESCRIPTION
Make FF stop complaining about the character encoding of the HTML document
not being declared.