### PR TITLE
[RN] Use a handset icon for audio-only mode button

### DIFF
--- a/react/features/toolbox/components/Toolbox.native.js
+++ b/react/features/toolbox/components/Toolbox.native.js
@@ -212,8 +212,8 @@ class Toolbox extends Component {
                     style = { style }
                     underlayColor = { underlayColor } />
                 <ToolbarButton
-                    iconName = 'star'
-                    iconStyle = { iconStyle }
+                    iconName = 'hangup'
+                    iconStyle = { styles.audioOnlyIcon }
                     onClick = { this.props._onToggleAudioOnly }
                     style = { style }
                     underlayColor = { underlayColor } />

--- a/react/features/toolbox/components/styles.js
+++ b/react/features/toolbox/components/styles.js
@@ -68,6 +68,15 @@ const toolbar = {
  */
 export const styles = createStyleSheet({
     /**
+     * The audio only (secondary) toolbar icon style.
+     */
+    audioOnlyIcon: {
+        ...smallIcon,
+        color: ColorPalette.white,
+        transform: [ { rotate: '135deg' } ]
+    },
+
+    /**
      * The toolbar button icon style.
      */
     icon,
@@ -116,6 +125,14 @@ export const styles = createStyleSheet({
     },
 
     /**
+     * The secondary toolbar icon style.
+     */
+    secondaryToolbarIcon: {
+        ...smallIcon,
+        color: ColorPalette.white
+    },
+
+    /**
      * The style of the root/top-level Container of Toolbar that contains
      * toolbars.
      */
@@ -132,14 +149,6 @@ export const styles = createStyleSheet({
      */
     whiteIcon: {
         ...icon,
-        color: ColorPalette.white
-    },
-
-    /**
-     * The secondary toolbar icon style.
-     */
-    secondaryToolbarIcon: {
-        ...smallIcon,
         color: ColorPalette.white
     }
 });


### PR DESCRIPTION
![upload](https://cloud.githubusercontent.com/assets/317464/24913771/79270ec2-1ed2-11e7-87d9-bc95070978f3.png)

@yanas Can you PTAL at the image?