### PR TITLE
Fix problem with resizing

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -332,6 +332,14 @@ UI.mucJoined = function () {
     VideoLayout.mucJoined();
 };
 
+/***
+ * Handler for toggling filmstrip
+ */
+UI.handleToggleFilmStrip = () => {
+    UI.toggleFilmStrip();
+    VideoLayout.resizeVideoArea(PanelToggler.isVisible(), true, false);
+};
+
 /**
  * Setup some UI event listeners.
  */
@@ -359,10 +367,7 @@ function registerListeners() {
 
     UI.addListener(UIEvents.TOGGLE_CONTACT_LIST, UI.toggleContactList);
 
-    UI.addListener(UIEvents.TOGGLE_FILM_STRIP, function () {
-        UI.toggleFilmStrip();
-        VideoLayout.resizeVideoArea(PanelToggler.isVisible(), true, false);
-    });
+    UI.addListener(UIEvents.TOGGLE_FILM_STRIP, UI.handleToggleFilmStrip);
 
     UI.addListener(UIEvents.FOLLOW_ME_ENABLED, function (isEnabled) {
         if (followMeHandler)
@@ -515,7 +520,6 @@ UI.start = function () {
     // conference ready.
     return true;
 };
-
 
 /**
  * Show local stream on UI.

--- a/modules/UI/toolbars/BottomToolbar.js
+++ b/modules/UI/toolbars/BottomToolbar.js
@@ -15,7 +15,7 @@ const defaultBottomToolbarButtons = {
         shortcutAttr: "filmstripPopover",
         shortcutFunc: function() {
             JitsiMeetJS.analytics.sendEvent("shortcut.film.toggled");
-            APP.UI.toggleFilmStrip();
+            APP.UI.handleToggleFilmStrip();
         },
         shortcutDescription: "keyboardShortcuts.toggleFilmstrip"
     }


### PR DESCRIPTION
The problem was in that when we hide filmstrip `VideoLayout` is not being resized. I extracted common handler (`UI.handleToggleFilmStrip`) for this behaviour and set it for hiding the filmstrip via shortcut and via clicking on the button on toolbar

__Little demo:__

![demo](https://cloud.githubusercontent.com/assets/5806075/18156447/edef5862-701e-11e6-8ffd-8ddec2f83666.gif)
