### PR TITLE
Limit long display names

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -58,7 +58,7 @@ const commands = {
  * Max length of the display names. If we receive longer display name the
  * additional chars are going to be cut.
  */
-const MAX_DISPLAYNAME_LENGTH = 50;
+const MAX_DISPLAY_NAME_LENGTH = 50;
 
 /**
  * Open Connection. When authentication failed it shows auth dialog.
@@ -288,7 +288,7 @@ function changeLocalEmail(email = '') {
  */
 function changeLocalDisplayName(nickname = '') {
     const formattedNickname
-        = nickname.trim().substr(0, MAX_DISPLAYNAME_LENGTH);
+        = nickname.trim().substr(0, MAX_DISPLAY_NAME_LENGTH);
 
     if (formattedNickname === APP.settings.getDisplayName()) {
         return;
@@ -1276,7 +1276,7 @@ export default {
 
         room.on(ConferenceEvents.DISPLAY_NAME_CHANGED, (id, displayName) => {
             const formattedDisplayName
-                = displayName.substr(0, MAX_DISPLAYNAME_LENGTH);
+                = displayName.substr(0, MAX_DISPLAY_NAME_LENGTH);
             APP.API.notifyDisplayNameChanged(id, formattedDisplayName);
             APP.UI.changeDisplayName(id, formattedDisplayName);
         });

--- a/conference.js
+++ b/conference.js
@@ -55,6 +55,12 @@ const commands = {
 };
 
 /**
+ * Max length of the display names. If we receive longer display name the
+ * additional chars are going to be cut.
+ */
+const MAX_DISPLAYNAME_LENGTH = 50;
+
+/**
  * Open Connection. When authentication failed it shows auth dialog.
  * @param roomName the room name to use
  * @returns Promise<JitsiConnection>
@@ -281,15 +287,16 @@ function changeLocalEmail(email = '') {
  * @param nickname {string} the new display name
  */
 function changeLocalDisplayName(nickname = '') {
-    nickname = nickname.trim();
+    const formattedNickname
+        = nickname.trim().substr(0, MAX_DISPLAYNAME_LENGTH);
 
-    if (nickname === APP.settings.getDisplayName()) {
+    if (formattedNickname === APP.settings.getDisplayName()) {
         return;
     }
 
-    APP.settings.setDisplayName(nickname);
-    room.setDisplayName(nickname);
-    APP.UI.changeDisplayName(APP.conference.getMyUserId(), nickname);
+    APP.settings.setDisplayName(formattedNickname);
+    room.setDisplayName(formattedNickname);
+    APP.UI.changeDisplayName(APP.conference.getMyUserId(), formattedNickname);
 }
 
 class ConferenceConnector {
@@ -1268,8 +1275,10 @@ export default {
         });
 
         room.on(ConferenceEvents.DISPLAY_NAME_CHANGED, (id, displayName) => {
-            APP.API.notifyDisplayNameChanged(id, displayName);
-            APP.UI.changeDisplayName(id, displayName);
+            const formattedDisplayName
+                = displayName.substr(0, MAX_DISPLAYNAME_LENGTH);
+            APP.API.notifyDisplayNameChanged(id, formattedDisplayName);
+            APP.UI.changeDisplayName(id, formattedDisplayName);
         });
 
         room.on(ConferenceEvents.PARTICIPANT_PROPERTY_CHANGED,

--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -107,6 +107,10 @@
     float: left;
     padding-left: 5px;
     font-weight: bold;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 95%;
+    overflow: hidden;
 }
 
 #chat_container .timestamp {


### PR DESCRIPTION
The local and remote display names are limited to 50 chars.  Any additional chars are cut when the remote display name is received or the local is entered. 

Displaying long nicknames in the chat panel is improved.