### PR TITLE
Fixed problem with resizing thumb avatars

### DIFF
--- a/css/_mixins.scss
+++ b/css/_mixins.scss
@@ -66,6 +66,14 @@
   @include transform(translate(-50%, -50%))
 }
 
+/**
+* Defines the maximum width and height
+**/
+@mixin maxSize($value) {
+    max-width: $value;
+    max-height: $value;
+}
+
 @mixin transform($func) {
   -moz-transform: $func;
   -ms-transform: $func;

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -399,7 +399,8 @@
 }
 
 .userAvatar {
-    @include circle(60px);
+    @include maxSize(60px);
+    @include circle(50%);
     @include absoluteAligning();
 }
 


### PR DESCRIPTION
In this PR I fixed the problem of resizing small video avatars. Now the maximum size for them is __60px__. But for small sized they have __50%__ size of their containers.