### PR TITLE
Remove duplication

### DIFF
--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -22,7 +22,7 @@ export class App extends AbstractApp {
     componentWillMount(...args) {
         super.componentWillMount(...args);
 
-        this.props.store.dispatch(appInit());
+        this._getStore().dispatch(appInit());
     }
 
     /**
@@ -44,7 +44,7 @@ export class App extends AbstractApp {
      */
     _navigate(route) {
         let path = route.path;
-        const store = this.props.store;
+        const store = this._getStore();
 
         // The syntax :room bellow is defined by react-router. It "matches a URL
         // segment up to the next /, ?, or #. The matched string is called a

--- a/react/index.native.js
+++ b/react/index.native.js
@@ -1,26 +1,8 @@
 import React, { Component } from 'react';
 import { AppRegistry, Linking } from 'react-native';
-import { createStore } from 'redux';
-import Thunk from 'redux-thunk';
 
 import config from './config';
 import { App } from './features/app';
-import {
-    MiddlewareRegistry,
-    ReducerRegistry
-} from './features/base/redux';
-
-// Create combined reducer from all reducers in registry.
-const reducer = ReducerRegistry.combineReducers();
-
-// Apply all registered middleware from the MiddlewareRegistry + additional
-// 3rd party middleware:
-// - Thunk - allows us to dispatch async actions easily. For more info
-// @see https://github.com/gaearon/redux-thunk.
-const middleware = MiddlewareRegistry.applyMiddleware(Thunk);
-
-// Create Redux store with our reducer and middleware.
-const store = createStore(reducer, middleware);
 
 /**
  * React Native doesn't support specifying props to the main/root component (in
@@ -83,7 +65,6 @@ class Root extends Component {
         return (
             <App
                 config = { config }
-                store = { store }
                 url = { this.state.url } />
         );
     }

--- a/react/index.web.js
+++ b/react/index.web.js
@@ -2,35 +2,11 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { compose, createStore } from 'redux';
-import Thunk from 'redux-thunk';
 
 import config from './config';
 import { App } from './features/app';
-import { MiddlewareRegistry, ReducerRegistry } from './features/base/redux';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
-
-// Create combined reducer from all reducers in registry.
-const reducer = ReducerRegistry.combineReducers();
-
-// Apply all registered middleware from the MiddlewareRegistry + additional
-// 3rd party middleware:
-// - Thunk - allows us to dispatch async actions easily. For more info
-// @see https://github.com/gaearon/redux-thunk.
-let middleware = MiddlewareRegistry.applyMiddleware(Thunk);
-
-// Try to enable Redux DevTools Chrome extension in order to make it available
-// for the purposes of facilitating development.
-let devToolsExtension;
-
-if (typeof window === 'object'
-        && (devToolsExtension = window.devToolsExtension)) {
-    middleware = compose(middleware, devToolsExtension());
-}
-
-// Create Redux store with our reducer and middleware.
-const store = createStore(reducer, middleware);
 
 /**
  * Renders the app when the DOM tree has been loaded.
@@ -43,9 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Render the main Component.
     ReactDOM.render(
-        <App
-            config = { config }
-            store = { store } />,
+        <App config = { config } />,
         document.getElementById('react'));
 });
 


### PR DESCRIPTION
The files react/index.native.js and react/index.web.js ended up having
very similar source code related to initializing the Redux store. Remove
the duplication.

Additionally, I always wanted the App React Component to be consumed
without the need to provide a Redux store to it.