### PR TITLE
Device selection rework

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1416,7 +1416,7 @@ export default {
                 .then(([stream]) => {
                     this.useVideoStream(stream);
                     console.log('switched local video device');
-                    APP.settings.setCameraDeviceId(cameraDeviceId);
+                    APP.settings.setCameraDeviceId(cameraDeviceId, true);
                 })
                 .catch((err) => {
                     APP.UI.showDeviceErrorDialog(null, err);
@@ -1438,7 +1438,7 @@ export default {
                 .then(([stream]) => {
                     this.useAudioStream(stream);
                     console.log('switched local audio device');
-                    APP.settings.setMicDeviceId(micDeviceId);
+                    APP.settings.setMicDeviceId(micDeviceId, true);
                 })
                 .catch((err) => {
                     APP.UI.showDeviceErrorDialog(err, null);
@@ -1533,13 +1533,13 @@ export default {
                 // storage and settings menu. This is a workaround until
                 // getConstraints() method will be implemented in browsers.
                 if (localAudio) {
-                    localAudio._setRealDeviceIdFromDeviceList(devices);
-                    APP.settings.setMicDeviceId(localAudio.getDeviceId());
+                    APP.settings.setMicDeviceId(
+                        localAudio.getDeviceId(), false);
                 }
 
                 if (localVideo) {
-                    localVideo._setRealDeviceIdFromDeviceList(devices);
-                    APP.settings.setCameraDeviceId(localVideo.getDeviceId());
+                    APP.settings.setCameraDeviceId(
+                        localVideo.getDeviceId(), false);
                 }
 
                 mediaDeviceHelper.setCurrentMediaDevices(devices);

--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -174,10 +174,12 @@ export default {
      * Set device id of the camera which is currently in use.
      * Empty string stands for default device.
      * @param {string} newId new camera device id
+     * @param {boolean} whether we need to store the value
      */
-    setCameraDeviceId: function (newId = '') {
+    setCameraDeviceId: function (newId, store) {
         cameraDeviceId = newId;
-        window.localStorage.cameraDeviceId = newId;
+        if (store)
+            window.localStorage.cameraDeviceId = newId;
     },
 
     /**
@@ -192,10 +194,12 @@ export default {
      * Set device id of the microphone which is currently in use.
      * Empty string stands for default device.
      * @param {string} newId new microphone device id
+     * @param {boolean} whether we need to store the value
      */
-    setMicDeviceId: function (newId = '') {
+    setMicDeviceId: function (newId, store) {
         micDeviceId = newId;
-        window.localStorage.micDeviceId = newId;
+        if (store)
+            window.localStorage.micDeviceId = newId;
     },
 
     /**


### PR DESCRIPTION
Skips storing device ids in localstorage if the user hasn't selected a device to use, and keeps using system defaults. Removes calls to private library method for setting initial realDeviceIds, as this had been added to the library.