### PR TITLE
Fix Recording button

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -324,6 +324,11 @@ UI.start = function () {
 
         // Initialize side panels
         SidePanels.init(eventEmitter);
+
+        // Initialise the recording module.
+        if (config.enableRecording) {
+            Recording.init(eventEmitter, config.recordingType);
+        }
     } else {
         $("body").addClass("filmstrip-only");
         UI.showToolbar();

--- a/react/features/toolbox/actions.web.js
+++ b/react/features/toolbox/actions.web.js
@@ -171,14 +171,13 @@ export function showDialPadButton(show: boolean): Function {
  */
 export function showRecordingButton(): Function {
     return (dispatch: Dispatch<*>) => {
-        const eventEmitter = APP.UI.eventEmitter;
         const buttonName = 'recording';
 
         dispatch(setToolbarButton(buttonName, {
             hidden: false
         }));
 
-        Recording.init(eventEmitter, config.recordingType);
+        Recording.initRecordingButton();
     };
 }
 


### PR DESCRIPTION
As a regression after merging of React Toolbox live streaming is not working as expected. Dialog saying that "Camera was not found" was displaying even if stream is started. This problem was caused by delayed initialization of Recording module as @yanas mentioned. This PR is intended to fix this problem. So as a result live streaming is now working correct:

__There is screenshot showing streaming to Youtube
from development deployment of Jitsi Meet:__
<img width="322" alt="screen shot 2017-04-12 at 7 12 53 pm" src="https://cloud.githubusercontent.com/assets/5806075/24968134/eed2bab2-1fb4-11e7-927b-18ab895af463.png">
