### PR TITLE
doc: document resolution config option and set it to 720 by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -80,5 +80,7 @@ var config = { // eslint-disable-line no-unused-vars
     // Suspending video might cause problems with audio playback. Disabling until these are fixed.
     disableSuspendVideo: true,
     // disables or enables RTX (RFC 4588).
-    disableRtx: true
+    disableRtx: true,
+    // Sets the preferred resolution (height) for local video. Defaults to 360.
+    resolution: 720
 };


### PR DESCRIPTION
It's time we use 720p by default so people see each other in glorious HD.