### PR TITLE
Unescape characters in thumbnails, chat messages, or notifications

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -233,8 +233,9 @@ UI.showLocalConnectionInterrupted = function (isInterrupted) {
 UI.setRaisedHandStatus = (participant, raisedHandStatus) => {
     VideoLayout.setRaisedHandStatus(participant.getId(), raisedHandStatus);
     if (raisedHandStatus) {
-        messageHandler.notify(participant.getDisplayName(), 'notify.somebody',
-                          'connected', 'notify.raisedHand');
+        messageHandler.notify(
+            UIUtil.unescapeHtml(participant.getDisplayName()),
+            'notify.somebody', 'connected', 'notify.raisedHand');
     }
 };
 
@@ -556,7 +557,8 @@ UI.addUser = function (user) {
         UI.ContactList.addContact(id);
 
     messageHandler.notify(
-        displayName,'notify.somebody', 'connected', 'notify.connected'
+        UIUtil.unescapeHtml(displayName),'notify.somebody',
+        'connected', 'notify.connected'
     );
 
     if (!config.startAudioMuted ||
@@ -584,7 +586,8 @@ UI.removeUser = function (id, displayName) {
         UI.ContactList.removeContact(id);
 
     messageHandler.notify(
-        displayName,'notify.somebody', 'disconnected', 'notify.disconnected'
+        UIUtil.unescapeHtml(displayName), 'notify.somebody', 'disconnected',
+        'notify.disconnected'
     );
 
     if (!config.startAudioMuted
@@ -643,10 +646,8 @@ UI.updateUserRole = function (user) {
     var displayName = user.getDisplayName();
     if (displayName) {
         messageHandler.notify(
-            displayName, 'notify.somebody',
-            'connected', 'notify.grantedTo', {
-                to: UIUtil.escapeHtml(displayName)
-            }
+            UIUtil.unescapeHtml(displayName), 'notify.somebody',
+            'connected', 'notify.grantedTo', { to: displayName }
         );
     } else {
         messageHandler.notify(
@@ -1008,7 +1009,8 @@ UI.markVideoInterrupted = function (interrupted) {
  * @param {number} stamp timestamp when message was created
  */
 UI.addMessage = function (from, displayName, message, stamp) {
-    Chat.updateChatConversation(from, displayName, message, stamp);
+    Chat.updateChatConversation(from, UIUtil.unescapeHtml(displayName),
+        message,stamp);
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/modules/UI/side_pannels/contactlist/ContactListView.js
+++ b/modules/UI/side_pannels/contactlist/ContactListView.js
@@ -125,8 +125,8 @@ var ContactListView = {
 
         return (
             `<div class="sideToolbarBlock first">
-                <button id="addParticipantsBtn" 
-                         data-i18n="${key}" 
+                <button id="addParticipantsBtn"
+                         data-i18n="${key}"
                          class="${classes}"></button>
                 <div>
                     ${lockedHtml}
@@ -257,7 +257,7 @@ var ContactListView = {
         let contactName = $(`#contacts #${id}>p`);
 
         if (contactName.text() !== name) {
-            contactName.text(name);
+            contactName.text(UIUtil.unescapeHtml(name));
         }
     },
 

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -102,11 +102,18 @@ const IndicatorFontSizes = {
     /**
      * Unescapes the given text.
      *
-     * @param {string} safe string which contains escaped html
+     * @param {string} unsafe string
      * @returns {string} unescaped html string.
      */
-    unescapeHtml: function (safe) {
-        return $('<div />').html(safe).text();
+    unescapeHtml: function (unsafe) {
+        // If string contains < or >, it is already unescaped and unsafe to
+        // unescape again. Other unescaped characters like &, ', ", and / can
+        // be handled by else statement;
+        if (/[<>]/.test(unsafe))
+            return unsafe;
+        // It is safe to use .html()
+        else
+            return $('<div />').html(unsafe).text();
     },
 
     imageToGrayScale: function (canvas) {

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -62,7 +62,7 @@ LocalVideo.prototype.setDisplayName = function(displayName) {
                     `${UIUtil.escapeHtml(displayName)} (${meHTML})`
                 );
                 $('#editDisplayName').val(
-                    `${UIUtil.escapeHtml(displayName)}`
+                    displayName
                 );
             } else {
                 $('#localDisplayName').html(defaultLocalDisplayName);

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -4,7 +4,7 @@ const logger = require("jitsi-meet-logger").getLogger(__filename);
 import ConnectionIndicator from './ConnectionIndicator';
 
 import SmallVideo from "./SmallVideo";
-import UIUtils from "../util/UIUtil";
+import UIUtil from "../util/UIUtil";
 import UIEvents from '../../../service/UI/UIEvents';
 import JitsiPopover from "../util/JitsiPopover";
 
@@ -596,7 +596,7 @@ RemoteVideo.prototype.addRemoteStreamElement = function (stream) {
     let streamElement = SmallVideo.createStreamElement(stream);
 
     // Put new stream element always in front
-    UIUtils.prependChild(this.container, streamElement);
+    UIUtil.prependChild(this.container, streamElement);
 
     // If we hide element when Temasys plugin is used then
     // we'll never receive 'onplay' event and other logic won't work as expected
@@ -688,7 +688,7 @@ RemoteVideo.prototype.setDisplayName = function(displayName) {
         if (displayName && displayName.length > 0) {
             var displaynameSpan = $('#' + this.videoSpanId + '_name');
             if (displaynameSpan.text() !== displayName)
-                displaynameSpan.text(displayName);
+                displaynameSpan.text(UIUtil.unescapeHtml(displayName));
         }
         else
             $('#' + this.videoSpanId + '_name').text(
@@ -700,7 +700,7 @@ RemoteVideo.prototype.setDisplayName = function(displayName) {
             .appendChild(nameSpan);
 
         if (displayName && displayName.length > 0) {
-            $(nameSpan).text(displayName);
+            $(nameSpan).text(UIUtil.unescapeHtml(displayName));
         } else {
             nameSpan.innerHTML = interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME;
         }


### PR DESCRIPTION
This PR fixes problem with apostrophes, quotes, and other escaped HTML characters in several elements of the UI.

The unescapeHtml() was updated to _accept_ unsafe strings because some local variables are passed partially or completely unescaped to some methods (like in the contact list and chat messages). 

If a string contains a < or >, it is assumed to be at its final state. 
The character & cannot be added to the check because it may or may not be part of an entity.
The characters ' and " are not added to the check because they are locally stored like ' and ", but they are received like &-apos; and &-quot;. Unescaping them again is not harmful.
(To test single and double quotes, try: **alert(window.localStorage.getItem('displayname'))** for the names **a**, **a'**, and **a&** in meet.jit.si. Check also how your name is shown to others)

The last commit is about escaping a string before editing it. Change your name to a&b for example and try editing by clicking on your user's thumbnail. It changes to **a&-amp;b**.

PS: I've added a dash - to the HTML entities because Github will render them :/