### PR TITLE
Uses videoType from the video track for the initial value.

### DIFF
--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -210,6 +210,9 @@ RemoteVideo.prototype.addRemoteStreamElement = function (stream) {
     let isVideo = stream.isVideoTrack();
     isVideo ? this.videoStream = stream : this.audioStream = stream;
 
+    if (isVideo)
+        this.setVideoType(stream.videoType);
+
     // Add click handler.
     let onClickHandler = (event) => {
         let source = event.target || event.srcElement;


### PR DESCRIPTION
Handles the case where the remote track is with initial value of camera and no further events are received for video type changed.