### PR TITLE
fix(iframe_api): toggle audio/video race condition

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -63,7 +63,8 @@ const ConnectionQualityEvents = JitsiMeetJS.events.connectionQuality;
 
 const eventEmitter = new EventEmitter();
 
-let room, connection, localAudio, localVideo;
+let room, connection, localAudio, localVideo,
+    initialAudioMutedState = false, initialVideoMutedState = false;
 
 /**
  * Indicates whether extension external installation is in progress or not.
@@ -581,6 +582,12 @@ export default {
                 analytics.init();
                 return createInitialLocalTracksAndConnect(options.roomName);
             }).then(([tracks, con]) => {
+                tracks.forEach(track => {
+                    if((track.isAudioTrack() && initialAudioMutedState)
+                        || (track.isVideoTrack() && initialVideoMutedState)) {
+                        track.mute();
+                    }
+                });
                 logger.log('initialized with %s local tracks', tracks.length);
                 con.addEventListener(
                     ConnectionEvents.CONNECTION_FAILED,
@@ -645,9 +652,17 @@ export default {
         return this.audioMuted;
     },
     /**
-     * Simulates toolbar button click for audio mute. Used by shortcuts and API.
+     * Simulates toolbar button click for audio mute. Used by shortcuts
+     * and API.
+     * @param {boolean} force - If the track is not created, the operation
+     * will be executed after the track is created. Otherwise the operation
+     * will be ignored.
      */
-    toggleAudioMuted () {
+    toggleAudioMuted (force = false) {
+        if(!localAudio && force) {
+            initialAudioMutedState = !initialAudioMutedState;
+            return;
+        }
         this.muteAudio(!this.audioMuted);
     },
     /**
@@ -659,8 +674,15 @@ export default {
     },
     /**
      * Simulates toolbar button click for video mute. Used by shortcuts and API.
+     * @param {boolean} force - If the track is not created, the operation
+     * will be executed after the track is created. Otherwise the operation
+     * will be ignored.
      */
-    toggleVideoMuted () {
+    toggleVideoMuted (force = false) {
+        if(!localVideo && force) {
+            initialVideoMutedState = !initialVideoMutedState;
+            return;
+        }
         this.muteVideo(!this.videoMuted);
     },
     /**

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -47,9 +47,9 @@ function initCommands() {
     commands = {
         "display-name":
             APP.conference.changeLocalDisplayName.bind(APP.conference),
-        "toggle-audio": APP.conference.toggleAudioMuted.bind(APP.conference),
-        "toggle-video": APP.conference.toggleVideoMuted.bind(APP.conference),
-        "toggle-film-strip": APP.UI.toggleFilmstrip,
+        "toggle-audio": () => APP.conference.toggleAudioMuted(true),
+        "toggle-video": () => APP.conference.toggleVideoMuted(true),
+        "toggle-film-strip": APP.UI.toggleFilmStrip,
         "toggle-chat": APP.UI.toggleChat,
         "toggle-contact-list": APP.UI.toggleContactList,
         "toggle-share-screen":


### PR DESCRIPTION
If toggle audio or video is executed too early and the local
tracks don't exist we fail to execute the operation. Now we store
the mute state and we are executing it after the tracks are
created