### PR TITLE
Fixes issue of method 'setTooltip'

### DIFF
--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -131,10 +131,12 @@ const TOOLTIP_POSITIONS = {
      * @param position the position of the tooltip in relation to the element
      */
     setTooltip: function (element, key, position) {
-        element.setAttribute('data-tooltip', TOOLTIP_POSITIONS[position]);
-        element.setAttribute('data-i18n', '[content]' + key);
+        if (element !== null) {
+            element.setAttribute('data-tooltip', TOOLTIP_POSITIONS[position]);
+            element.setAttribute('data-i18n', '[content]' + key);
 
-        APP.translation.translateElement($(element));
+            APP.translation.translateElement($(element));
+        }      
     },
 
     /**


### PR DESCRIPTION
Fixes issue of method 'setTooltip' in modules/UI/util/UIUtil.js: Excluded 'Uncaught TypeError':
```
UIUtil.js:134 Uncaught TypeError: Cannot read property 'setAttribute' of null
```