### PR TITLE
fix: do not apply user-select none to inputs

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -1,4 +1,9 @@
-* {
+/**
+ * Safari will limit input in input elements to one character when user-select
+ * none is applied. Other browsers already support selecting within inputs while
+ * user-select is none. As such, disallow user-select except on inputs.
+ */
+*:not(input) {
     -webkit-user-select: none;
     user-select: none;
 }


### PR DESCRIPTION
Safari will prevent proper input behavior when user-select none
is applied. It prevents such actions as putting in a room lock
password or setting a room lock password. Other browsers allow
selecting on inputs while user-select is none.