### PR TITLE
Stop the media when XMPP connection is dropped

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -566,6 +566,10 @@ export default {
                 APP.UI.showPageReloadOverlay();
                 connection.removeEventListener(
                     ConnectionEvents.CONNECTION_FAILED, handler);
+                // FIXME it feels like the conference should be stopped
+                // by lib-jitsi-meet
+                if (room)
+                    room.leave();
             }
         };
         connection.addEventListener(


### PR DESCRIPTION
It looks weird when the page reload overlay appears and the conference
continues in the background (the connection to the JVB remains active).
The library will not recover and the conference can not continue without
the signalling, so the room should be left and media stopped.