### PR TITLE
Object fit fix and refactoring around it

### DIFF
--- a/css/jitsi_popover.css
+++ b/css/jitsi_popover.css
@@ -71,7 +71,7 @@
     height: 35px;
     width: 100px;
     position: absolute;
-    bottom: -35;
+    bottom: -35px;
 }
 
 .jitsipopover_green

--- a/css/popup_menu.css
+++ b/css/popup_menu.css
@@ -1,27 +1,10 @@
 /*Initialize*/
 ul.popupmenu {
-    display:none;
-    position: absolute;
-    padding:10px;
+    padding: 0px 10px 0px 10px;
     margin: 0;
     bottom: 0;
-    margin-bottom: 35px;
-    padding-bottom:  10px;
-    padding-top: 10px;
-    right: 10px;
-    left: -5px;
     width: 100px;
-    background-color: rgba(0,0,0,0.9);
-    border: 1px solid rgba(256, 256, 256, 0.2);
-    border-radius:3px;
-}
-
-ul.popupmenu:after {
-    content: url('../images/popupPointer.png');
-    display: block;
-    position: absolute;
-    bottom: -8px;
-    left: 11px;
+    height: auto;
 }
 
 ul.popupmenu li {
@@ -36,11 +19,13 @@ ul.popupmenu li:hover {
 
 /*Link Appearance*/
 ul.popupmenu li a {
+    display: block;
     text-decoration: none;
     color: #fff;
     padding: 5px;
-    display: inline-block;
     font-size: 9pt;
+    width: 100%;
+    cursor: hand;
 }
 
 ul.popupmenu li a i.icon-kick {
@@ -54,6 +39,15 @@ ul.popupmenu li a span {
     text-align: center;
 }
 
+ul.popupmenu li a div {
+    display: inline-block;
+    line-height: 25px;
+}
+
+ul.popupmenu li a i {
+    line-height: 25px;
+}
+
 span.remotevideomenu:hover ul.popupmenu, ul.popupmenu:hover {
     display:block !important;
 }
@@ -61,12 +55,4 @@ span.remotevideomenu:hover ul.popupmenu, ul.popupmenu:hover {
 a.disabled {
     color: gray !important;
     pointer-events: none;
-}
-
-.popupmenuPadding {
-    height: 35px;
-    width: 100px;
-    position: absolute;
-    bottom: -35;
-    left: 0px;
 }

--- a/css/videolayout_default.css
+++ b/css/videolayout_default.css
@@ -144,8 +144,7 @@
 }
 
 #remoteVideos .videocontainer>span.focusindicator,
-#remoteVideos .videocontainer>span.remotevideomenu {
-    display: inline-block;
+#remoteVideos .videocontainer>div.remotevideomenu {
     position: absolute;
     color: #FFFFFF;
     top: 0;
@@ -157,6 +156,14 @@
     border: 0px;
     z-index: 2;
     text-align: center;
+}
+
+#remoteVideos .videocontainer>span.focusindicator {
+    display: inline-block;
+}
+
+#remoteVideos .videocontainer>div.remotevideomenu {
+    display: block;
 }
 
 .videocontainer>span.displayname,

--- a/css/videolayout_default.css
+++ b/css/videolayout_default.css
@@ -41,20 +41,22 @@
     background-size: contain;
     border-radius:1px;
     border: 1px solid #212425;
-    /*margin-right: 1px;*/
+    /**
+      * Some browsers don't have full support of the object-fit property for the
+      * video element and when we set video object-fit to "cover" the video
+      * actually overflows the boundaries of its container, so it's important
+      * to indicate that the "overflow" should be hidden.
+      */
+    overflow: hidden;
 }
 
-/*#remoteVideos .videocontainer:hover,*/
 #remoteVideos .videocontainer.videoContainerFocused {
     cursor: hand;
-    /* transform:scale(1.08, 1.08);
-    -webkit-transform:scale(1.08, 1.08); */
     transition-duration: 0.5s;
     -webkit-transition-duration: 0.5s;
     -webkit-animation-name: greyPulse;
     -webkit-animation-duration: 2s;
     -webkit-animation-iteration-count: 1;
-    overflow: visible !important;
 }
 
 #remoteVideos .videocontainer:hover {
@@ -82,6 +84,7 @@
     cursor: hand;
     border-radius:1px;
     object-fit: cover;
+    overflow: hidden;
 }
 
 .flipVideoX {


### PR DESCRIPTION
Some browsers don't render the object-fit: cover property correctly and the thumbnail video isn't clipped to fit the boundaries of its parent. So, we introduce a fix by adding a second property overflow:hidden to the parent elements containing the thumbnail video.

This however introduced a side effect. The remote participant menu (shown for moderators only) has disappeared. It was an element added directly to the DOM which parent was the container with the new overflow:hidden property. So, the new property was preventing anything to be shown out of the boundaries of the thumbnail. I've fixed this by refactoring the menu to be shown through the JitsiPopover. Thus making it almost identical to the implementation we have for the ConnectionIndicator for example.