### PR TITLE
Process do_external_connect.js through webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ deploy-appbundle:
 	cp \
 		$(BUILD_DIR)/app.bundle.min.js \
 		$(BUILD_DIR)/app.bundle.min.map \
+		$(BUILD_DIR)/do_external_connect.min.js \
+		$(BUILD_DIR)/do_external_connect.min.map \
 		$(BUILD_DIR)/external_api.min.js \
 		$(BUILD_DIR)/external_api.min.map \
 		$(OUTPUT_DIR)/analytics.js \

--- a/connection_optimization/.eslintrc.js
+++ b/connection_optimization/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    'extends': '../react/.eslintrc.js'
+};

--- a/connection_optimization/do_external_connect.js
+++ b/connection_optimization/do_external_connect.js
@@ -1,75 +1,87 @@
-/* global config, getRoomName, getConfigParamsFromUrl */
-/* global createConnectionExternally */
+/* global config,
+          createConnectionExternally,
+          getConfigParamsFromUrl,
+          getRoomName */
+
 /**
- * Implements extrnal connect using createConnectionExtenally function defined
+ * Implements external connect using createConnectionExternally function defined
  * in external_connect.js for Jitsi Meet. Parses the room name and token from
- * the url and executes createConnectionExtenally.
+ * the URL and executes createConnectionExternally.
  *
  * NOTE: If you are using lib-jitsi-meet without Jitsi Meet you should use this
- * file as reference only because the implementation is Jitsi Meet specific.
+ * file as reference only because the implementation is Jitsi Meet-specific.
  *
  * NOTE: For optimal results this file should be included right after
- * exrnal_connect.js.
+ * external_connect.js.
  */
+
+const hashParams = getConfigParamsFromUrl('hash', true);
+const searchParams = getConfigParamsFromUrl('search', true);
+
+// URL params have higher proirity than config params.
+let url
+    = hashParams.hasOwnProperty('config.externalConnectUrl')
+        ? hashParams['config.externalConnectUrl']
+        : config.externalConnectUrl;
+
+if (url && window.createConnectionExternally) {
+    const roomName = getRoomName();
+
+    if (roomName) {
+        url += `?room=${roomName}`;
+
+        const token
+            = hashParams['config.token'] || config.token || searchParams.jwt;
+
+        if (token) {
+            url += `&token=${token}`;
+        }
+
+        createConnectionExternally(
+            url,
+            connectionInfo => {
+                // Sets that global variable to be used later by connect method
+                // in connection.js.
+                window.XMPPAttachInfo = {
+                    status: 'success',
+                    data: connectionInfo
+                };
+                checkForConnectHandlerAndConnect();
+            },
+            errorCallback);
+    } else {
+        errorCallback();
+    }
+} else {
+    errorCallback();
+}
 
 /**
- * Executes createConnectionExternally function.
+ * Check if connect from connection.js was executed and executes the handler
+ * that is going to finish the connect work.
+ *
+ * @returns {void}
  */
-(function () {
-    var hashParams = getConfigParamsFromUrl("hash", true);
-    var searchParams = getConfigParamsFromUrl("search", true);
+function checkForConnectHandlerAndConnect() {
+    window.APP
+        && window.APP.connect.status === 'ready'
+        && window.APP.connect.handler();
+}
 
-    //Url params have higher proirity than config params
-    var url = config.externalConnectUrl;
-    if(hashParams.hasOwnProperty('config.externalConnectUrl'))
-        url = hashParams["config.externalConnectUrl"];
+/**
+ * Implements a callback to be invoked if anything goes wrong.
+ *
+ * @param {Error} error - The specifics of what went wrong.
+ * @returns {void}
+ */
+function errorCallback(error) {
+    // The value of error is undefined if external connect is disabled.
+    error && console.warn(error);
 
-    /**
-     * Check if connect from connection.js was executed and executes the handler
-     * that is going to finish the connect work.
-     */
-    function checkForConnectHandlerAndConnect() {
-
-        if(window.APP && window.APP.connect.status === "ready") {
-            window.APP.connect.handler();
-        }
-    }
-
-    function error_callback(error){
-        if(error) //error=undefined if external connect is disabled.
-            console.warn(error);
-        // Sets that global variable to be used later by connect method in
-        // connection.js
-        window.XMPPAttachInfo = {
-            status: "error"
-        };
-        checkForConnectHandlerAndConnect();
-    }
-
-    if(!url || !window.createConnectionExternally) {
-        error_callback();
-        return;
-    }
-    var room_name = getRoomName();
-    if(!room_name) {
-        error_callback();
-        return;
-    }
-
-    url += "?room=" + room_name;
-
-    var token = hashParams["config.token"] || config.token ||
-        searchParams.jwt;
-    if(token)
-        url += "&token=" + token;
-
-    createConnectionExternally(url, function(connectionInfo) {
-        // Sets that global variable to be used later by connect method in
-        // connection.js
-        window.XMPPAttachInfo = {
-            status: "success",
-            data: connectionInfo
-        };
-        checkForConnectHandlerAndConnect();
-    }, error_callback);
-})();
+    // Sets that global variable to be used later by connect method in
+    // connection.js.
+    window.XMPPAttachInfo = {
+        status: 'error'
+    };
+    checkForConnectHandlerAndConnect();
+}

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
     <script><!--#include virtual="/config.js" --></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
     <script src="static/utils.js?v=1"></script>
     <!--#include virtual="connection_optimization/connection_optimization.html" -->
-    <script src="connection_optimization/do_external_connect.js?v=1"></script>
+    <script src="libs/do_external_connect.min.js?v=1"></script>
     <script><!--#include virtual="/interface_config.js" --></script>
     <script><!--#include virtual="/logging_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -174,6 +174,16 @@ const configs = [
         })
     }),
 
+    // The Webpack configuration to bundle do_external_connect.js (which
+    // attempts to optimize Jitsi Meet's XMPP connection and, consequently, is
+    // also known as HTTP pre-bind).
+    Object.assign({}, config, {
+        entry: {
+            'do_external_connect':
+                './connection_optimization/do_external_connect.js'
+        }
+    }),
+
     // The Webpack configuration to bundle external_api.js (aka
     // JitsiMeetExternalAPI).
     Object.assign({}, config, {


### PR DESCRIPTION
Illya Daynatovich/@BeatC processed do_external_connect.js through webpack in https://github.com/jitsi/jitsi-meet/pull/1472 but I want it out of there because it's a standalone, logical piece that makes sense and can be accomplished without any connection to supporting JWT support on mobile.