### PR TITLE
Fix for left toolbar (FireFox)

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -56,11 +56,11 @@
 }
 
 #extendedToolbar {
-    display: flex;
-    display: -webkit-box;
     display: -moz-box;
     display: -ms-flexbox;
+    display: -webkit-box;
     display: -webkit-flex;
+    display: flex;
     width: $defaultToolbarSize;
     height: 100%;
     top: 0px;


### PR DESCRIPTION
Rule "display: -moz-box;" was located after "display: flex;" and that caused left toolbar to be stretched by width.