### PR TITLE
CallStats log level 'info'

### DIFF
--- a/logging_config.js
+++ b/logging_config.js
@@ -5,5 +5,6 @@ var loggingConfig = { // eslint-disable-line no-unused-vars
     // Option to disable LogCollector (which stores the logs on CallStats)
     //disableLogCollector: true,
     // Logging level adjustments for verbose modules:
-    'modules/xmpp/strophe.util.js': 'log'
+    'modules/xmpp/strophe.util.js': 'log',
+    'modules/statistics/CallStats.js': 'info'
 };


### PR DESCRIPTION
Reduces the log level for the CallStats module to 'info', because recent changes are adding a lot of debug logs.