### PR TITLE
Fix warning about missing key prop

### DIFF
--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -143,7 +143,9 @@ class WelcomePage extends AbstractWelcomePage {
      */
     _renderFeature(index) {
         return (
-            <div className = 'feature_holder'>
+            <div
+                className = 'feature_holder'
+                key = { index } >
                 <div
                     className = 'feature_icon'
                     data-i18n = { `welcomepage.feature${index}.title` } />


### PR DESCRIPTION
When rendering using a for loop each child whould have a key prop.