### PR TITLE
cleanup: remove adaptive las N config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -53,7 +53,6 @@ var config = { // eslint-disable-line no-unused-vars
     disableStats: false,
     disableAudioLevels: false,
     channelLastN: -1, // The default value of the channel attribute last-n.
-    adaptiveLastN: false,
     //disableAdaptiveSimulcast: false,
     enableRecording: false,
     enableWelcomePage: true,


### PR DESCRIPTION
The feature has been replaced so the option no longer applies.