### PR TITLE
[RN] Display avatars as circles in thumbnails

### DIFF
--- a/react/features/base/participants/components/Avatar.native.js
+++ b/react/features/base/participants/components/Avatar.native.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import { Image } from 'react-native';
 
-import { styles } from './styles';
-
 /**
  * Display a participant avatar.
  */
@@ -33,7 +31,7 @@ export default class Avatar extends Component {
                 // XXX Avatar is expected to display the whole image.
                 resizeMode = 'contain'
                 source = {{ uri: this.props.uri }}
-                style = { [ styles.avatar, this.props.style ] } />
+                style = { this.props.style } />
         );
     }
 }

--- a/react/features/base/participants/components/Avatar.native.js
+++ b/react/features/base/participants/components/Avatar.native.js
@@ -20,6 +20,68 @@ export default class Avatar extends Component {
     }
 
     /**
+     * Initializes a new Avatar instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        // Fork (in Facebook/React speak) the prop uri because Image will
+        // receive it through a source object. Additionally, other props may be
+        // forked as well.
+        this.componentWillReceiveProps(props);
+    }
+
+    /**
+     * Notifies this mounted React Component that it will receive new props.
+     * Forks (in Facebook/React speak) the prop {@code uri} because
+     * {@link Image} will receive it through a {@code source} object.
+     * Additionally, other props may be forked as well.
+     *
+     * @inheritdoc
+     * @param {Object} nextProps - The read-only React Component props that this
+     * instance will receive.
+     * @returns {void}
+     */
+    componentWillReceiveProps(nextProps) {
+        // uri
+        const prevURI = this.props && this.props.uri;
+        const nextURI = nextProps && nextProps.uri;
+        let nextState;
+
+        if (prevURI !== nextURI || !this.state) {
+            nextState = {
+                ...nextState,
+
+                /**
+                 * The source of the {@link Image} which is the actual
+                 * representation of this {@link Avatar}. As {@code Avatar}
+                 * accepts a single URI and {@code Image} deals with a set of
+                 * possibly multiple URIs, the state {@code source} was
+                 * explicitly introduced in order to reduce unnecessary renders.
+                 *
+                 * @type {{
+                 *     uri: string
+                 * }}
+                 */
+                source: {
+                    uri: nextURI
+                }
+            };
+        }
+
+        if (nextState) {
+            if (this.state) {
+                this.setState(nextState);
+            } else {
+                this.state = nextState;
+            }
+        }
+    }
+
+    /**
      * Implements React's {@link Component#render()}.
      *
      * @inheritdoc
@@ -30,7 +92,7 @@ export default class Avatar extends Component {
 
                 // XXX Avatar is expected to display the whole image.
                 resizeMode = 'contain'
-                source = {{ uri: this.props.uri }}
+                source = { this.state.source }
                 style = { this.props.style } />
         );
     }

--- a/react/features/base/participants/components/styles.js
+++ b/react/features/base/participants/components/styles.js
@@ -5,18 +5,11 @@ import { createStyleSheet } from '../../styles';
  */
 export const styles = createStyleSheet({
     /**
-     * Avatar style.
-     */
-    avatar: {
-        flex: 1,
-        width: '100%'
-    },
-
-    /**
      * ParticipantView style.
      */
     participantView: {
         alignItems: 'stretch',
-        flex: 1
+        flex: 1,
+        justifyContent: 'center'
     }
 });

--- a/react/features/filmstrip/components/Thumbnail.js
+++ b/react/features/filmstrip/components/Thumbnail.js
@@ -69,8 +69,6 @@ class Thumbnail extends Component {
             };
         }
 
-        const thumbToolbarStyle = styles.thumbnailIndicatorContainer;
-
         // We don't render audio in any of the following:
         // 1. The audio (source) is muted. There's no practical reason (that we
         //    know of, anyway) why we'd want to render it given that it's
@@ -107,7 +105,7 @@ class Thumbnail extends Component {
                 { participant.dominantSpeaker
                     && <DominantSpeakerIndicator /> }
 
-                <Container style = { thumbToolbarStyle }>
+                <Container style = { styles.thumbnailIndicatorContainer }>
                     { audioMuted
                         && <AudioMutedIndicator /> }
 

--- a/react/features/filmstrip/components/Thumbnail.js
+++ b/react/features/filmstrip/components/Thumbnail.js
@@ -95,6 +95,7 @@ class Thumbnail extends Component {
                             = { audioTrack.jitsiTrack.getOriginalStream() } /> }
 
                 <ParticipantView
+                    avatarStyle = { styles.avatar }
                     participantId = { participantId }
                     showAvatar = { participantNotInLargeVideo }
                     showVideo = { participantNotInLargeVideo }

--- a/react/features/filmstrip/components/styles.js
+++ b/react/features/filmstrip/components/styles.js
@@ -5,6 +5,17 @@ import { BoxModel, ColorPalette } from '../../base/styles';
  */
 export const styles = {
     /**
+     * Avatar style.
+     */
+    avatar: {
+        alignSelf: 'center',
+        borderRadius: 25,
+        flex: 0,
+        height: 50,
+        width: 50
+    },
+
+    /**
      * Dominant speaker indicator style.
      */
     dominantSpeakerIndicator: {

--- a/react/features/filmstrip/components/styles.js
+++ b/react/features/filmstrip/components/styles.js
@@ -1,3 +1,4 @@
+import { Platform } from '../../base/react';
 import { BoxModel, ColorPalette } from '../../base/styles';
 
 /**
@@ -9,7 +10,10 @@ export const styles = {
      */
     avatar: {
         alignSelf: 'center',
-        borderRadius: 25,
+
+        // XXX Workaround for Android: for images < 80 the border radius doesn't
+        // work properly, but applying a radius twice as big does the trick.
+        borderRadius: Platform.OS === 'android' ? 100 : 25,
         flex: 0,
         height: 50,
         width: 50

--- a/react/features/filmstrip/components/styles.js
+++ b/react/features/filmstrip/components/styles.js
@@ -74,7 +74,8 @@ export const styles = {
     },
 
     /**
-     * Video thumbnail style.
+     * The style of a participant's Thumbnail which renders either the video or
+     * the avatar of the associated participant.
      */
     thumbnail: {
         alignItems: 'stretch',


### PR DESCRIPTION
I couldn't test on iOS on Friday, so the previous attempt was pretty lame. This time around it's working on both platforms. I tweaked the style a bit more and moved it to the right place too.

Android requires a workaround (this has started to become a very annoying pattern) because images of size < 80 don't work ok. Read the commit description.