### PR TITLE
fix(chat): Issue with position of chat messages

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -129,7 +129,7 @@
 .chatmessage {
     background: #3a3a3a;
     width: 93%;
-    margin-left: 5%;
+    margin-left: 9px;
     margin-right: auto;
     border-radius: 5px;
     border-top-left-radius: 0px;


### PR DESCRIPTION
Changes the margin from % to px. The margin value was % of the side panel with but it is always 200px. So the margin in px should be always 8-9 px. 