### PR TITLE
Should not depend on deployment on root context

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -211,7 +211,14 @@ function maybeRedirectToWelcomePage(options) {
     if (config.enableWelcomePage) {
         setTimeout(() => {
             APP.settings.setWelcomePageEnabled(true);
-            window.location.pathname = "/";
+            if ( window.location.pathname.lastIndexOf("/") > -1 ) {
+                window.location.pathname =
+                    window.location.pathname.substring(
+                        0, window.location.pathname.lastIndexOf("/") + 1);
+            }
+            else {
+                window.location.pathname = "/";
+            }
         }, 3000);
     }
 }

--- a/index.html
+++ b/index.html
@@ -120,12 +120,12 @@
         window.addEventListener(
             'error', loadErrHandler, true /* capture phase type of listener */);
     </script>
-    <script><!--#include virtual="/config.js" --></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
+    <script><!--#include virtual="config.js" --></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
     <script src="utils.js?v=1"></script>
     <!--#include virtual="connection_optimization/connection_optimization.html" -->
     <script src="connection_optimization/do_external_connect.js?v=1"></script>
-    <script><!--#include virtual="/interface_config.js" --></script>
-    <script><!--#include virtual="/logging_config.js" --></script>
+    <script><!--#include virtual="interface_config.js" --></script>
+    <script><!--#include virtual="logging_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
     <script src="libs/app.bundle.min.js?v=139"></script>
     <!--#include virtual="title.html" -->

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -397,7 +397,8 @@ UI.getSharedVideoManager = function () {
 UI.start = function () {
     document.title = interfaceConfig.APP_NAME;
     var setupWelcomePage = null;
-    if(config.enableWelcomePage && window.location.pathname == "/" &&
+    var regex = /\/([a-zA-Z0-9=\?]+)$/g;
+    if(config.enableWelcomePage && !regex.exec(window.location.pathname) &&
        Settings.isWelcomePageEnabled()) {
         $("#videoconference_page").hide();
         if (!setupWelcomePage)

--- a/modules/UI/welcome_page/WelcomePage.js
+++ b/modules/UI/welcome_page/WelcomePage.js
@@ -8,7 +8,10 @@ function enterRoom() {
         val = $enterRoomField.data("room-name");
     }
     if (val) {
-        window.location.pathname = "/" + val;
+        if (val.slice(-1) !== "/") {
+            window.location.pathname += "/";
+        }
+        window.location.pathname += val;
     }
 }
 

--- a/title.html
+++ b/title.html
@@ -1,9 +1,9 @@
 <title>Jitsi Meet</title>
 <meta property="og:title" content="Jitsi Meet"/>
-<meta property="og:image" content="/images/jitsilogo.png?v=1"/>
+<meta property="og:image" content="images/jitsilogo.png?v=1"/>
 <meta property="og:description" content="Join a WebRTC video conference powered by the Jitsi Videobridge"/>
 <meta description="Join a WebRTC video conference powered by the Jitsi Videobridge"/>
 <meta itemprop="name" content="Jitsi Meet"/>
 <meta itemprop="description" content="Join a WebRTC video conference powered by the Jitsi Videobridge"/>
-<meta itemprop="image" content="/images/jitsilogo.png?v=1"/>
-<link rel="icon" type="image/png" href="/images/favicon.ico?v=1"/>
+<meta itemprop="image" content="images/jitsilogo.png?v=1"/>
+<link rel="icon" type="image/png" href="images/favicon.ico?v=1"/>

--- a/utils.js
+++ b/utils.js
@@ -20,15 +20,17 @@ function getRoomName () { // eslint-disable-line no-unused-vars
         roomName = config.getroomnode(path);
     } else {
         /* fall back to default strategy
-         * this is making assumptions about how the URL->room mapping happens.
-         * It currently assumes deployment at root, with a rewrite like the
-         * following one (for nginx):
-         location ~ ^/([a-zA-Z0-9]+)$ {
-         rewrite ^/(.*)$ / break;
-         }
-        */
+         * This is making assumptions about how the URL->room mapping happens.
+         * It assumes that the room name is expressed in the URL in the last
+         * part of the (non-empty) URL path, that matches the regular
+         * expression pattern used for rewrite rules in NGINX: [a-zA-Z0-9=\?]+
+         */
         if (path.length > 1) {
-            roomName = path.substr(1).toLowerCase();
+            var regex = /\/([a-zA-Z0-9=\?]+)$/g;
+            var match = regex.exec(path);
+            if ( match && match.length > 0 ) {
+                roomName = match[1].toLowerCase();
+            }
         }
     }
 


### PR DESCRIPTION
This commit improves support for exposure of the web application on an
URL that is not the 'root context' of a domain. In other words, with
this commit, one should be able to expose the application not only via
an URL like http://meet.example.org, but also via http://example.org/meet

This commit fixes:
 - the URL prefix on the "enter room container" in the welcome page.
 - determination of what is the room name.
 - redirection back to the welcome page after hangup.

Instead of assuming that a room name is the entire URL path, the code
now re-uses the regular expression as documented to be used in NGINX
(for forwarding 'room' HTTP requests back to the index.html file).
Although not a complete fix (a config can define a custom roomnode
function), this is an improvement over 'everything after the slash'.