### PR TITLE
Remove tooltip update

### DIFF
--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -144,6 +144,10 @@ const TOOLTIP_POSITIONS = {
      */
     removeTooltip: function (element) {
         AJS.$(element).tooltip('destroy');
+        element.setAttribute('data-tooltip', '');
+        element.setAttribute('data-i18n','');
+        element.setAttribute('content','');
+        element.setAttribute('shortcut','');
     },
 
     /**


### PR DESCRIPTION
Destroy is just hiding current tooltip, we also need to remove other attributes to stop showing the tooltip.