### PR TITLE
Fix disabled Welcome page broken with the introduction of React

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,9 +192,18 @@ function init() {
     APP.ConferenceUrl = new ConferenceUrl(window.location);
     // Clean up the URL displayed by the browser
     replaceHistoryState(APP.ConferenceUrl.getInviteUrl());
+
+    // TODO The execution of the mobile app starts from react/index.native.js.
+    // Similarly, the execution of the Web app should start from
+    // react/index.web.js for the sake of consistency and ease of understanding.
+    // Temporarily though because we are at the beginning of introducing React
+    // into the Web app, allow the execution of the Web app to start from app.js
+    // in order to reduce the complexity of the beginning step.
+    require('./react');
+
     const isUIReady = APP.UI.start();
     if (isUIReady) {
-        APP.conference.init({roomName: buildRoomName()}).then(function () {
+        APP.conference.init({roomName: buildRoomName()}).then(() => {
 
             if (APP.logCollector) {
                 // Start the LogCollector's periodic "store logs" task only if
@@ -227,13 +236,13 @@ function init() {
 
             APP.UI.initConference();
 
-            APP.UI.addListener(UIEvents.LANG_CHANGED, function (language) {
+            APP.UI.addListener(UIEvents.LANG_CHANGED, language => {
                 APP.translation.setLanguage(language);
                 APP.settings.setLanguage(language);
             });
 
             APP.keyboardshortcut.init();
-        }).catch(function (err) {
+        }).catch(err => {
             APP.UI.hideRingOverLay();
             APP.API.notifyConferenceLeft(APP.conference.roomName);
             logger.error(err);
@@ -283,14 +292,6 @@ $(document).ready(function () {
     logger.log("(TIME) document ready:\t", now);
 
     URLProcessor.setConfigParametersFromUrl();
-
-    // TODO The execution of the mobile app starts from react/index.native.js.
-    // Similarly, the execution of the Web app should start from
-    // react/index.web.js for the sake of consistency and ease of understanding.
-    // Temporarily though because we are at the beginning of introducing React
-    // into the Web app, allow the execution of the Web app to start from app.js
-    // in order to reduce the complexity of the beginning step.
-    require('./react');
 
     APP.init();
 

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 
+import { Conference } from '../../conference';
+
 /**
  * The web container rendering the welcome page.
  */
@@ -12,14 +14,23 @@ export default class WelcomePage extends Component {
      * @returns {ReactElement|null}
      */
     render() {
+        // FIXME The rendering of Conference bellow is a very quick and dirty
+        // temporary fix for the following issue: when the WelcomePage is
+        // disabled, app.js expects Conference to be rendered already and only
+        // then it builds a room name but the App component expects the room
+        // name to be built already (by looking at the window's location) in
+        // order to choose between WelcomePage and Conference.
         return (
-            <div id = 'welcome_page'>
-                {
-                    this._renderHeader()
-                }
-                {
-                    this._renderMain()
-                }
+            <div>
+                <div id = 'welcome_page'>
+                    {
+                        this._renderHeader()
+                    }
+                    {
+                        this._renderMain()
+                    }
+                </div>
+                <Conference />
             </div>
         );
     }


### PR DESCRIPTION
The React-based rewrite looks whether there's a room name (in the
window's location) in order to choose between WelcomePage and
Conference. But app.js expects Conference to be rendered before it
builds a room name if WelcomePage is disabled and there's no room name.
A quick and dirty workaround is to render Conference within WelcomePage
so that the rendered result closely resembles index.html before the
React-based rewrite.