### PR TITLE
Fix TypeError when one of audioTracks or videoTracks was undefined

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -594,7 +594,8 @@ export default {
                                             videoTrackCreationError);
                                     }
 
-                                    return audioTracks.concat(videoTracks);
+                                    return (audioTracks || [])
+                                        .concat(videoTracks || []);
                                 });
                         } else {
                             promise = createAudioTrack();


### PR DESCRIPTION
call to createLocalTracks may resolve with single argument, so "videoTracks" argument might be undefined in this case