### PR TITLE
lang: don't use "&nbsp;" for the default policy text

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -81,7 +81,7 @@
         "terms": "Terms"
     },
     "startupoverlay": {
-        "policyText": "&nbsp;",
+        "policyText": " ",
         "title": "__app__ needs to use your microphone and camera."
     },
     "suspendedoverlay": {


### PR DESCRIPTION
Firefox (at least) renders it verbatim.