### PR TITLE
deps: re-add babel-polyfill as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-core": "6.24.0",
     "babel-eslint": "7.2.1",
     "babel-loader": "6.4.1",
+    "babel-polyfill": "6.23.0",
     "babel-preset-es2015": "6.24.0",
     "babel-preset-react": "6.23.0",
     "babel-preset-stage-1": "6.22.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,7 +163,11 @@ const configs = [
     // The Webpack configuration to bundle app.bundle.js (aka APP).
     Object.assign({}, config, {
         entry: {
-            'app.bundle': './app.js'
+            'app.bundle': [
+                // XXX Requried by at least IE11 at the time of this writing.
+                'babel-polyfill',
+                './app.js'
+            ]
         },
         output: Object.assign({}, config.output, {
             library: 'APP'


### PR DESCRIPTION
babel does not modify existing builtins by default. That means
some newer methods, such as Array.prototype.includes, may not
be available unless babel-polyfill is used.