### PR TITLE
Filmstrip-only toolbar

### DIFF
--- a/css/_filmstrip.scss
+++ b/css/_filmstrip.scss
@@ -17,8 +17,8 @@
         flex-direction: column-reverse;
         flex-wrap: nowrap;
         position: relative;
-        z-index: $zindex1;              // Set z-index to make element visible
-        width: $hideFilmstripButtonWidth;
+        z-index: $zindex1; // Set z-index to make element visible.
+        width: $filmstripToggleButtonWidth;
 
         button {
             font-size: 14px;
@@ -50,7 +50,7 @@
         position:relative;
         height:196px;
         padding: 0;
-        /*The filmstrip should not be covered by the left toolbar*/
+        /* The filmstrip should not be covered by the left toolbar. */
         padding-left: $defaultToolbarSize + 5;
         bottom: 0;
         width:auto;
@@ -58,8 +58,8 @@
         z-index: $filmstripVideosZ;
         transition: bottom 2s;
         overflow: visible !important;
-        /*!!!Removes the gap between the local video container and the remote
-        videos.*/
+        /*!!! Removes the gap between the local video container and the remote
+        videos. */
         font-size: 0pt;
 
         &.hidden {
@@ -79,8 +79,8 @@
             }
 
             /**
-            * Focused video thumbnail.
-            */
+             * Focused video thumbnail.
+             */
             &.videoContainerFocused {
                 transition-duration: 0.5s;
                 -webkit-transition-duration: 0.5s;
@@ -97,8 +97,8 @@
             }
 
             /**
-            * Hovered video thumbnail.
-            */
+             * Hovered video thumbnail.
+             */
             &:hover {
                 cursor: hand;
                 border: $thumbnailVideoBorder solid $videoThumbnailHovered;
@@ -110,7 +110,7 @@
                 }
             }
 
-            /* With TemasysWebRTC plugin <object/> element is used
+            /* With the TemasysWebRTC plugin <object/> element is used
             instead of <video/> */
             & > video,
             & > object {
@@ -120,5 +120,14 @@
                 overflow: hidden;
             }
         }
+    }
+
+    /**
+     * Style the filmstrip videos in filmstrip-only mode.
+     */
+    &__videos-filmstripOnly {
+        margin-top: auto;
+        margin-bottom: auto;
+        padding-right: $defaultToolbarSize;
     }
 }

--- a/css/_toastr.scss
+++ b/css/_toastr.scss
@@ -94,7 +94,7 @@
 #toast-container.notification-bottom-right {
   $videoOffset: 2 * ($thumbnailVideoMargin + $thumbnailsBorder) + $thumbnailVideoBorder;
   bottom: 135px;
-  right: $hideFilmstripButtonWidth + $videoOffset;
+  right: $filmstripToggleButtonWidth + $videoOffset;
 }
 
 #toast-container * {

--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -19,9 +19,9 @@
     vertical-align: middle;
 }
 
-/**
-* Toolbar button styles.
-*/
+ /**
+  * Toolbar button styles.
+  */
 .button {
     color: #FFFFFF;
     cursor: pointer;
@@ -97,8 +97,8 @@
 }
 
 /**
-* Common toolbar styles.
-*/
+ * Common toolbar styles.
+ */
 .toolbar {
     background-color: $toolbarBackground;
     height: 100%;
@@ -119,8 +119,8 @@
     }
 
     /**
-    * Primary toolbar styles.
-    */
+     * Primary toolbar styles.
+     */
     &_primary {
         position: absolute;
         left: 50%;
@@ -148,8 +148,8 @@
     }
 
     /**
-    * Secondary toolbar styles.
-    */
+     * Secondary toolbar styles.
+     */
     &_secondary {
         position: absolute;
         align-items: center;
@@ -183,6 +183,28 @@
                     cursor: default;
                 }
             }
+        }
+    }
+
+    /**
+     * Styles the toolbar in filmstrip-only mode.
+     */
+    &_filmstrip-only {
+        border-radius: 3px;
+        bottom: 0;
+        display: inline-block;
+        height: auto;
+        position: absolute;
+        right: 0;
+        width: $defaultToolbarSize;
+
+        .button:first-child {
+            border-top-left-radius: 3px;
+            border-top-right-radius: 3px;
+        }
+        .button:last-child {
+            border-bottom-right-radius: 3px;
+            border-bottom-left-radius: 3px;
         }
     }
 

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -18,7 +18,7 @@ $thumbnailIndicatorSize: $thumbnailToolbarHeight;
 $thumbnailVideoMargin: 2px;
 $thumbnailsBorder: 2px;
 $thumbnailVideoBorder: 2px;
-$hideFilmstripButtonWidth: 17px;
+$filmstripToggleButtonWidth: 17px;
 
 
 /**

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -322,8 +322,8 @@ UI.start = function () {
         SidePanels.init(eventEmitter);
     } else {
         $("body").addClass("filmstrip-only");
-        UIUtil.setVisible('mainToolbarContainer', false);
-        FilmStrip.setupFilmStripOnly();
+        UI.showToolbar();
+        FilmStrip.setFilmStripOnly();
         messageHandler.enableNotifications(false);
         JitsiPopover.enabled = false;
     }

--- a/modules/UI/side_pannels/SideContainerToggler.js
+++ b/modules/UI/side_pannels/SideContainerToggler.js
@@ -16,17 +16,27 @@ const SideContainerToggler = {
     init(eventEmitter) {
         this.eventEmitter = eventEmitter;
 
-        // Adds a listener for the animation end event that would take care
-        // of hiding all internal containers when the extendedToolbarPanel is
+        // We may not have a side toolbar container, for example, in
+        // filmstrip-only mode.
+        const sideToolbarContainer
+            = document.getElementById("sideToolbarContainer");
+
+        if (!sideToolbarContainer)
+            return;
+
+        // Adds a listener for the animationend event that would take care of
+        // hiding all internal containers when the extendedToolbarPanel is
         // closed.
-        document.getElementById("sideToolbarContainer")
-            .addEventListener("animationend", function(e) {
-                if(e.animationName === "slideOutExt")
+        sideToolbarContainer.addEventListener(
+            "animationend",
+            function(e) {
+                if (e.animationName === "slideOutExt")
                     $("#sideToolbarContainer").children().each(function() {
                         if ($(this).hasClass("show"))
                             SideContainerToggler.hideInnerContainer($(this));
                     });
-            }, false);
+            },
+            false);
     },
 
     /**

--- a/modules/UI/videolayout/FilmStrip.js
+++ b/modules/UI/videolayout/FilmStrip.js
@@ -20,36 +20,38 @@ const FilmStrip = {
     },
 
     /**
-     * Initializes the filmstrip toolbar
+     * Initializes the filmstrip toolbar.
      */
     _initFilmStripToolbar() {
-        let toolbar = this._generateFilmStripToolbar();
+        // Do not show the toggle button in film strip only mode.
+        if (interfaceConfig.filmStripOnly)
+            return;
+
+        let toolbarContainerHTML = this._generateToolbarHTML();
         let className = this.filmStripContainerClassName;
         let container = document.querySelector(`.${className}`);
 
-        UIUtil.prependChild(container, toolbar);
+        UIUtil.prependChild(container, toolbarContainerHTML);
 
-        let iconSelector = '#hideVideoToolbar i';
+        let iconSelector = '#toggleFilmStripButton i';
         this.toggleFilmStripIcon = document.querySelector(iconSelector);
     },
 
     /**
-     * Generates HTML layout for filmstrip toolbar
+     * Generates HTML layout for filmstrip toggle button and wrapping container.
      * @returns {HTMLElement}
      * @private
      */
-    _generateFilmStripToolbar() {
+    _generateToolbarHTML() {
         let container = document.createElement('div');
         let isVisible = this.isFilmStripVisible();
         container.className = 'filmstrip__toolbar';
-        if(!interfaceConfig.filmStripOnly) {
-            container.innerHTML = `
-                <button id="hideVideoToolbar">
-                    <i class="icon-menu-${isVisible ? 'down' : 'up'}">
-                    </i>
-                </button>
-            `;
-        }
+        container.innerHTML = `
+            <button id="toggleFilmStripButton">
+                <i class="icon-menu-${isVisible ? 'down' : 'up'}">
+                </i>
+            </button>
+        `;
 
         return container;
     },
@@ -62,7 +64,7 @@ const FilmStrip = {
         // Firing the event instead of executing toggleFilmstrip method because
         // it's important to hide the filmstrip by UI.toggleFilmstrip in order
         // to correctly resize the video area.
-        $('#hideVideoToolbar').on('click',
+        $('#toggleFilmStripButton').on('click',
             () => this.eventEmitter.emit(UIEvents.TOGGLE_FILM_STRIP));
 
         this._registerToggleFilmstripShortcut();
@@ -162,11 +164,11 @@ const FilmStrip = {
         return !this.filmStrip.hasClass('hidden');
     },
 
-    setupFilmStripOnly() {
-        this.filmStrip.css({
-            padding: "0px 0px 18px 0px",
-            right: 0
-        });
+    /**
+     * Adjusts styles for film-strip only mode.
+     */
+    setFilmStripOnly() {
+        this.filmStrip.addClass('filmstrip__videos-filmstripOnly');
     },
 
     /**

--- a/react/features/toolbox/actions.web.js
+++ b/react/features/toolbox/actions.web.js
@@ -233,21 +233,22 @@ export function showSIPCallButton(show: boolean): Function {
  */
 export function showToolbox(timeout: number = 0): Object {
     return (dispatch: Dispatch<*>, getState: Function) => {
-        if (interfaceConfig.filmStripOnly) {
-            return;
-        }
-
         const state = getState();
-        const { timeoutMS, visible } = state['features/toolbox'];
+        const { alwaysVisible, timeoutMS, visible } = state['features/toolbox'];
 
         if (!visible) {
             dispatch(setToolboxVisible(true));
             dispatch(setSubjectSlideIn(true));
-            dispatch(
-                setToolboxTimeout(
-                    () => dispatch(hideToolbox()),
-                    timeout || timeoutMS));
-            dispatch(setToolboxTimeoutMS(interfaceConfig.TOOLBAR_TIMEOUT));
+
+            // If the Toolbox is always visible, there's no need for a timeout
+            // to toggle its visibility.
+            if (!alwaysVisible) {
+                dispatch(
+                    setToolboxTimeout(
+                        () => dispatch(hideToolbox()),
+                        timeout || timeoutMS));
+                dispatch(setToolboxTimeoutMS(interfaceConfig.TOOLBAR_TIMEOUT));
+            }
         }
     };
 }

--- a/react/features/toolbox/components/PrimaryToolbar.web.js
+++ b/react/features/toolbox/components/PrimaryToolbar.web.js
@@ -6,8 +6,8 @@ import { connect } from 'react-redux';
 import UIEvents from '../../../../service/UI/UIEvents';
 
 import { showDesktopSharingButton, toggleFullScreen } from '../actions';
-import Toolbar from './Toolbar';
 import { getToolbarClassNames } from '../functions';
+import Toolbar from './Toolbar';
 
 declare var APP: Object;
 declare var interfaceConfig: Object;
@@ -19,8 +19,6 @@ declare var interfaceConfig: Object;
  * @extends Component
  */
 class PrimaryToolbar extends Component {
-    state: Object;
-
     static propTypes = {
         /**
          * Handler for toggling fullscreen mode.
@@ -42,6 +40,8 @@ class PrimaryToolbar extends Component {
          */
         _visible: React.PropTypes.bool
     };
+
+    state: Object;
 
     /**
      * Constructs instance of primary toolbar React component.
@@ -68,10 +68,12 @@ class PrimaryToolbar extends Component {
              */
             fullscreen: {
                 onMount: () =>
-                    APP.UI.addListener(UIEvents.FULLSCREEN_TOGGLED,
+                    APP.UI.addListener(
+                        UIEvents.FULLSCREEN_TOGGLED,
                         this.props._onFullScreenToggled),
                 onUnmount: () =>
-                    APP.UI.removeListener(UIEvents.FULLSCREEN_TOGGLED,
+                    APP.UI.removeListener(
+                        UIEvents.FULLSCREEN_TOGGLED,
                         this.props._onFullScreenToggled)
             }
         };
@@ -105,21 +107,24 @@ class PrimaryToolbar extends Component {
         const { _primaryToolbarButtons } = this.props;
 
         // The number of buttons to show in the toolbar isn't fixed, it depends
-        // on availability of features and configuration parameters, so if we
-        // don't have anything to render we exit here.
+        // on the availability of features and configuration parameters. So
+        // there may be nothing to render.
         if (_primaryToolbarButtons.size === 0) {
             return null;
         }
 
         const { buttonHandlers, splitterIndex } = this.state;
         const { primaryToolbarClassName } = getToolbarClassNames(this.props);
+        const tooltipPosition
+            = interfaceConfig.filmStripOnly ? 'left' : 'bottom';
 
         return (
             <Toolbar
                 buttonHandlers = { buttonHandlers }
                 className = { primaryToolbarClassName }
                 splitterIndex = { splitterIndex }
-                toolbarButtons = { _primaryToolbarButtons } />
+                toolbarButtons = { _primaryToolbarButtons }
+                tooltipPosition = { tooltipPosition } />
         );
     }
 }
@@ -129,7 +134,7 @@ class PrimaryToolbar extends Component {
  *
  * @param {Function} dispatch - Redux action dispatcher.
  * @returns {{
- *      _onShowDesktopSharingButton: Function
+ *     _onShowDesktopSharingButton: Function
  * }}
  * @private
  */
@@ -162,8 +167,8 @@ function _mapDispatchToProps(dispatch: Function): Object {
  *
  * @param {Object} state - Snapshot of Redux store.
  * @returns {{
- *      _primaryToolbarButtons: Map,
- *      _visible: boolean
+ *     _primaryToolbarButtons: Map,
+ *     _visible: boolean
  * }}
  * @private
  */
@@ -177,7 +182,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Default toolbar buttons for primary toolbar.
          *
-         * @protected
+         * @private
          * @type {Map}
          */
         _primaryToolbarButtons: primaryToolbarButtons,
@@ -185,7 +190,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Shows whether toolbox is visible.
          *
-         * @protected
+         * @private
          * @type {boolean}
          */
         _visible: visible

--- a/react/features/toolbox/components/PrimaryToolbar.web.js
+++ b/react/features/toolbox/components/PrimaryToolbar.web.js
@@ -101,9 +101,17 @@ class PrimaryToolbar extends Component {
      *
      * @returns {ReactElement}
      */
-    render() {
-        const { buttonHandlers, splitterIndex } = this.state;
+    render(): ReactElement<*> | null {
         const { _primaryToolbarButtons } = this.props;
+
+        // The number of buttons to show in the toolbar isn't fixed, it depends
+        // on availability of features and configuration parameters, so if we
+        // don't have anything to render we exit here.
+        if (_primaryToolbarButtons.size === 0) {
+            return null;
+        }
+
+        const { buttonHandlers, splitterIndex } = this.state;
         const { primaryToolbarClassName } = getToolbarClassNames(this.props);
 
         return (

--- a/react/features/toolbox/components/SecondaryToolbar.web.js
+++ b/react/features/toolbox/components/SecondaryToolbar.web.js
@@ -150,9 +150,17 @@ class SecondaryToolbar extends Component {
      *
      * @returns {ReactElement}
      */
-    render(): ReactElement<*> {
-        const { buttonHandlers } = this.state;
+    render(): ReactElement<*> | null {
         const { _secondaryToolbarButtons } = this.props;
+
+        // The number of buttons to show in the toolbar isn't fixed, it depends
+        // on availability of features and configuration parameters, so if we
+        // don't have anything to render we exit here.
+        if (_secondaryToolbarButtons.size === 0) {
+            return null;
+        }
+
+        const { buttonHandlers } = this.state;
         const { secondaryToolbarClassName } = getToolbarClassNames(this.props);
 
         return (

--- a/react/features/toolbox/components/SecondaryToolbar.web.js
+++ b/react/features/toolbox/components/SecondaryToolbar.web.js
@@ -12,8 +12,8 @@ import {
     showRecordingButton,
     toggleSideToolbarContainer
 } from '../actions';
-import Toolbar from './Toolbar';
 import { getToolbarClassNames } from '../functions';
+import Toolbar from './Toolbar';
 
 declare var APP: Object;
 declare var config: Object;
@@ -79,10 +79,9 @@ class SecondaryToolbar extends Component {
              * @type {Object}
              */
             profile: {
-                onMount: () => {
+                onMount: () =>
                     APP.tokenData.isGuest
-                    || this.props._onSetProfileButtonUnclickable(true);
-                }
+                        || this.props._onSetProfileButtonUnclickable(true)
             },
 
             /**
@@ -91,14 +90,14 @@ class SecondaryToolbar extends Component {
              * @type {button}
              */
             raisehand: {
-                onMount: () => {
-                    APP.UI.addListener(UIEvents.LOCAL_RAISE_HAND_CHANGED,
-                        this.props._onLocalRaiseHandChanged);
-                },
-                onUnmount: () => {
-                    APP.UI.removeListener(UIEvents.LOCAL_RAISE_HAND_CHANGED,
-                        this.props._onLocalRaiseHandChanged);
-                }
+                onMount: () =>
+                    APP.UI.addListener(
+                        UIEvents.LOCAL_RAISE_HAND_CHANGED,
+                        this.props._onLocalRaiseHandChanged),
+                onUnmount: () =>
+                    APP.UI.removeListener(
+                        UIEvents.LOCAL_RAISE_HAND_CHANGED,
+                        this.props._onLocalRaiseHandChanged)
             },
 
             /**
@@ -107,11 +106,9 @@ class SecondaryToolbar extends Component {
              * @type {Object}
              */
             recording: {
-                onMount: () => {
-                    if (config.enableRecording) {
-                        this.props._onShowRecordingButton();
-                    }
-                }
+                onMount: () =>
+                    config.enableRecording
+                        && this.props._onShowRecordingButton()
             }
         };
 
@@ -131,7 +128,8 @@ class SecondaryToolbar extends Component {
      * @returns {void}
      */
     componentDidMount(): void {
-        APP.UI.addListener(UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
+        APP.UI.addListener(
+            UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
             this.props._onSideToolbarContainerToggled);
     }
 
@@ -141,7 +139,8 @@ class SecondaryToolbar extends Component {
      * @returns {void}
      */
     componentWillUnmount(): void {
-        APP.UI.removeListener(UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
+        APP.UI.removeListener(
+            UIEvents.SIDE_TOOLBAR_CONTAINER_TOGGLED,
             this.props._onSideToolbarContainerToggled);
     }
 
@@ -154,8 +153,8 @@ class SecondaryToolbar extends Component {
         const { _secondaryToolbarButtons } = this.props;
 
         // The number of buttons to show in the toolbar isn't fixed, it depends
-        // on availability of features and configuration parameters, so if we
-        // don't have anything to render we exit here.
+        // on the availability of features and configuration parameters. So
+        // there may be nothing to render.
         if (_secondaryToolbarButtons.size === 0) {
             return null;
         }
@@ -167,7 +166,8 @@ class SecondaryToolbar extends Component {
             <Toolbar
                 buttonHandlers = { buttonHandlers }
                 className = { secondaryToolbarClassName }
-                toolbarButtons = { _secondaryToolbarButtons }>
+                toolbarButtons = { _secondaryToolbarButtons }
+                tooltipPosition = { 'right' }>
                 <FeedbackButton />
             </Toolbar>
         );
@@ -179,10 +179,10 @@ class SecondaryToolbar extends Component {
  *
  * @param {Function} dispatch - Redux action dispatcher.
  * @returns {{
- *      _onLocalRaiseHandChanged: Function,
- *      _onSetProfileButtonUnclickable: Function,
- *      _onShowRecordingButton: Function,
- *      _onSideToolbarContainerToggled
+ *     _onLocalRaiseHandChanged: Function,
+ *     _onSetProfileButtonUnclickable: Function,
+ *     _onShowRecordingButton: Function,
+ *     _onSideToolbarContainerToggled
  * }}
  * @private
  */
@@ -237,8 +237,8 @@ function _mapDispatchToProps(dispatch: Function): Object {
  *
  * @param {Object} state - Snapshot of Redux store.
  * @returns {{
- *      _secondaryToolbarButtons: Map,
- *      _visible: boolean
+ *     _secondaryToolbarButtons: Map,
+ *     _visible: boolean
  * }}
  * @private
  */
@@ -252,7 +252,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Default toolbar buttons for secondary toolbar.
          *
-         * @protected
+         * @private
          * @type {Map}
          */
         _secondaryToolbarButtons: secondaryToolbarButtons,
@@ -260,7 +260,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Shows whether toolbar is visible.
          *
-         * @protected
+         * @private
          * @type {boolean}
          */
         _visible: visible

--- a/react/features/toolbox/components/Toolbar.web.js
+++ b/react/features/toolbox/components/Toolbar.web.js
@@ -8,10 +8,6 @@ import {
 } from '../actions';
 import ToolbarButton from './ToolbarButton';
 
-declare var APP: Object;
-declare var config: Object;
-declare var interfaceConfig: Object;
-
 /**
  * Implements a toolbar in React/Web. It is a strip that contains a set of
  * toolbar items such as buttons. Toolbar is commonly placed inside of a
@@ -152,6 +148,15 @@ class Toolbar extends Component {
             buttonHandlers,
             toolbarButtons
         } = this.props;
+
+        // Only a few buttons have custom button handlers defined, so this
+        // list may be undefined or empty depending on the buttons we're
+        // rendering.
+        // TODO: merge the buttonHandlers and onClick properties and come up
+        // with a consistent event handling property.
+        if (!buttonHandlers) {
+            return;
+        }
 
         Object.keys(buttonHandlers).forEach(key => {
             let button = toolbarButtons.get(key);

--- a/react/features/toolbox/components/Toolbar.web.js
+++ b/react/features/toolbox/components/Toolbar.web.js
@@ -60,7 +60,13 @@ class Toolbar extends Component {
         /**
          * Map with toolbar buttons.
          */
-        toolbarButtons: React.PropTypes.instanceOf(Map)
+        toolbarButtons: React.PropTypes.instanceOf(Map),
+
+        /**
+         * Indicates the position of the tooltip.
+         */
+        tooltipPosition:
+            React.PropTypes.oneOf([ 'bottom', 'left', 'right', 'top' ])
     };
 
     /**
@@ -73,7 +79,7 @@ class Toolbar extends Component {
 
         this._setButtonHandlers();
 
-        // Bind methods to save the context
+        // Bind callbacks to preverse this.
         this._renderToolbarButton = this._renderToolbarButton.bind(this);
     }
 
@@ -115,7 +121,7 @@ class Toolbar extends Component {
     _renderToolbarButton(acc: Array<*>, keyValuePair: Array<*>,
                          index: number): Array<ReactElement<*>> {
         const [ key, button ] = keyValuePair;
-        const { splitterIndex } = this.props;
+        const { splitterIndex, tooltipPosition } = this.props;
 
         if (splitterIndex && index === splitterIndex) {
             const splitter = <span className = 'toolbar__splitter' />;
@@ -131,7 +137,8 @@ class Toolbar extends Component {
                 key = { key }
                 onClick = { onClick }
                 onMount = { onMount }
-                onUnmount = { onUnmount } />
+                onUnmount = { onUnmount }
+                tooltipPosition = { tooltipPosition } />
         );
 
         return acc;
@@ -149,16 +156,11 @@ class Toolbar extends Component {
             toolbarButtons
         } = this.props;
 
-        // Only a few buttons have custom button handlers defined, so this
-        // list may be undefined or empty depending on the buttons we're
-        // rendering.
-        // TODO: merge the buttonHandlers and onClick properties and come up
-        // with a consistent event handling property.
-        if (!buttonHandlers) {
-            return;
-        }
-
-        Object.keys(buttonHandlers).forEach(key => {
+        // Only a few buttons have buttonHandlers defined, so it may be
+        // undefined or empty depending on the buttons rendered.
+        // TODO Merge the buttonHandlers and onClick properties and come up with
+        // a consistent event handling property.
+        buttonHandlers && Object.keys(buttonHandlers).forEach(key => {
             let button = toolbarButtons.get(key);
 
             if (button) {

--- a/react/features/toolbox/components/ToolbarButton.web.js
+++ b/react/features/toolbox/components/ToolbarButton.web.js
@@ -49,7 +49,13 @@ class ToolbarButton extends AbstractToolbarButton {
         /**
          * Translation helper function.
          */
-        t: React.PropTypes.func
+        t: React.PropTypes.func,
+
+        /**
+         * Indicates the position of the tooltip.
+         */
+        tooltipPosition:
+            React.PropTypes.oneOf([ 'bottom', 'left', 'right', 'top' ])
     };
 
     /**
@@ -199,13 +205,10 @@ class ToolbarButton extends AbstractToolbarButton {
      * @returns {void}
      */
     _setShortcutAndTooltip(): void {
-        const { button } = this.props;
+        const { button, tooltipPosition } = this.props;
         const name = button.buttonName;
 
         if (UIUtil.isButtonEnabled(name)) {
-            const tooltipPosition
-                = interfaceConfig.MAIN_TOOLBAR_BUTTONS.indexOf(name) > -1
-                ? 'bottom' : 'right';
 
             if (!button.unclickable) {
                 UIUtil.setTooltip(this.button,

--- a/react/features/toolbox/components/Toolbox.web.js
+++ b/react/features/toolbox/components/Toolbox.web.js
@@ -32,6 +32,11 @@ class Toolbox extends Component {
      */
     static propTypes = {
         /**
+         * Indicates if the toolbox should always be visible.
+         */
+        _alwaysVisible: React.PropTypes.bool,
+
+        /**
          * Handler dispatching setting default buttons action.
          */
         _setDefaultToolboxButtons: React.PropTypes.func,
@@ -159,8 +164,9 @@ class Toolbox extends Component {
      * @private
      */
     _renderToolbars(): ReactElement<*> | null {
-        // The toolbars should not be shown until timeoutID is initialized.
-        if (this.props._timeoutID === null) {
+        // In case we're not in alwaysVisible mode the toolbox should not be
+        // shown until timeoutID is initialized.
+        if (!this.props._alwaysVisible && this.props._timeoutID === null) {
             return null;
         }
 
@@ -202,8 +208,9 @@ function _mapDispatchToProps(dispatch: Function): Object {
          * @returns {Object} Dispatched action.
          */
         _setToolboxAlwaysVisible() {
-            dispatch(
-                setToolboxAlwaysVisible(config.alwaysVisibleToolbar === true));
+            dispatch(setToolboxAlwaysVisible(
+                config.alwaysVisibleToolbar === true
+                    || interfaceConfig.filmStripOnly));
         }
     };
 }
@@ -214,6 +221,7 @@ function _mapDispatchToProps(dispatch: Function): Object {
  * @param {Object} state - Redux state.
  * @private
  * @returns {{
+ *     _alwaysVisible: boolean,
  *     _audioMuted: boolean,
  *     _locked: boolean,
  *     _subjectSlideIn: boolean,
@@ -222,6 +230,7 @@ function _mapDispatchToProps(dispatch: Function): Object {
  */
 function _mapStateToProps(state: Object): Object {
     const {
+        alwaysVisible,
         subject,
         subjectSlideIn,
         timeoutID
@@ -231,9 +240,17 @@ function _mapStateToProps(state: Object): Object {
         ...abstractMapStateToProps(state),
 
         /**
+         * Indicates if the toolbox should always be visible.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _alwaysVisible: alwaysVisible,
+
+        /**
          * Property containing conference subject.
          *
-         * @protected
+         * @private
          * @type {string}
          */
         _subject: subject,
@@ -241,7 +258,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Flag showing whether to set subject slide in animation.
          *
-         * @protected
+         * @private
          * @type {boolean}
          */
         _subjectSlideIn: subjectSlideIn,
@@ -249,7 +266,7 @@ function _mapStateToProps(state: Object): Object {
         /**
          * Property containing toolbox timeout id.
          *
-         * @protected
+         * @private
          * @type {number}
          */
         _timeoutID: timeoutID

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -46,6 +46,7 @@ export default {
     camera: {
         classNames: [ 'button', 'icon-camera' ],
         enabled: true,
+        filmstripOnlyEnabled: true,
         id: 'toolbar_button_camera',
         onClick() {
             if (APP.conference.videoMuted) {
@@ -203,6 +204,7 @@ export default {
     hangup: {
         classNames: [ 'button', 'icon-hangup', 'button_hangup' ],
         enabled: true,
+        filmstripOnlyEnabled: true,
         id: 'toolbar_button_hangup',
         onClick() {
             JitsiMeetJS.analytics.sendEvent('toolbar.hangup');
@@ -231,6 +233,7 @@ export default {
     microphone: {
         classNames: [ 'button', 'icon-microphone' ],
         enabled: true,
+        filmstripOnlyEnabled: true,
         id: 'toolbar_button_mute',
         onClick() {
             const sharedVideoManager = APP.UI.getSharedVideoManager();

--- a/react/features/toolbox/functions.js
+++ b/react/features/toolbox/functions.js
@@ -167,6 +167,8 @@ export function getDefaultToolboxButtons(): Object {
 
     if (typeof interfaceConfig !== 'undefined'
             && interfaceConfig.TOOLBAR_BUTTONS) {
+        const { filmStripOnly } = interfaceConfig;
+
         toolbarButtons
             = interfaceConfig.TOOLBAR_BUTTONS.reduce(
                 (acc, buttonName) => {
@@ -176,7 +178,12 @@ export function getDefaultToolboxButtons(): Object {
                         const place = _getToolbarButtonPlace(buttonName);
 
                         button.buttonName = buttonName;
-                        acc[place].set(buttonName, button);
+
+                        // In filmstrip-only mode we only add a button if it's
+                        // filmstrip-only enabled.
+                        if (!filmStripOnly || button.filmstripOnlyEnabled) {
+                            acc[place].set(buttonName, button);
+                        }
                     }
 
                     return acc;
@@ -210,7 +217,11 @@ function _getToolbarButtonPlace(btn) {
  * @private
  */
 export function getToolbarClassNames(props: Object) {
-    const primaryToolbarClassNames = [ 'toolbar_primary' ];
+    const primaryToolbarClassNames = [
+        interfaceConfig.filmStripOnly
+            ? 'toolbar_filmstrip-only'
+            : 'toolbar_primary'
+    ];
     const secondaryToolbarClassNames = [ 'toolbar_secondary' ];
 
     if (props._visible) {

--- a/react/features/toolbox/reducer.js
+++ b/react/features/toolbox/reducer.js
@@ -207,6 +207,18 @@ function _setButton(state, { button, buttonName }): Object {
         ...button
     };
 
+    // In filmstrip-only mode we only show buttons if they're filmstrip-only
+    // enabled, so we don't need to update if this isn't the case.
+    // FIXME A reducer should be a pure function of the current state and the
+    // specified action so it should not use the global variable
+    // interfaceConfig. Anyway, we'll move interfaceConfig into the (redux)
+    // store so we'll surely revisit the source code bellow.
+    if (interfaceConfig.filmStripOnly && !selectedButton.filmstripOnlyEnabled) {
+        return {
+            ...state
+        };
+    }
+
     const updatedToolbar = state[place].set(buttonName, selectedButton);
 
     return {


### PR DESCRIPTION
Some fixes and additions have been needed in order to make the toolbox and inner toolbars filmstrip-only mode compatible. This PR is about providing a filmstrip-only mode of the toolbar. Currently only 3 buttons support filmstrip only and the idea is in the future to make this configurable and flexible and remove the property from the defaultToolbarButtons initialisation list.
<img width="737" alt="screenshot 2017-04-06 17 50 23" src="https://cloud.githubusercontent.com/assets/3264676/24778677/8f8feaba-1af1-11e7-9ea7-2987c2301173.png">
