### PR TITLE
Fixing various edge-cases when two gUM error dialogs might be shown and other possible bugs

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -1289,6 +1289,12 @@ UI.showDeviceErrorDialog = function (micError, cameraError) {
                         input.prop("checked");
                 }
             }
+        },
+        null,
+        function () {
+            // Reset dialog reference to null to avoid memory leaks when
+            // user closed the dialog manually.
+            deviceErrorDialog = null;
         }
     );
 

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -39,6 +39,8 @@ let sharedVideoManager;
 
 let followMeHandler;
 
+let deviceErrorDialog;
+
 const TrackErrors = JitsiMeetJS.errors.track;
 
 const JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP = {
@@ -1267,7 +1269,11 @@ UI.showDeviceErrorDialog = function (micError, cameraError) {
 
     message = `${message}${doNotShowWarningAgainSection}`;
 
-    messageHandler.openDialog(
+    // To make sure we don't have multiple error dialogs open at the same time,
+    // we will just close the previous one if we are going to show a new one.
+    deviceErrorDialog && deviceErrorDialog.close();
+
+    deviceErrorDialog = messageHandler.openDialog(
         titleMsg,
         message,
         false,

--- a/modules/UI/util/MessageHandler.js
+++ b/modules/UI/util/MessageHandler.js
@@ -113,9 +113,10 @@ var messageHandler = {
      * @param submitFunction function to be called on submit
      * @param loadedFunction function to be called after the prompt is fully
      *        loaded
+     * @param closeFunction function to be called on dialog close
      */
     openDialog: function (titleString, msgString, persistent, buttons,
-                              submitFunction, loadedFunction) {
+                              submitFunction, loadedFunction, closeFunction) {
         if (!popupEnabled)
             return;
 
@@ -125,11 +126,14 @@ var messageHandler = {
             buttons: buttons,
             defaultButton: 1,
             loaded: loadedFunction,
-            submit: submitFunction
+            submit: submitFunction,
+            close: closeFunction
         };
+
         if (persistent) {
             args.closeText = '';
         }
+        
         return new Impromptu(msgString, args);
     },
 

--- a/modules/devices/mediaDeviceHelper.js
+++ b/modules/devices/mediaDeviceHelper.js
@@ -194,15 +194,17 @@ export default {
             return createLocalTracks(
                     ['audio', 'video'], cameraDeviceId, micDeviceId)
                     // If we fail to do this, try to create them separately.
-                    .catch(() => Promise.all(
-                        [createAudioTrack(false), createVideoTrack(false)]))
-                    .then((audioTracks, videoTracks) => {
+                    .catch(() => Promise.all([
+                        createAudioTrack(false).then(([stream]) => stream),
+                        createVideoTrack(false).then(([stream]) => stream)
+                    ]))
+                    .then(tracks => {
                         if (audioTrackError || videoTrackError) {
                             APP.UI.showDeviceErrorDialog(
                                 audioTrackError, videoTrackError);
                         }
 
-                        return (audioTracks || []).concat(videoTracks || []);
+                        return tracks.filter(t => typeof t !== 'undefined');
                     });
         } else if (videoRequested && !audioRequested) {
             return createVideoTrack();


### PR DESCRIPTION
To make sure we a showing only one device error dialog at a time, we close the previous one every time.

It's better to be merged together with https://github.com/jitsi/lib-jitsi-meet/pull/139, though it's not mandatory.