### PR TITLE
Fix d17cc9fa

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -43,14 +43,14 @@ $toolbarBadgeColor: #FFFFFF;
 $toolbarToggleBackground: #12499C;
 $splitterToolbarButtonMargin: 18px;
 
-/*
+/**
  * Main controls
  * TODO: looks like we don't use it
  */
 $inputSemiBackground: rgba(132, 132, 132, .8);
 $inputLightBackground: #EBEBEB;
 
-/*
+/**
  * Video layout
  */
 $videoThumbnailHovered: rgba(22, 94, 204, .4);

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "react-native-vector-icons": "^3.0.0",
     "react-native-webrtc": "jitsi/react-native-webrtc",
     "react-redux": "^5.0.2",
-    "react-router": "^3.0.0",
-    "react-router-redux": "^4.0.7",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
     "retry": "0.6.1",

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -12,18 +12,6 @@ import {
 } from '../actions';
 
 /**
- * Default config.
- *
- * @type {Object}
- */
-const DEFAULT_CONFIG = {
-    configLocation: './config.js',
-    hosts: {
-        domain: 'meet.jit.si'
-    }
-};
-
-/**
  * Base (abstract) class for main App component.
  *
  * @abstract
@@ -57,12 +45,7 @@ export class AbstractApp extends Component {
 
         dispatch(localParticipantJoined());
 
-        const config
-            = typeof this.props.config === 'object'
-                ? this.props.config
-                : DEFAULT_CONFIG;
-
-        this._openURL(this.props.url || `https://${config.hosts.domain}`);
+        this._openURL(this._getDefaultURL());
     }
 
     /**
@@ -114,6 +97,68 @@ export class AbstractApp extends Component {
 
         // eslint-disable-next-line object-property-newline
         return React.createElement(component, { ...thisProps, ...props });
+    }
+
+    /**
+     * Gets the default URL to be opened when this App mounts.
+     *
+     * @private
+     * @returns {string} The default URL to be opened when this App mounts.
+     */
+    _getDefaultURL() {
+        // If the URL was explicitly specified to the React Component, then open
+        // it.
+        let url = this.props.url;
+
+        if (url) {
+            return url;
+        }
+
+        // If the execution environment provides a Location abstraction, then
+        // this App at already at that location but it must be made aware of the
+        // fact.
+        const windowLocation = this._getWindowLocation();
+
+        if (windowLocation) {
+            url = windowLocation.toString();
+            if (url) {
+                return url;
+            }
+        }
+
+        // By default, open the domain configured in the configuration file
+        // which may be the domain at which the whole server infrastructure is
+        // deployed.
+        const config = this.props.config;
+
+        if (typeof config === 'object') {
+            const hosts = config.hosts;
+
+            if (typeof hosts === 'object') {
+                const domain = hosts.domain;
+
+                if (domain) {
+                    return `https://${domain}`;
+                }
+            }
+        }
+
+        return 'https://meet.jit.si';
+    }
+
+    /**
+     * Gets a Location object from the window with information about the current
+     * location of the document. Explicitly defined to allow extenders to
+     * override because React Native does not usually have a location property
+     * on its window unless debugging remotely in which case the browser that is
+     * the remote debugger will provide a location property on the window.
+     *
+     * @protected
+     * @returns {Location} A Location object with information about the current
+     * location of the document.
+     */
+    _getWindowLocation() {
+        return undefined;
     }
 
     /**

--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -1,8 +1,10 @@
 /* global __DEV__ */
 
 import React from 'react';
-import { Linking, Navigator, Platform } from 'react-native';
+import { Linking, Navigator } from 'react-native';
 import { Provider } from 'react-redux';
+
+import { Platform } from '../../base/react';
 
 import { _getRouteToRender } from '../functions';
 import { AbstractApp } from './AbstractApp';

--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -1,12 +1,9 @@
 /* global __DEV__ */
 
-import React from 'react';
-import { Linking, Navigator } from 'react-native';
-import { Provider } from 'react-redux';
+import { Linking } from 'react-native';
 
 import { Platform } from '../../base/react';
 
-import { _getRouteToRender } from '../functions';
 import { AbstractApp } from './AbstractApp';
 
 /**
@@ -32,7 +29,6 @@ export class App extends AbstractApp {
         super(props);
 
         // Bind event handlers so they are only bound once for every instance.
-        this._navigatorRenderScene = this._navigatorRenderScene.bind(this);
         this._onLinkingURL = this._onLinkingURL.bind(this);
 
         // In the Release configuration, React Native will (intentionally) throw
@@ -71,47 +67,6 @@ export class App extends AbstractApp {
     }
 
     /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const store = this.props.store;
-
-        /* eslint-disable brace-style, react/jsx-no-bind */
-
-        return (
-            <Provider store = { store }>
-                <Navigator
-                    initialRoute = { _getRouteToRender(store.getState) }
-                    ref = { navigator => { this.navigator = navigator; } }
-                    renderScene = { this._navigatorRenderScene } />
-            </Provider>
-        );
-
-        /* eslint-enable brace-style, react/jsx-no-bind */
-    }
-
-    /**
-     * Navigates to a specific Route (via platform-specific means).
-     *
-     * @param {Route} route - The Route to which to navigate.
-     * @returns {void}
-     */
-    _navigate(route) {
-        const navigator = this.navigator;
-
-        // TODO Currently, the replace method doesn't support animation. Work
-        // towards adding it is done in
-        // https://github.com/facebook/react-native/issues/1981
-        // XXX React Native's Navigator adds properties to the route it's
-        // provided with. Clone the specified route in order to prevent its
-        // modification.
-        navigator && navigator.replace({ ...route });
-    }
-
-    /**
      * Attempts to disable the use of React Native
      * {@link ExceptionsManager#handleException} on platforms and in
      * configurations on/in which the use of the method in questions has been
@@ -147,24 +102,6 @@ export class App extends AbstractApp {
             newHandler.next = oldHandler;
             global.ErrorUtils.setGlobalHandler(newHandler);
         }
-    }
-
-    /**
-     * Renders the scene identified by a specific route in the Navigator of this
-     * instance.
-     *
-     * @param {Object} route - The route which identifies the scene to be
-     * rendered in the associated Navigator. In the fashion of NavigatorIOS, the
-     * specified route is expected to define a value for its component property
-     * which is the type of React component to be rendered.
-     * @private
-     * @returns {ReactElement}
-     */
-    _navigatorRenderScene(route) {
-        // We started with NavigatorIOS and then switched to Navigator in order
-        // to support Android as well. In order to reduce the number of
-        // modifications, accept the same format of route definition.
-        return this._createElement(route.component, {});
     }
 
     /**

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -1,10 +1,3 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import { browserHistory, Route, Router } from 'react-router';
-import { push, replace, syncHistoryWithStore } from 'react-router-redux';
-
-import { RouteRegistry } from '../../base/navigator';
-
 import { appInit } from '../actions';
 import { AbstractApp } from './AbstractApp';
 
@@ -22,26 +15,6 @@ export class App extends AbstractApp {
     static propTypes = AbstractApp.propTypes
 
     /**
-     * Initializes a new App instance.
-     *
-     * @param {Object} props - The read-only React Component props with which
-     * the new instance is to be initialized.
-     */
-    constructor(props) {
-        super(props);
-
-        /**
-         * Create an enhanced history that syncs navigation events with the
-         * store.
-         * @link https://github.com/reactjs/react-router-redux#how-it-works
-         */
-        this.history = syncHistoryWithStore(browserHistory, props.store);
-
-        // Bind event handlers so they are only bound once for every instance.
-        this._routerCreateElement = this._routerCreateElement.bind(this);
-    }
-
-    /**
      * Inits the app before component will mount.
      *
      * @inheritdoc
@@ -50,26 +23,6 @@ export class App extends AbstractApp {
         super.componentWillMount(...args);
 
         this.props.store.dispatch(appInit());
-    }
-
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        return (
-            <Provider store = { this.props.store }>
-                <Router
-                    createElement = { this._routerCreateElement }
-                    history = { this.history }>
-                    {
-                        this._renderRoutes()
-                    }
-                </Router>
-            </Provider>
-        );
     }
 
     /**
@@ -86,6 +39,7 @@ export class App extends AbstractApp {
      * Navigates to a specific Route (via platform-specific means).
      *
      * @param {Route} route - The Route to which to navigate.
+     * @protected
      * @returns {void}
      */
     _navigate(route) {
@@ -100,81 +54,19 @@ export class App extends AbstractApp {
                 /:room/g,
                 store.getState()['features/base/conference'].room);
 
-        return (
-            store.dispatch(
-                    (window.location.pathname === path ? replace : push)(
-                            path)));
-    }
+        // Navigate to the specified Route.
+        const windowLocation = this._getWindowLocation();
 
-    /**
-     * Invoked by react-router to notify this App that a Route is about to be
-     * rendered.
-     *
-     * @param {Route} route - The Route that is about to be rendered.
-     * @private
-     * @returns {void}
-     */
-    _onRouteEnter(route, ...args) {
-        // Notify the route that it is about to be entered.
-        const onEnter = route.onEnter;
-
-        if (typeof onEnter === 'function') {
-            onEnter(...args);
+        if (windowLocation.pathname === path) {
+            // The browser is at the specified path already and what remains is
+            // to make this App instance aware of the route to be rendered at
+            // the current location.
+            super._navigate(route);
+        } else {
+            // The browser must go to the specified location. Once the specified
+            // location becomes current, the App will be made aware of the route
+            // to be rendered at it.
+            windowLocation.pathname = path;
         }
-
-        // XXX The following is mandatory. Otherwise, moving back & forward
-        // through the browser's history could leave this App on the Conference
-        // page without a room name.
-
-        // Our Router configuration (at the time of this writing) is such that
-        // each Route corresponds to a single URL. Hence, entering into a Route
-        // is like opening a URL.
-        this._openURL(window.location.toString());
-    }
-
-    /**
-     * Renders a specific Route (for the purposes of the Router of this App).
-     *
-     * @param {Object} route - The Route to render.
-     * @returns {ReactElement}
-     * @private
-     */
-    _renderRoute(route) {
-        const onEnter = (...args) => {
-            this._onRouteEnter(route, ...args);
-        };
-
-        return (
-            <Route
-                component = { route.component }
-                key = { route.component }
-                onEnter = { onEnter }
-                path = { route.path } />
-        );
-    }
-
-    /**
-     * Renders the Routes of the Router of this App.
-     *
-     * @returns {Array.<ReactElement>}
-     * @private
-     */
-    _renderRoutes() {
-        return RouteRegistry.getRoutes().map(this._renderRoute, this);
-    }
-
-    /**
-     * Create a ReactElement from the specified component and props on behalf of
-     * the associated Router.
-     *
-     * @param {Component} component - The component from which the ReactElement
-     * is to be created.
-     * @param {Object} props - The read-only React Component props with which
-     * the ReactElement is to be initialized.
-     * @private
-     * @returns {ReactElement}
-     */
-    _routerCreateElement(component, props) {
-        return this._createElement(component, props);
     }
 }

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { browserHistory, Route, Router } from 'react-router';
-import { push, syncHistoryWithStore } from 'react-router-redux';
+import { push, replace, syncHistoryWithStore } from 'react-router-redux';
 
-import { getDomain } from '../../base/connection';
 import { RouteRegistry } from '../../base/navigator';
 
 import { appInit } from '../actions';
@@ -74,6 +73,16 @@ export class App extends AbstractApp {
     }
 
     /**
+     * Gets a Location object from the window with information about the current
+     * location of the document.
+     *
+     * @inheritdoc
+     */
+    _getWindowLocation() {
+        return window.location;
+    }
+
+    /**
      * Navigates to a specific Route (via platform-specific means).
      *
      * @param {Route} route - The Route to which to navigate.
@@ -91,7 +100,10 @@ export class App extends AbstractApp {
                 /:room/g,
                 store.getState()['features/base/conference'].room);
 
-        return store.dispatch(push(path));
+        return (
+            store.dispatch(
+                    (window.location.pathname === path ? replace : push)(
+                            path)));
     }
 
     /**
@@ -117,15 +129,7 @@ export class App extends AbstractApp {
         // Our Router configuration (at the time of this writing) is such that
         // each Route corresponds to a single URL. Hence, entering into a Route
         // is like opening a URL.
-
-        // XXX In order to unify work with URLs in web and native environments,
-        // we will construct URL here with correct domain from config.
-        const currentDomain = getDomain(this.props.store.getState);
-        const url
-            = new URL(window.location.pathname, `https://${currentDomain}`)
-                .toString();
-
-        this._openURL(url);
+        this._openURL(window.location.toString());
     }
 
     /**

--- a/react/features/app/functions.native.js
+++ b/react/features/app/functions.native.js
@@ -107,8 +107,8 @@ function _urlStringToObject(url) {
         try {
             urlObj = new URL(url);
         } catch (ex) {
-            // The return value will signal the failure & the logged
-            // exception will provide the details to the developers.
+            // The return value will signal the failure & the logged exception
+            // will provide the details to the developers.
             console.log(`${url} seems to be not a valid URL, but it's OK`, ex);
         }
     }

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -182,7 +182,11 @@ export function createConference() {
 
         // TODO Take options from config.
         const conference
-            = connection.initJitsiConference(room, { openSctp: true });
+            = connection.initJitsiConference(
+
+                    // XXX Lib-jitsi-meet does not accept uppercase letters.
+                    room.toLowerCase(),
+                    { openSctp: true });
 
         _addConferenceListeners(conference, dispatch);
 

--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -245,10 +245,7 @@ function _setPassword(state, action) {
 function _setRoom(state, action) {
     let room = action.room;
 
-    if (isRoomValid(room)) {
-        // XXX Lib-jitsi-meet does not accept uppercase letters.
-        room = room.toLowerCase();
-    } else {
+    if (!isRoomValid(room)) {
         // Technically, there are multiple values which don't represent valid
         // room names. Practically, each of them is as bad as the rest of them
         // because we can't use any of them to join a conference.

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -16,7 +16,9 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 export function connect() {
     return (dispatch, getState) => {
         const state = getState();
-        const room = state['features/base/conference'].room;
+
+        // XXX Lib-jitsi-meet does not accept uppercase letters.
+        const room = state['features/base/conference'].room.toLowerCase();
 
         // XXX For web based version we use conference initialization logic
         // from the old app (at the moment of writing).

--- a/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
+++ b/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
@@ -1,9 +1,6 @@
-import { Platform } from 'react-native';
-import {
-    RTCPeerConnection,
-    RTCSessionDescription
-} from 'react-native-webrtc';
+import { RTCPeerConnection, RTCSessionDescription } from 'react-native-webrtc';
 
+import { Platform } from '../../react';
 import { POSIX } from '../../react-native';
 
 // XXX At the time of this writing extending RTCPeerConnection using ES6 'class'

--- a/react/features/base/media/components/native/Video.js
+++ b/react/features/base/media/components/native/Video.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
-import { Platform, View } from 'react-native';
+import { View } from 'react-native';
 import { RTCView } from 'react-native-webrtc';
+
+import { Platform } from '../../../react';
 
 import { styles } from './styles';
 

--- a/react/features/base/react/Platform.native.js
+++ b/react/features/base/react/Platform.native.js
@@ -1,0 +1,4 @@
+// Re-export react-native's Platform because we want to provide a minimal
+// equivalent on Web.
+import { Platform } from 'react-native';
+export default Platform;

--- a/react/features/base/react/Platform.web.js
+++ b/react/features/base/react/Platform.web.js
@@ -1,0 +1,20 @@
+const userAgent = navigator.userAgent;
+let OS;
+
+if (userAgent.match(/Android/i)) {
+    OS = 'android';
+} else if (userAgent.match(/iP(ad|hone|od)/i)) {
+    OS = 'ios';
+}
+
+/**
+ * Provides a minimal equivalent of react-native's Platform abstraction.
+ */
+export default {
+    /**
+     * The operating system on which the application is executing.
+     *
+     * @type {string}
+     */
+    OS
+};

--- a/react/features/base/react/index.js
+++ b/react/features/base/react/index.js
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './functions';
+export { default as Platform } from './Platform';
 export { default as Symbol } from './Symbol';

--- a/react/index.web.js
+++ b/react/index.web.js
@@ -2,8 +2,6 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { browserHistory } from 'react-router';
-import { routerMiddleware, routerReducer } from 'react-router-redux';
 import { compose, createStore } from 'redux';
 import Thunk from 'redux-thunk';
 
@@ -13,23 +11,14 @@ import { MiddlewareRegistry, ReducerRegistry } from './features/base/redux';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
 
-// Create combined reducer from all reducers in registry + routerReducer from
-// 'react-router-redux' module (stores location updates from history).
-// @see https://github.com/reactjs/react-router-redux#routerreducer.
-const reducer = ReducerRegistry.combineReducers({
-    routing: routerReducer
-});
+// Create combined reducer from all reducers in registry.
+const reducer = ReducerRegistry.combineReducers();
 
 // Apply all registered middleware from the MiddlewareRegistry + additional
 // 3rd party middleware:
 // - Thunk - allows us to dispatch async actions easily. For more info
 // @see https://github.com/gaearon/redux-thunk.
-// - routerMiddleware - middleware from 'react-router-redux' module to track
-// changes in browser history inside Redux state. For more information
-// @see https://github.com/reactjs/react-router-redux.
-let middleware = MiddlewareRegistry.applyMiddleware(
-    Thunk,
-    routerMiddleware(browserHistory));
+let middleware = MiddlewareRegistry.applyMiddleware(Thunk);
 
 // Try to enable Redux DevTools Chrome extension in order to make it available
 // for the purposes of facilitating development.

--- a/react/index.web.js
+++ b/react/index.web.js
@@ -56,8 +56,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
         <App
             config = { config }
-            store = { store }
-            url = { window.location.toString() } />,
+            store = { store } />,
         document.getElementById('react'));
 });
 


### PR DESCRIPTION
A bug was discovered in d17cc9f which would raise a failure to push
into the browser's history if a base href was defined. Fix the failure
by removing react-router. Anyway, the usage of react-router was
incorrect because the app must hit the server infrastructure when it
enters a room because the server will choose the very app version then.