### PR TITLE
[RN] Fix use of undefined APP 

### DIFF
--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -307,7 +307,9 @@ export class AbstractApp extends Component {
             // non-reactified parts of the code (conference.js for example).
             // Don't use in the react code!!!
             // FIXME: remove when the reactification is finished!
-            APP.store = store;
+            if (typeof APP !== 'undefined') {
+                APP.store = store;
+            }
         }
 
         return store;

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -56,7 +56,7 @@ function _connectionEstablished(store, next, action) {
 
     // FIXME: workaround for the web version. Currently the creation of the
     // conference is handled by /conference.js
-    if (!APP) {
+    if (typeof APP === 'undefined') {
         store.dispatch(createConference());
     }
 


### PR DESCRIPTION
On RN we don't use the global APP object, so don't save the store there unless
it's defined, which is the case in the current web version. Also, check for
undefined explicitly, since a "if (!APP)" check will throw a ReferenceError.