### PR TITLE
Removed initial animation of the video thumbnail

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -1,5 +1,10 @@
+#videoconference_page {
+    min-height: 100%;
+}
+
 #videospace {
     display: block;
+    min-height: 100%;
     position: absolute;
     top: 0px;
     left: 0px;


### PR DESCRIPTION
Before:
![screencast-2016-09-28-15-11-52-before](https://cloud.githubusercontent.com/assets/22145346/18913163/fb19bb9c-858e-11e6-903b-94ce29c84788.gif)

After:
![screencast-2016-09-28-15-17-15-after](https://cloud.githubusercontent.com/assets/22145346/18913166/0420caa0-858f-11e6-97e1-c832c3903967.gif)

