### PR TITLE
prosody plugin to make all users owners/moderators

### DIFF
--- a/prosody-plugins/mod_muc_allowners.lua
+++ b/prosody-plugins/mod_muc_allowners.lua
@@ -1,0 +1,13 @@
+-- Copyright (c) 2015 &yet <https://andyet.com>
+-- https://github.com/otalk/mod_muc_allowners/blob/9a86266a25ed32ade150742cc79f5a1669765a8f/mod_muc_allowners.lua
+--
+-- Used under the terms of the MIT License
+-- https://github.com/otalk/mod_muc_allowners/blob/9a86266a25ed32ade150742cc79f5a1669765a8f/LICENSE
+
+local muc_service = module:depends("muc");
+local room_mt = muc_service.room_mt;
+
+
+room_mt.get_affiliation = function (room, jid)
+    return "owner";
+end

--- a/prosody-plugins/muc_owner_allow_kick.patch
+++ b/prosody-plugins/muc_owner_allow_kick.patch
@@ -1,0 +1,21 @@
+--- muc.lib.lua	2016-10-26 18:26:53.432377291 +0000
++++ muc.lib.lua	2016-10-26 18:41:40.754426072 +0000
+@@ -1256,15 +1256,16 @@
+ 	if actor == true then
+ 		actor = nil -- So we can pass it safely to 'publicise_occupant_status' below
+ 	else
++		local actor_affiliation = self:get_affiliation(actor);
++
+ 		-- Can't do anything to other owners or admins
+ 		local occupant_affiliation = self:get_affiliation(occupant.bare_jid);
+-		if occupant_affiliation == "owner" or occupant_affiliation == "admin" then
++		if (occupant_affiliation == "owner" and actor_affiliation ~= "owner") or (occupant_affiliation == "admin" and actor_affiliation ~= "admin" and actor_affiliation ~= "owner") then
+ 			return nil, "cancel", "not-allowed";
+ 		end
+ 
+ 		-- If you are trying to give or take moderator role you need to be an owner or admin
+ 		if occupant.role == "moderator" or role == "moderator" then
+-			local actor_affiliation = self:get_affiliation(actor);
+ 			if actor_affiliation ~= "owner" and actor_affiliation ~= "admin" then
+ 				return nil, "cancel", "not-allowed";
+ 			end


### PR DESCRIPTION
Added a prosody plugin for making all users into muc owners in prosody
Included a patch to prosody-trunk which allows owners to kick each other

Missing here is instructions on how best to use the plugin.  It is a module that should be placed into the prosody modules directory (/usr/lib/prosody/modules) and then needs to be enabled through prosody.conf inside the muc component modules_enabled command.