### PR TITLE
fix: honor updates of the local user role before conference join

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -34,6 +34,7 @@ import {
     isFatalJitsiConnectionError
 } from './react/features/base/lib-jitsi-meet';
 import {
+    localParticipantRoleChanged,
     participantJoined,
     participantLeft,
     participantRoleChanged,
@@ -1232,14 +1233,18 @@ export default {
 
 
         room.on(ConferenceEvents.USER_ROLE_CHANGED, (id, role) => {
-            APP.store.dispatch(participantRoleChanged(id, role));
             if (this.isLocalId(id)) {
                 logger.info(`My role changed, new role: ${role}`);
+
+                APP.store.dispatch(localParticipantRoleChanged(role));
+
                 if (this.isModerator !== room.isModerator()) {
                     this.isModerator = room.isModerator();
                     APP.UI.updateLocalRole(room.isModerator());
                 }
             } else {
+                APP.store.dispatch(participantRoleChanged(id, role));
+
                 let user = room.getParticipantById(id);
                 if (user) {
                     APP.UI.updateUserRole(user);

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -70,6 +70,30 @@ export function localParticipantJoined(participant = {}) {
 }
 
 /**
+ * Action to signal the role of the local participant has changed. This can
+ * happen when the participant has joined a conference, even before an id has
+ * been properly set, or after a moderator leaves.
+ *
+ * @param {string} role - New role for local participant.
+ * @returns {{
+ *     type: PARTICIPANT_UPDATED,
+ *     participant: {
+ *         id: string,
+ *         role: PARTICIPANT_ROLE
+ *     }
+ * }}
+ */
+export function localParticipantRoleChanged(role) {
+    return (dispatch, getState) => {
+        const participant = getLocalParticipant(getState);
+
+        if (participant) {
+            return dispatch(participantRoleChanged(participant.id, role));
+        }
+    };
+}
+
+/**
  * Action to update a participant's connection status.
  *
  * @param {string} id - Participant's ID.


### PR DESCRIPTION
When the prosidy setting has muc_allowners, everyone joins as a
moderator. In this case, the local user will not be set as a
moderator in the redux store as the USER_ROLE_CHANGE event will
trigger with the local user id before the redux store has set
the actual local user id--something that happens on
CONFERENCE_JOINED. The fix is to explicitly signal the local user
role has changed to the redux store, which follows the
implementation of pre-existing web logic.