### PR TITLE
Global handler for tooltips

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -329,6 +329,8 @@ UI.initConference = function () {
     // to the UI (depending on the moderator role of the local participant) and
     // (2) APP.conference as means of communication between the participants.
     followMeHandler = new FollowMe(APP.conference, UI);
+
+    UIUtil.activateTooltips();
 };
 
 UI.mucJoined = function () {

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -2,6 +2,17 @@
 
 import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
 
+const TOOLTIP_POSITIONS = {
+    'top': 's',
+    'left': 'e',
+    'right': 'w',
+    'bottom': 'n',
+    'top-left': 'se',
+    'top-right': 'sw',
+    'bottom-left': 'ne',
+    'bottom-right': 'nw'
+};
+
 /**
  * Created by hristo on 12/22/14.
  */
@@ -90,17 +101,13 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
      * appropriate class (ex. "tooltip-n") and "content" attribute.
      */
     activateTooltips: function () {
-        function getTitle () {
-            return this.getAttribute('content');
-        }
-
-        function getGravity () {
-            return this.getAttribute('data-tooltip');
-        }
-
         AJS.$('[data-tooltip]').tooltip({
-            gravity: getGravity,
-            title: getTitle,
+            gravity() {
+                return this.getAttribute('data-tooltip');
+            },
+            title() {
+                return this.getAttribute('content')
+            },
             html: true,      // handle multiline tooltips
             // two options to prevent tooltips from being stuck:
             live: true,      // attach listener to document element
@@ -116,25 +123,10 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
      * @param position the position of the tooltip in relation to the element
      */
     setTooltip: function (element, key, position) {
-        let positions = {
-            'top': 's',
-            'top-left': 'se',
-            'left': 'e',
-            'bottom-left': 'ne',
-            'bottom': 'n',
-            'bottom-right': 'nw',
-            'right': 'w',
-            'top-right': 'sw'
-        };
+        element.setAttribute('data-tooltip', TOOLTIP_POSITIONS[position]);
+        element.setAttribute('data-i18n', '[content]' + key);
 
-        $(element).each(function () {
-            var el = $(this);
-
-            el.attr("data-i18n", "[content]" + key)
-              .attr('data-tooltip', positions[position]);
-
-            APP.translation.translateElement(el);
-        });
+        APP.translation.translateElement($(element));
     },
 
     /**

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -2,6 +2,10 @@
 
 import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
 
+/**
+ * The 'TOOLTIP_POSITIONS' constant indicates what 'gravity' option should be 
+ * passed into AUI tooltip plugin using desired position of the tooltip
+ */
 const TOOLTIP_POSITIONS = {
     'top': 's',
     'left': 'e',

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -3,8 +3,8 @@
 import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
 
 /**
- * The 'TOOLTIP_POSITIONS' constant indicates what 'gravity' option should be 
- * passed into AUI tooltip plugin using desired position of the tooltip
+ * The 'TOOLTIP_POSITIONS' constant indicates a value of 'gravity' option 
+ * to be passed to AUI Tooltip plugin based on the desired tooltip position
  */
 const TOOLTIP_POSITIONS = {
     'top': 's',

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -90,30 +90,21 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
      * appropriate class (ex. "tooltip-n") and "content" attribute.
      */
     activateTooltips: function () {
-        var positions = [
-            {side: 'top', gravity: 's'},
-            {side: 'left', gravity: 'e'},
-            {side: 'right', gravity: 'w'},
-            {side: 'bottom', gravity: 'n'},
-            {side: 'top-left', gravity: 'se'},
-            {side: 'top-right', gravity: 'sw'},
-            {side: 'bottom-left', gravity: 'ne'},
-            {side: 'bottom-right', gravity: 'nw'}
-        ];
-
         function getTitle () {
             return this.getAttribute('content');
         }
 
-        positions.forEach(function (config) {
-            AJS.$('.tooltip-' + config.gravity).tooltip({
-                gravity: config.gravity,
-                title: getTitle,
-                html: true,      // handle multiline tooltips
-                // two options to prevent tooltips from being stuck:
-                live: true,      // attach listener to document element
-                hoverable: false // make custom tooltips to behave like native
-            });
+        function getGravity () {
+            return this.getAttribute('data-tooltip');
+        }
+
+        AJS.$('[data-tooltip]').tooltip({
+            gravity: getGravity,
+            title: getTitle,
+            html: true,      // handle multiline tooltips
+            // two options to prevent tooltips from being stuck:
+            live: true,      // attach listener to document element
+            hoverable: false // make custom tooltips to behave like native
         });
     },
 
@@ -139,8 +130,8 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
         $(element).each(function () {
             var el = $(this);
 
-            el.addClass('tooltip-' + positions[position])
-              .attr("data-i18n", "[content]" + key);
+            el.attr("data-i18n", "[content]" + key)
+              .attr('data-tooltip', positions[position]);
 
             APP.translation.translateElement(el);
         });

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -85,6 +85,39 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
     },
 
     /**
+     * Sets global handler for all tooltips. Once this function is invoked
+     * all you need to create new tooltip is to update DOM node with
+     * appropriate class (ex. "tooltip-n") and "content" attribute.
+     */
+    activateTooltips: function () {
+        var positions = [
+            {side: 'top', gravity: 's'},
+            {side: 'left', gravity: 'e'},
+            {side: 'right', gravity: 'w'},
+            {side: 'bottom', gravity: 'n'},
+            {side: 'top-left', gravity: 'se'},
+            {side: 'top-right', gravity: 'sw'},
+            {side: 'bottom-left', gravity: 'ne'},
+            {side: 'bottom-right', gravity: 'nw'}
+        ];
+
+        function getTitle () {
+            return this.getAttribute('content');
+        }
+
+        positions.forEach(function (config) {
+            AJS.$('.tooltip-' + config.gravity).tooltip({
+                gravity: config.gravity,
+                title: getTitle,
+                html: true,      // handle multiline tooltips
+                // two options to prevent tooltips from being stuck:
+                live: true,      // attach listener to document element
+                hoverable: false // make custom tooltips to behave like native
+            });
+        });
+    },
+
+    /**
      * Sets the tooltip to the given element.
      *
      * @param element the element to set the tooltip to
@@ -103,13 +136,13 @@ import KeyboardShortcut from '../../keyboardshortcut/keyboardshortcut';
             'top-right': 'sw'
         };
 
-        element.setAttribute("data-i18n", "[content]" + key);
-        APP.translation.translateElement($(element));
+        $(element).each(function () {
+            var el = $(this);
 
-        AJS.$(element).tooltip({
-            gravity: positions[position],
-            title: this._getTooltipText.bind(this, element),
-            html: true
+            el.addClass('tooltip-' + positions[position])
+              .attr("data-i18n", "[content]" + key);
+
+            APP.translation.translateElement(el);
         });
     },
 


### PR DESCRIPTION
Provided changes:
1) Fixed issue when tooltip become visible permanently
2) Improved memory management - one instance of the plugin handles all the tooltips
3) Improved management of the tooltips - they are created and destroyed automatically for the nodes with "data-tooltip" and "content" attributes