### PR TITLE
Unsupported browser

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -580,6 +580,11 @@ export default {
                     (new ConferenceConnector(
                         resolve, reject, this.invite)).connect();
                 });
+            }).catch((error) => {
+                logger.error(error.message);
+                APP.unsupportedBrowser = {
+                  isOldBrowser: error.isOldBrowser
+                };
         });
     },
     /**

--- a/conference.js
+++ b/conference.js
@@ -585,14 +585,12 @@ export default {
             })
             .catch((err) => {
                 const {
-                    isOldBrowser,
-                    isPluginRequired,
+                    status,
                     message,
                     webRTCReadyPromise
                 } = err;
                 const rejectValue = {
-                    isOldBrowser,
-                    isPluginRequired,
+                    status,
                     // Browser could require Temasys plugin to be installed
                     // and conference initialization was rejected but it could
                     // be reinitialized after installation of the plugin.

--- a/conference.js
+++ b/conference.js
@@ -669,11 +669,7 @@ export default {
      * false.
      */
     isCallstatsEnabled () {
-        if (room) {
-            return room.isCallstatsEnabled();
-        }
-
-        return false;
+        return room && room.isCallstatsEnabled();
     },
     /**
      * Sends the given feedback through CallStats if enabled.

--- a/conference.js
+++ b/conference.js
@@ -669,7 +669,11 @@ export default {
      * false.
      */
     isCallstatsEnabled () {
-        return room.isCallstatsEnabled();
+        if (room) {
+            return room.isCallstatsEnabled();
+        }
+
+        return false;
     },
     /**
      * Sends the given feedback through CallStats if enabled.

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -129,8 +129,13 @@ $linkFontColor: #489afe;
 $linkHoverFontColor: #287ade;
 
 /**
- * Landing
+ * Unsupported browser
  */
 $primaryUnsupportedBrowserButtonBgColor: #17a0db;
 $unsupportedBrowserButtonBgColor: #ff9a00;
 $unsupportedBrowserTextColor: #4a4a4a;
+$unsupportedBrowserTitleColor: #fff;
+$unsupportedBrowserTitleFontSize: 24px;
+$unsupportedDesktopBrowserTextColor: rgba(255, 255, 255, 0.7);
+$unsupportedDesktopBrowserTextFontSize: 21px;
+$unsupportedBrowserTextSmallFontSize: 17px;

--- a/css/main.scss
+++ b/css/main.scss
@@ -67,7 +67,6 @@
 @import '404';
 @import 'policy';
 @import 'filmstrip';
-@import 'unsupported-browser/unsupported-desktop-browser';
-@import 'unsupported-browser/unsupported-mobile-browser';
+@import 'unsupported-browser/main';
 
 /* Modules END */

--- a/css/unsupported-browser/_main.scss
+++ b/css/unsupported-browser/_main.scss
@@ -1,0 +1,3 @@
+@import 'no-mobile-app';
+@import 'unsupported-desktop-browser';
+@import 'unsupported-mobile-browser';

--- a/css/unsupported-browser/_no-mobile-app.scss
+++ b/css/unsupported-browser/_no-mobile-app.scss
@@ -1,0 +1,21 @@
+.no-mobile-app {
+    margin: 30% auto 0;
+    width: auto;
+    max-width: 25em;
+    text-align: center;
+
+    &__title {
+        padding-bottom: em(17, 24);
+        border-bottom: 1px solid $auiBorderColor;
+        font-weight: 400;
+        letter-spacing: 0.5px;
+        color: #fff;
+    }
+
+    &__description {
+        margin-top: 1em;
+        font-size: 17px;
+        font-weight: 300;
+        letter-spacing: 1px;
+    }
+}

--- a/css/unsupported-browser/_no-mobile-app.scss
+++ b/css/unsupported-browser/_no-mobile-app.scss
@@ -9,12 +9,12 @@
         border-bottom: 1px solid $auiBorderColor;
         font-weight: 400;
         letter-spacing: 0.5px;
-        color: #fff;
+        color: $unsupportedBrowserTitleColor;
     }
 
     &__description {
         margin-top: 1em;
-        font-size: 17px;
+        font-size: $unsupportedBrowserTextSmallFontSize;
         font-weight: 300;
         letter-spacing: 1px;
     }

--- a/css/unsupported-browser/_unsupported-desktop-browser.scss
+++ b/css/unsupported-browser/_unsupported-desktop-browser.scss
@@ -1,132 +1,39 @@
-.supported-browser {
-    color: #929391;
-    display: inline-block;
-    font-size: 20px;
-    margin: 1em 7px;
-    vertical-align: middle;
-    width: 138px;
+.unsupported-desktop-browser {
+    @include absoluteAligning();
 
-    &__button {
-        background-color: #62c82a;
-        border: 1px solid #3c8117;
-        border-radius: 10px;
-        color: #FFFFFF;
-        font-size: 12px;
-        height: 26px;
-        margin: 15px auto 0px auto;
-        padding-top: 13px;
-        text-align: center;
-        width: 115px;
+    display: block;
+    text-align: center;
+
+    &__title {
+        color: #fff;
+        font-weight: 300;
+        font-size: 24px;
+        letter-spacing: 1px;
+    }
+
+    &__description {
+        margin-top: 16px;
+        color: rgba(255, 255, 255, 0.7);
+        font-weight: 300;
+        font-size: 21px;
+        letter-spacing: 1px;
+
+        &_small {
+            @extend .unsupported-desktop-browser__description;
+            font-size: 16px;
+        }
     }
 
     &__link {
-        color: #087dba;
-        text-decoration: none;
+        color: $linkFontColor;
+        @include transition(color .1s ease-out);
 
         &:hover {
+            color: $linkHoverFontColor;
+            cursor: pointer;
             text-decoration: none;
+
+            @include transition(color .1s ease-in);
         }
-
-        &:active {
-            text-decoration: none;
-        }
-
-        &:focus {
-            text-decoration: none;
-        }
-    }
-
-    &-list
-    {
-        margin: 0 auto;
-    }
-
-    &__logo {
-        margin: 20px auto 0px auto;
-
-        &_chrome {
-            background-image: url('../../images/chrome.png');
-            height: 78px;
-            width: 78px;
-        }
-
-        &_chromium {
-            background-image: url('../../images/chromium.png');
-            height: 78px;
-            width: 77px;
-        }
-
-        &_firefox {
-            background-image: url('../../images/firefox.png');
-            height: 80px;
-            width: 86px;
-        }
-
-        &_opera {
-            background-image: url('../../images/opera.png');
-            height: 78px;
-            width: 73px;
-        }
-
-        &_ie {
-            background-image: url('../../images/ie.png');
-            height: 78px;
-            width: 80px;
-        }
-
-        &_safari {
-            background-image: url('../../images/safari.png');
-            height: 79px;
-            width: 78px;
-        }
-    }
-
-    &__text
-    {
-        line-height: 1.2em;
-
-        &_small {
-            font-size: small;
-        }
-    }
-
-    &__tile {
-        background-color: #e8e8e8;
-        border: 1px solid #cfcfcf;
-        border-radius: 10px;
-        height: 163px;
-        margin-top: 5px;
-        width: 138px;
-    }
-}
-
-.unsupported-desktop-browser {
-    display: block;
-    height: 565px;
-    margin: auto;
-    overflow:hidden;
-    position: absolute;
-    text-align: center;
-    top: 0; left: 0; bottom: 0; right: 0;
-    width:500px;
-
-    &__page {
-        display:inline-block;
-        font-size: 28px;
-        padding-top: 25px;
-        vertical-align:middle;
-    }
-
-    &__title {
-        margin: 0 auto;
-        width: 20em;
-    }
-
-    &-wrapper {
-        background: #fff;
-        display: block;
-        height: 100%;
-        position: absolute;
-        width: 100%;
     }
 }

--- a/css/unsupported-browser/_unsupported-desktop-browser.scss
+++ b/css/unsupported-browser/_unsupported-desktop-browser.scss
@@ -5,22 +5,22 @@
     text-align: center;
 
     &__title {
-        color: #fff;
+        color: $unsupportedBrowserTitleColor;
         font-weight: 300;
-        font-size: 24px;
+        font-size: $unsupportedBrowserTitleFontSize;
         letter-spacing: 1px;
     }
 
     &__description {
         margin-top: 16px;
-        color: rgba(255, 255, 255, 0.7);
+        color: $unsupportedDesktopBrowserTextColor;
         font-weight: 300;
-        font-size: 21px;
+        font-size: $unsupportedDesktopBrowserTextFontSize;
         letter-spacing: 1px;
 
         &_small {
             @extend .unsupported-desktop-browser__description;
-            font-size: 16px;
+            font-size: $unsupportedBrowserTextSmallFontSize;
         }
     }
 

--- a/interface_config.js
+++ b/interface_config.js
@@ -73,5 +73,6 @@ var interfaceConfig = { // eslint-disable-line no-unused-vars
     REMOTE_THUMBNAIL_RATIO: 1, //1:1
     // Documentation reference for the live streaming feature.
     LIVE_STREAMING_HELP_LINK: "https://jitsi.org/live",
+    // Enabling mobile landing page with the link to mobile app.
     MOBILE_APP_ENABLED: true
 };

--- a/interface_config.js
+++ b/interface_config.js
@@ -72,5 +72,6 @@ var interfaceConfig = { // eslint-disable-line no-unused-vars
     LOCAL_THUMBNAIL_RATIO: 16/9, //16:9
     REMOTE_THUMBNAIL_RATIO: 1, //1:1
     // Documentation reference for the live streaming feature.
-    LIVE_STREAMING_HELP_LINK: "https://jitsi.org/live"
+    LIVE_STREAMING_HELP_LINK: "https://jitsi.org/live",
+    MOBILE_APP_ENABLED: true
 };

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -93,57 +93,6 @@ JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.NO_DATA_FROM_SOURCE]
     = "dialog.micNotSendingData";
 
 /**
- * Prompt user for nickname.
- */
-function promptDisplayName() {
-    let labelKey = 'dialog.enterDisplayName';
-    let message = (
-        `<div class="form-control">
-            <label data-i18n="${labelKey}" class="form-control__label"></label>
-            <input name="displayName" type="text"
-               data-i18n="[placeholder]defaultNickname"
-               class="input-control" autofocus>
-         </div>`
-    );
-
-    // Don't use a translation string, because we're too early in the call and
-    // the translation may not be initialised.
-    let buttons = {Ok:true};
-
-    let dialog = messageHandler.openDialog(
-        'dialog.displayNameRequired',
-        message,
-        true,
-        buttons,
-        function (e, v, m, f) {
-            e.preventDefault();
-            if (v) {
-                let displayName = f.displayName;
-                if (displayName) {
-                    UI.inputDisplayNameHandler(displayName);
-                    dialog.close();
-                    return;
-                }
-            }
-        },
-        function () {
-            let form  = $.prompt.getPrompt();
-            let input = form.find("input[name='displayName']");
-            input.focus();
-            let button = form.find("button");
-            button.attr("disabled", "disabled");
-            input.keyup(function () {
-                if (input.val()) {
-                    button.removeAttr("disabled");
-                } else {
-                    button.attr("disabled", "disabled");
-                }
-            });
-        }
-    );
-}
-
-/**
  * Initialize toolbars with side panels.
  */
 function setupToolbars() {
@@ -391,12 +340,6 @@ UI.start = function () {
     }
 
     document.title = interfaceConfig.APP_NAME;
-
-    if(config.requireDisplayName) {
-        if (!APP.settings.getDisplayName()) {
-            promptDisplayName();
-        }
-    }
 
     if (!interfaceConfig.filmStripOnly) {
         toastr.options = {
@@ -951,6 +894,59 @@ UI.handleLastNEndpoints = function (ids, enteringIds) {
  */
 UI.participantConnectionStatusChanged = function (id, isActive) {
     VideoLayout.onParticipantConnectionStatusChanged(id, isActive);
+};
+
+/**
+ * Prompt user for nickname.
+ */
+UI.promptDisplayName = () => {
+    const labelKey = 'dialog.enterDisplayName';
+    const message = (
+        `<div class="form-control">
+            <label data-i18n="${labelKey}" class="form-control__label"></label>
+            <input name="displayName" type="text"
+               data-i18n="[placeholder]defaultNickname"
+               class="input-control" autofocus>
+         </div>`
+    );
+
+    // Don't use a translation string, because we're too early in the call and
+    // the translation may not be initialised.
+    const buttons = { Ok: true };
+
+    const dialog = messageHandler.openDialog(
+        'dialog.displayNameRequired',
+        message,
+        true,
+        buttons,
+        (e, v, m, f) => {
+            e.preventDefault();
+            if (v) {
+                const displayName = f.displayName;
+
+                if (displayName) {
+                    UI.inputDisplayNameHandler(displayName);
+                    dialog.close();
+                    return;
+                }
+            }
+        },
+        () => {
+            const form  = $.prompt.getPrompt();
+            const input = form.find("input[name='displayName']");
+            const button = form.find("button");
+
+            input.focus();
+            button.attr("disabled", "disabled");
+            input.keyup(() => {
+                if (input.val()) {
+                    button.removeAttr("disabled");
+                } else {
+                    button.attr("disabled", "disabled");
+                }
+            });
+        }
+    );
 };
 
 /**

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -53,15 +53,6 @@ let followMeHandler;
 
 let deviceErrorDialog;
 
-/**
- * Object representing name of some UI events and their handlers.
- *
- * @type {{
- *      event: Function
- * }}
- */
-let UIListeners;
-
 const TrackErrors = JitsiMeetJS.errors.track;
 
 const JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP = {
@@ -371,8 +362,8 @@ UI.start = function () {
  * Setup some UI event listeners.
  */
 UI.registerListeners = () => {
-    Object.keys(UIListeners).map((key) => {
-        UI.addListener(key, UIListeners[key]);
+    UIListeners.forEach((value, key) => {
+        UI.addListener(key, value);
     });
 };
 
@@ -380,8 +371,8 @@ UI.registerListeners = () => {
  * Unregister some UI event listeners.
  */
 UI.unregisterListeners = () => {
-    Object.keys(UIListeners).map((key) => {
-        UI.removeListener(key, UIListeners[key]);
+    UIListeners.forEach((value, key) => {
+        UI.removeListener(key, value);
     });
 };
 
@@ -1411,40 +1402,44 @@ UI.onUserFeaturesChanged = function (user) {
     VideoLayout.onUserFeaturesChanged(user);
 };
 
-UIListeners = {
-    [UIEvents.ETHERPAD_CLICKED]: () => {
-        if (etherpadManager) {
-            etherpadManager.toggleEtherpad();
+const UIListeners = new Map([
+    [
+        UIEvents.ETHERPAD_CLICKED, () => {
+            if (etherpadManager) {
+                etherpadManager.toggleEtherpad();
+            }
         }
-    },
-    [UIEvents.SHARED_VIDEO_CLICKED]: () => {
-        if (sharedVideoManager) {
-            sharedVideoManager.toggleSharedVideo();
+    ], [
+        UIEvents.SHARED_VIDEO_CLICKED, () => {
+            if (sharedVideoManager) {
+                sharedVideoManager.toggleSharedVideo();
+            }
         }
-    },
-    [UIEvents.TOGGLE_FULLSCREEN]: UI.toggleFullScreen,
-
-    [UIEvents.TOGGLE_CHAT]: UI.toggleChat,
-
-    [UIEvents.TOGGLE_SETTINGS]: () => {
-        UI.toggleSidePanel("settings_container");
-    },
-
-    [UIEvents.TOGGLE_CONTACT_LIST]: UI.toggleContactList,
-
-    [UIEvents.TOGGLE_PROFILE]: () => {
-        if(APP.tokenData.isGuest) {
-            UI.toggleSidePanel("profile_container");
+    ], [
+        UIEvents.TOGGLE_FULLSCREEN,  UI.toggleFullScreen
+    ], [
+        UIEvents.TOGGLE_CHAT, UI.toggleChat
+    ], [
+        UIEvents.TOGGLE_SETTINGS, () => {
+            UI.toggleSidePanel("settings_container");
         }
-    },
-
-    [UIEvents.TOGGLE_FILM_STRIP]: UI.handleToggleFilmStrip,
-
-    [UIEvents.FOLLOW_ME_ENABLED]: (isEnabled) => {
-        if (followMeHandler) {
-            followMeHandler.enableFollowMe(isEnabled);
+    ], [
+        UIEvents.TOGGLE_CONTACT_LIST, UI.toggleContactList
+    ], [
+        UIEvents.TOGGLE_PROFILE, () => {
+            if(APP.tokenData.isGuest) {
+                UI.toggleSidePanel("profile_container");
+            }
         }
-    }
-};
+    ], [
+        UIEvents.TOGGLE_FILM_STRIP, UI.handleToggleFilmStrip
+    ], [
+        UIEvents.FOLLOW_ME_ENABLED, (isEnabled) => {
+            if (followMeHandler) {
+                followMeHandler.enableFollowMe(isEnabled);
+            }
+        }
+    ]
+]);
 
 module.exports = UI;

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -53,6 +53,15 @@ let followMeHandler;
 
 let deviceErrorDialog;
 
+/**
+ * Object representing name of some UI events and their handlers.
+ *
+ * @type {{
+ *      event: Function
+ * }}
+ */
+let UIListeners;
+
 const TrackErrors = JitsiMeetJS.errors.track;
 
 const JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP = {
@@ -325,69 +334,6 @@ function _setTooltipDefaults() {
 }
 
 /**
- * Setup some UI event listeners.
- */
-function registerListeners() {
-
-    UI.addListener(UIEvents.ETHERPAD_CLICKED, function () {
-        if (etherpadManager) {
-            etherpadManager.toggleEtherpad();
-        }
-    });
-
-    UI.addListener(UIEvents.SHARED_VIDEO_CLICKED, function () {
-        if (sharedVideoManager) {
-            sharedVideoManager.toggleSharedVideo();
-        }
-    });
-
-    UI.addListener(UIEvents.TOGGLE_FULLSCREEN, UI.toggleFullScreen);
-
-    UI.addListener(UIEvents.TOGGLE_CHAT, UI.toggleChat);
-
-    UI.addListener(UIEvents.TOGGLE_SETTINGS, function () {
-        UI.toggleSidePanel("settings_container");
-    });
-
-    UI.addListener(UIEvents.TOGGLE_CONTACT_LIST, UI.toggleContactList);
-
-    UI.addListener( UIEvents.TOGGLE_PROFILE, function() {
-        if(APP.tokenData.isGuest)
-            UI.toggleSidePanel("profile_container");
-    });
-
-    UI.addListener(UIEvents.TOGGLE_FILM_STRIP, UI.handleToggleFilmStrip);
-
-    UI.addListener(UIEvents.FOLLOW_ME_ENABLED, function (isEnabled) {
-        if (followMeHandler)
-            followMeHandler.enableFollowMe(isEnabled);
-    });
-}
-
-/**
- * Setup some DOM event listeners.
- */
-function bindEvents() {
-    function onResize() {
-        SideContainerToggler.resize();
-        VideoLayout.resizeVideoArea();
-    }
-
-    // Resize and reposition videos in full screen mode.
-    $(document).on(
-        'webkitfullscreenchange mozfullscreenchange fullscreenchange',
-        () => {
-            eventEmitter.emit(  UIEvents.FULLSCREEN_TOGGLED,
-                                UIUtil.isFullScreen());
-
-            onResize();
-        }
-    );
-
-    $(window).resize(onResize);
-}
-
-/**
  * Returns the shared document manager object.
  * @return {EtherpadManager} the shared document manager object
  */
@@ -410,8 +356,6 @@ UI.start = function () {
     // Set the defaults for tooltips.
     _setTooltipDefaults();
 
-    registerListeners();
-
     ToolbarToggler.init();
     SideContainerToggler.init(eventEmitter);
     FilmStrip.init(eventEmitter);
@@ -422,7 +366,6 @@ UI.start = function () {
     }
     VideoLayout.resizeVideoArea(true, true);
 
-    bindEvents();
     sharedVideoManager = new SharedVideoManager(eventEmitter);
     if (!interfaceConfig.filmStripOnly) {
         let debouncedShowToolbar = debounce(() => {
@@ -479,10 +422,57 @@ UI.start = function () {
     if(APP.tokenData.callee) {
         UI.showRingOverlay();
     }
+};
 
-    // Return true to indicate that the UI has been fully started and
-    // conference ready.
-    return true;
+/**
+ * Setup some UI event listeners.
+ */
+UI.registerListeners = () => {
+    Object.keys(UIListeners).map((key) => {
+        UI.addListener(key, UIListeners[key]);
+    });
+};
+
+/**
+ * Unregister some UI event listeners.
+ */
+UI.unregisterListeners = () => {
+    Object.keys(UIListeners).map((key) => {
+        UI.removeListener(key, UIListeners[key]);
+    });
+};
+
+/**
+ * Setup some DOM event listeners.
+ */
+UI.bindEvents = () => {
+    function onResize() {
+        SideContainerToggler.resize();
+        VideoLayout.resizeVideoArea();
+    }
+
+    // Resize and reposition videos in full screen mode.
+    $(document).on(
+        'webkitfullscreenchange mozfullscreenchange fullscreenchange',
+        () => {
+            eventEmitter.emit(UIEvents.FULLSCREEN_TOGGLED,
+                UIUtil.isFullScreen());
+
+            onResize();
+        }
+    );
+
+    $(window).resize(onResize);
+};
+
+/**
+ * Unbind some DOM event listeners.
+ */
+UI.unbindEvents = () => {
+    $(document)
+        .off('webkitfullscreenchange mozfullscreenchange fullscreenchange');
+
+    $(window).off('resize');
 };
 
 /**
@@ -1423,6 +1413,42 @@ UI.isRingOverlayVisible = function () {
  */
 UI.onUserFeaturesChanged = function (user) {
     VideoLayout.onUserFeaturesChanged(user);
+};
+
+UIListeners = {
+    [UIEvents.ETHERPAD_CLICKED]: () => {
+        if (etherpadManager) {
+            etherpadManager.toggleEtherpad();
+        }
+    },
+    [UIEvents.SHARED_VIDEO_CLICKED]: () => {
+        if (sharedVideoManager) {
+            sharedVideoManager.toggleSharedVideo();
+        }
+    },
+    [UIEvents.TOGGLE_FULLSCREEN]: UI.toggleFullScreen,
+
+    [UIEvents.TOGGLE_CHAT]: UI.toggleChat,
+
+    [UIEvents.TOGGLE_SETTINGS]: () => {
+        UI.toggleSidePanel("settings_container");
+    },
+
+    [UIEvents.TOGGLE_CONTACT_LIST]: UI.toggleContactList,
+
+    [UIEvents.TOGGLE_PROFILE]: () => {
+        if(APP.tokenData.isGuest) {
+            UI.toggleSidePanel("profile_container");
+        }
+    },
+
+    [UIEvents.TOGGLE_FILM_STRIP]: UI.handleToggleFilmStrip,
+
+    [UIEvents.FOLLOW_ME_ENABLED]: (isEnabled) => {
+        if (followMeHandler) {
+            followMeHandler.enableFollowMe(isEnabled);
+        }
+    }
 };
 
 module.exports = UI;

--- a/modules/UI/toolbars/Toolbar.js
+++ b/modules/UI/toolbars/Toolbar.js
@@ -328,6 +328,39 @@ function getToolbarButtonPlace (btn) {
         'extended';
 }
 
+/**
+ * Event handler for side toolbar container toggled event.
+ *
+ * @param {string} containerId - ID of the container.
+ * @param {boolean} isVisible - Flag showing whether container
+ * is visible.
+ * @returns {void}
+ */
+function onSideToolbarContainerToggled(containerId, isVisible) {
+    Toolbar._handleSideToolbarContainerToggled(containerId, isVisible);
+}
+
+/**
+ * Event handler for local raise hand changed event.
+ *
+ * @param {boolean} isRaisedHand - Flag showing whether hand is raised.
+ * @returns {void}
+ */
+function onLocalRaiseHandChanged(isRaisedHand) {
+    Toolbar._setToggledState("toolbar_button_raisehand", isRaisedHand);
+}
+
+/**
+ * Event handler for full screen toggled event.
+ *
+ * @param {boolean} isFullScreen - Flag showing whether app in full
+ * screen mode.
+ * @returns {void}
+ */
+function onFullScreenToggled(isFullScreen) {
+    Toolbar._handleFullScreenToggled(isFullScreen);
+}
+
 Toolbar = {
     init (eventEmitter) {
         emitter = eventEmitter;
@@ -335,6 +368,9 @@ Toolbar = {
         this.enabled = true;
         this.toolbarSelector = $("#mainToolbarContainer");
         this.extendedToolbarSelector = $("#extendedToolbar");
+
+        // Unregister listeners in case of reinitialization.
+        this.unregisterListeners();
 
         // Initialise the toolbar buttons.
         // The main toolbar will only take into account
@@ -345,21 +381,7 @@ Toolbar = {
 
         this._setButtonHandlers();
 
-        APP.UI.addListener(UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
-            (containerId, isVisible) => {
-                Toolbar._handleSideToolbarContainerToggled( containerId,
-                                                            isVisible);
-            });
-
-        APP.UI.addListener(UIEvents.LOCAL_RAISE_HAND_CHANGED,
-            (isRaisedHand) => {
-                this._setToggledState("toolbar_button_raisehand", isRaisedHand);
-            });
-
-        APP.UI.addListener(UIEvents.FULLSCREEN_TOGGLED,
-            (isFullScreen) => {
-                Toolbar._handleFullScreenToggled(isFullScreen);
-            });
+        this.registerListeners();
 
         APP.UI.addListener(UIEvents.SHOW_CUSTOM_TOOLBAR_BUTTON_POPUP,
             (popupID, show, timeout) => {
@@ -371,6 +393,35 @@ Toolbar = {
             UIUtil.removeTooltip(
                 document.getElementById('toolbar_button_profile'));
         }
+    },
+    /**
+     *  Register listeners for UI events of toolbar component.
+     *
+     *  @returns {void}
+     */
+    registerListeners() {
+        APP.UI.addListener(UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
+            onSideToolbarContainerToggled);
+
+        APP.UI.addListener(UIEvents.LOCAL_RAISE_HAND_CHANGED,
+            onLocalRaiseHandChanged);
+
+        APP.UI.addListener(UIEvents.FULLSCREEN_TOGGLED, onFullScreenToggled);
+    },
+    /**
+     *  Unregisters handlers for UI events of Toolbar component.
+     *
+     *  @returns {void}
+     */
+    unregisterListeners() {
+        APP.UI.removeListener(UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
+            onSideToolbarContainerToggled);
+
+        APP.UI.removeListener(UIEvents.LOCAL_RAISE_HAND_CHANGED,
+            onLocalRaiseHandChanged);
+
+        APP.UI.removeListener(UIEvents.FULLSCREEN_TOGGLED,
+            onFullScreenToggled);
     },
     /**
      * Enables / disables the toolbar.

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -68,6 +68,17 @@ function onContactClicked (id) {
 }
 
 /**
+ * Handler for local flip X changed event.
+ * @param {Object} val
+ */
+function onLocalFlipXChanged (val) {
+    localFlipX = val;
+    if(largeVideo) {
+        largeVideo.onLocalFlipXChange(val);
+    }
+}
+
+/**
  * Returns the corresponding resource id to the given peer container
  * DOM element.
  *
@@ -91,11 +102,10 @@ let largeVideo;
 var VideoLayout = {
     init (emitter) {
         eventEmitter = emitter;
-        eventEmitter.addListener(UIEvents.LOCAL_FLIPX_CHANGED, function (val) {
-                localFlipX = val;
-                if(largeVideo)
-                    largeVideo.onLocalFlipXChange(val);
-            });
+
+        // Unregister listeners in case of reinitialization
+        this.unregisterListeners();
+
         localVideoThumbnail = new LocalVideo(VideoLayout, emitter);
         // sets default video type of local video
         // FIXME container type is totally different thing from the video type
@@ -104,8 +114,29 @@ var VideoLayout = {
         // the local video thumb maybe one pixel
         this.resizeThumbnails(false, true);
 
-        emitter.addListener(UIEvents.CONTACT_CLICKED, onContactClicked);
         this.lastNCount = config.channelLastN;
+
+        this.registerListeners();
+    },
+
+    /**
+     * Registering listeners for UI events in Video layout component.
+     *
+     * @returns {void}
+     */
+    registerListeners() {
+        eventEmitter.addListener(UIEvents.LOCAL_FLIPX_CHANGED,
+            onLocalFlipXChanged);
+        eventEmitter.addListener(UIEvents.CONTACT_CLICKED, onContactClicked);
+    },
+
+    /**
+     * Unregistering listeners for UI events in Video layout component.
+     *
+     * @returns {void}
+     */
+    unregisterListeners() {
+        eventEmitter.removeListener(UIEvents.CONTACT_CLICKED, onContactClicked);
     },
 
     initLargeVideo () {

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -7,6 +7,7 @@ import UIEvents from '../../../../service/UI/UIEvents';
 import { SET_DOMAIN } from './actionTypes';
 
 import { appNavigate } from '../../app';
+import { setUnsupportedBrowser } from '../../unsupported-browser';
 
 declare var APP: Object;
 declare var JitsiMeetJS: Object;
@@ -34,13 +35,6 @@ export function connect() {
         // XXX For web based version we use conference initialization logic
         // from the old app (at the moment of writing).
         return APP.conference.init({ roomName: room }).then(() => {
-            // If during the conference initialization was defined that browser
-            // doesn't support WebRTC then we should define which route
-            // to render.
-            if (APP.unsupportedBrowser) {
-                dispatch(appNavigate(room));
-            }
-
             if (APP.logCollector) {
                 // Start the LogCollector's periodic "store logs" task
                 APP.logCollector.start();
@@ -82,6 +76,25 @@ export function connect() {
                 APP.UI.hideRingOverLay();
                 APP.API.notifyConferenceLeft(APP.conference.roomName);
                 logger.error(err);
+
+                dispatch(setUnsupportedBrowser(err));
+
+                // If during the conference initialization was defined that
+                // browser doesn't support WebRTC then we should define
+                // which route to render.
+                dispatch(appNavigate(room));
+
+                // Force reinitialization of the conference if WebRTC is ready.
+                if (err.webRTCReadyPromise) {
+                    err.webRTCReadyPromise.then(() => {
+                        // Setting plugin required flag to false because
+                        // it's already been installed.
+                        dispatch(setUnsupportedBrowser({
+                            isPluginRequired: false
+                        }));
+                        dispatch(appNavigate(room));
+                    });
+                }
             });
     };
 }

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -6,6 +6,8 @@ import UIEvents from '../../../../service/UI/UIEvents';
 
 import { SET_DOMAIN } from './actionTypes';
 
+import { appNavigate } from '../../app';
+
 declare var APP: Object;
 declare var JitsiMeetJS: Object;
 
@@ -32,6 +34,13 @@ export function connect() {
         // XXX For web based version we use conference initialization logic
         // from the old app (at the moment of writing).
         return APP.conference.init({ roomName: room }).then(() => {
+            // If during the conference initialization was defined that browser
+            // doesn't support WebRTC then we should define which route
+            // to render.
+            if (APP.unsupportedBrowser) {
+                dispatch(appNavigate(room));
+            }
+
             if (APP.logCollector) {
                 // Start the LogCollector's periodic "store logs" task
                 APP.logCollector.start();

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -11,6 +11,7 @@ import { setUnsupportedBrowser } from '../../unsupported-browser';
 
 declare var APP: Object;
 declare var JitsiMeetJS: Object;
+declare var config: Object;
 
 const JitsiConferenceEvents = JitsiMeetJS.events.conference;
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -71,6 +72,12 @@ export function connect() {
             });
 
             APP.keyboardshortcut.init();
+
+            if (config.requireDisplayName) {
+                if (!APP.settings.getDisplayName()) {
+                    APP.UI.promptDisplayName();
+                }
+            }
         })
             .catch(err => {
                 APP.UI.hideRingOverLay();

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -97,7 +97,7 @@ export function connect() {
                         // Setting plugin required flag to false because
                         // it's already been installed.
                         dispatch(setUnsupportedBrowser({
-                            isPluginRequired: false
+                            status: 'OK'
                         }));
                         dispatch(appNavigate(room));
                     });

--- a/react/features/base/lib-jitsi-meet/_.web.js
+++ b/react/features/base/lib-jitsi-meet/_.web.js
@@ -1,8 +1,8 @@
 /* @flow */
 
-declare var JitsiMeetJS: Object;
-
 // Polyfill for URL constructor
 import 'url-polyfill';
+
+declare var JitsiMeetJS: Object;
 
 export default JitsiMeetJS;

--- a/react/features/base/lib-jitsi-meet/_.web.js
+++ b/react/features/base/lib-jitsi-meet/_.web.js
@@ -2,4 +2,7 @@
 
 declare var JitsiMeetJS: Object;
 
+// Polyfill for URL constructor
+import 'url-polyfill';
+
 export default JitsiMeetJS;

--- a/react/features/base/react/Platform.web.js
+++ b/react/features/base/react/Platform.web.js
@@ -7,6 +7,10 @@ if (userAgent.match(/Android/i)) {
     OS = 'android';
 } else if (userAgent.match(/iP(ad|hone|od)/i)) {
     OS = 'ios';
+} else if (userAgent.match(/windows/i)) {
+    OS = 'windows';
+} else if (userAgent.match(/mac/i)) {
+    OS = 'mac';
 }
 
 /**

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -1,5 +1,11 @@
+/* global APP */
+
 import { Platform } from '../react';
-import { UnsupportedMobileBrowser } from '../../unsupported-browser';
+import {
+    UnsupportedDesktopBrowser,
+    PluginRequiredBrowser,
+    UnsupportedMobileBrowser
+} from '../../unsupported-browser';
 
 /**
  * Array of rules defining whether we should intercept component to render
@@ -25,6 +31,17 @@ const _RULES = [
 
         if (OS === 'android' || OS === 'ios') {
             return UnsupportedMobileBrowser;
+        }
+    },
+    () => {
+        if (APP.unsupportedBrowser) {
+            const { isOldBrowser } = APP.unsupportedBrowser;
+
+            if (isOldBrowser) {
+                return UnsupportedDesktopBrowser;
+            }
+
+            return PluginRequiredBrowser;
         }
     }
 ];

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -1,9 +1,10 @@
-/* global APP */
+/* global APP, interfaceConfig */
 
 import { Platform } from '../react';
 import {
-    UnsupportedDesktopBrowser,
+    NoMobileApp,
     PluginRequiredBrowser,
+    UnsupportedDesktopBrowser,
     UnsupportedMobileBrowser
 } from '../../unsupported-browser';
 
@@ -30,7 +31,13 @@ const _RULES = [
         const OS = Platform.OS;
 
         if (OS === 'android' || OS === 'ios') {
-            return UnsupportedMobileBrowser;
+            const mobileAppEnabled = interfaceConfig.MOBILE_APP_ENABLED;
+
+            if (mobileAppEnabled) {
+                return UnsupportedMobileBrowser;
+            }
+
+            return NoMobileApp;
         }
     },
     () => {

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -16,6 +16,7 @@ declare var interfaceConfig: Object;
  * or not.
  *
  * @private
+ * @param {Object} state - Object containing current Redux state.
  * @returns {ReactElement|void}
  * @type {Function[]}
  */
@@ -26,6 +27,8 @@ const _RULES = [
      * browser. In order to promote the app, we choose to suggest the mobile
      * app even if the browser supports the app (e.g. Google Chrome with
      * WebRTC support on Android).
+     *
+     * @param {Object} state - Redux state of the app.
      *
      * @returns {UnsupportedMobileBrowser|void} If the rule is satisfied then
      * we should intercept existing component by UnsupportedMobileBrowser.
@@ -43,14 +46,17 @@ const _RULES = [
             return NoMobileApp;
         }
     },
-    () => {
-        if (APP.unsupportedBrowser) {
-            const { isOldBrowser } = APP.unsupportedBrowser;
+    state => {
+        const {
+            isOldBrowser,
+            isPluginRequired
+        } = state['features/unsupported-browser'];
 
-            if (isOldBrowser) {
-                return UnsupportedDesktopBrowser;
-            }
+        if (isOldBrowser) {
+            return UnsupportedDesktopBrowser;
+        }
 
+        if (isPluginRequired) {
             return PluginRequiredBrowser;
         }
     }

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -1,4 +1,4 @@
-/* global APP, interfaceConfig */
+/* @flow */
 
 import { Platform } from '../react';
 import {
@@ -7,6 +7,9 @@ import {
     UnsupportedDesktopBrowser,
     UnsupportedMobileBrowser
 } from '../../unsupported-browser';
+
+declare var APP: Object;
+declare var interfaceConfig: Object;
 
 /**
  * Array of rules defining whether we should intercept component to render
@@ -59,11 +62,12 @@ const _RULES = [
  *
  * @param {Object|Function} stateOrGetState - Either Redux state object or
  * getState() function.
- * @param {ReactElement} currentComponent - Current route component to render.
+ * @param {ReactElement} component - Current route component to render.
  * @returns {ReactElement} If any of rules is satisfied returns intercepted
  * component.
  */
-export function interceptComponent(stateOrGetState, currentComponent) {
+export function interceptComponent(stateOrGetState: Object,
+                                   component: ReactElement<*>) {
     let result;
     const state
         = typeof stateOrGetState === 'function'
@@ -77,5 +81,5 @@ export function interceptComponent(stateOrGetState, currentComponent) {
         }
     }
 
-    return result || currentComponent;
+    return result || component;
 }

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -37,9 +37,7 @@ const _RULES = [
         const OS = Platform.OS;
 
         if (OS === 'android' || OS === 'ios') {
-            const mobileAppEnabled = interfaceConfig.MOBILE_APP_ENABLED;
-
-            if (mobileAppEnabled) {
+            if (interfaceConfig.MOBILE_APP_ENABLED) {
                 return UnsupportedMobileBrowser;
             }
 

--- a/react/features/base/util/interceptComponent.js
+++ b/react/features/base/util/interceptComponent.js
@@ -10,6 +10,9 @@ import {
 
 declare var APP: Object;
 declare var interfaceConfig: Object;
+declare var JitsiMeetJS: Object;
+
+const ConferenceErrors = JitsiMeetJS.errors.conference;
 
 /**
  * Array of rules defining whether we should intercept component to render
@@ -45,16 +48,13 @@ const _RULES = [
         }
     },
     state => {
-        const {
-            isOldBrowser,
-            isPluginRequired
-        } = state['features/unsupported-browser'];
+        const { status } = state['features/unsupported-browser'];
 
-        if (isOldBrowser) {
+        switch (status) {
+        case ConferenceErrors.WEBRTC_IS_NOT_SUPPORTED:
             return UnsupportedDesktopBrowser;
-        }
 
-        if (isPluginRequired) {
+        case ConferenceErrors.PLUGIN_REQUIRED:
             return PluginRequiredBrowser;
         }
     }

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -1,4 +1,4 @@
-/* global $, APP */
+/* @flow */
 
 import React, { Component } from 'react';
 import { connect as reactReduxConnect } from 'react-redux';
@@ -7,6 +7,9 @@ import { connect, disconnect } from '../../base/connection';
 import { Watermarks } from '../../base/react';
 import { FeedbackButton } from '../../feedback';
 import { OverlayContainer } from '../../overlay';
+
+declare var $: Function;
+declare var APP: Object;
 
 /**
  * For legacy reasons, inline style for display none.

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -4,9 +4,10 @@ import React, { Component } from 'react';
 import { connect as reactReduxConnect } from 'react-redux';
 
 import { connect, disconnect } from '../../base/connection';
-import { Watermarks } from '../../base/react';
 import { FeedbackButton } from '../../feedback';
+import { HideNotificationBarStyle } from '../../unsupported-browser';
 import { OverlayContainer } from '../../overlay';
+import { Watermarks } from '../../base/react';
 
 declare var $: Function;
 declare var APP: Object;
@@ -176,6 +177,7 @@ class Conference extends Component {
                 </div>
 
                 <OverlayContainer />
+                <HideNotificationBarStyle />
             </div>
         );
     }

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -47,6 +47,9 @@ class Conference extends Component {
     componentDidMount() {
         APP.UI.start();
 
+        APP.UI.registerListeners();
+        APP.UI.bindEvents();
+
         // XXX Temporary solution until we add React translation.
         APP.translation.translateElement($('#videoconference_page'));
 
@@ -60,6 +63,9 @@ class Conference extends Component {
      * @inheritdoc
      */
     componentWillUnmount() {
+        APP.UI.unregisterListeners();
+        APP.UI.unbindEvents();
+
         if (APP.conference.isJoined()) {
             this.props.dispatch(disconnect());
         }

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -57,7 +57,9 @@ class Conference extends Component {
      * @inheritdoc
      */
     componentWillUnmount() {
-        this.props.dispatch(disconnect());
+        if (APP.conference.isJoined()) {
+            this.props.dispatch(disconnect());
+        }
     }
 
     /**

--- a/react/features/unsupported-browser/actionTypes.js
+++ b/react/features/unsupported-browser/actionTypes.js
@@ -16,3 +16,14 @@ import { Symbol } from '../base/react';
  * }
  */
 export const DISMISS_MOBILE_APP_PROMO = Symbol('DISMISS_MOBILE_APP_PROMO');
+
+/**
+ * Action signalling to change information about unsupported browser
+ * in Redux store.
+ *
+ * {
+ *      type: SET_UNSUPPORTED_BROWSER,
+ *      unsupportedBrowser: Object
+ * }
+ */
+export const SET_UNSUPPORTED_BROWSER = Symbol('SET_UNSUPPORTED_BROWSER');

--- a/react/features/unsupported-browser/actionTypes.js
+++ b/react/features/unsupported-browser/actionTypes.js
@@ -18,8 +18,8 @@ import { Symbol } from '../base/react';
 export const DISMISS_MOBILE_APP_PROMO = Symbol('DISMISS_MOBILE_APP_PROMO');
 
 /**
- * Action signalling to change information about unsupported browser
- * in Redux store.
+ * The type of Redux action which signals to change information about
+ * unsupported browser in Redux store.
  *
  * {
  *      type: SET_UNSUPPORTED_BROWSER,

--- a/react/features/unsupported-browser/actions.js
+++ b/react/features/unsupported-browser/actions.js
@@ -1,4 +1,7 @@
-import { DISMISS_MOBILE_APP_PROMO } from './actionTypes';
+import {
+    DISMISS_MOBILE_APP_PROMO,
+    SET_UNSUPPORTED_BROWSER
+} from './actionTypes';
 
 /**
  * Returns a Redux action which signals that the UnsupportedMobileBrowser which
@@ -17,5 +20,22 @@ import { DISMISS_MOBILE_APP_PROMO } from './actionTypes';
 export function dismissMobileAppPromo() {
     return {
         type: DISMISS_MOBILE_APP_PROMO
+    };
+}
+
+/**
+ * Sets unsupported browser object.
+ *
+ * @param {Object} unsupportedBrowser - Object describing the unsupported
+ * browser.
+ * @returns {{
+ *      type: SET_UNSUPPORTED_BROWSER,
+ *      unsupportedBrowser: Object
+ *  }}
+ */
+export function setUnsupportedBrowser(unsupportedBrowser) {
+    return {
+        type: SET_UNSUPPORTED_BROWSER,
+        unsupportedBrowser
     };
 }

--- a/react/features/unsupported-browser/components/HideNotificationBarStyle.js
+++ b/react/features/unsupported-browser/components/HideNotificationBarStyle.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
  * @private
  * @returns {ReactElement}
  */
-export default class UnsupportedMobileBrowserStyle extends Component {
+export default class HideNotificationBarStyles extends Component {
 
     /**
      * Implements React's {@link Component#render()}.

--- a/react/features/unsupported-browser/components/NoMobileApp.js
+++ b/react/features/unsupported-browser/components/NoMobileApp.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import UnsupportedMobileBrowserStyle from './UnsupportedMobileBrowserStyle';
+import HideNotificationBarStyle from './HideNotificationBarStyle';
 
 declare var interfaceConfig: Object;
 
@@ -30,7 +30,7 @@ export default class NoMobileApp extends Component {
                     Please use {interfaceConfig.APP_NAME} on
                     Desktop to join calls.
                 </p>
-                <UnsupportedMobileBrowserStyle />
+                <HideNotificationBarStyle />
             </div>
         );
     }

--- a/react/features/unsupported-browser/components/NoMobileApp.js
+++ b/react/features/unsupported-browser/components/NoMobileApp.js
@@ -2,6 +2,8 @@
 
 import React, { Component } from 'react';
 
+import UnsupportedMobileBrowserStyle from './UnsupportedMobileBrowserStyle';
+
 declare var interfaceConfig: Object;
 
 /**
@@ -22,12 +24,13 @@ export default class NoMobileApp extends Component {
         return (
             <div className = { ns }>
                 <h2 className = { `${ns}__title` }>
-                    Video chat isn't available in the mobile apps
+                    Video chat isn't available on mobile
                 </h2>
                 <p className = { `${ns}__description` }>
-                    Video chat isn't available on mobile
+                    Please use {interfaceConfig.APP_NAME} on
                     Desktop to join calls.
                 </p>
+                <UnsupportedMobileBrowserStyle />
             </div>
         );
     }

--- a/react/features/unsupported-browser/components/NoMobileApp.js
+++ b/react/features/unsupported-browser/components/NoMobileApp.js
@@ -1,0 +1,31 @@
+/* global interfaceConfig */
+import React, { Component } from 'react';
+
+/**
+ * React component representing no mobile page.
+ *
+ * @class NoMobileApp
+ */
+export default class NoMobileApp extends Component {
+
+    /**
+     * Renders the component.
+     *
+     * @returns {ReactElement}
+     */
+    render() {
+        const ns = 'no-mobile-app';
+
+        return (
+            <div className = { ns }>
+                <h2 className = { `${ns}__title` }>
+                    Video chat isn't available in the mobile apps
+                </h2>
+                <p className = { `${ns}__description` }>
+                    Please use { interfaceConfig.APP_NAME } on <br />
+                    Desktop top join calls.
+                </p>
+            </div>
+        );
+    }
+}

--- a/react/features/unsupported-browser/components/NoMobileApp.js
+++ b/react/features/unsupported-browser/components/NoMobileApp.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 declare var interfaceConfig: Object;
 
 /**
- * React component representing no mobile page.
+ * React component representing no mobile app page.
  *
  * @class NoMobileApp
  */
@@ -25,8 +25,8 @@ export default class NoMobileApp extends Component {
                     Video chat isn't available in the mobile apps
                 </h2>
                 <p className = { `${ns}__description` }>
-                    Please use { interfaceConfig.APP_NAME } on <br />
-                    Desktop top join calls.
+                    Video chat isn't available on mobile
+                    Desktop to join calls.
                 </p>
             </div>
         );

--- a/react/features/unsupported-browser/components/NoMobileApp.js
+++ b/react/features/unsupported-browser/components/NoMobileApp.js
@@ -1,5 +1,8 @@
-/* global interfaceConfig */
+/* @flow */
+
 import React, { Component } from 'react';
+
+declare var interfaceConfig: Object;
 
 /**
  * React component representing no mobile page.

--- a/react/features/unsupported-browser/components/PluginRequiredBrowser.js
+++ b/react/features/unsupported-browser/components/PluginRequiredBrowser.js
@@ -1,3 +1,5 @@
+/*  @flow */
+
 import React, { Component } from 'react';
 
 import BROWSER_LINKS from './browserLinks';

--- a/react/features/unsupported-browser/components/PluginRequiredBrowser.js
+++ b/react/features/unsupported-browser/components/PluginRequiredBrowser.js
@@ -18,6 +18,7 @@ export default class PluginRequiredBrowser extends Component {
      */
     render() {
         const ns = 'unsupported-desktop-browser';
+        const nsLink = `${ns}__link`;
 
         return (
             <div className = { ns }>
@@ -30,13 +31,13 @@ export default class PluginRequiredBrowser extends Component {
                     however, we strongly recommend that you do that using
                     the&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.CHROME }>Chrome</a>,&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.CHROMIUM }>Chromium</a> or&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.FIREFOX }>Firefox</a> browsers.
                 </p>
             </div>

--- a/react/features/unsupported-browser/components/PluginRequiredBrowser.js
+++ b/react/features/unsupported-browser/components/PluginRequiredBrowser.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react';
+
+import BROWSER_LINKS from './browserLinks';
+
+/**
+ * React component representing plugin installation required page.
+ *
+ * @class PluginRequiredBrowser
+ */
+export default class PluginRequiredBrowser extends Component {
+
+    /**
+     * Renders the component.
+     *
+     * @returns {ReactElement}
+     */
+    render() {
+        const ns = 'unsupported-desktop-browser';
+
+        return (
+            <div className = { ns }>
+                <h2 className = { `${ns}__title` }>
+                    Your browser requires a plugin for this conversation.
+                </h2>
+                <p className = { `${ns}__description_small` }>
+                    Once you install the plugin, it will be possible for you
+                    to have your conversation here. For best experience,
+                    however, we strongly recommend that you do that using
+                    the&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.CHROME }>Chrome</a>,&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.CHROMIUM }>Chromium</a> or&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.FIREFOX }>Firefox</a> browsers.
+                </p>
+            </div>
+        );
+    }
+}
+

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React, { Component } from 'react';
 
 import BROWSER_LINKS from './browserLinks';

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -4,6 +4,8 @@ import React, { Component } from 'react';
 
 import { Platform } from '../../base/react';
 
+import HideNotificationBarStyle from './HideNotificationBarStyle';
+
 import BROWSER_LINKS from './browserLinks';
 
 /**
@@ -42,6 +44,7 @@ export default class UnsupportedDesktopBrowser extends Component {
                     { this._showSafariLinkIfRequired() }
                     { this._showIELinkIfRequired() }.
                 </p>
+                <HideNotificationBarStyle />
             </div>
         );
     }

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -18,6 +18,7 @@ export default class UnsupportedDesktopBrowser extends Component {
      */
     render() {
         const ns = 'unsupported-desktop-browser';
+        const nsLink = `${ns}__link`;
 
         return (
             <div className = { ns }>
@@ -25,18 +26,18 @@ export default class UnsupportedDesktopBrowser extends Component {
                     It looks like you're using a browser we don't support.
                 </h2>
                 <p className = { `${ns}__description` }>
-                    Please try again with&nbsp;
+                    Please try again with the latest version of&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.CHROME } >Chrome</a>,&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.FIREFOX }>Firefox</a>,&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.SAFARI }>Safari</a> or&nbsp;
                     <a
-                        className = { `${ns}__link` }
+                        className = { nsLink }
                         href = { BROWSER_LINKS.IE }>IE</a>.
                 </p>
             </div>

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -1,37 +1,6 @@
 import React, { Component } from 'react';
 
-/**
- * The list of all browsers supported by the application.
- */
-const SUPPORTED_BROWSERS = [
-    {
-        link: 'http://google.com/chrome',
-        name: 'chrome',
-        title: 'Chrome 44+'
-    }, {
-        link: 'http://www.chromium.org/',
-        name: 'chromium',
-        title: 'Chromium 44+'
-    }, {
-        link: 'http://www.getfirefox.com/',
-        name: 'firefox',
-        title: 'Firefox and Iceweasel 40+'
-    }, {
-        link: 'http://www.opera.com',
-        name: 'opera',
-        title: 'Opera 32+'
-    }, {
-        link: 'https://temasys.atlassian.net/wiki/display/TWPP/WebRTC+Plugins',
-        name: 'ie',
-        plugin: 'Temasys 0.8.854+',
-        title: 'IE'
-    }, {
-        link: 'https://temasys.atlassian.net/wiki/display/TWPP/WebRTC+Plugins',
-        name: 'safari',
-        plugin: 'Temasys 0.8.854+',
-        title: 'Safari'
-    }
-];
+import BROWSER_LINKS from './browserLinks';
 
 /**
  * React component representing unsupported browser page.
@@ -39,6 +8,7 @@ const SUPPORTED_BROWSERS = [
  * @class UnsupportedDesktopBrowser
  */
 export default class UnsupportedDesktopBrowser extends Component {
+
     /**
      * Renders the component.
      *
@@ -48,78 +18,27 @@ export default class UnsupportedDesktopBrowser extends Component {
         const ns = 'unsupported-desktop-browser';
 
         return (
-            <div className = { `${ns}-wrapper` }>
-                <div className = { ns }>
-                    <div className = { `${ns}__content` }>
-                        <h2 className = { `${ns}__title` }>
-                            This application is currently only supported by
-                        </h2>
-                        {
-                            this._renderSupportedBrowsers()
-                        }
-                    </div>
-                </div>
-            </div>
-        );
-    }
-
-    /**
-     * Renders a specific browser supported by the application.
-     *
-     * @param {Object} browser - The (information about the) browser supported
-     * by the application to render.
-     * @private
-     * @returns {ReactElement}
-     */
-    _renderSupportedBrowser(browser) {
-        const { link, name, plugin, title } = browser;
-        const ns = 'supported-browser';
-
-        // Browsers which do not support WebRTC could support the application
-        // with the Temasys plugin.
-        const pluginElement
-            = plugin
-                ? <p className = { `${ns}__text_small` }>{ plugin }</p>
-                : null;
-
-        return (
-            <div
-                className = { ns }
-                key = { name }>
-                <div className = { `${ns}__text` }>
-                    {
-                        title
-                    }
-                    {
-                        pluginElement
-                    }
-                </div>
-                <div className = { `${ns}__tile` }>
-                    <div
-                        className = { `${ns}__logo ${ns}__logo_${name}` } />
+            <div className = { ns }>
+                <h2 className = { `${ns}__title` }>
+                    It looks like you're using a browser we don't support.
+                </h2>
+                <p className = { `${ns}__description` }>
+                    Please try again with&nbsp;
                     <a
                         className = { `${ns}__link` }
-                        href = { link }>
-                        <div className = { `${ns}__button` }>DOWNLOAD</div>
-                    </a>
-                </div>
-            </div>
-        );
-    }
-
-    /**
-     * Renders the list of browsers supported by the application.
-     *
-     * @private
-     * @returns {ReactElement}
-     */
-    _renderSupportedBrowsers() {
-        return (
-            <div className = 'supported-browser-list'>
-                {
-                    SUPPORTED_BROWSERS.map(this._renderSupportedBrowser)
-                }
+                        href = { BROWSER_LINKS.CHROME } >Chrome</a>,&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.FIREFOX }>Firefox</a>,&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.SAFARI }>Safari</a> or&nbsp;
+                    <a
+                        className = { `${ns}__link` }
+                        href = { BROWSER_LINKS.IE }>IE</a>.
+                </p>
             </div>
         );
     }
 }
+

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -2,7 +2,16 @@
 
 import React, { Component } from 'react';
 
+import { Platform } from '../../base/react';
+
 import BROWSER_LINKS from './browserLinks';
+
+/**
+ * Describes styles namespace for this component.
+ *
+ * @type {string}
+ */
+const NS = 'unsupported-desktop-browser';
 
 /**
  * React component representing unsupported browser page.
@@ -17,31 +26,60 @@ export default class UnsupportedDesktopBrowser extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const ns = 'unsupported-desktop-browser';
-        const nsLink = `${ns}__link`;
-
         return (
-            <div className = { ns }>
-                <h2 className = { `${ns}__title` }>
+            <div className = { NS }>
+                <h2 className = { `${NS}__title` }>
                     It looks like you're using a browser we don't support.
                 </h2>
-                <p className = { `${ns}__description` }>
+                <p className = { `${NS}__description` }>
                     Please try again with the latest version of&nbsp;
                     <a
-                        className = { nsLink }
+                        className = { `${NS}__link` }
                         href = { BROWSER_LINKS.CHROME } >Chrome</a>,&nbsp;
                     <a
-                        className = { nsLink }
-                        href = { BROWSER_LINKS.FIREFOX }>Firefox</a>,&nbsp;
-                    <a
-                        className = { nsLink }
-                        href = { BROWSER_LINKS.SAFARI }>Safari</a> or&nbsp;
-                    <a
-                        className = { nsLink }
-                        href = { BROWSER_LINKS.IE }>IE</a>.
+                        className = { `${NS}__link` }
+                        href = { BROWSER_LINKS.FIREFOX }>Firefox</a> or&nbsp;
+                    { this._showSafariLinkIfRequired() }
+                    { this._showIELinkIfRequired() }.
                 </p>
             </div>
         );
+    }
+
+    /**
+     * Depending on the platform returns the link to Safari browser.
+     *
+     * @returns {ReactElement|null}
+     * @private
+     */
+    _showSafariLinkIfRequired() {
+        if (Platform.OS === 'mac') {
+            return (
+                <a
+                    className = { `${NS}__link` }
+                    href = { BROWSER_LINKS.SAFARI }>Safari</a>
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Depending on the platform returns the link to IE browser.
+     *
+     * @returns {ReactElement|null}
+     * @private
+     */
+    _showIELinkIfRequired() {
+        if (Platform.OS === 'windows') {
+            return (
+                <a
+                    className = { `${NS}__link` }
+                    href = { BROWSER_LINKS.IE }>IE</a>
+            );
+        }
+
+        return null;
     }
 }
 

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -20,6 +22,9 @@ const _URLS = {
  * @class UnsupportedMobileBrowser
  */
 class UnsupportedMobileBrowser extends Component {
+
+    state: Object;
+
     /**
      * UnsupportedMobileBrowser component's property types.
      *

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import { Platform } from '../../base/react';
 
-import UnsupportedMobileBrowserStyle from './UnsupportedMobileBrowserStyle';
+import HideNotificationBarStyle from './HideNotificationBarStyle';
 
 /**
  * The map of platforms to URLs at which the mobile app for the associated
@@ -104,7 +104,7 @@ class UnsupportedMobileBrowser extends Component {
                         </button>
                     </a>
                 </div>
-                <UnsupportedMobileBrowserStyle />
+                <HideNotificationBarStyle />
             </div>
         );
     }

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 
 import { Platform } from '../../base/react';
 
+import UnsupportedMobileBrowserStyle from './UnsupportedMobileBrowserStyle';
+
 /**
  * The map of platforms to URLs at which the mobile app for the associated
  * platform is available for download.
@@ -102,38 +104,8 @@ class UnsupportedMobileBrowser extends Component {
                         </button>
                     </a>
                 </div>
-
-                {
-                    this._renderStyle()
-                }
+                <UnsupportedMobileBrowserStyle />
             </div>
-        );
-    }
-
-    /**
-     * Renders an HTML style element with CSS specific to
-     * this UnsupportedMobileBrowser.
-     *
-     * @private
-     * @returns {ReactElement}
-     */
-    _renderStyle() {
-        // Temasys provide lib-jitsi-meet/modules/RTC/adapter.screenshare.js
-        // which detects whether the browser supports WebRTC. If the browser
-        // does not support WebRTC, it displays an alert in the form of a yellow
-        // bar at the top of the page. The alert notifies the user that the
-        // browser does not support WebRTC and, if Temasys provide a plugin for
-        // the browser, the alert contains a button to initiate installing the
-        // browser. When Temasys do not provide a plugin for the browser, we do
-        // not want the alert on the unsupported-browser page because the
-        // notification about the lack of WebRTC support is the whole point of
-        // the unsupported-browser page.
-        return (
-            <style type = 'text/css'>
-                {
-                    'iframe[name="adapterjs-alert"] { display: none; }'
-                }
-            </style>
         );
     }
 }

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowserStyle.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowserStyle.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+
+/**
+ * React component that represents HTML style element with CSS specific to
+ * unsupported mobile browser components.
+ *
+ * @private
+ * @returns {ReactElement}
+ */
+export default class UnsupportedMobileBrowserStyle extends Component {
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        // Temasys provide lib-jitsi-meet/modules/RTC/adapter.screenshare.js
+        // which detects whether the browser supports WebRTC. If the browser
+        // does not support WebRTC, it displays an alert in the form of a yellow
+        // bar at the top of the page. The alert notifies the user that the
+        // browser does not support WebRTC and, if Temasys provide a plugin for
+        // the browser, the alert contains a button to initiate installing the
+        // browser. When Temasys do not provide a plugin for the browser, we do
+        // not want the alert on the unsupported-browser page because the
+        // notification about the lack of WebRTC support is the whole point of
+        // the unsupported-browser page.
+        return (
+            <style type = 'text/css'>
+                {
+                    'iframe[name="adapterjs-alert"] { display: none; }'
+                }
+            </style>
+        );
+    }
+}

--- a/react/features/unsupported-browser/components/browserLinks.js
+++ b/react/features/unsupported-browser/components/browserLinks.js
@@ -1,3 +1,5 @@
+/* @flow */
+
 /**
  * Represents hash map that contains browser download links.
  *

--- a/react/features/unsupported-browser/components/browserLinks.js
+++ b/react/features/unsupported-browser/components/browserLinks.js
@@ -1,0 +1,14 @@
+/**
+ * Represents hash map that contains browser download links.
+ *
+ * @type {Object}
+ */
+const BROWSER_LINKS = {
+    CHROME: 'http://google.com/chrome',
+    CHROMIUM: 'http://www.chromium.org/',
+    FIREFOX: 'http://www.getfirefox.com/',
+    SAFARI: 'https://support.apple.com/downloads/safari',
+    IE: 'https://www.microsoft.com/en-us/download/internet-explorer.aspx'
+};
+
+export default BROWSER_LINKS;

--- a/react/features/unsupported-browser/components/browserLinks.js
+++ b/react/features/unsupported-browser/components/browserLinks.js
@@ -9,8 +9,8 @@ const BROWSER_LINKS = {
     CHROME: 'http://google.com/chrome',
     CHROMIUM: 'http://www.chromium.org/',
     FIREFOX: 'http://www.getfirefox.com/',
-    SAFARI: 'https://support.apple.com/downloads/safari',
-    IE: 'https://www.microsoft.com/en-us/download/internet-explorer.aspx'
+    IE: 'https://www.microsoft.com/en-us/download/internet-explorer.aspx',
+    SAFARI: 'https://support.apple.com/downloads/safari'
 };
 
 export default BROWSER_LINKS;

--- a/react/features/unsupported-browser/components/index.js
+++ b/react/features/unsupported-browser/components/index.js
@@ -1,3 +1,4 @@
+export { default as NoMobileApp } from './NoMobileApp';
 export { default as PluginRequiredBrowser } from './PluginRequiredBrowser';
 export { default as UnsupportedDesktopBrowser }
     from './UnsupportedDesktopBrowser';

--- a/react/features/unsupported-browser/components/index.js
+++ b/react/features/unsupported-browser/components/index.js
@@ -1,3 +1,5 @@
+export { default as HideNotificationBarStyle }
+    from './HideNotificationBarStyle';
 export { default as NoMobileApp } from './NoMobileApp';
 export { default as PluginRequiredBrowser } from './PluginRequiredBrowser';
 export { default as UnsupportedDesktopBrowser }

--- a/react/features/unsupported-browser/components/index.js
+++ b/react/features/unsupported-browser/components/index.js
@@ -1,3 +1,4 @@
+export { default as PluginRequiredBrowser } from './PluginRequiredBrowser';
 export { default as UnsupportedDesktopBrowser }
     from './UnsupportedDesktopBrowser';
 export { default as UnsupportedMobileBrowser }

--- a/react/features/unsupported-browser/reducer.js
+++ b/react/features/unsupported-browser/reducer.js
@@ -1,6 +1,9 @@
 import { ReducerRegistry } from '../base/redux';
 
-import { DISMISS_MOBILE_APP_PROMO } from './actionTypes';
+import {
+    DISMISS_MOBILE_APP_PROMO,
+    SET_UNSUPPORTED_BROWSER
+} from './actionTypes';
 
 ReducerRegistry.register(
         'features/unsupported-browser',
@@ -20,6 +23,11 @@ ReducerRegistry.register(
                      * @type {boolean}
                      */
                     mobileAppPromoDismissed: true
+                };
+            case SET_UNSUPPORTED_BROWSER:
+                return {
+                    ...state,
+                    ...action.unsupportedBrowser
                 };
             }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ var plugins = [
     new HasteResolverPlugin()
 ];
 var strophe = /\/node_modules\/strophe(js-plugins)?\/.*\.js$/;
+var urlPolyfill = /\/node_modules\/url-polyfill\/.*\.js$/;
 
 if (minimize) {
     // XXX Webpack's command line argument -p is not enough. Further
@@ -99,6 +100,11 @@ var config = {
 
             loader: 'imports-loader?define=>false&this=>window',
             test: strophe
+        }, {
+            // Set scope to the window for URL polyfill.
+
+            loader: 'imports?this=>window',
+            test: urlPolyfill
         }, {
             // Allow CSS to be imported into JavaScript.
 


### PR DESCRIPTION
This PR is related to unsupported browser feature and requires changes in `lib-jitsi-meet` (https://github.com/jitsi/lib-jitsi-meet/pull/353).

1. __Fix "continuous redirections"__ in Internet Explorer. Problem was caused by checking if url string is correct by means of instantiating `URL` object. Since Internet Explorer doesn't support URL API app was working incorrect. This issue was fixed by using `url-polyfill` which we're using in mobile app.
<img width="1203" alt="screen shot 2017-02-06 at 2 36 17 pm" src="https://cloud.githubusercontent.com/assets/5806075/22702571/db4bd866-ed69-11e6-8051-eced3d2e7c94.png">


2. __Unsupported desktop browser__. Some browsers like MS Edge, old versions of FF, Chrome etc don't support WebRTC and Temasys plugin. So there isn't any way to start web app using that browsers. In order to inform user that she should install supported browser we added `UnsupportedDesktopBrowser` component. MS Edge is considered as non supporting WebRTC because it supports its own implementation (ORTC) but Jitsi Meet doesn't support ORTC (but Microsoft announced that new version of MS Edge will support WebRTC API).
<img width="1277" alt="screen shot 2017-02-02 at 6 14 49 pm" src="https://cloud.githubusercontent.com/assets/5806075/22702680/27750f1e-ed6a-11e6-9f15-bfae855ae8eb.png">


3. __Temasys plugin required__ page. There are browsers that don't support WebRTC but Temasys plugin could be installed. In order to inform user that her browser can run the app with Temasys plugin installed.

4. __No mobile app page__. Since some deployments of Jitsi Meet couldn't support mobile app `NoMobileApp` page was created. It can be enabled by setting `MOBILE_APP_ENABLED` to `false` in `interfaceConfig.js`.

![jkd3gnail5g](https://cloud.githubusercontent.com/assets/5806075/22702615/fe13a9c8-ed69-11e6-9224-c48bf7cd7d48.jpg)

