### PR TITLE
Attach keyboard shortcuts to features

### DIFF
--- a/css/keyboard-shortcuts.css
+++ b/css/keyboard-shortcuts.css
@@ -16,4 +16,9 @@
 #keyboard-shortcuts .item-action {
     color: #209EFF;
     font-size: 14pt;
+    padding-right: 5px;
+}
+
+#keyboard-shortcuts-list {
+    list-style-type: none;
 }

--- a/index.html
+++ b/index.html
@@ -279,67 +279,7 @@
     <div id="keyboard-shortcuts" class="keyboard-shortcuts" style="display:none;">
         <div class="header"><h3 data-i18n="keyboardShortcuts.keyboardShortcuts"></h3></div>
         <div class="content">
-            <ul class="item">
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">M</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.mute"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">V</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.videoMute"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">C</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.toggleChat"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">R</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.raiseHand"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">T</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.pushToTalk"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">D</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.toggleScreensharing"></span>
-                </li>
-                <li class="item-details">
-                    <span class="item-action">
-                        <kbd class="regular-key">F</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.toggleFilmstrip"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">?</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.toggleShortcuts"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">0</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.focusLocal"></span>
-                </li>
-                <li>
-                    <span class="item-action">
-                        <kbd class="regular-key">1-9</kbd>
-                    </span>
-                    <span class="item-description" data-i18n="keyboardShortcuts.focusRemote"></span>
-                </li>
+            <ul id="keyboard-shortcuts-list" class="item">
             </ul>
         </div>
     </div>

--- a/modules/UI/toolbars/BottomToolbar.js
+++ b/modules/UI/toolbars/BottomToolbar.js
@@ -3,9 +3,15 @@ import UIUtil from '../util/UIUtil';
 import UIEvents from '../../../service/UI/UIEvents';
 
 const defaultBottomToolbarButtons = {
-    'chat':      '#bottom_toolbar_chat',
-    'contacts':  '#bottom_toolbar_contact_list',
-    'filmstrip': '#bottom_toolbar_film_strip'
+    'chat': {
+        id: '#bottom_toolbar_chat'
+    },
+    'contacts': {
+        id: '#bottom_toolbar_contact_list'
+    },
+    'filmstrip': {
+        id: '#bottom_toolbar_film_strip'
+    }
 };
 
 const BottomToolbar = {

--- a/modules/UI/toolbars/BottomToolbar.js
+++ b/modules/UI/toolbars/BottomToolbar.js
@@ -10,7 +10,14 @@ const defaultBottomToolbarButtons = {
         id: '#bottom_toolbar_contact_list'
     },
     'filmstrip': {
-        id: '#bottom_toolbar_film_strip'
+        id: '#bottom_toolbar_film_strip',
+        shortcut: "F",
+        shortcutAttr: "filmstripPopover",
+        shortcutFunc: function() {
+            JitsiMeetJS.analytics.sendEvent("shortcut.film.toggled");
+            APP.UI.toggleFilmStrip();
+        },
+        shortcutDescription: "keyboardShortcuts.toggleFilmstrip"
     }
 };
 
@@ -38,6 +45,7 @@ const BottomToolbar = {
     isEnabled() {
         return this.enabled;
     },
+
     setupListeners (emitter) {
         UIUtil.hideDisabledButtons(defaultBottomToolbarButtons);
 
@@ -57,6 +65,22 @@ const BottomToolbar = {
                 emitter.emit(UIEvents.TOGGLE_CHAT);
             }
         };
+
+        Object.keys(defaultBottomToolbarButtons).forEach(
+                id => {
+                if (UIUtil.isButtonEnabled(id)) {
+                    var button = defaultBottomToolbarButtons[id];
+
+                    if (button.shortcut)
+                        APP.keyboardshortcut.registerShortcut(
+                            button.shortcut,
+                            button.shortcutAttr,
+                            button.shortcutFunc,
+                            button.shortcutDescription
+                        );
+                }
+            }
+        );
 
         Object.keys(buttonHandlers).forEach(
             buttonId => $(`#${buttonId}`).click(buttonHandlers[buttonId])

--- a/modules/UI/toolbars/Toolbar.js
+++ b/modules/UI/toolbars/Toolbar.js
@@ -2,6 +2,7 @@
 /* jshint -W101 */
 import UIUtil from '../util/UIUtil';
 import UIEvents from '../../../service/UI/UIEvents';
+import KeyboardShortcut from '../../keyboardshortcut/KeyboardShortcut';
 
 let roomUrl = null;
 let emitter = null;
@@ -110,7 +111,8 @@ const buttonHandlers = {
     },
     "toolbar_button_fullScreen": function() {
         JitsiMeetJS.analytics.sendEvent('toolbar.fullscreen.enabled');
-        UIUtil.buttonClick("#toolbar_button_fullScreen", "icon-full-screen icon-exit-full-screen");
+        UIUtil.buttonClick("#toolbar_button_fullScreen",
+            "icon-full-screen icon-exit-full-screen");
         emitter.emit(UIEvents.FULLSCREEN_TOGGLE);
     },
     "toolbar_button_sip": function () {
@@ -152,16 +154,64 @@ const buttonHandlers = {
     }
 };
 const defaultToolbarButtons = {
-    'microphone': '#toolbar_button_mute',
-    'camera':     '#toolbar_button_camera',
-    'desktop':    '#toolbar_button_desktopsharing',
-    'security':   '#toolbar_button_security',
-    'invite':     '#toolbar_button_link',
-    'chat':       '#toolbar_button_chat',
-    'etherpad':   '#toolbar_button_etherpad',
-    'fullscreen': '#toolbar_button_fullScreen',
-    'settings':   '#toolbar_button_settings',
-    'hangup':     '#toolbar_button_hangup'
+    'microphone': {
+        id: '#toolbar_button_mute',
+        shortcut: 'M',
+        shortcutAttr: 'mutePopover',
+        shortcutFunc: function() {
+            JitsiMeetJS.analytics.sendEvent('shortcut.audiomute.toggled');
+            APP.conference.toggleAudioMuted();
+        },
+        shortcutDescription: "keyboardShortcuts.mute"
+    },
+    'camera': {
+        id: '#toolbar_button_camera',
+        shortcut: 'V',
+        shortcutAttr: 'toggleVideoPopover',
+        shortcutFunc: function() {
+            JitsiMeetJS.analytics.sendEvent('shortcut.videomute.toggled');
+            APP.conference.toggleVideoMuted();
+        },
+        shortcutDescription: "keyboardShortcuts.videoMute"
+    },
+    'desktop': {
+        id: '#toolbar_button_desktopsharing',
+        shortcut: 'D',
+        shortcutAttr: 'toggleDesktopSharingPopover',
+        shortcutFunc: function() {
+            JitsiMeetJS.analytics.sendEvent('shortcut.screen.toggled');
+            APP.conference.toggleScreenSharing();
+        },
+        shortcutDescription: "keyboardShortcuts.toggleScreensharing"
+    },
+    'security': {
+        id: '#toolbar_button_security'
+    },
+    'invite': {
+        id: '#toolbar_button_link'
+    },
+    'chat': {
+        id: '#toolbar_button_chat',
+        shortcut: 'C',
+        shortcutAttr: 'toggleChatPopover',
+        shortcutFunc: function() {
+            JitsiMeetJS.analytics.sendEvent('shortcut.chat.toggled');
+            APP.UI.toggleChat();
+        },
+        shortcutDescription: "keyboardShortcuts.toggleChat"
+    },
+    'etherpad': {
+        id: '#toolbar_button_etherpad'
+    },
+    'fullscreen': {
+        id: '#toolbar_button_fullScreen'
+    },
+    'settings': {
+        id: '#toolbar_button_settings'
+    },
+    'hangup': {
+        id: '#toolbar_button_hangup'
+    }
 };
 
 function dialpadButtonClicked() {
@@ -196,6 +246,22 @@ const Toolbar = {
         this.toolbarSelector = $("#header");
 
         UIUtil.hideDisabledButtons(defaultToolbarButtons);
+
+        Object.keys(defaultToolbarButtons).forEach(
+            id => {
+                if (UIUtil.isButtonEnabled(id)) {
+                    var button = defaultToolbarButtons[id];
+
+                    if (button.shortcut)
+                        KeyboardShortcut.registerShortcut(
+                            button.shortcut,
+                            button.shortcutAttr,
+                            button.shortcutFunc,
+                            button.shortcutDescription
+                        );
+                }
+            }
+        );
 
         Object.keys(buttonHandlers).forEach(
             buttonId => $(`#${buttonId}`).click(function(event) {

--- a/modules/UI/toolbars/Toolbar.js
+++ b/modules/UI/toolbars/Toolbar.js
@@ -2,7 +2,7 @@
 /* jshint -W101 */
 import UIUtil from '../util/UIUtil';
 import UIEvents from '../../../service/UI/UIEvents';
-import KeyboardShortcut from '../../keyboardshortcut/KeyboardShortcut';
+import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
 
 let roomUrl = null;
 let emitter = null;

--- a/modules/UI/toolbars/Toolbar.js
+++ b/modules/UI/toolbars/Toolbar.js
@@ -2,7 +2,6 @@
 /* jshint -W101 */
 import UIUtil from '../util/UIUtil';
 import UIEvents from '../../../service/UI/UIEvents';
-import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
 
 let roomUrl = null;
 let emitter = null;
@@ -253,7 +252,7 @@ const Toolbar = {
                     var button = defaultToolbarButtons[id];
 
                     if (button.shortcut)
-                        KeyboardShortcut.registerShortcut(
+                        APP.keyboardshortcut.registerShortcut(
                             button.shortcut,
                             button.shortcutAttr,
                             button.shortcutFunc,

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -130,7 +130,7 @@
         var selector = Object.keys(mappings)
           .map(function (buttonName) {
                 return UIUtil.isButtonEnabled(buttonName)
-                    ? null : mappings[buttonName]; })
+                    ? null : mappings[buttonName].id; })
           .filter(function (item) { return item; })
           .join(',');
         $(selector).hide();

--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -27,12 +27,10 @@ function initGlobalShortcuts() {
         APP.conference.muteAudio(true);
     }, "keyboardShortcuts.pushToTalk");
 
-    KeyboardShortcut.registerShortcut("F", 'filmstripPopover', function() {
-        JitsiMeetJS.analytics.sendEvent("shortcut.film.toggled");
-        APP.UI.toggleFilmStrip();
-    }, "keyboardShortcuts.toggleFilmstrip");
-
-    // Focus keys are directly implemented below.
+    /**
+     * FIXME: Currently focus keys are directly implemented below in onkeyup.
+     * They should be moved to the SmallVideo instead.
+     */
     KeyboardShortcut._addShortcutToHelp("0", "keyboardShortcuts.focusLocal");
     KeyboardShortcut._addShortcutToHelp("1-9", "keyboardShortcuts.focusRemote");
 }
@@ -123,6 +121,8 @@ var KeyboardShortcut = {
      */
     unregisterShortcut: function(shortcutChar) {
         _shortcuts.remove(shortcutChar);
+
+        this._removeShortcutFromHelp(shortcutChar);
     },
 
     /**
@@ -177,6 +177,7 @@ var KeyboardShortcut = {
     _addShortcutToHelp: function (shortcutChar, shortcutDescriptionKey) {
 
         var listElement = document.createElement("li");
+        listElement.id = shortcutChar;
 
         var spanElement = document.createElement("span");
         spanElement.className = "item-action";
@@ -200,6 +201,21 @@ var KeyboardShortcut = {
 
         if (parentListElement)
             parentListElement.appendChild(listElement);
+    },
+
+    /**
+     * Removes the list element corresponding to the given shortcut from the
+     * help dialog
+     * @private
+     */
+    _removeShortcutFromHelp: function (shortcutChar) {
+        var parentListElement
+            = document.getElementById("keyboard-shortcuts-list");
+
+        var shortcutElement = document.getElementById(shortcutChar);
+
+        if (shortcutElement)
+            parentListElement.removeChild(shortcutElement);
     }
 };
 


### PR DESCRIPTION
Shortcuts are now registered dynamically through the toolbar button they represent. Only enabled buttons would register a shortcut. Thus only the registered shortcuts will appear in the help menu. I have also added an "unregisterShortcut" method, which isn't currently used. So an open question is, do we need to unregister a shortcut at some point, keeping in mind that we cannot currently enable/disable a feature (toolbar button) during runtime.