### PR TITLE
Remove bottom toolbar button separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,6 @@
                         </i>
                     </a>
                 </span>
-                <div class="bottom_button_separator"></div>
                 <span class="bottomToolbar_span">
                     <a class="bottomToolbarButton" id="bottom_toolbar_contact_list" data-container="body" data-toggle="popover" data-placement="top" id="contactlistpopover"  data-i18n="[content]bottomtoolbar.contactlist" content="Open / close contact list">
                         <i id="contactListButton" class="icon-contactList">
@@ -199,7 +198,6 @@
                         </i>
                     </a>
                 </span>
-                <div class="bottom_button_separator"></div>
                 <span class="bottomToolbar_span">
                     <a class="bottomToolbarButton" id="bottom_toolbar_film_strip" data-container="body" data-toggle="popover" shortcut="filmstripPopover" data-placement="top" data-i18n="[content]bottomtoolbar.filmstrip" content="Show / hide film strip">
                         <i id="filmStripButton" class="icon-filmstrip"></i>


### PR DESCRIPTION
We have removed toolbar separators in the top toolbar, so this change is to make bottom toolbar consistent with the top toolbar.