### PR TITLE
Remove strophe-caps dependancy

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ import "jquery-contextmenu";
 import "jquery-ui";
 import "strophe";
 import "strophe-disco";
-import "strophe-caps";
 import "jQuery-Impromptu";
 import "autosize";
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "jQuery-Impromptu": "jQuery-Impromptu/src/jquery-impromptu.js",
     "popover": "./node_modules/bootstrap/js/popover.js",
     "strophe-disco": "./node_modules/strophejs-plugins/disco/strophe.disco.js",
-    "strophe-caps": "./node_modules/strophejs-plugins/caps/strophe.caps.jsonly.js",
     "tooltip": "./node_modules/bootstrap/js/tooltip.js"
   }
 }


### PR DESCRIPTION
Since https://github.com/jitsi/lib-jitsi-meet/pull/333 we don’t need strophe-caps plugin anymore.