### PR TITLE
[RN] Remove workaround for video mirroring on iOS

### DIFF
--- a/react/features/base/media/components/native/Video.js
+++ b/react/features/base/media/components/native/Video.js
@@ -1,19 +1,7 @@
 import React, { Component } from 'react';
-import { View } from 'react-native';
 import { RTCView } from 'react-native-webrtc';
 
-import { Platform } from '../../../react';
-
 import { styles } from './styles';
-
-/**
- * Indicates whether RTCView (is to be considered that it) natively supports
- * i.e. implements mirroring the video it renders. If false, a workaround will
- * be used in an attempt to support mirroring in Video. If RTCView does not
- * implement mirroring on a specific platform but the workaround causes issues,
- * set to true for that platform to disable the workaround.
- */
-const RTCVIEW_SUPPORTS_MIRROR = Platform.OS === 'android';
 
 /**
  * The React Native component which is similar to Web's video element and wraps
@@ -91,31 +79,15 @@ export class Video extends Component {
             const style = styles.video;
             const objectFit = (style && style.objectFit) || 'cover';
 
-            const { mirror } = this.props;
-
-            // XXX RTCView may not support support mirroring, even when
-            // providing a transform style property (e.g. iOS) . As a
-            // workaround, wrap the RTCView inside another View and apply the
-            // transform style property to that View instead.
-            const mirrorWorkaround = mirror && !RTCVIEW_SUPPORTS_MIRROR;
-
             // eslint-disable-next-line no-extra-parens
-            const video = (
+            return (
                 <RTCView
-                    mirror = { mirrorWorkaround ? false : mirror }
+                    mirror = { this.props.mirror }
                     objectFit = { objectFit }
                     streamURL = { streamURL }
                     style = { style }
                     zOrder = { this.props.zOrder } />
             );
-
-            if (mirrorWorkaround) {
-                return (
-                    <View style = { styles.mirroredVideo }>{ video }</View>
-                );
-            }
-
-            return video;
         }
 
         // RTCView has peculiarities which may or may not be platform specific.

--- a/react/features/base/media/components/native/styles.js
+++ b/react/features/base/media/components/native/styles.js
@@ -8,17 +8,8 @@ const video = {
 };
 
 /**
- * Transform local videos to behave like a mirror.
- */
-const mirroredVideo = {
-    ...video,
-    transform: [ { scaleX: -1 } ]
-};
-
-/**
  * Native-specific styles for media components.
  */
 export const styles = StyleSheet.create({
-    mirroredVideo,
     video
 });


### PR DESCRIPTION
It's now natively supported:
https://github.com/oney/react-native-webrtc/pull/244