### PR TITLE
Fixes hiding toolbar.

### DIFF
--- a/modules/UI/side_pannels/chat/Chat.js
+++ b/modules/UI/side_pannels/chat/Chat.js
@@ -3,6 +3,7 @@
 import {processReplacements, linkify} from './Replacement';
 import CommandsProcessor from './Commands';
 import ToolbarToggler from '../../toolbars/ToolbarToggler';
+import VideoLayout from "../../videolayout/VideoLayout";
 
 import UIUtil from '../../util/UIUtil';
 import UIEvents from '../../../../service/UI/UIEvents';
@@ -179,6 +180,12 @@ var Chat = {
 
                 unreadMessages = 0;
                 updateVisualNotification();
+
+                // Undock the toolbar when the chat is shown and if we're in a
+                // video mode.
+                if (VideoLayout.isLargeVideoVisible()) {
+                    ToolbarToggler.dockToolbar(false);
+                }
 
                 // if we are in conversation mode focus on the text input
                 // if we are not, focus on the display name input


### PR DESCRIPTION
Receiving messages docks the toolbar to be able to see number of unread messages. We need to undock it when we read the messages. We skip undocking if we are not in video mode (on large), cause stuff like youtube video share is docking/undocking the toolbar.