### PR TITLE
Fix problem with last video preview

### DIFF
--- a/css/videolayout_default.css
+++ b/css/videolayout_default.css
@@ -8,7 +8,15 @@
 }
 
 #remoteVideos {
-    display:block;
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+
     position:absolute;
     text-align:right;
     height:196px;
@@ -30,8 +38,6 @@
 
 .videocontainer {
     position: relative;
-    margin-left: auto;
-    margin-right: auto;
     text-align: center;
 }
 


### PR DESCRIPTION
In this PR I fixed the problem with moving the last video preview down when user resizes window of jitsi-meet app. I changed displaying behavior of `videocontainer`s to `flexbox`. It allows us to render them along one row and resize ones automatically.