### PR TITLE
Name Redux actions consistently

### DIFF
--- a/react/features/base/media/actionTypes.js
+++ b/react/features/base/media/actionTypes.js
@@ -1,31 +1,31 @@
 import { Symbol } from '../react';
 
 /**
- * Action to change muted state of the local audio.
+ * Action to change the muted state of the local audio.
  *
  * {
- *      type: AUDIO_MUTED_CHANGED,
+ *      type: SET_AUDIO_MUTED,
  *      muted: boolean
  * }
  */
-export const AUDIO_MUTED_CHANGED = Symbol('AUDIO_MUTED_CHANGED');
+export const SET_AUDIO_MUTED = Symbol('SET_AUDIO_MUTED');
 
 /**
- * Action to signal a change of the facing mode of the local video camera.
+ * Action to change the facing mode of the local video camera.
  *
  * {
- *      type: CAMERA_FACING_MODE_CHANGED,
+ *      type: SET_CAMERA_FACING_MODE,
  *      cameraFacingMode: CAMERA_FACING_MODE
  * }
  */
-export const CAMERA_FACING_MODE_CHANGED = Symbol('CAMERA_FACING_MODE_CHANGED');
+export const SET_CAMERA_FACING_MODE = Symbol('SET_CAMERA_FACING_MODE');
 
 /**
- * Action to change muted state of the local video.
+ * Action to change the muted state of the local video.
  *
  * {
- *      type: VIDEO_MUTED_CHANGED,
+ *      type: SET_VIDEO_MUTED,
  *      muted: boolean
  * }
  */
-export const VIDEO_MUTED_CHANGED = Symbol('VIDEO_MUTED_CHANGED');
+export const SET_VIDEO_MUTED = Symbol('SET_VIDEO_MUTED');

--- a/react/features/base/media/actions.js
+++ b/react/features/base/media/actions.js
@@ -1,40 +1,40 @@
 import {
-    AUDIO_MUTED_CHANGED,
-    CAMERA_FACING_MODE_CHANGED,
-    VIDEO_MUTED_CHANGED
+    SET_AUDIO_MUTED,
+    SET_CAMERA_FACING_MODE,
+    SET_VIDEO_MUTED
 } from './actionTypes';
 import { CAMERA_FACING_MODE } from './constants';
 import './middleware';
 import './reducer';
 
 /**
- * Action to signal the change in local audio muted state.
+ * Action to change the local audio muted state.
  *
  * @param {boolean} muted - If local audio is muted.
  * @returns {{
- *      type: AUDIO_MUTED_CHANGED,
+ *      type: SET_AUDIO_MUTED,
  *      muted: boolean
  *  }}
  */
-export function audioMutedChanged(muted) {
+export function setAudioMuted(muted) {
     return {
-        type: AUDIO_MUTED_CHANGED,
+        type: SET_AUDIO_MUTED,
         muted
     };
 }
 
 /**
- * Action to signal the change in facing mode of local video camera.
+ * Action to change the facing mode of the local video camera.
  *
  * @param {CAMERA_FACING_MODE} cameraFacingMode - Camera facing mode.
  * @returns {{
- *      type: CAMERA_FACING_MODE_CHANGED,
+ *      type: SET_CAMERA_FACING_MODE,
  *      cameraFacingMode: CAMERA_FACING_MODE
  *  }}
  */
-export function cameraFacingModeChanged(cameraFacingMode) {
+export function setCameraFacingMode(cameraFacingMode) {
     return {
-        type: CAMERA_FACING_MODE_CHANGED,
+        type: SET_CAMERA_FACING_MODE,
         cameraFacingMode
     };
 }
@@ -48,7 +48,7 @@ export function toggleAudioMuted() {
     return (dispatch, getState) => {
         const muted = getState()['features/base/media'].audio.muted;
 
-        return dispatch(audioMutedChanged(!muted));
+        return dispatch(setAudioMuted(!muted));
     };
 }
 
@@ -67,7 +67,7 @@ export function toggleCameraFacingMode() {
                 ? CAMERA_FACING_MODE.ENVIRONMENT
                 : CAMERA_FACING_MODE.USER;
 
-        return dispatch(cameraFacingModeChanged(cameraFacingMode));
+        return dispatch(setCameraFacingMode(cameraFacingMode));
     };
 }
 
@@ -80,22 +80,22 @@ export function toggleVideoMuted() {
     return (dispatch, getState) => {
         const muted = getState()['features/base/media'].video.muted;
 
-        return dispatch(videoMutedChanged(!muted));
+        return dispatch(setVideoMuted(!muted));
     };
 }
 
 /**
- * Action to signal the change in local video muted state.
+ * Action to change the local video muted state.
  *
  * @param {boolean} muted - If local video is muted.
  * @returns {{
- *      type: VIDEO_MUTED_CHANGED,
+ *      type: SET_VIDEO_MUTED,
  *      muted: boolean
  *  }}
  */
-export function videoMutedChanged(muted) {
+export function setVideoMuted(muted) {
     return {
-        type: VIDEO_MUTED_CHANGED,
+        type: SET_VIDEO_MUTED,
         muted
     };
 }

--- a/react/features/base/media/middleware.js
+++ b/react/features/base/media/middleware.js
@@ -3,9 +3,9 @@ import { MiddlewareRegistry } from '../redux';
 import { setTrackMuted, TRACK_ADDED } from '../tracks';
 
 import {
-    audioMutedChanged,
-    cameraFacingModeChanged,
-    videoMutedChanged
+    setAudioMuted,
+    setCameraFacingMode,
+    setVideoMuted
 } from './actions';
 import { CAMERA_FACING_MODE } from './constants';
 
@@ -42,10 +42,10 @@ function resetInitialMediaState(store) {
     const { dispatch, getState } = store;
     const state = getState()['features/base/media'];
 
-    state.audio.muted && dispatch(audioMutedChanged(false));
+    state.audio.muted && dispatch(setAudioMuted(false));
     (state.video.facingMode !== CAMERA_FACING_MODE.USER)
-        && dispatch(cameraFacingModeChanged(CAMERA_FACING_MODE.USER));
-    state.video.muted && dispatch(videoMutedChanged(false));
+        && dispatch(setCameraFacingMode(CAMERA_FACING_MODE.USER));
+    state.video.muted && dispatch(setVideoMuted(false));
 }
 
 /**

--- a/react/features/base/media/reducer.js
+++ b/react/features/base/media/reducer.js
@@ -3,9 +3,9 @@ import { combineReducers } from 'redux';
 import { ReducerRegistry } from '../redux';
 
 import {
-    AUDIO_MUTED_CHANGED,
-    CAMERA_FACING_MODE_CHANGED,
-    VIDEO_MUTED_CHANGED
+    SET_AUDIO_MUTED,
+    SET_CAMERA_FACING_MODE,
+    SET_VIDEO_MUTED
 } from './actionTypes';
 import { CAMERA_FACING_MODE } from './constants';
 
@@ -35,7 +35,7 @@ const AUDIO_INITIAL_MEDIA_STATE = {
  */
 function audio(state = AUDIO_INITIAL_MEDIA_STATE, action) {
     switch (action.type) {
-    case AUDIO_MUTED_CHANGED:
+    case SET_AUDIO_MUTED:
         return {
             ...state,
             muted: action.muted
@@ -74,13 +74,13 @@ const VIDEO_INITIAL_MEDIA_STATE = {
  */
 function video(state = VIDEO_INITIAL_MEDIA_STATE, action) {
     switch (action.type) {
-    case CAMERA_FACING_MODE_CHANGED:
+    case SET_CAMERA_FACING_MODE:
         return {
             ...state,
             facingMode: action.cameraFacingMode
         };
 
-    case VIDEO_MUTED_CHANGED:
+    case SET_VIDEO_MUTED:
         return {
             ...state,
             muted: action.muted

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -3,12 +3,12 @@ import {
     LIB_INITIALIZED
 } from '../lib-jitsi-meet';
 import {
-    AUDIO_MUTED_CHANGED,
-    audioMutedChanged,
-    CAMERA_FACING_MODE_CHANGED,
     MEDIA_TYPE,
-    VIDEO_MUTED_CHANGED,
-    videoMutedChanged
+    SET_AUDIO_MUTED,
+    SET_CAMERA_FACING_MODE,
+    SET_VIDEO_MUTED,
+    setAudioMuted,
+    setVideoMuted
 } from '../media';
 import { MiddlewareRegistry } from '../redux';
 
@@ -32,11 +32,11 @@ import {
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-    case AUDIO_MUTED_CHANGED:
-        _mutedChanged(store, action, MEDIA_TYPE.AUDIO);
+    case SET_AUDIO_MUTED:
+        _setMuted(store, action, MEDIA_TYPE.AUDIO);
         break;
 
-    case CAMERA_FACING_MODE_CHANGED:
+    case SET_CAMERA_FACING_MODE:
         store.dispatch(
             createLocalTracks({
                 devices: [ MEDIA_TYPE.VIDEO ],
@@ -56,8 +56,8 @@ MiddlewareRegistry.register(store => next => action => {
     case TRACK_UPDATED:
         return _trackUpdated(store, next, action);
 
-    case VIDEO_MUTED_CHANGED:
-        _mutedChanged(store, action, MEDIA_TYPE.VIDEO);
+    case SET_VIDEO_MUTED:
+        _setMuted(store, action, MEDIA_TYPE.VIDEO);
         break;
     }
 
@@ -91,7 +91,7 @@ function _getLocalTrack(store, mediaType) {
  * @private
  * @returns {void}
  */
-function _mutedChanged(store, action, mediaType) {
+function _setMuted(store, action, mediaType) {
     const localTrack = _getLocalTrack(store, mediaType);
 
     localTrack && setTrackMuted(localTrack.jitsiTrack, action.muted);
@@ -145,10 +145,10 @@ function _trackUpdated(store, next, action) {
             if (oldMuted !== newMuted) {
                 switch (mediaType) {
                 case MEDIA_TYPE.AUDIO:
-                    store.dispatch(audioMutedChanged(newMuted));
+                    store.dispatch(setAudioMuted(newMuted));
                     break;
                 case MEDIA_TYPE.VIDEO:
-                    store.dispatch(videoMutedChanged(newMuted));
+                    store.dispatch(setVideoMuted(newMuted));
                     break;
                 }
             }

--- a/react/features/largeVideo/actionTypes.js
+++ b/react/features/largeVideo/actionTypes.js
@@ -1,12 +1,12 @@
 import { Symbol } from '../base/react';
 
 /**
- * Action to change the participant to be displayed in LargeVideo.
+ * Action to select the participant to be displayed in LargeVideo.
  *
  * {
- *     type: LARGE_VIDEO_PARTICIPANT_CHANGED,
+ *     type: SELECT_LARGE_VIDEO_PARTICIPANT,
  *     participantId: (string|undefined)
  * }
  */
-export const LARGE_VIDEO_PARTICIPANT_CHANGED
-    = Symbol('LARGE_VIDEO_PARTICIPANT_CHANGED');
+export const SELECT_LARGE_VIDEO_PARTICIPANT
+    = Symbol('SELECT_LARGE_VIDEO_PARTICIPANT');

--- a/react/features/largeVideo/actions.js
+++ b/react/features/largeVideo/actions.js
@@ -8,7 +8,7 @@ import {
     getTrackByMediaTypeAndParticipant
 } from '../base/tracks';
 
-import { LARGE_VIDEO_PARTICIPANT_CHANGED } from './actionTypes';
+import { SELECT_LARGE_VIDEO_PARTICIPANT } from './actionTypes';
 import './middleware';
 import './reducer';
 
@@ -60,7 +60,7 @@ export function selectParticipantInLargeVideo() {
 
         if (participantId !== largeVideo.participantId) {
             dispatch({
-                type: LARGE_VIDEO_PARTICIPANT_CHANGED,
+                type: SELECT_LARGE_VIDEO_PARTICIPANT,
                 participantId
             });
 

--- a/react/features/largeVideo/reducer.js
+++ b/react/features/largeVideo/reducer.js
@@ -1,7 +1,7 @@
 import { PARTICIPANT_ID_CHANGED } from '../base/participants';
 import { ReducerRegistry } from '../base/redux';
 
-import { LARGE_VIDEO_PARTICIPANT_CHANGED } from './actionTypes';
+import { SELECT_LARGE_VIDEO_PARTICIPANT } from './actionTypes';
 
 ReducerRegistry.register('features/largeVideo', (state = {}, action) => {
     switch (action.type) {
@@ -20,7 +20,7 @@ ReducerRegistry.register('features/largeVideo', (state = {}, action) => {
         }
         break;
 
-    case LARGE_VIDEO_PARTICIPANT_CHANGED:
+    case SELECT_LARGE_VIDEO_PARTICIPANT:
         return {
             ...state,
             participantId: action.participantId


### PR DESCRIPTION
Redux actions which represent "commands" should be imperative, and those
representing events should use the past tense.