### PR TITLE
Prevent tooltips from frozen state

### DIFF
--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -525,7 +525,7 @@ SmallVideo.prototype.showDominantSpeakerIndicator = function (show) {
         tooltip: 'speaker'
     });
 
-    $(indicatorSpan)[show ? "show" : "hide"]();
+    indicatorSpan.style.display = show ? "" : "none";
 };
 
 /**
@@ -545,7 +545,7 @@ SmallVideo.prototype.showRaisedHandIndicator = function (show) {
         tooltip: 'raisedHand'
     });
 
-    $(indicatorSpan)[show ? "show" : "hide"]();
+    indicatorSpan.style.display = show ? "" : "none";
 };
 
 /**

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -555,7 +555,7 @@ SmallVideo.prototype.showRaisedHandIndicator = function (show) {
  * @param options.content {String} HTML content of the indicator
  * @param options.tooltip {String} The key that should be passed to tooltip
  *
- * @returns {HTMLElement} the raised hand indicator
+ * @returns {HTMLElement} DOM represention of the indicator
  */
 SmallVideo.prototype.getIndicatorSpan = function(options) {
     var indicator = this.container.querySelector('#' + options.id);
@@ -570,6 +570,10 @@ SmallVideo.prototype.getIndicatorSpan = function(options) {
 
     indicator.innerHTML = options.content;
 
+    // This element will be translated by UIUtil.setTooltip and 
+    // that's why it is not translated here.
+    // Do not translate the same element multiple times in a row
+    // because it prevents tooltip from disappearing.
     UIUtil.setTooltip(indicator, options.tooltip, "top");
 
     this.container.appendChild(indicator);

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -1,4 +1,4 @@
-/* global $, APP, JitsiMeetJS, interfaceConfig */
+/* global $, JitsiMeetJS, interfaceConfig */
 import Avatar from "../avatar/Avatar";
 import UIUtil from "../util/UIUtil";
 import UIEvents from "../../../service/UI/UIEvents";
@@ -519,16 +519,13 @@ SmallVideo.prototype.showDominantSpeakerIndicator = function (show) {
         return;
     }
 
-    var indicatorSpanId = "dominantspeakerindicator";
-    var indicatorSpan = this.getIndicatorSpan(indicatorSpanId);
+    var indicatorSpan = this.getIndicatorSpan({
+        id: 'dominantspeakerindicator',
+        content: '<i id="indicatoricon" class="fa fa-bullhorn"></i>',
+        tooltip: 'speaker'
+    });
 
-    indicatorSpan.innerHTML
-        = "<i id='indicatoricon' class='fa fa-bullhorn'></i>";
-    // adds a tooltip
-    UIUtil.setTooltip(indicatorSpan, "speaker", "top");
-    APP.translation.translateElement($(indicatorSpan));
-
-    $(indicatorSpan).css("visibility", show ? "visible" : "hidden");
+    $(indicatorSpan)[show ? "show" : "hide"]();
 };
 
 /**
@@ -542,35 +539,42 @@ SmallVideo.prototype.showRaisedHandIndicator = function (show) {
         return;
     }
 
-    var indicatorSpanId = "raisehandindicator";
-    var indicatorSpan = this.getIndicatorSpan(indicatorSpanId);
+    var indicatorSpan = this.getIndicatorSpan({
+        id: 'raisehandindicator',
+        content: '<i id="indicatoricon" class="icon-raised-hand"></i>',
+        tooltip: 'raisedHand'
+    });
 
-    indicatorSpan.innerHTML
-        = "<i id='indicatoricon' class='icon-raised-hand'></i>";
-
-    // adds a tooltip
-    UIUtil.setTooltip(indicatorSpan, "raisedHand", "top");
-    APP.translation.translateElement($(indicatorSpan));
-
-    $(indicatorSpan).css("visibility", show ? "visible" : "hidden");
+    $(indicatorSpan)[show ? "show" : "hide"]();
 };
 
 /**
- * Gets (creating if necessary) the "indicator" span for this SmallVideo
-  identified by an ID.
+ * Gets (creating if necessary) the "indicator" span for this SmallVideo.
+ * 
+ * @param options.id {String} element ID
+ * @param options.content {String} HTML content of the indicator
+ * @param options.tooltip {String} The key that should be passed to tooltip
+ *
+ * @returns {HTMLElement} the raised hand indicator
  */
-SmallVideo.prototype.getIndicatorSpan = function(id) {
-    var indicatorSpan;
-    var spans = $(`#${this.videoSpanId}>[id=${id}`);
-    if (spans.length <= 0) {
-        indicatorSpan = document.createElement('span');
-        indicatorSpan.id = id;
-        indicatorSpan.className = "indicator";
-        $('#' + this.videoSpanId)[0].appendChild(indicatorSpan);
-    } else {
-        indicatorSpan = spans[0];
+SmallVideo.prototype.getIndicatorSpan = function(options) {
+    var indicator = this.container.querySelector('#' + options.id);
+
+    if (indicator) {
+        return indicator;
     }
-    return indicatorSpan;
+
+    indicator = document.createElement('span');
+    indicator.className = 'indicator';
+    indicator.id = options.id;
+
+    indicator.innerHTML = options.content;
+
+    UIUtil.setTooltip(indicator, options.tooltip, "top");
+
+    this.container.appendChild(indicator);
+
+    return indicator;
 };
 
 /**


### PR DESCRIPTION
The tooltip became frozen because there were multiple calls to Translation API.

Before:
![screencast-2016-10-17-19-47-56-before](https://cloud.githubusercontent.com/assets/22145346/19447082/8d4d534c-94a4-11e6-9a37-bc014d4ada82.gif)

After:
![screencast-2016-10-17-19-44-52-after](https://cloud.githubusercontent.com/assets/22145346/19447076/834b3f3a-94a4-11e6-9902-1a7bf603b166.gif)