### PR TITLE
Add 'build' dir to jshintignore

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
+build/
 debian/
 libs/
 node_modules/


### PR DESCRIPTION
If build directory is not ignored, then one will not be able to commit anything while using "webpack --watch" incremental builds.