### PR TITLE
Do not display avatar on top of the connection problem messages

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -438,7 +438,6 @@
     margin: auto;
     position: relative;
     border-radius: 100px;
-    z-index: 3;
     visibility: inherit;
     background-color: #000000;
 }


### PR DESCRIPTION
Previously the z-index was introduced in order to have the avatar
visible on top of the black video element, but now we're always hiding
the video element when the avatar is displayed, so it's no longer
required.