### PR TITLE
Executes npm update before making.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ IFRAME_API_DIR = ./modules/API/external
 all: update-deps compile compile-iframe-api uglify uglify-iframe-api deploy clean
 
 update-deps:
-	$(NPM) install
+	$(NPM) update
 
 compile:
 	$(BROWSERIFY) $(BROWSERIFY_FLAGS) -e app.js -s APP | $(EXORCIST) $(OUTPUT_DIR)/app.bundle.js.map > $(OUTPUT_DIR)/app.bundle.js

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npm link lib-jitsi-meet
 ```
 
 So now after changes in local `lib-jitsi-meet` repository you can rebuild it with `npm run install` and your `jitsi-meet` repository will use that modified library.
+Note: when using node version 4.x, the make file of jitsi-meet do npm update which will delete the link, no longer the case with version 6.x.
 
 If you do not want to use local repository anymore you should run
 ```bash


### PR DESCRIPTION
Executes npm update before making, in order to update latest version of packages like lib-jitsi-meet which are updated from git. The npm install method is supposed to only resolve dependencies and not update to latest versions.