### PR TITLE
Filter rayo module

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1594,7 +1594,10 @@ export default {
         });
 
         APP.UI.addListener(UIEvents.SIP_DIAL, (sipNumber) => {
-            room.dial(sipNumber);
+            room.dial(sipNumber)
+                .catch((err) => {
+                    logger.error("Error dialing out", err);
+                });
         });
 
         APP.UI.addListener(UIEvents.RESOLUTION_CHANGED,

--- a/react/features/toolbox/actions.web.js
+++ b/react/features/toolbox/actions.web.js
@@ -209,10 +209,15 @@ export function showSharedVideoButton(): Function {
 export function showSIPCallButton(show: boolean): Function {
     return (dispatch: Dispatch<*>) => {
         const buttonName = 'sip';
+
+        // hide the button if there is a config to check for user roles,
+        // based on the token and the the user is guest
         const shouldShow
             = APP.conference.sipGatewayEnabled()
                 && UIUtil.isButtonEnabled(buttonName)
-                && show;
+                && show
+                && (!config.enableUserRolesBasedOnToken
+                        || !APP.tokenData.isGuest);
 
         if (shouldShow) {
             dispatch(setToolbarButton(buttonName, {

--- a/resources/prosody-plugins/mod_filter_iq_rayo.lua
+++ b/resources/prosody-plugins/mod_filter_iq_rayo.lua
@@ -1,0 +1,41 @@
+local st = require "util.stanza";
+
+local token_util = module:require "token/util".new(module);
+
+-- no token configuration but required
+if token_util == nil then
+    log("error", "no token configuration but it is required");
+    return;
+end
+
+-- filters rayo iq in case of requested from not jwt authenticated sessions
+module:hook("pre-iq/full", function(event)
+    local stanza = event.stanza;
+    if stanza.name == "iq" then
+        local dial = stanza:get_child('dial', 'urn:xmpp:rayo:1');
+        if dial then
+            local session = event.origin;
+            local token = session.auth_token;
+
+            -- find header with attr name 'JvbRoomName' and extract its value
+            local headerName = 'JvbRoomName';
+            local roomName;
+            for _, child in ipairs(dial.tags) do
+                if (child.name == 'header'
+                        and child.attr.name == headerName) then
+                    roomName = child.attr.value;
+                    break;
+                end
+            end
+
+            if token == nil
+                or roomName == nil
+                or not token_util:verify_room(session, roomName) then
+                module:log("info",
+                    "Filtering stanza dial, stanza:%s", tostring(stanza));
+                session.send(st.error_reply(stanza, "auth", "forbidden"));
+                return true;
+            end
+        end
+    end
+end);


### PR DESCRIPTION
Adds a prosody module to filter rayo incoming iqs if user is not authenticated using jwt. Hides the button in the UI if roles evaluation is enabled in config and the user is guest.

Depends on https://github.com/jitsi/jitsi-meet/pull/1548