### PR TITLE
Fix Raise hand bug

### DIFF
--- a/flow-typed/npm/redux_v3.x.x.js
+++ b/flow-typed/npm/redux_v3.x.x.js
@@ -53,4 +53,8 @@ declare module 'redux' {
 
   declare function compose<S, A>(...fns: Array<StoreEnhancer<S, A>>): Function;
 
+  // Utility function in Redux that can be used for function composition
+  // e.g. bar(foo(baz)) is equivalent to compose(bar, foo)(baz).
+  declare function compose(...fns: Array<Function>): Function;
+
 }

--- a/react/features/toolbox/actions.native.js
+++ b/react/features/toolbox/actions.native.js
@@ -4,7 +4,6 @@ import type { Dispatch } from 'redux-thunk';
 
 import {
     CLEAR_TOOLBOX_TIMEOUT,
-    SET_DEFAULT_TOOLBOX_BUTTONS,
     SET_SUBJECT,
     SET_SUBJECT_SLIDE_IN,
     SET_TOOLBAR_BUTTON,
@@ -15,7 +14,6 @@ import {
     SET_TOOLBOX_TIMEOUT_MS,
     SET_TOOLBOX_VISIBLE
 } from './actionTypes';
-import { getDefaultToolboxButtons } from './functions';
 
 /**
  * Event handler for local raise hand changed event.
@@ -67,22 +65,6 @@ export function setAudioIconEnabled(enabled: boolean = false): Function {
         };
 
         dispatch(setToolbarButton('microphone', button));
-    };
-}
-
-/**
- * Sets the default toolbar buttons of the Toolbox.
- *
- * @returns {{
- *     type: SET_DEFAULT_TOOLBOX_BUTTONS,
- *     primaryToolbarButtons: Map,
- *     secondaryToolbarButtons: Map
- * }}
- */
-export function setDefaultToolboxButtons(): Object {
-    return {
-        type: SET_DEFAULT_TOOLBOX_BUTTONS,
-        ...getDefaultToolboxButtons()
     };
 }
 

--- a/react/features/toolbox/components/PrimaryToolbar.web.js
+++ b/react/features/toolbox/components/PrimaryToolbar.web.js
@@ -3,13 +3,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import UIEvents from '../../../../service/UI/UIEvents';
-
-import { showDesktopSharingButton, toggleFullScreen } from '../actions';
 import { getToolbarClassNames } from '../functions';
 import Toolbar from './Toolbar';
 
-declare var APP: Object;
 declare var interfaceConfig: Object;
 
 /**
@@ -20,15 +16,6 @@ declare var interfaceConfig: Object;
  */
 class PrimaryToolbar extends Component {
     static propTypes = {
-        /**
-         * Handler for toggling fullscreen mode.
-         */
-        _onFullScreenToggled: React.PropTypes.func,
-
-        /**
-         * Handler for showing desktop sharing button.
-         */
-        _onShowDesktopSharingButton: React.PropTypes.func,
 
         /**
          * Contains toolbar buttons for primary toolbar.
@@ -51,42 +38,9 @@ class PrimaryToolbar extends Component {
     constructor(props) {
         super(props);
 
-        const buttonHandlers = {
-            /**
-             * Mount handler for desktop button.
-             *
-             * @type {Object}
-             */
-            desktop: {
-                onMount: () => this.props._onShowDesktopSharingButton()
-            },
-
-            /**
-             * Mount/Unmount handler for toggling fullscreen button.
-             *
-             * @type {Object}
-             */
-            fullscreen: {
-                onMount: () =>
-                    APP.UI.addListener(
-                        UIEvents.FULLSCREEN_TOGGLED,
-                        this.props._onFullScreenToggled),
-                onUnmount: () =>
-                    APP.UI.removeListener(
-                        UIEvents.FULLSCREEN_TOGGLED,
-                        this.props._onFullScreenToggled)
-            }
-        };
         const splitterIndex = interfaceConfig.MAIN_TOOLBAR_SPLITTER_INDEX;
 
         this.state = {
-
-            /**
-             * Object containing on mount/unmount handlers for toolbar buttons.
-             *
-             * @type {Object}
-             */
-            buttonHandlers,
 
             /**
              * If deployment supports toolbar splitter this value contains its
@@ -113,53 +67,19 @@ class PrimaryToolbar extends Component {
             return null;
         }
 
-        const { buttonHandlers, splitterIndex } = this.state;
+        const { splitterIndex } = this.state;
         const { primaryToolbarClassName } = getToolbarClassNames(this.props);
         const tooltipPosition
             = interfaceConfig.filmStripOnly ? 'left' : 'bottom';
 
         return (
             <Toolbar
-                buttonHandlers = { buttonHandlers }
                 className = { primaryToolbarClassName }
                 splitterIndex = { splitterIndex }
                 toolbarButtons = { _primaryToolbarButtons }
                 tooltipPosition = { tooltipPosition } />
         );
     }
-}
-
-/**
- * Maps some of the Redux actions to the component props.
- *
- * @param {Function} dispatch - Redux action dispatcher.
- * @returns {{
- *     _onShowDesktopSharingButton: Function
- * }}
- * @private
- */
-function _mapDispatchToProps(dispatch: Function): Object {
-    return {
-        /**
-         * Dispatches an action signalling that full screen mode is toggled.
-         *
-         * @param {boolean} isFullScreen - Show whether fullscreen mode is on.
-         * @returns {Object} Dispatched action.
-         */
-        _onFullScreenToggled(isFullScreen: boolean) {
-            return dispatch(toggleFullScreen(isFullScreen));
-        },
-
-        /**
-         * Dispatches an action signalling that desktop sharing button
-         * should be shown.
-         *
-         * @returns {Object} Dispatched action.
-         */
-        _onShowDesktopSharingButton() {
-            dispatch(showDesktopSharingButton());
-        }
-    };
 }
 
 /**
@@ -197,4 +117,4 @@ function _mapStateToProps(state: Object): Object {
     };
 }
 
-export default connect(_mapStateToProps, _mapDispatchToProps)(PrimaryToolbar);
+export default connect(_mapStateToProps)(PrimaryToolbar);

--- a/react/features/toolbox/components/SecondaryToolbar.web.js
+++ b/react/features/toolbox/components/SecondaryToolbar.web.js
@@ -7,16 +7,12 @@ import { FeedbackButton } from '../../feedback';
 import UIEvents from '../../../../service/UI/UIEvents';
 
 import {
-    changeLocalRaiseHand,
-    setProfileButtonUnclickable,
-    showRecordingButton,
     toggleSideToolbarContainer
 } from '../actions';
 import { getToolbarClassNames } from '../functions';
 import Toolbar from './Toolbar';
 
 declare var APP: Object;
-declare var config: Object;
 
 /**
  * Implementation of secondary toolbar React component.
@@ -33,20 +29,6 @@ class SecondaryToolbar extends Component {
      * @static
      */
     static propTypes = {
-        /**
-         * Handler dispatching local "Raise hand".
-         */
-        _onLocalRaiseHandChanged: React.PropTypes.func,
-
-        /**
-         * Handler setting profile button unclickable.
-         */
-        _onSetProfileButtonUnclickable: React.PropTypes.func,
-
-        /**
-         * Handler for showing recording button.
-         */
-        _onShowRecordingButton: React.PropTypes.func,
 
         /**
          * Handler dispatching toggle toolbar container.
@@ -63,64 +45,6 @@ class SecondaryToolbar extends Component {
          */
         _visible: React.PropTypes.bool
     };
-
-    /**
-     * Constructs instance of SecondaryToolbar component.
-     *
-     * @param {Object} props - React component properties.
-     */
-    constructor(props) {
-        super(props);
-
-        const buttonHandlers = {
-            /**
-             * Mount handler for profile button.
-             *
-             * @type {Object}
-             */
-            profile: {
-                onMount: () =>
-                    APP.tokenData.isGuest
-                        || this.props._onSetProfileButtonUnclickable(true)
-            },
-
-            /**
-             * Mount/Unmount handlers for raisehand button.
-             *
-             * @type {button}
-             */
-            raisehand: {
-                onMount: () =>
-                    APP.UI.addListener(
-                        UIEvents.LOCAL_RAISE_HAND_CHANGED,
-                        this.props._onLocalRaiseHandChanged),
-                onUnmount: () =>
-                    APP.UI.removeListener(
-                        UIEvents.LOCAL_RAISE_HAND_CHANGED,
-                        this.props._onLocalRaiseHandChanged)
-            },
-
-            /**
-             * Mount handler for recording button.
-             *
-             * @type {Object}
-             */
-            recording: {
-                onMount: () =>
-                    config.enableRecording
-                        && this.props._onShowRecordingButton()
-            }
-        };
-
-        this.state = {
-            /**
-             * Object containing on mount/unmount handlers for toolbar buttons.
-             *
-             * @type {Object}
-             */
-            buttonHandlers
-        };
-    }
 
     /**
      * Register legacy UI listener.
@@ -159,12 +83,10 @@ class SecondaryToolbar extends Component {
             return null;
         }
 
-        const { buttonHandlers } = this.state;
         const { secondaryToolbarClassName } = getToolbarClassNames(this.props);
 
         return (
             <Toolbar
-                buttonHandlers = { buttonHandlers }
                 className = { secondaryToolbarClassName }
                 toolbarButtons = { _secondaryToolbarButtons }
                 tooltipPosition = { 'right' }>
@@ -179,45 +101,12 @@ class SecondaryToolbar extends Component {
  *
  * @param {Function} dispatch - Redux action dispatcher.
  * @returns {{
- *     _onLocalRaiseHandChanged: Function,
- *     _onSetProfileButtonUnclickable: Function,
- *     _onShowRecordingButton: Function,
  *     _onSideToolbarContainerToggled
  * }}
  * @private
  */
 function _mapDispatchToProps(dispatch: Function): Object {
     return {
-        /**
-         * Dispatches an action that 'hand' is raised.
-         *
-         * @param {boolean} isRaisedHand - Show whether hand is raised.
-         * @returns {Object} Dispatched action.
-         */
-        _onLocalRaiseHandChanged(isRaisedHand: boolean) {
-            return dispatch(changeLocalRaiseHand(isRaisedHand));
-        },
-
-        /**
-         * Dispatches an action signalling to set profile button unclickable.
-         *
-         * @param {boolean} unclickable - Flag showing whether unclickable
-         * property is true.
-         * @returns {Object} Dispatched action.
-         */
-        _onSetProfileButtonUnclickable(unclickable: boolean) {
-            return dispatch(setProfileButtonUnclickable(unclickable));
-        },
-
-        /**
-         * Dispatches an action signalling that recording button should be
-         * shown.
-         *
-         * @returns {Object} Dispatched action.
-         */
-        _onShowRecordingButton() {
-            return dispatch(showRecordingButton());
-        },
 
         /**
          * Dispatches an action signalling that side toolbar container is

--- a/react/features/toolbox/components/Toolbar.web.js
+++ b/react/features/toolbox/components/Toolbar.web.js
@@ -37,11 +37,6 @@ class Toolbar extends Component {
         _onMouseOver: React.PropTypes.func,
 
         /**
-         * Contains button handlers.
-         */
-        buttonHandlers: React.PropTypes.object,
-
-        /**
          * Children of current React component.
          */
         children: React.PropTypes.element,
@@ -76,8 +71,6 @@ class Toolbar extends Component {
      */
     constructor(props) {
         super(props);
-
-        this._setButtonHandlers();
 
         // Bind callbacks to preverse this.
         this._renderToolbarButton = this._renderToolbarButton.bind(this);
@@ -142,35 +135,6 @@ class Toolbar extends Component {
         );
 
         return acc;
-    }
-
-    /**
-     * Sets handlers for some of the buttons.
-     *
-     * @private
-     * @returns {void}
-     */
-    _setButtonHandlers(): void {
-        const {
-            buttonHandlers,
-            toolbarButtons
-        } = this.props;
-
-        // Only a few buttons have buttonHandlers defined, so it may be
-        // undefined or empty depending on the buttons rendered.
-        // TODO Merge the buttonHandlers and onClick properties and come up with
-        // a consistent event handling property.
-        buttonHandlers && Object.keys(buttonHandlers).forEach(key => {
-            let button = toolbarButtons.get(key);
-
-            if (button) {
-                button = {
-                    ...button,
-                    ...buttonHandlers[key]
-                };
-                toolbarButtons.set(key, button);
-            }
-        });
     }
 }
 

--- a/react/features/toolbox/functions.js
+++ b/react/features/toolbox/functions.js
@@ -157,9 +157,11 @@ export function getButtonAttributesByProps(props: Object = {})
  * Returns an object which contains the default buttons for the primary and
  * secondary toolbars.
  *
+ * @param {Object} buttonHandlers - Contains additional toolbox button
+ * handlers.
  * @returns {Object}
  */
-export function getDefaultToolboxButtons(): Object {
+export function getDefaultToolboxButtons(buttonHandlers: Object): Object {
     let toolbarButtons = {
         primaryToolbarButtons: new Map(),
         secondaryToolbarButtons: new Map()
@@ -172,12 +174,20 @@ export function getDefaultToolboxButtons(): Object {
         toolbarButtons
             = interfaceConfig.TOOLBAR_BUTTONS.reduce(
                 (acc, buttonName) => {
-                    const button = defaultToolbarButtons[buttonName];
+                    let button = defaultToolbarButtons[buttonName];
+                    const currentButtonHandlers = buttonHandlers[buttonName];
 
                     if (button) {
                         const place = _getToolbarButtonPlace(buttonName);
 
                         button.buttonName = buttonName;
+
+                        if (currentButtonHandlers) {
+                            button = {
+                                ...button,
+                                ...currentButtonHandlers
+                            };
+                        }
 
                         // In filmstrip-only mode we only add a button if it's
                         // filmstrip-only enabled.


### PR DESCRIPTION
Jitsi Meet allows user to change toolbox buttons order set by default. But some of the buttons requires additional setting of `onMount`/`onUnmount` handlers. Logic doing that was tightly coupled with toolbars component. That could cause incorrect behavior on deployments with changed order of buttons. This PR is intended to solve this problem. Now setting of these handlers is being done in actions but not in the specific component. Solving the problem using these approach allows us to keep this part of app stable even after changing the default order of toolbox buttons.