### PR TITLE
fix: set button font-size for modals

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -80,6 +80,11 @@ $rateStarActivity: #165ecc;
 $rateStarSize: 34px;
 
 /**
+ * Modals
+ */
+$modalButtonFontSize: 14px;
+
+/**
  * Notifications
  */
 $notificationFontSize: 13px;

--- a/css/modals/_dialog.scss
+++ b/css/modals/_dialog.scss
@@ -76,3 +76,7 @@
         border-bottom: 1px solid $auiBorderColor;
     }
 }
+
+.modal-dialog-footer {
+    font-size: $modalButtonFontSize;
+}

--- a/react/features/base/dialog/components/Dialog.web.js
+++ b/react/features/base/dialog/components/Dialog.web.js
@@ -93,7 +93,7 @@ class Dialog extends AbstractDialog {
      */
     _renderFooter() {
         return (
-            <footer>
+            <footer className = 'modal-dialog-footer'>
                 <AKButtonGroup>
                     { this._renderCancelButton() }
                     { this._renderOKButton() }


### PR DESCRIPTION
Atlaskit at times will have localized styling for font-size and
sometimes will not. The button component will inherit its
font-size whereas selectors have localized font-size of 14px. For
consistency, the cancel/submit buttons on the atlaskit modals
will also have 14px. The atlaskit story book examples also use
buttons with 14px font-size.