### PR TITLE
Fixes LoginDialog.js: Uncaught TypeError

### DIFF
--- a/modules/UI/authentication/LoginDialog.js
+++ b/modules/UI/authentication/LoginDialog.js
@@ -94,7 +94,8 @@ function LoginDialog(successCallback, cancelCallback) {
                     }
                 } else {
                     // User cancelled
-                    cancelCallback();
+                    if (typeof cancelCallback === "function")
+                        cancelCallback();
                 }
             }
         },
@@ -115,7 +116,8 @@ function LoginDialog(successCallback, cancelCallback) {
                     connDialog.goToState('login');
                 } else {
                     // User cancelled
-                    cancelCallback();
+                    if (typeof cancelCallback === "function")
+                        cancelCallback();
                 }
             }
         }


### PR DESCRIPTION
Fixes modules/UI/authentication/LoginDialog.js Uncaught TypeError: cancelCallback is not a function
