### PR TITLE
Moves the number in the code, not as a translation parameter.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1,5 +1,5 @@
 {
-    "contactlist": "On Call (__participants__)",
+    "contactlist": "On Call",
     "connectionsettings": "Connection Settings",
     "poweredby": "powered by",
     "feedback": "Give us your feedback",

--- a/modules/UI/side_pannels/contactlist/ContactList.js
+++ b/modules/UI/side_pannels/contactlist/ContactList.js
@@ -26,9 +26,8 @@ function updateNumberOfParticipants(delta) {
         .parent()[numberOfContacts > 1 ? 'show' : 'hide']();
 
     $("#contacts_container>div.title").text(
-        APP.translation.translateString(
-            "contactlist", {participants: numberOfContacts}
-        ));
+        APP.translation.translateString("contactlist")
+            + ' (' + numberOfContacts + ')');
 }
 
 /**


### PR DESCRIPTION
There is sometimes problems with cache and late loading of the translations, this commit avoids showing translation key in the contactlist title, by moving the parameter into the code.