### PR TITLE
Post load error handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,11 @@
 
                     window.setTimeout(
                         function () { window.location.replace(href); }, delay);
+
+                    // Call extra handler if defined.
+                    if (typeof postLoadErrorHandler === "function") {
+                        postLoadErrorHandler();
+                    }
                 };
                 window.removeEventListener(
                     'error', loadErrHandler, true /* capture phase */);


### PR DESCRIPTION
Adds a placeholder which allows to write a plugin for executing some code after the "load error handler" is triggered. A function named "postLoadErrorHandler" should be defined in one of
the "#include virtual" files.