### PR TITLE
fix: change string displayed when previewing a muted video input

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -424,6 +424,7 @@
         "speakerTime": "Speaker Time"
     },
     "deviceSelection": {
+        "currentlyVideoMuted": "Video is currently muted",
         "deviceSettings": "Device settings",
         "noOtherDevices": "No other devices available",
         "selectADevice": "Select a device",

--- a/react/features/device-selection/components/VideoInputPreview.js
+++ b/react/features/device-selection/components/VideoInputPreview.js
@@ -81,7 +81,7 @@ class VideoInputPreview extends Component {
                     className = 'video-input-preview-display flipVideoX'
                     ref = { this._setVideoElement } />
                 <div className = 'video-input-preview-muted'>
-                    { this.props.t('videothumbnail.muted') }
+                    { this.props.t('deviceSelection.currentlyVideoMuted') }
                 </div>
             </div>
         );


### PR DESCRIPTION
Device Selection re-uses the local video track for its preview.
When displaying Device Selection while video muted, the text
"muted" displays within the video preview, but some translations
may mistake this to mean audio muted. The text has been changed
to be explicit about video mute. This is a temporary solution;
at some point Device Selection should not re-use the local track
except for IE, the one browser that cannot get multiple tracks
from the same video input.