### PR TITLE
Uses new peer connection statuses to check and show different user msgs.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -50,6 +50,9 @@ const ConnectionErrors = JitsiMeetJS.errors.connection;
 const ConferenceEvents = JitsiMeetJS.events.conference;
 const ConferenceErrors = JitsiMeetJS.errors.conference;
 
+const ParticipantConnectionStatus
+    = JitsiMeetJS.constants.participantConnectionStatus;
+
 const TrackEvents = JitsiMeetJS.events.track;
 const TrackErrors = JitsiMeetJS.errors.track;
 
@@ -801,11 +804,27 @@ export default {
      * @param {string} id participant's identifier(MUC nickname)
      *
      * @returns {boolean|null} true if participant's connection is ok or false
-     * if the user is having connectivity issues.
+     * if the user is having connectivity issues. Returns null if there is no
+     * such participant.
      */
     isParticipantConnectionActive (id) {
         let participant = this.getParticipantById(id);
-        return participant ? participant.isConnectionActive() : null;
+        return participant
+            ? participant.getConnectionStatus()
+                === ParticipantConnectionStatus.ACTIVE : null;
+    },
+    /**
+     * Get participant connection status for the participant.
+     *
+     * @param {string} id participant's identifier(MUC nickname)
+     *
+     * @returns {ParticipantConnectionStatus|null} the status of the participant
+     * or null if no such participant is found or participant is the local user.
+     */
+    getParticipantConnectionStatus (id) {
+        let participant = this.getParticipantById(id);
+        return participant
+            ? participant.getConnectionStatus() : null;
     },
     /**
      * Gets the display name foe the <tt>JitsiParticipant</tt> identified by
@@ -1312,8 +1331,8 @@ export default {
 
         room.on(
             ConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
-            (id, isActive) => {
-                APP.UI.participantConnectionStatusChanged(id, isActive);
+            id => {
+                APP.UI.participantConnectionStatusChanged(id);
         });
         room.on(ConferenceEvents.DOMINANT_SPEAKER_CHANGED, (id) => {
             if (this.isLocalId(id)) {

--- a/conference.js
+++ b/conference.js
@@ -50,9 +50,6 @@ const ConnectionErrors = JitsiMeetJS.errors.connection;
 const ConferenceEvents = JitsiMeetJS.events.conference;
 const ConferenceErrors = JitsiMeetJS.errors.conference;
 
-const ParticipantConnectionStatus
-    = JitsiMeetJS.constants.participantConnectionStatus;
-
 const TrackEvents = JitsiMeetJS.events.track;
 const TrackErrors = JitsiMeetJS.errors.track;
 
@@ -797,21 +794,6 @@ export default {
      */
     getParticipantById (id) {
         return room ? room.getParticipantById(id) : null;
-    },
-    /**
-     * Checks whether the user identified by given id is currently connected.
-     *
-     * @param {string} id participant's identifier(MUC nickname)
-     *
-     * @returns {boolean|null} true if participant's connection is ok or false
-     * if the user is having connectivity issues. Returns null if there is no
-     * such participant.
-     */
-    isParticipantConnectionActive (id) {
-        let participant = this.getParticipantById(id);
-        return participant
-            ? participant.getConnectionStatus()
-                === ParticipantConnectionStatus.ACTIVE : null;
     },
     /**
      * Get participant connection status for the participant.

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -845,11 +845,9 @@ UI.handleLastNEndpoints = function (leavingIds, enteringIds) {
  * Will handle notification about participant's connectivity status change.
  *
  * @param {string} id the id of remote participant(MUC jid)
- * @param {boolean} isActive true if the connection is ok or false if the user
- * is having connectivity issues.
  */
-UI.participantConnectionStatusChanged = function (id, isActive) {
-    VideoLayout.onParticipantConnectionStatusChanged(id, isActive);
+UI.participantConnectionStatusChanged = function (id) {
+    VideoLayout.onParticipantConnectionStatusChanged(id);
 };
 
 /**

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -1,4 +1,4 @@
-/* global $, APP */
+/* global $, APP, JitsiMeetJS */
 const logger = require("jitsi-meet-logger").getLogger(__filename);
 
 import Avatar from "../avatar/Avatar";
@@ -8,6 +8,9 @@ import UIUtil from "../util/UIUtil";
 import {VideoContainer, VIDEO_CONTAINER_TYPE} from "./VideoContainer";
 
 import AudioLevels from "../audio_levels/AudioLevels";
+
+const ParticipantConnectionStatus
+    = JitsiMeetJS.constants.participantConnectionStatus;
 
 /**
  * Manager for all Large containers.
@@ -114,7 +117,7 @@ export default class LargeVideoManager {
             // (camera or desktop) is a completely different thing than
             // the video container type (Etherpad, SharedVideo, VideoContainer).
             // ----------------------------------------------------------------
-            // If we the continer is VIDEO_CONTAINER_TYPE, we need to check
+            // If we the container is VIDEO_CONTAINER_TYPE, we need to check
             // its stream whether exist and is muted to set isVideoMuted
             // in rest of the cases it is false
             let showAvatar
@@ -160,10 +163,17 @@ export default class LargeVideoManager {
             const isConnected = APP.conference.isConnectionInterrupted()
                                 || !isHavingConnectivityIssues;
 
+            // when isHavingConnectivityIssues, state can be inactive,
+            // interrupted or restoring. We show different message for
+            // interrupted and the rest.
+            const isConnectionInterrupted =
+                APP.conference.getParticipantConnectionStatus(id)
+                    === ParticipantConnectionStatus.INTERRUPTED;
+
             this.updateParticipantConnStatusIndication(
                     id,
                     isConnected,
-                    (isHavingConnectivityIssues)
+                    (isConnectionInterrupted)
                         ? "connection.USER_CONNECTION_INTERRUPTED"
                         : "connection.LOW_BANDWIDTH");
 

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -1,4 +1,4 @@
-/* global $, APP, interfaceConfig */
+/* global $, APP, interfaceConfig, JitsiMeetJS */
 const logger = require("jitsi-meet-logger").getLogger(__filename);
 
 import ConnectionIndicator from './ConnectionIndicator';
@@ -12,6 +12,8 @@ const MUTED_DIALOG_BUTTON_VALUES = {
     cancel: 0,
     muted: 1
 };
+const ParticipantConnectionStatus
+    = JitsiMeetJS.constants.participantConnectionStatus;
 
 /**
  * Creates new instance of the <tt>RemoteVideo</tt>.
@@ -447,7 +449,7 @@ RemoteVideo.prototype.updateRemoteVideoMenu = function (isMuted, force) {
 RemoteVideo.prototype.setMutedView = function(isMuted) {
     SmallVideo.prototype.setMutedView.call(this, isMuted);
     // Update 'mutedWhileDisconnected' flag
-    this._figureOutMutedWhileDisconnected(this.isConnectionActive() === false);
+    this._figureOutMutedWhileDisconnected(this.isConnectionInterrupted());
 };
 
 /**
@@ -534,7 +536,8 @@ RemoteVideo.prototype.removeRemoteStreamElement = function (stream) {
  * <tt>false</tt> otherwise.
  */
 RemoteVideo.prototype.isConnectionActive = function() {
-    return this.user.isConnectionActive();
+    return this.user.getConnectionStatus()
+        === ParticipantConnectionStatus.ACTIVE;
 };
 
 /**

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -658,14 +658,18 @@ var VideoLayout = {
      * Shows/hides warning about remote user's connectivity issues.
      *
      * @param {string} id the ID of the remote participant(MUC nickname)
-     * @param {boolean} isActive true if the connection is ok or false when
-     * the user is having connectivity issues.
      */
     // eslint-disable-next-line no-unused-vars
-    onParticipantConnectionStatusChanged (id, isActive) {
+    onParticipantConnectionStatusChanged (id) {
         // Show/hide warning on the large video
         if (this.isCurrentlyOnLarge(id)) {
-            if (largeVideo) {
+            // when pinning and we have lastN enabled, we have rapid connection
+            // status changed between inactive, restoring and active and
+            // if there was a large video update scheduled already it will
+            // reflect the current status and no need to schedule new one
+            // otherwise we end up scheduling updates for endpoints which are
+            // were on large while checking, but a change was already scheduled
+            if (largeVideo && !largeVideo.updateInProcess) {
                 // We have to trigger full large video update to transition from
                 // avatar to video on connectivity restored.
                 this.updateLargeVideo(id, true /* force update */);


### PR DESCRIPTION
Checks for interrupted state of peer connection and shows appropriate messages. In case of inactive or restoring state a message is show to user that video was stopped on purpose. Removes some unused parameters from the event handlers about peer connection status change.