### PR TITLE
Remove obsolete UnsupportedMobileBrowser functionality

### DIFF
--- a/react/features/base/connection/reducer.js
+++ b/react/features/base/connection/reducer.js
@@ -62,6 +62,7 @@ function _connectionEstablished(state, action) {
  *
  * @param {string} domain - The domain with which the returned options are to be
  * populated.
+ * @private
  * @returns {Object}
  */
 function _constructConnectionOptions(domain) {

--- a/react/features/base/lib-jitsi-meet/reducer.js
+++ b/react/features/base/lib-jitsi-meet/reducer.js
@@ -11,8 +11,8 @@ import {
  * Initial state of 'features/base/lib-jitsi-meet'.
  *
  * @type {{
- *      initializationError: null,
- *      initialized: boolean
+ *     initializationError: null,
+ *     initialized: boolean
  * }}
  */
 const INITIAL_STATE = {

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -17,16 +17,13 @@ const RULES = [
      * app even if the browser supports the app (e.g. Google Chrome with
      * WebRTC support on Android).
      *
-     * @param {Object} state - Object containing Redux state.
      * @returns {UnsupportedMobileBrowser|void} If the rule is satisfied then
      * we should intercept existing component by UnsupportedMobileBrowser.
      */
-    state => {
+    () => {
         const OS = Platform.OS;
-        const { mobileBrowserPageIsShown }
-            = state['features/unsupported-browser'];
 
-        if ((OS === 'android' || OS === 'ios') && !mobileBrowserPageIsShown) {
+        if (OS === 'android' || OS === 'ios') {
             return UnsupportedMobileBrowser;
         }
     }

--- a/react/features/film-strip/components/FilmStrip.js
+++ b/react/features/film-strip/components/FilmStrip.js
@@ -19,7 +19,13 @@ class FilmStrip extends Component {
      * @static
      */
     static propTypes = {
-        participants: React.PropTypes.array,
+        /**
+         * The participants in the conference.
+         *
+         * @private
+         * @type {Participant[]}
+         */
+        _participants: React.PropTypes.array,
         visible: React.PropTypes.bool.isRequired
     }
 
@@ -43,7 +49,7 @@ class FilmStrip extends Component {
                     showsHorizontalScrollIndicator = { false }
                     showsVerticalScrollIndicator = { false }>
                     {
-                        this._sort(this.props.participants)
+                        this._sort(this.props._participants)
                             .map(p =>
                                 <Thumbnail
                                     key = { p.id }
@@ -94,12 +100,18 @@ class FilmStrip extends Component {
  *
  * @param {Object} state - Redux state.
  * @returns {{
- *      participants: Participant[],
+ *      _participants: Participant[],
  *  }}
  */
 function mapStateToProps(state) {
     return {
-        participants: state['features/base/participants']
+        /**
+         * The participants in the conference.
+         *
+         * @private
+         * @type {Participant[]}
+         */
+        _participants: state['features/base/participants']
     };
 }
 

--- a/react/features/film-strip/components/Thumbnail.js
+++ b/react/features/film-strip/components/Thumbnail.js
@@ -26,11 +26,11 @@ class Thumbnail extends Component {
      * @static
      */
     static propTypes = {
-        audioTrack: React.PropTypes.object,
+        _audioTrack: React.PropTypes.object,
+        _largeVideo: React.PropTypes.object,
+        _videoTrack: React.PropTypes.object,
         dispatch: React.PropTypes.func,
-        largeVideo: React.PropTypes.object,
-        participant: React.PropTypes.object,
-        videoTrack: React.PropTypes.object
+        participant: React.PropTypes.object
     }
 
     /**
@@ -64,12 +64,10 @@ class Thumbnail extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const {
-            audioTrack,
-            largeVideo,
-            participant,
-            videoTrack
-        } = this.props;
+        const audioTrack = this.props._audioTrack;
+        const largeVideo = this.props._largeVideo;
+        const participant = this.props.participant;
+        const videoTrack = this.props._videoTrack;
 
         let style = styles.thumbnail;
 
@@ -136,9 +134,9 @@ class Thumbnail extends Component {
  * @param {Object} state - Redux state.
  * @param {Object} ownProps - Properties of component.
  * @returns {{
- *      audioTrack: Track,
- *      largeVideo: Object,
- *      videoTrack: Track
+ *      _audioTrack: Track,
+ *      _largeVideo: Object,
+ *      _videoTrack: Track
  *  }}
  */
 function mapStateToProps(state, ownProps) {
@@ -154,9 +152,9 @@ function mapStateToProps(state, ownProps) {
         = getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, id);
 
     return {
-        audioTrack,
-        largeVideo,
-        videoTrack
+        _audioTrack: audioTrack,
+        _largeVideo: largeVideo,
+        _videoTrack: videoTrack
     };
 }
 

--- a/react/features/toolbar/components/AbstractToolbar.js
+++ b/react/features/toolbar/components/AbstractToolbar.js
@@ -19,15 +19,18 @@ export class AbstractToolbar extends Component {
      * @static
      */
     static propTypes = {
-        audioMuted: React.PropTypes.bool,
-        dispatch: React.PropTypes.func,
+        _audioMuted: React.PropTypes.bool,
 
         /**
          * The indicator which determines whether the conference is
          * locked/password-protected.
+         *
+         * @protected
+         * @type {boolean}
          */
-        locked: React.PropTypes.bool,
-        videoMuted: React.PropTypes.bool,
+        _locked: React.PropTypes.bool,
+        _videoMuted: React.PropTypes.bool,
+        dispatch: React.PropTypes.func,
         visible: React.PropTypes.bool.isRequired
     }
 
@@ -65,7 +68,7 @@ export class AbstractToolbar extends Component {
         let iconStyle;
         let style = styles.primaryToolbarButton;
 
-        if (this.props[`${mediaType}Muted`]) {
+        if (this.props[`_${mediaType}Muted`]) {
             iconName = this[`${mediaType}MutedIcon`];
             iconStyle = styles.whiteIcon;
             style = {
@@ -135,22 +138,27 @@ export class AbstractToolbar extends Component {
  * Maps parts of media state to component props.
  *
  * @param {Object} state - Redux state.
- * @returns {{ audioMuted: boolean, videoMuted: boolean }}
+ * @returns {{
+ *     _audioMuted: boolean,
+ *     _locked: boolean,
+ *     _videoMuted: boolean
+ * }}
  */
 export function mapStateToProps(state) {
     const conference = state['features/base/conference'];
     const media = state['features/base/media'];
 
     return {
-        audioMuted: media.audio.muted,
+        _audioMuted: media.audio.muted,
 
         /**
          * The indicator which determines whether the conference is
          * locked/password-protected.
          *
+         * @protected
          * @type {boolean}
          */
-        locked: conference.locked,
-        videoMuted: media.video.muted
+        _locked: conference.locked,
+        _videoMuted: media.video.muted
     };
 }

--- a/react/features/toolbar/components/Toolbar.native.js
+++ b/react/features/toolbar/components/Toolbar.native.js
@@ -123,7 +123,7 @@ class Toolbar extends AbstractToolbar {
                     underlayColor = { underlayColor } />
                 <ToolbarButton
                     iconName = {
-                        this.props.locked ? 'security-locked' : 'security'
+                        this.props._locked ? 'security-locked' : 'security'
                     }
                     iconStyle = { iconStyle }
                     onClick = { this._onRoomLock }

--- a/react/features/unsupported-browser/actionTypes.js
+++ b/react/features/unsupported-browser/actionTypes.js
@@ -1,12 +1,18 @@
 import { Symbol } from '../base/react';
 
 /**
- * The type of the Redux action which signals that a mobile browser page
- * is shown.
+ * The type of the Redux action which signals that the React Component
+ * UnsupportedMobileBrowser which was rendered as a promotion of the mobile app
+ * on a browser was dismissed by the user. For example, the Web app may possibly
+ * run in Google Chrome on Android but we choose to promote the mobile app
+ * anyway claiming the user experience provided by the Web app is inferior to
+ * that of the mobile app. Eventually, the user may choose to dismiss the
+ * promotion of the mobile app and take their chances with the Web app instead.
+ * If unused, then we have chosen to force the mobile app and not allow the Web
+ * app in mobile browsers.
  *
  * {
- *     type: MOBILE_BROWSER_PAGE_IS_SHOWN
+ *     type: DISMISS_MOBILE_APP_PROMO
  * }
  */
-// eslint-disable-next-line max-len
-export const MOBILE_BROWSER_PAGE_IS_SHOWN = Symbol('MOBILE_BROWSER_PAGE_IS_SHOWN');
+export const DISMISS_MOBILE_APP_PROMO = Symbol('DISMISS_MOBILE_APP_PROMO');

--- a/react/features/unsupported-browser/actions.js
+++ b/react/features/unsupported-browser/actions.js
@@ -1,16 +1,22 @@
-import { MOBILE_BROWSER_PAGE_IS_SHOWN } from './actionTypes';
+import { DISMISS_MOBILE_APP_PROMO } from './actionTypes';
 import './reducer';
 
 /**
- * Returns an action that mobile browser page is shown and there is no need
- * to show it on other pages.
+ * Returns a Redux action which signals that the UnsupportedMobileBrowser which
+ * was rendered as a promotion of the mobile app on a browser was dismissed by
+ * the user. For example, the Web app may possibly run in Google Chrome
+ * on Android but we choose to promote the mobile app anyway claiming the user
+ * experience provided by the Web app is inferior to that of the mobile app.
+ * Eventually, the user may choose to dismiss the promotion of the mobile app
+ * and take their chances with the Web app instead. If unused, then we have
+ * chosen to force the mobile app and not allow the Web app in mobile browsers.
  *
  * @returns {{
- *     type: MOBILE_BROWSER_PAGE_IS_SHOWN
+ *     type: DISMISS_MOBILE_APP_PROMO
  * }}
  */
-export function mobileBrowserPageIsShown() {
+export function dismissMobileAppPromo() {
     return {
-        type: MOBILE_BROWSER_PAGE_IS_SHOWN
+        type: DISMISS_MOBILE_APP_PROMO
     };
 }

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
@@ -1,10 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { appNavigate } from '../../app';
 import { Platform } from '../../base/react';
-
-import { mobileBrowserPageIsShown } from '../actions';
 
 /**
  * The map of platforms to URLs at which the mobile app for the associated
@@ -27,8 +24,14 @@ class UnsupportedMobileBrowser extends Component {
      * @static
      */
     static propTypes = {
-        dispatch: React.PropTypes.func,
-        room: React.PropTypes.string
+        /**
+         * The name of the conference room to be joined upon clicking the
+         * respective button.
+         *
+         * @private
+         * @type {string}
+         */
+        _room: React.PropTypes.string
     }
 
     /**
@@ -41,16 +44,7 @@ class UnsupportedMobileBrowser extends Component {
         super(props);
 
         // Bind methods
-        this._onClickJoin = this._onClickJoin.bind(this);
-    }
-
-    /**
-     * React lifecycle method triggered after component is mounted.
-     *
-     * @returns {void}
-     */
-    componentDidMount() {
-        this.props.dispatch(mobileBrowserPageIsShown());
+        this._onJoinClick = this._onJoinClick.bind(this);
     }
 
     /**
@@ -59,21 +53,11 @@ class UnsupportedMobileBrowser extends Component {
      * @returns {void}
      */
     componentWillMount() {
-        const { room } = this.props;
-        let btnText;
-        let link;
-
-        if (room) {
-            btnText = 'Join the conversation';
-            link = room;
-        } else {
-            btnText = 'Start a conference';
-            link = '';
-        }
+        const joinButtonText
+            = this.props._room ? 'Join the conversation' : 'Start a conference';
 
         this.setState({
-            btnText,
-            link
+            joinButtonText
         });
     }
 
@@ -84,8 +68,7 @@ class UnsupportedMobileBrowser extends Component {
      */
     render() {
         const ns = 'unsupported-mobile-browser';
-        const primaryButtonClasses
-            = `${ns}__button ${ns}__button_primary`;
+        const downloadButtonClassName = `${ns}__button ${ns}__button_primary`;
 
         return (
             <div className = { ns }>
@@ -98,7 +81,7 @@ class UnsupportedMobileBrowser extends Component {
                         conversation on your mobile
                     </p>
                     <a href = { URLS[Platform.OS] }>
-                        <button className = { primaryButtonClasses }>
+                        <button className = { downloadButtonClassName }>
                             Download the App
                         </button>
                     </a>
@@ -109,9 +92,9 @@ class UnsupportedMobileBrowser extends Component {
                     </p>
                     <button
                         className = { `${ns}__button` }
-                        onClick = { this._onClickJoin }>
+                        onClick = { this._onJoinClick }>
                         {
-                            this.state.btnText
+                            this.state.joinButtonText
                         }
                     </button>
                 </div>
@@ -120,13 +103,19 @@ class UnsupportedMobileBrowser extends Component {
     }
 
     /**
-     * Navigates to the next state of the app.
+     * Handles clicks on the button that joins the local participant in a
+     * conference.
      *
      * @private
      * @returns {void}
      */
-    _onClickJoin() {
-        this.props.dispatch(appNavigate(this.state.link));
+    _onJoinClick() {
+        // If the user installed the app while this Component was displayed
+        // (e.g. the user clicked the Download the App button), then we would
+        // like to open the current URL in the mobile app.
+
+        // TODO The only way to do it appears to be a link with an app-specific
+        // scheme, not a Universal Link.
     }
 }
 
@@ -136,12 +125,19 @@ class UnsupportedMobileBrowser extends Component {
  *
  * @param {Object} state - Redux state.
  * @returns {{
- *     room: string
+ *     _room: string
  * }}
  */
 function mapStateToProps(state) {
     return {
-        room: state['features/base/conference'].room
+        /**
+         * The name of the conference room to be joined upon clicking the
+         * respective button.
+         *
+         * @private
+         * @type {string}
+         */
+        _room: state['features/base/conference'].room
     };
 }
 

--- a/react/features/unsupported-browser/reducer.js
+++ b/react/features/unsupported-browser/reducer.js
@@ -1,21 +1,25 @@
 import { ReducerRegistry } from '../base/redux';
 
-import { MOBILE_BROWSER_PAGE_IS_SHOWN } from './actionTypes';
+import { DISMISS_MOBILE_APP_PROMO } from './actionTypes';
 
 ReducerRegistry.register(
         'features/unsupported-browser',
         (state = {}, action) => {
             switch (action.type) {
-            case MOBILE_BROWSER_PAGE_IS_SHOWN:
+            case DISMISS_MOBILE_APP_PROMO:
                 return {
                     ...state,
 
                     /**
-                     * Flag that shows that mobile browser page is shown.
+                     * The indicator which determines whether the React
+                     * Component UnsupportedMobileBrowser which was rendered as
+                     * a promotion of the mobile app on a browser was dismissed
+                     * by the user. If unused, then we have chosen to force the
+                     * mobile app and not allow the Web app in mobile browsers.
                      *
                      * @type {boolean}
                      */
-                    mobileBrowserPageIsShown: true
+                    mobileAppPromoDismissed: true
                 };
             }
 

--- a/react/features/welcome/components/AbstractWelcomePage.js
+++ b/react/features/welcome/components/AbstractWelcomePage.js
@@ -18,9 +18,9 @@ export class AbstractWelcomePage extends Component {
      * @static
      */
     static propTypes = {
-        dispatch: React.PropTypes.func,
-        localVideoTrack: React.PropTypes.object,
-        room: React.PropTypes.string
+        _localVideoTrack: React.PropTypes.object,
+        _room: React.PropTypes.string,
+        dispatch: React.PropTypes.func
     }
 
     /**
@@ -69,7 +69,7 @@ export class AbstractWelcomePage extends Component {
      * @param {Object} nextProps - New props component will receive.
      */
     componentWillReceiveProps(nextProps) {
-        this.setState({ room: nextProps.room });
+        this.setState({ room: nextProps._room });
     }
 
     /**
@@ -167,7 +167,7 @@ export class AbstractWelcomePage extends Component {
      */
     _renderLocalVideo() {
         return (
-            <VideoTrack videoTrack = { this.props.localVideoTrack } />
+            <VideoTrack videoTrack = { this.props._localVideoTrack } />
         );
     }
 
@@ -202,8 +202,8 @@ export class AbstractWelcomePage extends Component {
  *
  * @param {Object} state - Redux state.
  * @returns {{
- *      localVideoTrack: (Track|undefined),
- *      room: string
+ *     _localVideoTrack: (Track|undefined),
+ *     _room: string
  * }}
  */
 export function mapStateToProps(state) {
@@ -211,7 +211,7 @@ export function mapStateToProps(state) {
     const tracks = state['features/base/tracks'];
 
     return {
-        localVideoTrack: getLocalVideoTrack(tracks),
-        room: conference.room
+        _localVideoTrack: getLocalVideoTrack(tracks),
+        _room: conference.room
     };
 }


### PR DESCRIPTION
The desired behavior of the button 'Start a conference' / 'Join the
conversation' is to launch the mobile app if installed; otherwise, do
nothing i.e. continue to display UnsupportedMobileBrowser.

Anyway, we may change our minds about allowing the user to continue in a
supported mobile browser so preserve the source code that enables that
but give it more appropriate naming.