### PR TITLE
build: drop dependency on babel-pollyfill

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 /* application specific logic */
 
-import "babel-polyfill";
 import "jquery";
 import "jquery-contextmenu";
 import "jquery-ui";

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "babel-core": "6.24.0",
     "babel-eslint": "7.2.1",
     "babel-loader": "6.4.1",
-    "babel-polyfill": "6.23.0",
     "babel-preset-es2015": "6.24.0",
     "babel-preset-react": "6.23.0",
     "babel-preset-stage-1": "6.22.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,28 +1,26 @@
 /* global __dirname */
 
-require('babel-polyfill'); // Define Object.assign() from ES6 in ES5.
+const HasteResolverPlugin = require('haste-resolver-webpack-plugin');
+const process = require('process');
+const webpack = require('webpack');
 
-var HasteResolverPlugin = require('haste-resolver-webpack-plugin');
-var process = require('process');
-var webpack = require('webpack');
-
-var aui_css = __dirname + '/node_modules/@atlassian/aui/dist/aui/css/';
+const aui_css = __dirname + '/node_modules/@atlassian/aui/dist/aui/css/';
 
 /**
  * The URL of the Jitsi Meet deployment to be proxy to in the context of
  * development with webpack-dev-server.
  */
-var devServerProxyTarget
+const devServerProxyTarget
     = process.env.WEBPACK_DEV_SERVER_PROXY_TARGET || 'https://beta.meet.jit.si';
 
-var minimize
+const minimize
     = process.argv.indexOf('-p') !== -1
         || process.argv.indexOf('--optimize-minimize') !== -1;
-var node_modules = __dirname + '/node_modules/';
-var plugins = [
+const node_modules = __dirname + '/node_modules/';
+const plugins = [
     new HasteResolverPlugin()
 ];
-var strophe = /\/node_modules\/strophe(js-plugins)?\/.*\.js$/;
+const strophe = /\/node_modules\/strophe(js-plugins)?\/.*\.js$/;
 
 if (minimize) {
     // XXX Webpack's command line argument -p is not enough. Further
@@ -54,7 +52,7 @@ if (minimize) {
 
 // The base Webpack configuration to bundle the JavaScript artifacts of
 // jitsi-meet such as app.bundle.js and external_api.js.
-var config = {
+const config = {
     devServer: {
         https: true,
         inline: true,
@@ -160,7 +158,7 @@ var config = {
     }
 };
 
-var configs = [
+const configs = [
 
     // The Webpack configuration to bundle app.bundle.js (aka APP).
     Object.assign({}, config, {
@@ -196,7 +194,7 @@ module.exports = configs;
  * target, undefined; otherwise, the path to the local file to be served.
  */
 function devServerProxyBypass(request) {
-    var path = request.path;
+    let path = request.path;
 
     // Use local files from the css and libs directories.
     if (path.startsWith('/css/')) {


### PR DESCRIPTION
It's no longer needed for building since Node >= 6 already has the minimum
required ES6 syntax. In addition, drop it from app.js since we use Webpack with
the Babel loader to transpile ES5 to ES6.