### PR TITLE
error layout added

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+    <link rel="stylesheet" href="css/all.css"/>
+</head>
+<body>
+    <div class="error_page">
+        <h2>404 Not Found</h2>
+        <p class="error_page__message">You can create new conversation <a href="/">here</a></p>
+    </div>
+</body>
+</html>

--- a/css/404.scss
+++ b/css/404.scss
@@ -1,0 +1,14 @@
+.error_page {
+    width: 60%;
+    margin: 20% auto;
+    text-align: center;
+
+    h2 {
+        font-size: 36px;
+    }
+
+    &__message {
+        font-size: 24px;
+        margin-top: 20px;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -64,5 +64,6 @@
 @import "modals/invite/invite";
 @import "connection-info";
 @import 'aui-components/dropdown';
+@import '404';
 
 /* Modules END */


### PR DESCRIPTION
404.html error page added

User can go to meeting with "meeting-name" name by mistake. In this case we are showing nginx 404 error. I think we should rewrite this page and show error page with button for redirection on home page

Logic:
jitsi.net/                                  --> WelcomePage
jitsi.net/lettersOrNumbers     --> VideoPage
jitsi.net/letters-test                --> 404 ErrorPage

But we should setup our server after merge this PR.