### PR TITLE
Moved keyboard initialization to filmstrip toolbar

### DIFF
--- a/modules/UI/toolbars/Toolbar.js
+++ b/modules/UI/toolbars/Toolbar.js
@@ -117,10 +117,6 @@ const buttonHandlers = {
             }
         });
     },
-    "toolbar_film_strip": function () {
-        JitsiMeetJS.analytics.sendEvent('toolbar.filmstrip.toggled');
-        emitter.emit(UIEvents.TOGGLE_FILM_STRIP);
-    },
     "toolbar_button_raisehand": function () {
         JitsiMeetJS.analytics.sendEvent('toolbar.raiseHand.clicked');
         APP.conference.maybeToggleRaisedHand();
@@ -260,18 +256,6 @@ const defaultToolbarButtons = {
         className: "button icon-hangup",
         content: "Hang Up",
         i18n: "[content]toolbar.hangup"
-    },
-    'filmstrip': {
-        id: 'toolbar_film_strip',
-        tooltipKey: 'toolbar.filmstrip',
-        className: "button icon-toggle-filmstrip",
-        shortcut: "F",
-        shortcutAttr: "filmstripPopover",
-        shortcutFunc: function() {
-            JitsiMeetJS.analytics.sendEvent("shortcut.film.toggled");
-            APP.UI.toggleFilmStrip();
-        },
-        shortcutDescription: "keyboardShortcuts.toggleFilmstrip"
     },
     'raisehand': {
         id: "toolbar_button_raisehand",

--- a/modules/UI/videolayout/FilmStrip.js
+++ b/modules/UI/videolayout/FilmStrip.js
@@ -1,4 +1,4 @@
-/* global $, interfaceConfig */
+/* global $, APP, JitsiMeetJS, interfaceConfig */
 
 import UIEvents from "../../../service/UI/UIEvents";
 import UIUtil from "../util/UIUtil";
@@ -58,6 +58,29 @@ const FilmStrip = {
         let toggleFilmstripMethod = this.toggleFilmStrip.bind(this);
         let selector = '#hideVideoToolbar';
         $('#videospace').on('click', selector, toggleFilmstripMethod);
+
+        this._registerToggleFilmstripShortcut();
+    },
+
+    /**
+     * Registering toggle filmstrip shortcut
+     * @private
+     */
+    _registerToggleFilmstripShortcut() {
+        let shortcut = 'F';
+        let shortcutAttr = 'filmstripPopover';
+        let description = 'keyboardShortcuts.toggleFilmstrip';
+        let handler = () => {
+            JitsiMeetJS.analytics.sendEvent('toolbar.filmstrip.toggled');
+            APP.UI.toggleFilmStrip();
+        };
+
+        APP.keyboardshortcut.registerShortcut(
+            shortcut,
+            shortcutAttr,
+            handler,
+            description
+        );
     },
 
     /**

--- a/modules/UI/videolayout/FilmStrip.js
+++ b/modules/UI/videolayout/FilmStrip.js
@@ -72,7 +72,7 @@ const FilmStrip = {
         let description = 'keyboardShortcuts.toggleFilmstrip';
         let handler = () => {
             JitsiMeetJS.analytics.sendEvent('toolbar.filmstrip.toggled');
-            APP.UI.toggleFilmStrip();
+            this.eventEmitter.emit(UIEvents.TOGGLE_FILM_STRIP);
         };
 
         APP.keyboardshortcut.registerShortcut(


### PR DESCRIPTION
In this PR is moved initialization of toggle filmstrip shortcut from extended toolbar to filmstrip module. Also, delete corresponding button from extended toolbar in order to remove duplications.