### PR TITLE
Fixes profile panel translation.

### DIFF
--- a/modules/UI/side_pannels/profile/Profile.js
+++ b/modules/UI/side_pannels/profile/Profile.js
@@ -36,6 +36,9 @@ const htmlStr = `
 function initHTML() {
     $(`#${sidePanelsContainerId}`)
         .append(htmlStr);
+    // make sure we translate the panel, as adding it can be after i18n
+    // library had initialized and translated already present html
+    APP.translation.translateElement($(`#${sidePanelsContainerId}`));
 }
 
 export default {


### PR DESCRIPTION
Strings are not translated when opening the profile side panel on FF. It was that we were creating profile panel html after i18n library had loaded and had translated the rest of the html.