### PR TITLE
[Web] Add audio-only mode

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -28,7 +28,8 @@ import {
     conferenceFailed,
     conferenceJoined,
     conferenceLeft,
-    EMAIL_COMMAND
+    EMAIL_COMMAND,
+    setLastN
 } from './react/features/base/conference';
 import {
     updateDeviceList
@@ -534,6 +535,7 @@ export default {
     isModerator: false,
     audioMuted: false,
     videoMuted: false,
+    isAudioOnly: false,
     isSharingScreen: false,
     isDesktopSharingEnabled: false,
     /*
@@ -1077,6 +1079,26 @@ export default {
      */
     getLocalAudioTrack() {
         return room.getLocalAudioTrack();
+    },
+
+    /**
+     * Toggles the "audio only" mode. In such mode local video is muted and
+     * last N is set to 0 (effectively muting remote video). This can be used
+     * as a bandwidth saving mechanism.
+     *
+     * @param {boolean} audioOnly True if audio only mode should be enabled,
+     * false otherwise.
+     * @returns {void}
+     */
+    toggleAudioOnly(audioOnly = !this.isAudioOnly) {
+        this.muteVideo(audioOnly);
+
+        // Setting last N to undefined will set it to the default value
+        APP.store.dispatch(setLastN(audioOnly ? 0 : undefined));
+
+        APP.UI.setAudioOnly(audioOnly);
+
+        this.isAudioOnly = audioOnly;
     },
 
     videoSwitchInProgress: false,
@@ -1681,6 +1703,10 @@ export default {
                             'will be used instead.', err);
                     });
             }
+        );
+
+        APP.UI.addListener(
+            UIEvents.TOGGLE_AUDIO_ONLY, this.toggleAudioOnly.bind(this)
         );
 
         APP.UI.addListener(

--- a/css/_font.scss
+++ b/css/_font.scss
@@ -25,6 +25,13 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
+
+.icon-audioonly:before {
+  content: "\e90a";
+}
+.icon-audioonly-set:before {
+  content: "\e916";
+}
 .icon-mic-camera-combined:before {
   content: "\e903";
 }

--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -60,6 +60,10 @@
     &.toggled {
         background: $toolbarToggleBackground;
 
+        &.icon-audioonly {
+            @extend .icon-audioonly-set;
+        }
+
         &.icon-camera {
             @extend .icon-camera-disabled;
         }

--- a/lang/main.json
+++ b/lang/main.json
@@ -92,6 +92,7 @@
         "rejoinKeyTitle": "Rejoin"
     },
     "toolbar": {
+        "audioonly": "Enable / Disable audio only mode (saves bandwidth).",
         "mute": "Mute / Unmute",
         "videomute": "Start / Stop camera",
         "authenticate": "Authenticate",

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -705,6 +705,15 @@ UI.setVideoMuted = function (id, muted) {
 };
 
 /**
+ * Sets the audio only mode.
+ */
+UI.setAudioOnly = function (audioOnly) {
+    APP.store.dispatch(setToolbarButton('audioonly', {
+        toggled: audioOnly
+    }));
+};
+
+/**
  * Adds a listener that would be notified on the given type of event.
  *
  * @param type the type of the event we're listening for

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -136,6 +136,11 @@ export default class LargeVideoManager {
                 showAvatar = true;
             }
 
+            // If audio only mode is enabled, always show the avatar.
+            if (APP.conference.isAudioOnly) {
+                showAvatar = true;
+            }
+
             let promise;
 
             // do not show stream if video is muted
@@ -159,7 +164,10 @@ export default class LargeVideoManager {
 
             // Make sure no notification about remote failure is shown as
             // its UI conflicts with the one for local connection interrupted.
-            const isConnected = APP.conference.isConnectionInterrupted()
+            // For the purposes of UI indicators, audio only is considered as
+            // an "active" connection.
+            const isConnected = APP.conference.isAudioOnly
+                                ||APP.conference.isConnectionInterrupted()
                                 || isConnectionActive;
 
             // when isHavingConnectivityIssues, state can be inactive,

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -41,6 +41,24 @@ function _showSIPNumberInput() {
  */
 export default {
     /**
+     * The descriptor of the desktop sharing toolbar button.
+     */
+    audioonly: {
+        classNames: [ 'button', 'icon-audioonly' ],
+        enabled: true,
+        id: 'toolbar_button_audioonly',
+        onClick() {
+            if (APP.conference.isAudioOnly) {
+                JitsiMeetJS.analytics.sendEvent('toolbar.audioonly.disabled');
+            } else {
+                JitsiMeetJS.analytics.sendEvent('toolbar.audioonly.enabled');
+            }
+            APP.UI.emitEvent(UIEvents.TOGGLE_AUDIO_ONLY);
+        },
+        tooltipKey: 'toolbar.audioonly'
+    },
+
+    /**
      * The descriptor of the camera toolbar button.
      */
     camera: {

--- a/service/UI/UIEvents.js
+++ b/service/UI/UIEvents.js
@@ -37,6 +37,10 @@ export default {
     TOGGLE_FULLSCREEN: "UI.toogle_fullscreen",
     FULLSCREEN_TOGGLED: "UI.fullscreen_toggled",
     AUTH_CLICKED: "UI.auth_clicked",
+    /**
+     * Notifies that the audio only mode was toggled.
+     */
+    TOGGLE_AUDIO_ONLY: "UI.toggle_audioonly",
     TOGGLE_CHAT: "UI.toggle_chat",
     TOGGLE_SETTINGS: "UI.toggle_settings",
     TOGGLE_CONTACT_LIST: "UI.toggle_contact_list",


### PR DESCRIPTION
Audio only mode can be used to save bandwidth. In this mode local video is muted
and last N is set to 0, thus disabling all remote video.

Behold!

![screen shot 2017-04-05 at 17 09 08](https://cloud.githubusercontent.com/assets/317464/24713029/c2dfa22a-1a24-11e7-8f18-499180aabd4f.png)
