### PR TITLE
Makes close button non-focusable.

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -474,7 +474,9 @@ UI.start = function () {
             "hideEasing": "linear",
             "showMethod": "fadeIn",
             "hideMethod": "fadeOut",
-            "newestOnTop": false
+            "newestOnTop": false,
+            // this is the default toastr close button html, just adds tabIndex
+            "closeHtml": '<button type="button" tabIndex="-1">&times;</button>'
         };
 
     }

--- a/modules/UI/util/MessageHandler.js
+++ b/modules/UI/util/MessageHandler.js
@@ -439,7 +439,7 @@ var messageHandler = {
      * @param messageKey the key from the language file for the text of the
      * message.
      * @param messageArguments object with the arguments for the message.
-     * @param options object with language options.
+     * @param options passed to toastr (e.g. timeOut)
      */
     notify: function(displayName, displayNameKey, cls, messageKey,
                      messageArguments, options) {


### PR DESCRIPTION
Prevents the close button to take focus while user clicks tab in the page, which will privent the toast to be closed.