### PR TITLE
Remove query string

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -280,7 +280,10 @@ UI.setLocalRaisedHandStatus = (raisedHandStatus) => {
  */
 UI.initConference = function () {
     let id = APP.conference.getMyUserId();
-    Toolbar.updateRoomUrl(window.location.href);
+    Toolbar.updateRoomUrl(
+        // Do not include query parameters
+        // "https://example.com" + "/SomeConference1245"
+        window.location.origin + window.location.pathname);
 
     // Add myself to the contact list.
     ContactList.addContact(id);

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -280,10 +280,15 @@ UI.setLocalRaisedHandStatus = (raisedHandStatus) => {
  */
 UI.initConference = function () {
     let id = APP.conference.getMyUserId();
-    Toolbar.updateRoomUrl(
-        // Do not include query parameters
-        // "https://example.com" + "/SomeConference1245"
-        window.location.origin + window.location.pathname);
+
+    // Do not include query parameters in the invite URL
+    // "https://example.com" + "/SomeConference1245"
+    var inviteURL = window.location.origin + window.location.pathname;
+    Toolbar.updateRoomUrl(inviteURL);
+    // Clean up the URL displayed by the browser
+    if (window.history && typeof window.history.replaceState === 'function') {
+        window.history.replaceState({}, document.title, inviteURL);
+    }
 
     // Add myself to the contact list.
     ContactList.addContact(id);


### PR DESCRIPTION
This PR removes query arguments like JWT token from the invite URL. It also cleans up the URL visible to the user.