### PR TITLE
Log the page reload from one place

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -370,11 +370,6 @@ class ConferenceConnector {
 
         case ConferenceErrors.FOCUS_LEFT:
         case ConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE:
-            // Log the page reload event
-            // FIXME (CallStats - issue) this event will not make it to
-            // the CallStats, because the log queue is not flushed, before
-            // "fabric terminated" is sent to the backed
-            APP.conference.logEvent('page.reload');
             // FIXME the conference should be stopped by the library and not by
             // the app. Both the errors above are unrecoverable from the library
             // perspective.

--- a/modules/UI/reload_overlay/PageReloadOverlay.js
+++ b/modules/UI/reload_overlay/PageReloadOverlay.js
@@ -116,6 +116,13 @@ export default {
         if (!overlay) {
             overlay = new PageReloadOverlayImpl(timeoutSeconds);
         }
+        // Log the page reload event
+        if (!this.isVisible()) {
+            // FIXME (CallStats - issue) this event will not make it to
+            // the CallStats, because the log queue is not flushed, before
+            // "fabric terminated" is sent to the backed
+            APP.conference.logEvent('page.reload');
+        }
         overlay.show();
     }
 };


### PR DESCRIPTION
The event was not logged in case when the page reload overlay was shown on XMPP connection dropped event:
https://github.com/jitsi/jitsi-meet/blob/master/conference.js#L564