### PR TITLE
Hide the toolbar when the the ring overlay is displayed

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -298,7 +298,9 @@ UI.initConference = function () {
     UI.updateLocalRole(false);
 
     // Once we've joined the muc show the toolbar
-    ToolbarToggler.showToolbar();
+    if (!RingOverlay.isDisplayed()) {
+        ToolbarToggler.showToolbar();
+    }
 
     let displayName = config.displayJids ? id : Settings.getDisplayName();
 
@@ -1413,14 +1415,12 @@ let bottomToolbarEnabled = null;
 
 UI.showRingOverLay = function () {
     RingOverlay.show(APP.tokenData.callee);
-    ToolbarToggler.setAlwaysVisibleToolbar(true);
     FilmStrip.toggleFilmStrip(false);
 };
 
 UI.hideRingOverLay = function () {
     if (!RingOverlay.hide())
         return;
-    ToolbarToggler.resetAlwaysVisibleToolbar();
     FilmStrip.toggleFilmStrip(true);
 };
 

--- a/modules/UI/ring_overlay/RingOverlay.js
+++ b/modules/UI/ring_overlay/RingOverlay.js
@@ -78,5 +78,14 @@ export default {
         overlay.destroy();
         overlay = null;
         return true;
+    },
+    /**
+     * Checks whether or not the ring overlay is currently displayed.
+     *
+     * @returns {boolean} true if the ring overlay is currently displayed or
+     * false otherwise.
+     */
+    isDisplayed () {
+        return overlay !== null;
     }
 };


### PR DESCRIPTION
After this PR is merged, the toolbar will no longer be displayed when the "ring overlay" is shown.