### PR TITLE
Match the exact version of jquery-ui.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jQuery-Impromptu": "git+https://github.com/trentrichardson/jQuery-Impromptu.git#v6.0.0",
     "lib-jitsi-meet": "jitsi/lib-jitsi-meet",
     "jquery-contextmenu": "*",
-    "jquery-ui": "^1.10.5",
+    "jquery-ui": "1.10.5",
     "jssha": "1.5.0",
     "retry": "0.6.1",
     "strophe": "^1.2.2",


### PR DESCRIPTION
Using "compatible version" as ^... matches latest version 1.12.0 and not 1.10.5 (matches >=1.10.5 < 2.0.0) and this prevents it building from source with latest nodejs on clean environment.