### PR TITLE
[RN] Temporarily disable camera toggling button

### DIFF
--- a/react/features/toolbar/components/Toolbar.native.js
+++ b/react/features/toolbar/components/Toolbar.native.js
@@ -115,12 +115,16 @@ class Toolbar extends AbstractToolbar {
         // TODO Use an appropriate icon for toggle camera facing mode.
         return (
             <View style = { styles.secondaryToolbar }>
+                {/*
+                  * XXX Temporarily disabled until issues are fixed in
+                  * react-native-webrtc.
                 <ToolbarButton
                     iconName = 'switch-camera'
                     iconStyle = { iconStyle }
                     onClick = { this._toggleCameraFacingMode }
                     style = { style }
                     underlayColor = { underlayColor } />
+                */}
                 <ToolbarButton
                     iconName = {
                         this.props._locked ? 'security-locked' : 'security'


### PR DESCRIPTION
It doesn't work properly and gives a very bad user experience. Disble it until
all underlying issues in react-native-webrtc are ironed out.