### PR TITLE
Fixes desktop expansion on filmstirp shortcut hide.

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -345,7 +345,6 @@ UI.mucJoined = function () {
  */
 UI.handleToggleFilmStrip = () => {
     UI.toggleFilmStrip();
-    VideoLayout.resizeVideoArea(true, false);
 };
 
 /**
@@ -729,6 +728,7 @@ UI.toggleSmileys = function () {
 UI.toggleFilmStrip = function () {
     var self = FilmStrip;
     self.toggleFilmStrip.apply(self, arguments);
+    VideoLayout.resizeVideoArea(true, false);
 };
 
 /**


### PR DESCRIPTION
Currently, when hiding the filmstrip during a desktop sharing session, Meet resizes the desktop to fullscreen. This only works when hiding from the toolbar button though and not from the "F" shortcut.

The fix, makes it also work for the shortcut.