### PR TITLE
fix: desktop streming screen size

### DIFF
--- a/modules/UI/videolayout/FilmStrip.js
+++ b/modules/UI/videolayout/FilmStrip.js
@@ -157,7 +157,7 @@ const FilmStrip = {
      */
     getFilmStripHeight() {
         if (this.isFilmStripVisible()) {
-            return this.filmStrip.outerHeight();
+            return $(`.${this.filmStripContainerClassName}`).outerHeight();
         } else {
             return 0;
         }

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -24,7 +24,7 @@ export default class LargeVideoManager {
             () => this.resizeContainer(VIDEO_CONTAINER_TYPE), emitter);
         this.addContainer(VIDEO_CONTAINER_TYPE, this.videoContainer);
 
-        // use the same video container to handle and desktop tracks
+        // use the same video container to handle desktop tracks
         this.addContainer("desktop", this.videoContainer);
 
         this.width = 0;

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -32,6 +32,10 @@ function getStreamOwnerId(stream) {
  * ratio and fits available area with it's larger dimension. This method
  * ensures that whole video will be visible and can leave empty areas.
  *
+ * @param videoWidth the width of the video to position
+ * @param videoHeight the height of the video to position
+ * @param videoSpaceWidth the width of the available space
+ * @param videoSpaceHeight the height of the available space
  * @return an array with 2 elements, the video width and the video height
  */
 function getDesktopVideoSize(videoWidth,


### PR DESCRIPTION
In desktop streaming mode the desktop screen show area wasn't calculated correctly and was appearing behind the video thumbnails. This PR fixes that problem.