### PR TITLE
Initialise the invite dialog on user action

### DIFF
--- a/modules/UI/invite/Invite.js
+++ b/modules/UI/invite/Invite.js
@@ -15,7 +15,6 @@ class Invite {
     constructor(conference) {
         this.conference = conference;
         this.createRoomLocker(conference);
-        this.initDialog();
         this.registerListeners();
     }
 


### PR DESCRIPTION
We're already checking if the invite dialog view isn't created when the person clicks on invite and we need to open the dialog, so this initialisation at the beginning of the call is not correct. In addition this dialog was initialised so early in the call that often we wouldn't get translations by this point and will end up with empty title. The translation problem is a bigger one though and will be addressed in a separate fix.