### PR TITLE
Moves local video thumb initializations where they belong.

### DIFF
--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -24,6 +24,11 @@ function LocalVideo(VideoLayout, emitter) {
     this.initBrowserSpecificProperties();
 
     SmallVideo.call(this, VideoLayout);
+
+    // Set default display name.
+    this.setDisplayName();
+
+    this.createConnectionIndicator();
 }
 
 LocalVideo.prototype = Object.create(SmallVideo.prototype);

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -107,7 +107,9 @@ var VideoLayout = {
         localVideoThumbnail.setVideoType(VIDEO_CONTAINER_TYPE);
         // if we do not resize the thumbs here, if there is no video device
         // the local video thumb maybe one pixel
-        this.resizeThumbnails(false, true, false);
+        let {thumbWidth, thumbHeight}
+            = this.resizeThumbnails(false, true, false);
+        AudioLevels.updateAudioLevelCanvas(null, thumbWidth, thumbHeight);
 
         emitter.addListener(UIEvents.CONTACT_CLICKED, onContactClicked);
         this.lastNCount = config.channelLastN;
@@ -158,15 +160,8 @@ var VideoLayout = {
     },
 
     changeLocalVideo (stream) {
-        // Set default display name.
-        localVideoThumbnail.setDisplayName();
-        localVideoThumbnail.createConnectionIndicator();
-
         let localId = APP.conference.getMyUserId();
         this.onVideoTypeChanged(localId, stream.videoType);
-
-        let {thumbWidth, thumbHeight} = this.resizeThumbnails(false, true);
-        AudioLevels.updateAudioLevelCanvas(null, thumbWidth, thumbHeight);
 
         if (!stream.isMuted()) {
             localVideoThumbnail.changeVideo(stream);


### PR DESCRIPTION
Moves local video thumb initializations where they belong in the local video constructor. Fixes a problem when there is no video device, then audio levels and gsm bars are missing. We were doing this initializations every time a video device is changed.