### PR TITLE
Webapplication should be aware of context root.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -198,6 +198,7 @@ function muteLocalVideo (muted) {
  * @param {boolean} options.feedbackSubmitted - whether feedback was submitted
  */
 function maybeRedirectToWelcomePage(options) {
+    var context;
     // if close page is enabled redirect to it, without further action
     if (config.enableClosePage) {
         // save whether current user is guest or not, before navigating
@@ -219,7 +220,16 @@ function maybeRedirectToWelcomePage(options) {
     if (config.enableWelcomePage) {
         setTimeout(() => {
             APP.settings.setWelcomePageEnabled(true);
-            window.location.pathname = "/";
+            if (config.context) {
+                context = config.context;
+                // Ensure that the context ends with a slash.
+                if (context.slice(-1) != "/") {
+                    context += "/";
+                }
+            } else {
+                context = "/";
+            }
+            window.location.pathname = context;
         }, 3000);
     }
 }

--- a/config.js
+++ b/config.js
@@ -12,6 +12,7 @@ var config = { // eslint-disable-line no-unused-vars
         //focus: 'focus.jitsi-meet.example.com', // defaults to 'focus.jitsi-meet.example.com'
     },
 //  getroomnode: function (path) { return 'someprefixpossiblybasedonpath'; },
+//  context: "/",
 //  useStunTurn: true, // use XEP-0215 to fetch STUN and TURN server
 //  useIPv6: true, // ipv6 support. use at your own risk
     useNicks: false,

--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -34,7 +34,7 @@ export function appNavigate(urlOrRoom) {
         const state = getState();
         const oldDomain = getDomain(state);
 
-        const { domain, room } = _getRoomAndDomainFromUrlString(urlOrRoom);
+        const { domain, room } = _getRoomAndDomainFromUrlString(state, urlOrRoom);
 
         // TODO Kostiantyn Tsaregradskyi: We should probably detect if user is
         // currently in a conference and ask her if she wants to close the

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -245,9 +245,14 @@ export class AbstractApp extends Component {
 
             if (typeof hosts === 'object') {
                 const domain = hosts.domain;
+                const context = hosts.context;
 
                 if (domain) {
-                    return `https://${domain}`;
+                    if (context) {
+                        return `https://${domain}${context}`
+                    } else {
+                        return `https://${domain}`;
+                    }
                 }
             }
         }

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -46,13 +46,28 @@ export class App extends AbstractApp {
         let path = route.path;
         const store = this._getStore();
 
-        // The syntax :room bellow is defined by react-router. It "matches a URL
+        // The syntax :room below is defined by react-router. It "matches a URL
         // segment up to the next /, ?, or #. The matched string is called a
         // param."
         path
             = path.replace(
                 /:room/g,
                 store.getState()['features/base/conference'].room);
+
+        const config = this.props.config;
+        if (typeof config === 'object') {
+            const hosts = config.hosts;
+            if (typeof hosts === 'object') {
+                let urlContext = hosts.context;
+                if (urlContext) {
+                    // Last character of the context should be a slash.
+                    if (urlContext.slice(-1) !== '/') {
+                        urlContext += '/';
+                    }
+                    path = urlContext + path.substr(1);
+                }
+            }
+        }
 
         // Navigate to the specified Route.
         const windowLocation = this._getWindowLocation();

--- a/react/features/app/functions.native.js
+++ b/react/features/app/functions.native.js
@@ -13,13 +13,22 @@ import { WelcomePage } from '../welcome';
  *      room: (string|undefined)
  *  }}
  */
-function _getRoomAndDomainFromUrlObject(url) {
+function _getRoomAndDomainFromUrlObject(state, url) {
     let domain;
     let room;
+    let urlContext;
+
+    // TODO get this from state.
+    urlContext = '/ofmeet/jitsi-meet/' || '/';
+
+    // Last character of the context should be a slash.
+    if (urlContext.slice(-1) !== '/') {
+        urlContext += '/';
+    }
 
     if (url) {
         domain = url.hostname;
-        room = url.pathname.substr(1);
+        room = url.pathname.substr( urlContext.length );
 
         // Convert empty string to undefined to simplify checks.
         if (room === '') {
@@ -45,7 +54,7 @@ function _getRoomAndDomainFromUrlObject(url) {
  *      room: (string|undefined)
  *  }}
  */
-export function _getRoomAndDomainFromUrlString(url) {
+export function _getRoomAndDomainFromUrlString(state, url) {
     // Rewrite the specified URL in order to handle special cases such as
     // hipchat.com and enso.me which do not follow the common pattern of most
     // Jitsi Meet deployments.
@@ -71,7 +80,7 @@ export function _getRoomAndDomainFromUrlString(url) {
         }
     }
 
-    return _getRoomAndDomainFromUrlObject(_urlStringToObject(url));
+    return _getRoomAndDomainFromUrlObject(state, _urlStringToObject(url));
 }
 
 /**

--- a/utils.js
+++ b/utils.js
@@ -12,6 +12,7 @@
 function getRoomName () { // eslint-disable-line no-unused-vars
     var path = window.location.pathname;
     var roomName;
+    var context;
 
     // determinde the room node from the url
     // TODO: just the roomnode or the whole bare jid?
@@ -19,16 +20,21 @@ function getRoomName () { // eslint-disable-line no-unused-vars
         // custom function might be responsible for doing the pushstate
         roomName = config.getroomnode(path);
     } else {
-        /* fall back to default strategy
-         * this is making assumptions about how the URL->room mapping happens.
-         * It currently assumes deployment at root, with a rewrite like the
-         * following one (for nginx):
-         location ~ ^/([a-zA-Z0-9]+)$ {
-         rewrite ^/(.*)$ / break;
-         }
-        */
-        if (path.length > 1) {
-            roomName = path.substr(1).toLowerCase();
+        // Fall back to default strategy, which locates the roomname
+        // on the URL (anything after the context on which the application
+        // is exposed, e.g. http://example.org/mycontext/myroom )
+        if (config.context) {
+            context = config.context;
+            // Ensure that the context ends with a slash.
+            if (context.slice(-1) != "/") {
+                context += "/";
+            }
+        } else {
+            context = "/";
+        }
+        if (path.lastIndexOf(context, 0) === 0
+                && path.length > context.length) {
+            roomName = path.substr(context.length).toLowerCase();
         }
     }
 


### PR DESCRIPTION
The webapplication should be aware of the context root on which it is exposed. Before this commit, the application assumed that its context was the root context of the domain.

This commit adds a configuration property named 'context', that, if set, allows an administrator to define the context root under which the application is made available. When unset, the root context is assumed.

This change is applied to code responsible for:
- determining what a room name is, based on the current URL.
- redirecting the user back to the inital / welcome page.