### PR TITLE
Add detect translation freeze in interface config

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -16,6 +16,7 @@ var interfaceConfig = { // eslint-disable-line no-unused-vars
     SHOW_POWERED_BY: false,
     GENERATE_ROOMNAMES_ON_WELCOME_PAGE: true,
     APP_NAME: "Jitsi Meet",
+    LANG_DETECTION: false,    // Allow i18n to detect the system language
     INVITATION_POWERED_BY: true,
     /**
      * If we should show authentication block in profile

--- a/modules/translation/translation.js
+++ b/modules/translation/translation.js
@@ -83,6 +83,12 @@ module.exports = {
         let options = defaultOptions;
 
         let lang = getLangFromQuery() || settingsLang || config.defaultLanguage;
+        let langDetection = interfaceConfig.LANG_DETECTION;
+
+        if (!langDetection && !lang) {
+            lang = DEFAULT_LANG;
+        }
+
         if (lang) {
             options.lng = lang;
         }


### PR DESCRIPTION
Fixed the problem with automatic language detection. Added new option to interface config `LANG_DETECTION`. When it's enabled then we allow 18n to detect the language of user agent otherwise we're setting default language (which is English).