### PR TITLE
Explicitly set c2s_require_encryption to false

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -23,6 +23,8 @@ VirtualHost "jitmeet.example.com"
             "ping"; -- Enable mod_ping
         }
 
+        c2s_require_encryption = false
+
 Component "conference.jitmeet.example.com" "muc"
     --modules_enabled = { "token_verification" }
 admins = { "focusUser@auth.jitmeet.example.com" }

--- a/doc/example-config-files/prosody.cfg.lua.example
+++ b/doc/example-config-files/prosody.cfg.lua.example
@@ -179,6 +179,8 @@ VirtualHost "jitsi.example.com"
 		certificate = "/var/lib/prosody/jitsi.example.com.crt";
 	}
 
+	c2s_require_encryption = false
+
 ------ Components ------
 -- You can specify components to add hosts that provide special services,
 -- like multi-user conferences, and transports.

--- a/doc/manual-install.md
+++ b/doc/manual-install.md
@@ -55,6 +55,7 @@ VirtualHost "jitsi.example.com"
         "bosh";
         "pubsub";
     }
+    c2s_require_encryption = false
 ```
 - add domain with authentication for conference focus user:
 ```


### PR DESCRIPTION
Jitsi Meet doesn't seem to work with `c2s_require_encryption` set to `true`. `c2s_require_encryption` is `false` by default. However it is possible that in some Prosody configurations it is overriden by a global config to be `true`. In that case Jitsi Meet might not work out-of-box. So let's set it explicitly to be sure it is correct.