### PR TITLE
[RN] Polyfill Symbol

### DIFF
--- a/react/features/app/actionTypes.js
+++ b/react/features/app/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the actions which signals that a specific App will mount (in the
  * terms of React).

--- a/react/features/base/conference/actionTypes.js
+++ b/react/features/base/conference/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of (redux) action which signals that a specific conference failed.
  *

--- a/react/features/base/config/actionTypes.js
+++ b/react/features/base/config/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The redux action which sets the configuration represented by the feature
  * base/config. The configuration is defined and consumed by the library

--- a/react/features/base/connection/actionTypes.js
+++ b/react/features/base/connection/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of (redux) action which signals that a connection disconnected.
  *

--- a/react/features/base/devices/actionTypes.js
+++ b/react/features/base/devices/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of Redux action which signals that the currently used audio
  * input device should be changed.

--- a/react/features/base/dialog/actionTypes.js
+++ b/react/features/base/dialog/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of Redux action which closes a dialog
  *

--- a/react/features/base/lib-jitsi-meet/actionTypes.js
+++ b/react/features/base/lib-jitsi-meet/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of Redux action which signals that {@link JitsiMeetJS} was disposed.
  *

--- a/react/features/base/logging/actionTypes.js
+++ b/react/features/base/logging/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of redux action which sets the configuration of the feature
  * base/logging.

--- a/react/features/base/media/actionTypes.js
+++ b/react/features/base/media/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * The type of (redux) action to set the muted state of the local audio.
  *

--- a/react/features/base/participants/actionTypes.js
+++ b/react/features/base/participants/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * Create an action for when dominant speaker changes.
  *

--- a/react/features/base/react/Symbol.js
+++ b/react/features/base/react/Symbol.js
@@ -1,5 +1,0 @@
-// XXX React Native 0.41.2 does not polyfill Symbol. The React source code of
-// jitsi/jitsi-meet does utilize Symbol though. However, it is satisfied with a
-// ponyfill.
-import Symbol from 'es6-symbol';
-export { Symbol as default };

--- a/react/features/base/react/index.js
+++ b/react/features/base/react/index.js
@@ -2,4 +2,3 @@ export * from './components';
 export * from './functions';
 export { default as Platform } from './Platform';
 export { default as RouteRegistry } from './RouteRegistry';
-export { default as Symbol } from './Symbol';

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../react';
-
 /**
  * Action for when a track has been added to the conference,
  * local or remote.

--- a/react/features/desktop-picker/actionTypes.js
+++ b/react/features/desktop-picker/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * Action to remove known DesktopCapturerSources.
  *

--- a/react/features/dial-out/actionTypes.js
+++ b/react/features/dial-out/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the action which signals a check for a dial-out phone number has
  * succeeded.

--- a/react/features/filmstrip/actionTypes.js
+++ b/react/features/filmstrip/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of action which signals to change the visibility of remote videos in
  * the filmstrip.

--- a/react/features/invite/actionTypes.js
+++ b/react/features/invite/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the action which signals an error occurred while requesting dial-
  * in numbers.
@@ -23,5 +21,3 @@ export const UPDATE_DIAL_IN_NUMBERS_FAILED
  */
 export const UPDATE_DIAL_IN_NUMBERS_SUCCESS
     = Symbol('UPDATE_DIAL_IN_NUMBERS_SUCCESS');
-
-

--- a/react/features/jwt/actionTypes.js
+++ b/react/features/jwt/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of redux action which stores a specific JSON Web Token (JWT) into
  * the redux store.

--- a/react/features/large-video/actionTypes.js
+++ b/react/features/large-video/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * Action to select the participant to be displayed in LargeVideo.
  *

--- a/react/features/mobile/background/actionTypes.js
+++ b/react/features/mobile/background/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../../base/react';
-
 /**
  * The type of redux action to set the AppState API change event listener.
  *

--- a/react/features/overlay/actionTypes.js
+++ b/react/features/overlay/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the Redux action which signals that the prompt for media
  * permission is visible or not.

--- a/react/features/share-room/actionTypes.js
+++ b/react/features/share-room/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of (redux) action which begins the UI procedure to share the current
  * conference/room URL.

--- a/react/features/toolbox/actionTypes.js
+++ b/react/features/toolbox/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the action which clears the Toolbox visibility timeout.
  *

--- a/react/features/unsupported-browser/actionTypes.js
+++ b/react/features/unsupported-browser/actionTypes.js
@@ -1,5 +1,3 @@
-import { Symbol } from '../base/react';
-
 /**
  * The type of the Redux action which signals that the React Component
  * UnsupportedMobileBrowser which was rendered as a promotion of the mobile app

--- a/react/index.native.js
+++ b/react/index.native.js
@@ -1,3 +1,4 @@
+import 'es6-symbol/implement';
 import React, { Component } from 'react';
 import { AppRegistry, Linking } from 'react-native';
 


### PR DESCRIPTION
We might use it in other dependencies, polyfill it globally so we don't need to
import it explicitly.

It's necessary to do this very early on, so do it in index.native.js, which is
as early as it gets.