### PR TITLE
fix(ringoverlay): Path of the ogg file

### DIFF
--- a/modules/UI/ring_overlay/RingOverlay.js
+++ b/modules/UI/ring_overlay/RingOverlay.js
@@ -69,7 +69,7 @@ class RingOverlay {
                         <p>${callee.getName()}${callerStateLabel}</p>
                     </div>
                 </div>
-                <audio id="${this._audioContainerId}" src="/sounds/ring.ogg" />
+                <audio id="${this._audioContainerId}" src="./sounds/ring.ogg" />
             </div>`;
     }
 


### PR DESCRIPTION
The absolute path is not working for some cases. That's why we are changing it to relative.