### PR TITLE
Fixes settings panel translation.

### DIFF
--- a/modules/UI/side_pannels/settings/SettingsMenu.js
+++ b/modules/UI/side_pannels/settings/SettingsMenu.js
@@ -61,6 +61,9 @@ const htmlStr = `
 function initHTML() {
     $(`#${sidePanelsContainerId}`)
         .append(htmlStr);
+    // make sure we translate the panel, as adding it can be after i18n
+    // library had initialized and translated already present html
+    APP.translation.translateElement($(`#${sidePanelsContainerId}`));
 }
 
 /**
@@ -162,6 +165,9 @@ export default {
             selectInput[0].dataset.i18n =
                 `languages:${APP.translation.getCurrentLanguage()}`;
 
+            // translate selectInput, which is the currently selected language
+            // otherwise there will be no selected option
+            APP.translation.translateElement(selectInput);
             APP.translation.translateElement(selectEl);
 
             APP.translation.addLanguageChangedListener(


### PR DESCRIPTION
Strings are not translated when opening the settings side panel. It was that we were creating settings panel html after i18n library had loaded and had translated the rest of the html.
The element selecting the current language was also not translated, which end up with no selection in the UI for the current language.