### PR TITLE
config: Don't require an extension for firefox >=52.

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,7 +40,7 @@ var config = { // eslint-disable-line no-unused-vars
     // up to and including 41. On Firefox 42 and higher, we will run without the
     // extension.
     // If set to -1, an extension will be required for all versions of Firefox.
-    desktopSharingFirefoxMaxVersionExtRequired: -1,
+    desktopSharingFirefoxMaxVersionExtRequired: 51,
     // The URL to the Firefox extension for desktop sharing.
     desktopSharingFirefoxExtensionURL: null,
 


### PR DESCRIPTION
Starting with firefox 52, no extension is required for screensharing.