### PR TITLE
Redux logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ local.properties
 #
 node_modules/
 npm-debug.log
+yarn.lock
+
+# iOS/CocoaPods
+#
+ios/Pods
 
 # BUCK
 #

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ STYLES_DESTINATION = css/all.css
 STYLES_MAIN = css/main.scss
 STYLES_UNSUPPORTED_BROWSER = css/unsupported_browser.scss
 WEBPACK = ./node_modules/.bin/webpack
+WEBPACK_DEV_SERVER = ./node_modules/.bin/webpack-dev-server
 
 all: update-deps compile deploy clean
 
-all-dev: compile-dev deploy clean
+dev-server:
+	$(WEBPACK_DEV_SERVER)
 
 # FIXME: there is a problem with node-sass not correctly installed (compiled)
 # a quick fix to make sure it is installed on every update

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,8 @@ STYLES_DESTINATION = css/all.css
 STYLES_MAIN = css/main.scss
 STYLES_UNSUPPORTED_BROWSER = css/unsupported_browser.scss
 WEBPACK = ./node_modules/.bin/webpack
-WEBPACK_DEV_SERVER = ./node_modules/.bin/webpack-dev-server
 
 all: update-deps compile deploy clean
-
-dev-server:
-	$(WEBPACK_DEV_SERVER)
 
 # FIXME: there is a problem with node-sass not correctly installed (compiled)
 # a quick fix to make sure it is installed on every update

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ WEBPACK = ./node_modules/.bin/webpack
 
 all: update-deps compile deploy clean
 
+all-dev: compile-dev deploy clean
+
 # FIXME: there is a problem with node-sass not correctly installed (compiled)
 # a quick fix to make sure it is installed on every update
 # the problem appears on linux and not on macosx
@@ -21,6 +23,9 @@ update-deps:
 
 compile:
 	$(WEBPACK) -p
+
+compile-dev:
+	$(WEBPACK)
 
 clean:
 	rm -fr $(BUILD_DIR)
@@ -32,10 +37,10 @@ deploy-init:
 
 deploy-appbundle:
 	cp \
-		$(BUILD_DIR)/app.bundle.min.js \
-		$(BUILD_DIR)/app.bundle.min.map \
-		$(BUILD_DIR)/external_api.min.js \
-		$(BUILD_DIR)/external_api.min.map \
+		$(BUILD_DIR)/app.bundle.js \
+		$(BUILD_DIR)/app.bundle.map \
+		$(BUILD_DIR)/external_api.js \
+		$(BUILD_DIR)/external_api.map \
 		$(OUTPUT_DIR)/analytics.js \
 		$(DEPLOY_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ deploy-init:
 
 deploy-appbundle:
 	cp \
-		$(BUILD_DIR)/app.bundle.js \
-		$(BUILD_DIR)/app.bundle.map \
-		$(BUILD_DIR)/external_api.js \
-		$(BUILD_DIR)/external_api.map \
+		$(BUILD_DIR)/app.bundle.min.js \
+		$(BUILD_DIR)/app.bundle.min.map \
+		$(BUILD_DIR)/external_api.min.js \
+		$(BUILD_DIR)/external_api.min.map \
 		$(OUTPUT_DIR)/analytics.js \
 		$(DEPLOY_DIR)
 

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     <script><!--#include virtual="/interface_config.js" --></script>
     <script><!--#include virtual="/logging_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
-    <script src="libs/app.bundle.min.js?v=139"></script>
+    <script src="libs/app.bundle.js?v=139"></script>
     <!--#include virtual="title.html" -->
     <link rel="stylesheet" href="css/all.css">
     <!--#include virtual="plugin.head.html" -->

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     <script><!--#include virtual="/interface_config.js" --></script>
     <script><!--#include virtual="/logging_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
-    <script src="libs/app.bundle.js?v=139"></script>
+    <script src="libs/app.bundle.min.js?v=139"></script>
     <!--#include virtual="title.html" -->
     <link rel="stylesheet" href="css/all.css">
     <!--#include virtual="plugin.head.html" -->

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-router": "^3.0.0",
     "react-router-redux": "^4.0.7",
     "redux": "^3.5.2",
+    "redux-logger": "^2.7.4",
     "redux-thunk": "^2.1.0",
     "retry": "0.6.1",
     "strophe": "1.2.4",

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -204,7 +204,9 @@ class WelcomePage extends AbstractWelcomePage {
      */
     _renderFeature(index) {
         return (
-            <div className = 'feature_holder'>
+            <div
+                className = 'feature_holder'
+                key = { index }>
                 <div
                     className = 'feature_icon'
                     data-i18n = { `welcomepage.feature${index}.title` } />

--- a/react/index.web.js
+++ b/react/index.web.js
@@ -1,3 +1,5 @@
+/* global process */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { browserHistory } from 'react-router';
@@ -14,6 +16,7 @@ import {
     MiddlewareRegistry,
     ReducerRegistry
 } from './features/base/redux';
+import createLogger from 'redux-logger';
 
 // Create combined reducer from all reducers in registry + routerReducer from
 // 'react-router-redux' module (stores location updates from history).
@@ -22,6 +25,17 @@ const reducer = ReducerRegistry.combineReducers({
     routing: routerReducer
 });
 
+const additionalMiddlewares = [
+    Thunk,
+    routerMiddleware(browserHistory)
+];
+
+// Enable logger for development environment
+if (process.env.NODE_ENV !== 'production') {
+    additionalMiddlewares.push(createLogger());
+}
+
+
 // Apply all registered middleware from the MiddlewareRegistry + additional
 // 3rd party middleware:
 // - Thunk - allows us to dispatch async actions easily. For more info
@@ -29,9 +43,7 @@ const reducer = ReducerRegistry.combineReducers({
 // - routerMiddleware - middleware from 'react-router-redux' module to track
 // changes in browser history inside Redux state. For more information
 // @see https://github.com/reactjs/react-router-redux.
-let middleware = MiddlewareRegistry.applyMiddleware(
-    Thunk,
-    routerMiddleware(browserHistory));
+let middleware = MiddlewareRegistry.applyMiddleware(...additionalMiddlewares);
 
 // Try to enable Redux DevTools Chrome extension in order to make it available
 // for the purposes of facilitating development.


### PR DESCRIPTION
  In this PR I added support of `redux-logger`. It logs to console after any action being dispatched such things as: state before and after dispatching the action and the action object itself. It is quite useful to trace changing the state of application and also easier to debug redux apps.
  Also I added task in `Makefile` for bundling development version of `js`'s (where actually `redux-logger` is enabled) and production version (`all-dev` and `all` respectively). 
  And made some changes in `.gitignore` (added to ignor list cocoa pods dependencies and `yarn.lock` file (see more on https://yarnpkg.com/)

__redux-logger logging example:__

<img width="643" alt="screen shot 2016-12-02 at 5 30 34 pm" src="https://cloud.githubusercontent.com/assets/5806075/20839956/3e839f96-b8b7-11e6-8817-c52e9337790c.png">

Also, here I pushed changes related to `webpack-dev-server` that can increase the speed of development on jitsi meet app. It servers files from `libs` and `css` folder from your local machine and proxies all other requests to the instance that you define in `JITSI_MEET_SERVER` env variable (by default it's `https://meet.jit.si`). Webpack devserver is encasulated in `dev-server` task in Makefile e.g. I run `JITSI_MEET_SERVER="https://illia.jitsi.net" make dev-server` to run the development version of the application proxying to my development server at `https://illia.jitsi.net`

