### PR TITLE
Prosody tokens case insensitive room name

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1220,8 +1220,9 @@ export default {
             APP.UI.handleLastNEndpoints(ids, enteringIds);
         });
         room.on(
-            ConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED, (id, isActive) => {
-            APP.UI.participantConnectionStatusChanged(id, isActive);
+            ConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
+            (id, isActive) => {
+                APP.UI.participantConnectionStatusChanged(id, isActive);
         });
         room.on(ConferenceEvents.DOMINANT_SPEAKER_CHANGED, (id) => {
             if (this.isLocalId(id)) {

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -92,7 +92,7 @@ export default class LargeVideoManager {
      */
     onVideoInterrupted () {
         this.enableLocalConnectionProblemFilter(true);
-        this._setLocalConnectionMessage("connection.RECONNECTING")
+        this._setLocalConnectionMessage("connection.RECONNECTING");
         // Show the message only if the video is currently being displayed
         this.showLocalConnectionMessage(this.state === VIDEO_CONTAINER_TYPE);
     }

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -197,7 +197,7 @@ RemoteVideo.prototype.setMutedView = function(isMuted) {
     SmallVideo.prototype.setMutedView.call(this, isMuted);
     // Update 'mutedWhileDisconnected' flag
     this._figureOutMutedWhileDisconnected(this.isConnectionActive() === false);
-}
+};
 
 /**
  * Figures out the value of {@link #mutedWhileDisconnected} flag by taking into
@@ -215,7 +215,7 @@ RemoteVideo.prototype._figureOutMutedWhileDisconnected
     } else if (!isDisconnected && !this.isVideoMuted) {
         this.mutedWhileDisconnected = false;
     }
-}
+};
 
 /**
  * Adds the remote video menu element for the given <tt>id</tt> in the

--- a/prosody-plugins/mod_token_verification.lua
+++ b/prosody-plugins/mod_token_verification.lua
@@ -60,7 +60,7 @@ local function verify_user(session, stanza)
 
 	local token = session.auth_token;
 	local auth_room = session.jitsi_meet_room;
-	if room ~= auth_room and disableRoomNameConstraints ~= true then
+	if disableRoomNameConstraints ~= true and room ~= string.lower(auth_room) then
 		log("error", "Token %s not allowed to join: %s",
 			tostring(token), tostring(auth_room));
 		session.send(


### PR DESCRIPTION
Room names used inside prosody are all lower case, when verify with room name from token make sure we use the room name in lower case.