### PR TITLE
Stick to clean-css version 3.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
-    "clean-css": "*",
+    "clean-css": "^3.0.0",
     "css-loader": "*",
     "eslint": "^3.13.1",
     "eslint-plugin-jsdoc": "*",


### PR DESCRIPTION
Starting version 4.x clean-css is split into two packages and we should depend on clean-css-cli for versions 4 and above. Tested it and we have currently some problem with it like fonts and images got referenced under css folder. So sticking version to 3.x for now.