### PR TITLE
Allow hyphens in room names

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -25,7 +25,7 @@ server {
         alias /etc/jitsi/meet/jitsi-meet.example.com-config.js;
     }
 
-    location ~ ^/([a-zA-Z0-9=\?]+)$ {
+    location ~ ^/([a-zA-Z0-9=\?-]+)$ {
         rewrite ^/(.*)$ / break;
     }
 


### PR DESCRIPTION
Currently, using hyphens leads to an nginx 404 page.

This is currently the case on either self-hosted or public version.
https://meet.jit.si/check-it-out

This patch was tested locally and it works.
