### PR TITLE
Switch back to 'luajwt' in order to fix broken JWT

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -67,8 +67,8 @@ case "$1" in
                 sed -i 's/ --modules_enabled = { "token_verification" }/ modules_enabled = { "token_verification" }/g' $PROSODY_HOST_CONFIG
 
                 # Install luajwt
-                if ! luarocks install jwt; then
-                   echo "Failed to install jwt - try installing it manually"
+                if ! luarocks install luajwtjitsi; then
+                   echo "Failed to install luajwtjitsi - try installing it manually"
                 fi
 
                 if [ -x "/etc/init.d/prosody" ]; then

--- a/prosody-plugins/token/util.lib.lua
+++ b/prosody-plugins/token/util.lib.lua
@@ -1,7 +1,7 @@
 -- Token authentication
 -- Copyright (C) 2015 Atlassian
 
-local jwt = require "jwt";
+local jwt = require "luajwtjitsi";
 
 local _M = {};
 


### PR DESCRIPTION
We need to switch back to the 'luajwt' library which is capable to work with other libraries(the old lib converts raw signature to hash string which makes it not RFC compliant), provides better error messages and actually works once installed through luarocks.

Temporarily reference 'luajwtjitsi' luarock for immediate deployment until our changes with RS256 support eventually get merged with the master.