### PR TITLE
Sending unpin after clicking local video and unpinning remote.

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -341,13 +341,19 @@ var VideoLayout = {
      * @param id the identifier of the video thumbnail
      */
     handleVideoThumbClicked (id) {
+        var smallVideo = VideoLayout.getSmallVideo(id);
         if(pinnedId) {
             var oldSmallVideo = VideoLayout.getSmallVideo(pinnedId);
-            if (oldSmallVideo && !interfaceConfig.filmStripOnly)
+            if (oldSmallVideo && !interfaceConfig.filmStripOnly) {
                 oldSmallVideo.focus(false);
+                // as no pinned event will be sent for local video
+                // and we will unpin old one, lets signal it
+                // otherwise we will just send the new pinned one
+                if (smallVideo.isLocal)
+                    eventEmitter.emit(
+                        UIEvents.PINNED_ENDPOINT, oldSmallVideo, false);
+            }
         }
-
-        var smallVideo = VideoLayout.getSmallVideo(id);
 
         // Unpin if currently pinned.
         if (pinnedId === id)


### PR DESCRIPTION
If we:
 - pin a remote and click it, unpin is signalled.
 - pin a remote and the click another remote, the new one is pinned and signalled.
 - pin a remote and then click local. UI pins local, but unpinning remote is not signaled, fix addressed with this commit.
 - pin/unpin local, nothing is signalled.