### PR TITLE
Check for "none" alg in JWT signing

### DIFF
--- a/prosody-plugins/token/util.lib.lua
+++ b/prosody-plugins/token/util.lib.lua
@@ -21,6 +21,11 @@ local function _verify_token(token, appId, appSecret, roomName, disableRoomNameC
 		return nil, err;
 	end
 
+	local alg = claims["alg"];
+	if alg ~= nil and (alg == "none" or alg == "") then
+		return nil, "'alg' claim must not be empty";
+	end
+
 	local issClaim = claims["iss"];
 	if issClaim == nil then
 		return nil, "'iss' claim is missing";


### PR DESCRIPTION
This is not currently a vulnerability because the upstream `jwt` package does not support `none` in the `alg` claim at all, however, in case they ever do add support in the future we don't want to become vulnerable to downgrade attacks, so let's check the alg claim ourselves as well.