### PR TITLE
Adds participant connection status notifications

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -714,6 +714,28 @@ export default {
         let participant = this.getParticipantById(id);
         return participant ? participant.isConnectionActive() : null;
     },
+    /**
+     * Gets the display name foe the <tt>JitsiParticipant</tt> identified by
+     * the given <tt>id</tt>.
+     *
+     * @param id {string} the participant's id(MUC nickname/JVB endpoint id)
+     *
+     * @return {string} the participant's display name or the default string if
+     * absent.
+     */
+    getParticipantDisplayName (id) {
+        let displayName = getDisplayName(id);
+        if (displayName) {
+            return displayName;
+        } else {
+            if (APP.conference.isLocalId(id)) {
+                return APP.translation.generateTranslationHTML(
+                    interfaceConfig.DEFAULT_LOCAL_DISPLAY_NAME);
+            } else {
+                return interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME;
+            }
+        }
+    },
     getMyUserId () {
         return this._room
             && this._room.myUserId();

--- a/conference.js
+++ b/conference.js
@@ -1197,6 +1197,10 @@ export default {
             ConferenceEvents.LAST_N_ENDPOINTS_CHANGED, (ids, enteringIds) => {
             APP.UI.handleLastNEndpoints(ids, enteringIds);
         });
+        room.on(
+            ConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED, (id, isActive) => {
+            APP.UI.participantConnectionStatusChanged(id, isActive);
+        });
         room.on(ConferenceEvents.DOMINANT_SPEAKER_CHANGED, (id) => {
             if (this.isLocalId(id)) {
                 this.isDominantSpeaker = true;

--- a/conference.js
+++ b/conference.js
@@ -1205,10 +1205,12 @@ export default {
         room.on(ConferenceEvents.CONNECTION_INTERRUPTED, () => {
             connectionIsInterrupted = true;
             ConnectionQuality.updateLocalConnectionQuality(0);
+            APP.UI.showLocalConnectionInterrupted(true);
         });
 
         room.on(ConferenceEvents.CONNECTION_RESTORED, () => {
             connectionIsInterrupted = false;
+            APP.UI.showLocalConnectionInterrupted(false);
         });
 
         room.on(ConferenceEvents.DISPLAY_NAME_CHANGED, (id, displayName) => {

--- a/conference.js
+++ b/conference.js
@@ -691,6 +691,29 @@ export default {
     isConnectionInterrupted () {
         return connectionIsInterrupted;
     },
+    /**
+     * Finds JitsiParticipant for given id.
+     *
+     * @param {string} id participant's identifier(MUC nickname).
+     *
+     * @returns {JitsiParticipant|null} participant instance for given id or
+     * null if not found.
+     */
+    getParticipantById (id) {
+        return room ? room.getParticipantById(id) : null;
+    },
+    /**
+     * Checks whether the user identified by given id is currently connected.
+     *
+     * @param {string} id participant's identifier(MUC nickname)
+     *
+     * @returns {boolean|null} true if participant's connection is ok or false
+     * if the user is having connectivity issues.
+     */
+    isParticipantConnectionActive (id) {
+        let participant = this.getParticipantById(id);
+        return participant ? participant.isConnectionActive() : null;
+    },
     getMyUserId () {
         return this._room
             && this._room.myUserId();

--- a/conference.js
+++ b/conference.js
@@ -1085,7 +1085,7 @@ export default {
 
             console.log('USER %s connnected', id, user);
             APP.API.notifyUserJoined(id);
-            APP.UI.addUser(id, user.getDisplayName());
+            APP.UI.addUser(user);
 
             // check the roles for the new user and reflect them
             APP.UI.updateUserRole(user);

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -221,6 +221,12 @@
     overflow: hidden;
 }
 
+.connection.connection_lost
+{
+    color: #8B8B8B;
+    overflow: visible;
+}
+
 .connection.connection_full
 {
     color: #FFFFFF;/*#15A1ED*/

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -455,6 +455,11 @@
     filter: blur(10px) grayscale(.5) opacity(0.8);
 }
 
+.videoThumbnailProblemFilter {
+    -webkit-filter: grayscale(100%);
+    filter: grayscale(100%);
+}
+
 #videoConnectionMessage {
     display: none;
     position: absolute;

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -487,7 +487,7 @@
     padding-right: 10px;
 }
 
-#videoConnectionMessage {
+#localConnectionMessage {
     display: none;
     position: absolute;
     width: 100%;

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -450,6 +450,11 @@
     filter: grayscale(.5) opacity(0.8);
 }
 
+.remoteVideoProblemFilter {
+    -webkit-filter: grayscale(100%);
+    filter: grayscale(100%);
+}
+
 .videoProblemFilter {
     -webkit-filter: blur(10px) grayscale(.5) opacity(0.8);
     filter: blur(10px) grayscale(.5) opacity(0.8);
@@ -458,6 +463,28 @@
 .videoThumbnailProblemFilter {
     -webkit-filter: grayscale(100%);
     filter: grayscale(100%);
+}
+
+#remoteConnectionMessage {
+    display: none;
+    position: absolute;
+    width: auto;
+    z-index: 1011;
+    font-weight: 600;
+    font-size: 14px;
+    text-align: center;
+    color: #FFF;
+    opacity: .80;
+    text-shadow:    0px 0px 1px rgba(0,0,0,0.3),
+                    0px 1px 1px rgba(0,0,0,0.3),
+                    1px 0px 1px rgba(0,0,0,0.3),
+                    0px 0px 1px rgba(0,0,0,0.3);
+
+    background: rgba(0,0,0,.5);
+    border-radius: 5px;
+    padding: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 #videoConnectionMessage {

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
                 <div id="largeVideoWrapper">
                     <video id="largeVideo" muted="true" autoplay></video>
                 </div>
-                <span id="videoConnectionMessage"></span>
+                <span id="localConnectionMessage"></span>
                 <span id="videoResolutionLabel">HD</span>
                 <span id="recordingLabel" class="centeredVideoLabel">
                     <span id="recordingLabelText"></span>

--- a/index.html
+++ b/index.html
@@ -228,6 +228,7 @@
                     <img id="dominantSpeakerAvatar" src=""/>
                     <canvas id="dominantSpeakerAudioLevel"></canvas>
                 </div>
+                <span id="remoteConnectionMessage"></span>
                 <div id="largeVideoWrapper">
                     <video id="largeVideo" muted="true" autoplay></video>
                 </div>

--- a/lang/main.json
+++ b/lang/main.json
@@ -324,7 +324,8 @@
         "ATTACHED": "Attached",
         "FETCH_SESSION_ID": "Obtaining session-id...",
         "GOT_SESSION_ID": "Obtaining session-id... Done",
-        "GET_SESSION_ID_ERROR": "Get session-id error: "
+        "GET_SESSION_ID_ERROR": "Get session-id error: ",
+        "USER_CONNECTION_INTERRUPTED": "__displayName__ is having connectivity issues..."
     },
     "recording":
     {

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -996,6 +996,17 @@ UI.handleLastNEndpoints = function (ids, enteringIds) {
 };
 
 /**
+ * Will handle notification about participant's connectivity status change.
+ *
+ * @param {string} id the id of remote participant(MUC jid)
+ * @param {boolean} isActive true if the connection is ok or false if the user
+ * is having connectivity issues.
+ */
+UI.participantConnectionStatusChanged = function (id, isActive) {
+    VideoLayout.onParticipantConnectionStatusChanged(id, isActive);
+};
+
+/**
  * Update audio level visualization for specified user.
  * @param {string} id user id
  * @param {number} lvl audio level

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -262,6 +262,17 @@ UI.changeDisplayName = function (id, displayName) {
 };
 
 /**
+ * Shows/hides the indication about local connection being interrupted.
+ *
+ * @param {boolean} isInterrupted <tt>true</tt> if local connection is
+ * currently in the interrupted state or <tt>false</tt> if the connection
+ * is fine.
+ */
+UI.showLocalConnectionInterrupted = function (isInterrupted) {
+    VideoLayout.showLocalConnectionInterrupted(isInterrupted);
+};
+
+/**
  * Sets the "raised hand" status for a participant.
  */
 UI.setRaisedHandStatus = (participant, raisedHandStatus) => {

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -602,10 +602,11 @@ UI.getSharedDocumentManager = function () {
 
 /**
  * Show user on UI.
- * @param {string} id user id
- * @param {string} displayName user nickname
+ * @param {JitsiParticipant} user
  */
-UI.addUser = function (id, displayName) {
+UI.addUser = function (user) {
+    var id = user.getId();
+    var displayName = user.getDisplayName();
     UI.hideRingOverLay();
     ContactList.addContact(id);
 
@@ -618,7 +619,7 @@ UI.addUser = function (id, displayName) {
         UIUtil.playSoundNotification('userJoined');
 
     // Add Peer's container
-    VideoLayout.addParticipantContainer(id);
+    VideoLayout.addParticipantContainer(user);
 
     // Configure avatar
     UI.setUserEmail(id);

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -243,7 +243,7 @@ export default class SharedVideoManager {
 
             let thumb = new SharedVideoThumb(self.url);
             thumb.setDisplayName(player.getVideoData().title);
-            VideoLayout.addParticipantContainer(self.url, thumb);
+            VideoLayout.addRemoteVideoContainer(self.url, thumb);
 
             let iframe = player.getIframe();
             self.sharedVideo = new SharedVideoContainer(

--- a/modules/UI/videolayout/ConnectionIndicator.js
+++ b/modules/UI/videolayout/ConnectionIndicator.js
@@ -314,12 +314,14 @@ ConnectionIndicator.prototype.updateConnectionQuality =
             this.connectionIndicatorContainer.style.display = "block";
         }
     }
-    this.bandwidth = object.bandwidth;
-    this.bitrate = object.bitrate;
-    this.packetLoss = object.packetLoss;
-    this.transport = object.transport;
-    if (object.resolution) {
-        this.resolution = object.resolution;
+    if (object) {
+        this.bandwidth = object.bandwidth;
+        this.bitrate = object.bitrate;
+        this.packetLoss = object.packetLoss;
+        this.transport = object.transport;
+        if (object.resolution) {
+            this.resolution = object.resolution;
+        }
     }
     for (var quality in ConnectionIndicator.connectionQualityValues) {
         if (percent >= quality) {
@@ -327,7 +329,7 @@ ConnectionIndicator.prototype.updateConnectionQuality =
                 ConnectionIndicator.connectionQualityValues[quality];
         }
     }
-    if (object.isResolutionHD) {
+    if (object && typeof object.isResolutionHD === 'boolean') {
         this.isResolutionHD = object.isResolutionHD;
     }
     this.updateResolutionIndicator();

--- a/modules/UI/videolayout/ConnectionIndicator.js
+++ b/modules/UI/videolayout/ConnectionIndicator.js
@@ -245,13 +245,13 @@ ConnectionIndicator.prototype.showMore = function () {
 };
 
 
-function createIcon(classes) {
+function createIcon(classes, iconClass) {
     var icon = document.createElement("span");
     for(var i in classes) {
         icon.classList.add(classes[i]);
     }
     icon.appendChild(
-        document.createElement("i")).classList.add("icon-connection");
+        document.createElement("i")).classList.add(iconClass);
     return icon;
 }
 
@@ -282,9 +282,9 @@ ConnectionIndicator.prototype.create = function () {
     }.bind(this);
 
     this.emptyIcon = this.connectionIndicatorContainer.appendChild(
-        createIcon(["connection", "connection_empty"]));
+        createIcon(["connection", "connection_empty"], "icon-connection"));
     this.fullIcon = this.connectionIndicatorContainer.appendChild(
-        createIcon(["connection", "connection_full"]));
+        createIcon(["connection", "connection_full"], "icon-connection"));
 };
 
 /**

--- a/modules/UI/videolayout/ConnectionIndicator.js
+++ b/modules/UI/videolayout/ConnectionIndicator.js
@@ -285,6 +285,9 @@ ConnectionIndicator.prototype.create = function () {
         createIcon(["connection", "connection_empty"], "icon-connection"));
     this.fullIcon = this.connectionIndicatorContainer.appendChild(
         createIcon(["connection", "connection_full"], "icon-connection"));
+    this.interruptedIndicator = this.connectionIndicatorContainer.appendChild(
+        createIcon(["connection", "connection_lost"],"icon-connection-lost"));
+    $(this.interruptedIndicator).hide();
 };
 
 /**
@@ -296,6 +299,27 @@ ConnectionIndicator.prototype.remove = function() {
             this.connectionIndicatorContainer);
     }
     this.popover.forceHide();
+};
+
+/**
+ * Updates the UI which displays warning about user's connectivity problems.
+ *
+ * @param {boolean} isActive true if the connection is working fine or false if
+ * the user is having connectivity issues.
+ */
+ConnectionIndicator.prototype.updateConnectionStatusIndicator
+= function (isActive) {
+    this.isConnectionActive = isActive;
+    if (this.isConnectionActive) {
+        $(this.interruptedIndicator).hide();
+        $(this.emptyIcon).show();
+        $(this.fullIcon).show();
+    } else {
+        $(this.interruptedIndicator).show();
+        $(this.emptyIcon).hide();
+        $(this.fullIcon).hide();
+        this.updateConnectionQuality(0 /* zero bars */);
+    }
 };
 
 /**

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -92,10 +92,7 @@ export default class LargeVideoManager {
      */
     onVideoInterrupted () {
         this.enableLocalConnectionProblemFilter(true);
-        let reconnectingKey = "connection.RECONNECTING";
-        $('#videoConnectionMessage')
-            .attr("data-i18n", reconnectingKey)
-            .text(APP.translation.translateString(reconnectingKey));
+        this._setVideoConnectionMessage("connection.RECONNECTING")
         // Show the message only if the video is currently being displayed
         this.showVideoConnectionMessage(this.state === VIDEO_CONTAINER_TYPE);
     }
@@ -280,6 +277,21 @@ export default class LargeVideoManager {
         } else {
             $('#videoConnectionMessage').css({display: "none"});
         }
+    }
+
+    /**
+     * Updated the text which is to be shown on the top of large video.
+     *
+     * @param {string} msgKey the translation key which will be used to get
+     * the message text to be displayed on the large video.
+     * @param {object} msgOptions translation options object
+     *
+     * @private
+     */
+    _setVideoConnectionMessage (msgKey, msgOptions) {
+        $('#videoConnectionMessage')
+            .attr("data-i18n", msgKey)
+            .text(APP.translation.translateString(msgKey, msgOptions));
     }
 
     /**

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -91,7 +91,7 @@ export default class LargeVideoManager {
      * Called when the media connection has been interrupted.
      */
     onVideoInterrupted () {
-        this.enableVideoProblemFilter(true);
+        this.enableLocalConnectionProblemFilter(true);
         let reconnectingKey = "connection.RECONNECTING";
         $('#videoConnectionMessage')
             .attr("data-i18n", reconnectingKey)
@@ -104,7 +104,7 @@ export default class LargeVideoManager {
      * Called when the media connection has been restored.
      */
     onVideoRestored () {
-        this.enableVideoProblemFilter(false);
+        this.enableLocalConnectionProblemFilter(false);
         this.showVideoConnectionMessage(false);
     }
 
@@ -240,12 +240,13 @@ export default class LargeVideoManager {
     }
 
     /**
-     * Enables/disables the filter indicating a video problem to the user.
+     * Enables/disables the filter indicating a video problem to the user caused
+     * by the problems with local media connection.
      *
      * @param enable <tt>true</tt> to enable, <tt>false</tt> to disable
      */
-    enableVideoProblemFilter (enable) {
-        this.videoContainer.enableVideoProblemFilter(enable);
+    enableLocalConnectionProblemFilter (enable) {
+        this.videoContainer.enableLocalConnectionProblemFilter(enable);
     }
 
     /**

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -121,7 +121,8 @@ export default class LargeVideoManager {
 
         // Include hide()/fadeOut only if we're switching between users
         let preUpdate;
-        if (this.newStreamData.id != this.id) {
+        let isUserSwitch = this.newStreamData.id != this.id;
+        if (isUserSwitch) {
             preUpdate = container.hide();
         } else {
             preUpdate = Promise.resolve();
@@ -146,23 +147,44 @@ export default class LargeVideoManager {
             // If we the continer is VIDEO_CONTAINER_TYPE, we need to check
             // its stream whether exist and is muted to set isVideoMuted
             // in rest of the cases it is false
-            let isVideoMuted = false;
+            let showAvatar = false;
             if (videoType == VIDEO_CONTAINER_TYPE)
-                isVideoMuted = stream ? stream.isMuted() : true;
+                showAvatar = stream ? stream.isMuted() : true;
 
-            // show the avatar on large if needed
-            container.showAvatar(isVideoMuted);
+            // If the user's connection is disrupted then the avatar will be
+            // displayed in case we have no video image cached. That is if
+            // there was a user switch(image is lost on stream detach) or if
+            // the video was not rendered, before the connection has failed.
+            let isHavingConnectivityIssues
+                = APP.conference.isParticipantConnectionActive(id) === false;
+            if (isHavingConnectivityIssues
+                    && (isUserSwitch | !container.wasVideoRendered)) {
+                showAvatar = true;
+            }
 
             let promise;
 
             // do not show stream if video is muted
             // but we still should show watermark
-            if (isVideoMuted) {
+            if (showAvatar) {
                 this.showWatermark(true);
-                // If the avatar is to be displayed the video should be hidden
+                // If the intention of this switch is to show the avatar
+                // we need to make sure that the video is hidden
                 promise = container.hide();
             } else {
                 promise = container.show();
+            }
+
+            // show the avatar on large if needed
+            container.showAvatar(showAvatar);
+
+            // Make sure no notification about remote failure is shown as
+            // it's UI conflicts with the one for local connection interrupted.
+            if (APP.conference.isConnectionInterrupted()) {
+                this.updateParticipantConnStatusIndication(id, true);
+            } else {
+                this.updateParticipantConnStatusIndication(
+                    id, !isHavingConnectivityIssues);
             }
 
             // resolve updateLargeVideo promise after everything is done
@@ -175,6 +197,38 @@ export default class LargeVideoManager {
             this.updateInProcess = false;
             this.scheduleLargeVideoUpdate();
         });
+    }
+
+    /**
+     * Shows/hides notification about participant's connectivity issues to be
+     * shown on the large video area.
+     *
+     * @param {string} id the id of remote participant(MUC nickname)
+     * @param {boolean} isConnected true if the connection is active or false
+     * when the user is having connectivity issues.
+     *
+     * @private
+     */
+    updateParticipantConnStatusIndication (id, isConnected) {
+
+        // Apply grey filter on the large video
+        this.videoContainer.showRemoteConnectionProblemIndicator(!isConnected);
+
+        if (isConnected) {
+            // Hide the message
+            this.showRemoteConnectionMessage(false);
+        } else {
+            // Get user's display name
+            let displayName
+                = APP.conference.getParticipantDisplayName(id);
+            this._setRemoteConnectionMessage(
+                "connection.USER_CONNECTION_INTERRUPTED",
+                { displayName: displayName });
+
+            // Show it now only if the VideoContainer is on top
+            this.showRemoteConnectionMessage(
+                this.state === VIDEO_CONTAINER_TYPE);
+        }
     }
 
     /**
@@ -274,9 +328,57 @@ export default class LargeVideoManager {
 
         if (show) {
             $('#videoConnectionMessage').css({display: "block"});
+            // Avatar message conflicts with 'videoConnectionMessage',
+            // so it must be hidden
+            this.showRemoteConnectionMessage(false);
         } else {
             $('#videoConnectionMessage').css({display: "none"});
         }
+    }
+
+    /**
+     * Shows hides the "avatar" message which is to be displayed either in
+     * the middle of the screen or below the avatar image.
+     *
+     * @param {null|boolean} show (optional) <tt>true</tt> to show the avatar
+     * message or <tt>false</tt> to hide it. If not provided then the connection
+     * status of the user currently on the large video will be obtained form
+     * "APP.conference" and the message will be displayed if the user's
+     * connection is interrupted.
+     */
+    showRemoteConnectionMessage (show) {
+        if (typeof show !== 'boolean') {
+            show = APP.conference.isParticipantConnectionActive(this.id);
+        }
+
+        if (show) {
+            $('#remoteConnectionMessage').css({display: "block"});
+            // 'videoConnectionMessage' message conflicts with 'avatarMessage',
+            // so it must be hidden
+            this.showVideoConnectionMessage(false);
+        } else {
+            $('#remoteConnectionMessage').hide();
+        }
+    }
+
+    /**
+     * Updates the text which describes that the remote user is having
+     * connectivity issues.
+     *
+     * @param {string} msgKey the translation key which will be used to get
+     * the message text.
+     * @param {object} msgOptions translation options object.
+     *
+     * @private
+     */
+    _setRemoteConnectionMessage (msgKey, msgOptions) {
+        if (msgKey) {
+            let text = APP.translation.translateString(msgKey, msgOptions);
+            $('#remoteConnectionMessage')
+                .attr("data-i18n", msgKey).text(text);
+        }
+
+        this.videoContainer.positionRemoteConnectionMessage();
     }
 
     /**
@@ -353,6 +455,7 @@ export default class LargeVideoManager {
         if (this.state === VIDEO_CONTAINER_TYPE) {
             this.showWatermark(false);
             this.showVideoConnectionMessage(false);
+            this.showRemoteConnectionMessage(false);
         }
         oldContainer.hide();
 
@@ -366,6 +469,10 @@ export default class LargeVideoManager {
                 // the container would be taking care of it by itself, but that
                 // is a bigger refactoring
                 this.showWatermark(true);
+                // "avatar" and "video connection" can not be displayed both
+                // at the same time, but the latter is of higher priority and it
+                // will hide the avatar one if will be displayed.
+                this.showRemoteConnectionMessage(/* fet the current state */);
                 this.showVideoConnectionMessage(/* fetch the current state */);
             }
         });

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -5,12 +5,18 @@ import Avatar from "../avatar/Avatar";
 import {createDeferred} from '../../util/helpers';
 import UIUtil from "../util/UIUtil";
 import {VideoContainer, VIDEO_CONTAINER_TYPE} from "./VideoContainer";
+import LargeContainer from "./LargeContainer";
 
 /**
  * Manager for all Large containers.
  */
 export default class LargeVideoManager {
     constructor (emitter) {
+        /**
+         * The map of <tt>LargeContainer</tt>s where the key is the video
+         * container type.
+         * @type {Object.<string, LargeContainer>}
+         */
         this.containers = {};
 
         this.state = VIDEO_CONTAINER_TYPE;
@@ -136,6 +142,10 @@ export default class LargeVideoManager {
             // change the avatar url on large
             this.updateAvatar(Avatar.getAvatarUrl(id));
 
+            // FIXME that does not really make sense, because the videoType
+            // (camera or desktop) is a completely different thing than
+            // the video container type (Etherpad, SharedVideo, VideoContainer).
+            // ----------------------------------------------------------------
             // If we the continer is VIDEO_CONTAINER_TYPE, we need to check
             // its stream whether exist and is muted to set isVideoMuted
             // in rest of the cases it is false

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -92,9 +92,9 @@ export default class LargeVideoManager {
      */
     onVideoInterrupted () {
         this.enableLocalConnectionProblemFilter(true);
-        this._setVideoConnectionMessage("connection.RECONNECTING")
+        this._setLocalConnectionMessage("connection.RECONNECTING")
         // Show the message only if the video is currently being displayed
-        this.showVideoConnectionMessage(this.state === VIDEO_CONTAINER_TYPE);
+        this.showLocalConnectionMessage(this.state === VIDEO_CONTAINER_TYPE);
     }
 
     /**
@@ -102,7 +102,7 @@ export default class LargeVideoManager {
      */
     onVideoRestored () {
         this.enableLocalConnectionProblemFilter(false);
-        this.showVideoConnectionMessage(false);
+        this.showLocalConnectionMessage(false);
     }
 
     get id () {
@@ -316,23 +316,23 @@ export default class LargeVideoManager {
     }
 
     /**
-     * Shows/hides the "video connection message".
+     * Shows/hides the message indicating problems with local media connection.
      * @param {boolean|null} show(optional) tells whether the message is to be
      * displayed or not. If missing the condition will be based on the value
      * obtained from {@link APP.conference.isConnectionInterrupted}.
      */
-    showVideoConnectionMessage (show) {
+    showLocalConnectionMessage (show) {
         if (typeof show !== 'boolean') {
             show = APP.conference.isConnectionInterrupted();
         }
 
         if (show) {
-            $('#videoConnectionMessage').css({display: "block"});
+            $('#localConnectionMessage').css({display: "block"});
             // Avatar message conflicts with 'videoConnectionMessage',
             // so it must be hidden
             this.showRemoteConnectionMessage(false);
         } else {
-            $('#videoConnectionMessage').css({display: "none"});
+            $('#localConnectionMessage').css({display: "none"});
         }
     }
 
@@ -355,7 +355,7 @@ export default class LargeVideoManager {
             $('#remoteConnectionMessage').css({display: "block"});
             // 'videoConnectionMessage' message conflicts with 'avatarMessage',
             // so it must be hidden
-            this.showVideoConnectionMessage(false);
+            this.showLocalConnectionMessage(false);
         } else {
             $('#remoteConnectionMessage').hide();
         }
@@ -382,7 +382,8 @@ export default class LargeVideoManager {
     }
 
     /**
-     * Updated the text which is to be shown on the top of large video.
+     * Updated the text which is to be shown on the top of large video, when
+     * local media connection is interrupted.
      *
      * @param {string} msgKey the translation key which will be used to get
      * the message text to be displayed on the large video.
@@ -390,8 +391,8 @@ export default class LargeVideoManager {
      *
      * @private
      */
-    _setVideoConnectionMessage (msgKey, msgOptions) {
-        $('#videoConnectionMessage')
+    _setLocalConnectionMessage (msgKey, msgOptions) {
+        $('#localConnectionMessage')
             .attr("data-i18n", msgKey)
             .text(APP.translation.translateString(msgKey, msgOptions));
     }
@@ -454,7 +455,7 @@ export default class LargeVideoManager {
         // be taking care of it by itself, but that is a bigger refactoring
         if (this.state === VIDEO_CONTAINER_TYPE) {
             this.showWatermark(false);
-            this.showVideoConnectionMessage(false);
+            this.showLocalConnectionMessage(false);
             this.showRemoteConnectionMessage(false);
         }
         oldContainer.hide();
@@ -473,7 +474,7 @@ export default class LargeVideoManager {
                 // at the same time, but the latter is of higher priority and it
                 // will hide the avatar one if will be displayed.
                 this.showRemoteConnectionMessage(/* fet the current state */);
-                this.showVideoConnectionMessage(/* fetch the current state */);
+                this.showLocalConnectionMessage(/* fetch the current state */);
             }
         });
     }

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -162,7 +162,8 @@ export default class LargeVideoManager {
             // but we still should show watermark
             if (isVideoMuted) {
                 this.showWatermark(true);
-                promise = Promise.resolve();
+                // If the avatar is to be displayed the video should be hidden
+                promise = container.hide();
             } else {
                 promise = container.show();
             }

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -201,7 +201,7 @@ LocalVideo.prototype.changeVideo = function (stream) {
         localVideoContainer.removeChild(localVideo);
         // when removing only the video element and we are on stage
         // update the stage
-        if(this.VideoLayout.isCurrentlyOnLarge(this.id))
+        if(this.isCurrentlyOnLargeVideo())
             this.VideoLayout.updateLargeVideo(this.id);
         stream.off(TrackEvents.LOCAL_TRACK_STOPPED, endedHandler);
     };

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -268,6 +268,12 @@ RemoteVideo.prototype.updateConnectionStatusIndicator = function (isActive) {
 
     if(this.connectionIndicator)
         this.connectionIndicator.updateConnectionStatusIndicator(isActive);
+
+    // Toggle thumbnail video problem filter
+    this.selectVideoElement().toggleClass(
+        "videoThumbnailProblemFilter", !isActive);
+    this.$avatar().toggleClass(
+        "videoThumbnailProblemFilter", !isActive);
 };
 
 /**
@@ -300,6 +306,8 @@ RemoteVideo.prototype.waitForPlayback = function (streamElement, stream) {
     var onPlayingHandler = function () {
         self.VideoLayout.videoactive(streamElement, self.id);
         streamElement.onplaying = null;
+        // Refresh to show the video
+        self.updateView();
     };
     streamElement.onplaying = onPlayingHandler;
 };

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -8,14 +8,24 @@ import UIUtils from "../util/UIUtil";
 import UIEvents from '../../../service/UI/UIEvents';
 import JitsiPopover from "../util/JitsiPopover";
 
-function RemoteVideo(id, VideoLayout, emitter) {
-    this.id = id;
+/**
+ * Creates new instance of the <tt>RemoteVideo</tt>.
+ * @param user {JitsiParticipant} the user for whom remote video instance will
+ * be created.
+ * @param {VideoLayout} VideoLayout the video layout instance.
+ * @param {EventEmitter} emitter the event emitter which will be used by
+ * the new instance to emit events.
+ * @constructor
+ */
+function RemoteVideo(user, VideoLayout, emitter) {
+    this.user = user;
+    this.id = user.getId();
     this.emitter = emitter;
-    this.videoSpanId = `participant_${id}`;
+    this.videoSpanId = `participant_${this.id}`;
     SmallVideo.call(this, VideoLayout);
     this.hasRemoteVideoMenu = false;
     this.addRemoteVideoContainer();
-    this.connectionIndicator = new ConnectionIndicator(this, id);
+    this.connectionIndicator = new ConnectionIndicator(this, this.id);
     this.setDisplayName();
     this.flipX = false;
     this.isLocal = false;

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -228,6 +228,49 @@ RemoteVideo.prototype.removeRemoteStreamElement = function (stream) {
 };
 
 /**
+ * Checks whether the remote user associated with this <tt>RemoteVideo</tt>
+ * has connectivity issues.
+ *
+ * @return {boolean} <tt>true</tt> if the user's connection is fine or
+ * <tt>false</tt> otherwise.
+ */
+RemoteVideo.prototype.isConnectionActive = function() {
+    return this.user.isConnectionActive();
+};
+
+/**
+ * @inheritDoc
+ */
+RemoteVideo.prototype.updateView = function () {
+    SmallVideo.prototype.updateView.call(this);
+    this.updateConnectionStatusIndicator(
+        null /* will obtain the status from 'conference' */);
+};
+
+/**
+ * Updates the UI to reflect user's connectivity status.
+ * @param isActive {boolean|null} 'true' if user's connection is active or
+ * 'false' when the use is having some connectivity issues and a warning
+ * should be displayed. When 'null' is passed then the current value will be
+ * obtained from the conference instance.
+ */
+RemoteVideo.prototype.updateConnectionStatusIndicator = function (isActive) {
+    // Check for initial value if 'isActive' is not defined
+    if (typeof isActive !== "boolean") {
+        isActive = this.isConnectionActive();
+        if (isActive === null) {
+            // Cancel processing at this point - no update
+            return;
+        }
+    }
+
+    console.debug(this.id + " thumbnail is connection active ? " + isActive);
+
+    if(this.connectionIndicator)
+        this.connectionIndicator.updateConnectionStatusIndicator(isActive);
+};
+
+/**
  * Removes RemoteVideo from the page.
  */
 RemoteVideo.prototype.remove = function () {

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -223,7 +223,7 @@ RemoteVideo.prototype.removeRemoteStreamElement = function (stream) {
 
     // when removing only the video element and we are on stage
     // update the stage
-    if (isVideo && this.VideoLayout.isCurrentlyOnLarge(this.id))
+    if (isVideo && this.isCurrentlyOnLargeVideo())
         this.VideoLayout.updateLargeVideo(this.id);
 };
 

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -29,6 +29,14 @@ function RemoteVideo(user, VideoLayout, emitter) {
     this.setDisplayName();
     this.flipX = false;
     this.isLocal = false;
+    /**
+     * The flag is set to <tt>true</tt> after the 'onplay' event has been
+     * triggered on the current video element. It goes back to <tt>false</tt>
+     * when the stream is removed. It is used to determine whether the video
+     * playback has ever started.
+     * @type {boolean}
+     */
+    this.wasVideoPlayed = false;
 }
 
 RemoteVideo.prototype = Object.create(SmallVideo.prototype);
@@ -218,6 +226,10 @@ RemoteVideo.prototype.removeRemoteStreamElement = function (stream) {
     var select = $('#' + elementID);
     select.remove();
 
+    if (isVideo) {
+        this.wasVideoPlayed = false;
+    }
+
     console.info((isVideo ? "Video" : "Audio") +
                  " removed " + this.id, select);
 
@@ -316,6 +328,7 @@ RemoteVideo.prototype.waitForPlayback = function (streamElement, stream) {
     // Register 'onplaying' listener to trigger 'videoactive' on VideoLayout
     // when video playback starts
     var onPlayingHandler = function () {
+        self.wasVideoPlayed = true;
         self.VideoLayout.videoactive(streamElement, self.id);
         streamElement.onplaying = null;
         // Refresh to show the video
@@ -325,15 +338,13 @@ RemoteVideo.prototype.waitForPlayback = function (streamElement, stream) {
 };
 
 /**
- * Checks whether or not video stream exists and has started for this
- * RemoteVideo instance. This is checked by trying to select video element in
- * this container and checking if 'currentTime' field's value is greater than 0.
+ * Checks whether the video stream has started for this RemoteVideo instance.
  *
- * @returns {*|boolean} true if this RemoteVideo has active video stream running
+ * @returns {boolean} true if this RemoteVideo has a video stream for which
+ * the playback has been started.
  */
 RemoteVideo.prototype.hasVideoStarted = function () {
-    var videoSelector = this.selectVideoElement();
-    return videoSelector.length && videoSelector[0].currentTime > 0;
+    return this.wasVideoPlayed;
 };
 
 RemoteVideo.prototype.addRemoteStreamElement = function (stream) {

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -239,6 +239,18 @@ RemoteVideo.prototype.isConnectionActive = function() {
 };
 
 /**
+ * The remote video is considered "playable" once the stream has started
+ * according to the {@link #hasVideoStarted} result.
+ *
+ * @inheritdoc
+ * @override
+ */
+RemoteVideo.prototype.isVideoPlayable = function () {
+    return SmallVideo.prototype.isVideoPlayable.call(this)
+        && this.hasVideoStarted();
+};
+
+/**
  * @inheritDoc
  */
 RemoteVideo.prototype.updateView = function () {

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -370,6 +370,17 @@ SmallVideo.prototype.hasVideo = function () {
 };
 
 /**
+ * Checks whether the user associated with this <tt>SmallVideo</tt> is currently
+ * being displayed on the "large video".
+ *
+ * @return {boolean} <tt>true</tt> if the user is displayed on the large video
+ * or <tt>false</tt> otherwise.
+ */
+SmallVideo.prototype.isCurrentlyOnLargeVideo = function () {
+    return this.VideoLayout.isCurrentlyOnLarge(this.id);
+};
+
+/**
  * Hides or shows the user's avatar.
  * This update assumes that large video had been updated and we will
  * reflect it on this small video.
@@ -392,7 +403,7 @@ SmallVideo.prototype.updateView = function () {
 
     let avatar = this.$avatar;
 
-    var isCurrentlyOnLarge = this.VideoLayout.isCurrentlyOnLarge(this.id);
+    var isCurrentlyOnLarge = this.isCurrentlyOnLargeVideo();
 
     var showVideo = !this.isVideoMuted && !isCurrentlyOnLarge;
     var showAvatar;

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -338,6 +338,16 @@ SmallVideo.prototype.selectVideoElement = function () {
 };
 
 /**
+ * Selects the HTML image element which displays user's avatar.
+ *
+ * @return {jQuery|HTMLElement} a jQuery selector pointing to the HTML image
+ * element which displays the user's avatar.
+ */
+SmallVideo.prototype.$avatar = function () {
+    return $('#' + this.videoSpanId + ' .userAvatar');
+};
+
+/**
  * Enables / disables the css responsible for focusing/pinning a video
  * thumbnail.
  *
@@ -380,7 +390,7 @@ SmallVideo.prototype.updateView = function () {
 
     let video = this.selectVideoElement();
 
-    let avatar = $('#' + this.videoSpanId + ' .userAvatar');
+    let avatar = this.$avatar;
 
     var isCurrentlyOnLarge = this.VideoLayout.isCurrentlyOnLarge(this.id);
 
@@ -406,18 +416,18 @@ SmallVideo.prototype.updateView = function () {
 
 SmallVideo.prototype.avatarChanged = function (avatarUrl) {
     var thumbnail = $('#' + this.videoSpanId);
-    var avatar = $('#' + this.videoSpanId + ' .userAvatar');
+    var avatarSel = this.$avatar();
     this.hasAvatar = true;
 
     // set the avatar in the thumbnail
-    if (avatar && avatar.length > 0) {
-        avatar[0].src = avatarUrl;
+    if (avatarSel && avatarSel.length > 0) {
+        avatarSel[0].src = avatarUrl;
     } else {
         if (thumbnail && thumbnail.length > 0) {
-            avatar = document.createElement('img');
-            avatar.className = 'userAvatar';
-            avatar.src = avatarUrl;
-            thumbnail.append(avatar);
+            var avatarElement = document.createElement('img');
+            avatarElement.className = 'userAvatar';
+            avatarElement.src = avatarUrl;
+            thumbnail.append(avatarElement);
         }
     }
 };

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -173,7 +173,18 @@ export class VideoContainer extends LargeContainer {
 
         this.isVisible = false;
 
+        /**
+         * Flag indicates whether or not the avatar is currently displayed.
+         * @type {boolean}
+         */
+        this.avatarDisplayed = false;
         this.$avatar = $('#dominantSpeaker');
+
+        /**
+         * A jQuery selector of the remote connection message.
+         * @type {jQuery|HTMLElement}
+         */
+        this.$remoteConnectionMessage = $('#remoteConnectionMessage');
 
         /**
          * Indicates whether or not the video stream attached to the video
@@ -266,6 +277,30 @@ export class VideoContainer extends LargeContainer {
         }
     }
 
+    /**
+     * Update position of the remote connection message which describes that
+     * the remote user is having connectivity issues.
+     */
+    positionRemoteConnectionMessage () {
+
+        if (this.avatarDisplayed) {
+            let $avatarImage = $("#dominantSpeakerAvatar");
+            this.$remoteConnectionMessage.css(
+                'top',
+                $avatarImage.offset().top + $avatarImage.height() + 10);
+        } else {
+            let height = this.$remoteConnectionMessage.height();
+            let parentHeight = this.$remoteConnectionMessage.parent().height();
+            this.$remoteConnectionMessage.css(
+                'top', (parentHeight/2) - (height/2));
+        }
+
+        let width = this.$remoteConnectionMessage.width();
+        let parentWidth = this.$remoteConnectionMessage.parent().width();
+        this.$remoteConnectionMessage.css(
+            'left', ((parentWidth/2) - (width/2)));
+    }
+
     resize (containerWidth, containerHeight, animate = false) {
         let [width, height]
             = this.getVideoSize(containerWidth, containerHeight);
@@ -277,6 +312,8 @@ export class VideoContainer extends LargeContainer {
         let top = containerHeight / 2 - this.avatarHeight / 4 * 3;
 
         this.$avatar.css('top', top);
+
+        this.positionRemoteConnectionMessage();
 
         this.$wrapper.animate({
             width: width,
@@ -362,8 +399,21 @@ export class VideoContainer extends LargeContainer {
             (show) ? interfaceConfig.DEFAULT_BACKGROUND : "#000");
 
         this.$avatar.css("visibility", show ? "visible" : "hidden");
+        this.avatarDisplayed = show;
 
         this.emitter.emit(UIEvents.LARGE_VIDEO_AVATAR_DISPLAYED, show);
+    }
+
+    /**
+     * Indicates that the remote user who is currently displayed by this video
+     * container is having connectivity issues.
+     *
+     * @param {boolean} show <tt>true</tt> to show or <tt>false</tt> to hide
+     * the indication.
+     */
+    showRemoteConnectionProblemIndicator (show) {
+        this.$video.toggleClass("remoteVideoProblemFilter", show);
+        this.$avatar.toggleClass("remoteVideoProblemFilter", show);
     }
 
     // We are doing fadeOut/fadeIn animations on parent div which wraps

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -186,12 +186,12 @@ export class VideoContainer extends LargeContainer {
 
     /**
      * Enables a filter on the video which indicates that there are some
-     * problems with the media connection.
+     * problems with the local media connection.
      *
      * @param {boolean} enable <tt>true</tt> if the filter is to be enabled or
      * <tt>false</tt> otherwise.
      */
-    enableVideoProblemFilter (enable) {
+    enableLocalConnectionProblemFilter (enable) {
         this.$video.toggleClass("videoProblemFilter", enable);
     }
 

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -174,14 +174,29 @@ export class VideoContainer extends LargeContainer {
         this.isVisible = false;
 
         this.$avatar = $('#dominantSpeaker');
+
+        /**
+         * Indicates whether or not the video stream attached to the video
+         * element has started(which means that there is any image rendered
+         * even if the video is stalled).
+         * @type {boolean}
+         */
+        this.wasVideoRendered = false;
+
         this.$wrapper = $('#largeVideoWrapper');
 
         this.avatarHeight = $("#dominantSpeakerAvatar").height();
 
+        var onPlayCallback = function (event) {
+            if (typeof onPlay === 'function') {
+                onPlay(event);
+            }
+            this.wasVideoRendered = true;
+        }.bind(this);
         // This does not work with Temasys plugin - has to be a property to be
         // copied between new <object> elements
         //this.$video.on('play', onPlay);
-        this.$video[0].onplay = onPlay;
+        this.$video[0].onplay = onPlayCallback;
     }
 
     /**
@@ -284,6 +299,14 @@ export class VideoContainer extends LargeContainer {
      * @param {string} videoType video type
      */
     setStream (stream, videoType) {
+
+        if (this.stream === stream) {
+            return;
+        } else {
+            // The stream has changed, so the image will be lost on detach
+            this.wasVideoRendered = false;
+        }
+
         // detach old stream
         if (this.stream) {
             this.stream.detach(this.$video[0]);

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -650,6 +650,12 @@ var VideoLayout = {
      * the user is having connectivity issues.
      */
     onParticipantConnectionStatusChanged (id, isActive) {
+        // Show/hide warning on the large video
+        if (this.isCurrentlyOnLarge(id)) {
+            if (largeVideo) {
+                largeVideo.updateParticipantConnStatusIndication(id, isActive);
+            }
+        }
         // Show/hide warning on the thumbnail
         let remoteVideo = remoteVideos[id];
         if (remoteVideo) {

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -498,6 +498,18 @@ var VideoLayout = {
     },
 
     /**
+     * Shows/hides the indication about local connection being interrupted.
+     *
+     * @param {boolean} isInterrupted <tt>true</tt> if local connection is
+     * currently in the interrupted state or <tt>false</tt> if the connection
+     * is fine.
+     */
+    showLocalConnectionInterrupted (isInterrupted) {
+        localVideoThumbnail.connectionIndicator
+            .updateConnectionStatusIndicator(!isInterrupted);
+    },
+
+    /**
      * Resizes thumbnails.
      */
     resizeThumbnails (  animate = false,

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -382,18 +382,30 @@ var VideoLayout = {
     },
 
     /**
-     * Creates a participant container for the given id and smallVideo.
+     * Creates or adds a participant container for the given id and smallVideo.
      *
-     * @param id the id of the participant to add
+     * @param {JitsiParticipant} user the participant to add
      * @param {SmallVideo} smallVideo optional small video instance to add as a
-     * remote video, if undefined RemoteVideo will be created
+     * remote video, if undefined <tt>RemoteVideo</tt> will be created
      */
-    addParticipantContainer (id, smallVideo) {
+    addParticipantContainer (user, smallVideo) {
+        let id = user.getId();
         let remoteVideo;
         if(smallVideo)
             remoteVideo = smallVideo;
         else
-            remoteVideo = new RemoteVideo(id, VideoLayout, eventEmitter);
+            remoteVideo = new RemoteVideo(user, VideoLayout, eventEmitter);
+        this.addRemoteVideoContainer(id, remoteVideo);
+    },
+
+    /**
+     * Adds remote video container for the given id and <tt>SmallVideo</tt>.
+     *
+     * @param {string} the id of the video to add
+     * @param {SmallVideo} smallVideo the small video instance to add as a
+     * remote video
+     */
+    addRemoteVideoContainer (id, remoteVideo) {
         remoteVideos[id] = remoteVideo;
 
         let videoType = VideoLayout.getRemoteVideoType(id);

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -423,6 +423,8 @@ var VideoLayout = {
         } else {
             VideoLayout.resizeThumbnails(false, true);
         }
+        // Initialize the view
+        remoteVideo.updateView();
     },
 
     videoactive (videoelem, resourceJid) {
@@ -637,6 +639,21 @@ var VideoLayout = {
             && remoteVideo.hasVideoStarted()
             && !this.getCurrentlyOnLargeContainer().stayOnStage()) {
             this.updateLargeVideo(id);
+        }
+    },
+
+    /**
+     * Shows/hides warning about remote user's connectivity issues.
+     *
+     * @param {string} id the ID of the remote participant(MUC nickname)
+     * @param {boolean} isActive true if the connection is ok or false when
+     * the user is having connectivity issues.
+     */
+    onParticipantConnectionStatusChanged (id, isActive) {
+        // Show/hide warning on the thumbnail
+        let remoteVideo = remoteVideos[id];
+        if (remoteVideo) {
+            remoteVideo.updateConnectionStatusIndicator(isActive);
         }
     },
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -653,7 +653,13 @@ var VideoLayout = {
         // Show/hide warning on the thumbnail
         let remoteVideo = remoteVideos[id];
         if (remoteVideo) {
-            remoteVideo.updateConnectionStatusIndicator(isActive);
+            // Updating only connection status indicator is not enough, because
+            // when we the connection is restored while the avatar was displayed
+            // (due to 'muted while disconnected' condition) we may want to show
+            // the video stream again and in order to do that the display mode
+            // must be updated.
+            //remoteVideo.updateConnectionStatusIndicator(isActive);
+            remoteVideo.updateView();
         }
     },
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -653,7 +653,9 @@ var VideoLayout = {
         // Show/hide warning on the large video
         if (this.isCurrentlyOnLarge(id)) {
             if (largeVideo) {
-                largeVideo.updateParticipantConnStatusIndication(id, isActive);
+                // We have to trigger full large video update to transition from
+                // avatar to video on connectivity restored.
+                this.updateLargeVideo(id, true /* force update */);
             }
         }
         // Show/hide warning on the thumbnail


### PR DESCRIPTION
This PR implements the UI for https://github.com/jitsi/lib-jitsi-meet/pull/259 which adds the notifications about participant's media connection status changes(indicates problems with the connection between the peer and jvb).

When the user is having problem we will try to apply greyscale filter on top of the frozen video either on the "large video" or on the thumbnail, but only if such image is available. If not then the user's avatar will be displayed in greyscale. In addition to that there will be a message saying that "the user is having connectivity issues" displayed on the large video and a "disconnected GSM bars" icon will be shown on the thumbnail.