### PR TITLE
deps: include styled-components package for @atlaskit components

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,7 @@
 .*/node_modules/babel-core/.*
 .*/node_modules/bower/.*
 .*/node_modules/jsonlint/.*
+.*/node_modules/styled-components/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "retry": "0.6.1",
     "strophe": "1.2.4",
     "strophejs-plugins": "0.0.7",
+    "styled-components": "1.3.0",
     "toastr": "2.1.2",
     "url-polyfill": "github/url-polyfill",
     "xmldom": "0.1.27"


### PR DESCRIPTION
@atlaskit components will all require styled-components in the
future. Including it now will remove the unmet peer
dependency warning during npm install and prevent future build
breakages that might occur from using a new @atlaskit component
that requires it.