### PR TITLE
[RN] Make AudioMode more resilient on Android

### DIFF
--- a/android/app/src/main/java/org/jitsi/meet/audiomode/AudioModeModule.java
+++ b/android/app/src/main/java/org/jitsi/meet/audiomode/AudioModeModule.java
@@ -188,7 +188,13 @@ public class AudioModeModule extends ReactContextBaseJavaModule {
         Runnable r = new Runnable() {
             @Override
             public void run() {
-                if (updateAudioRoute(mode)) {
+                boolean success = false;
+                try {
+                    success = updateAudioRoute(mode);
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                }
+                if (success) {
                     AudioModeModule.this.mode = mode;
                     promise.resolve(null);
                 } else {


### PR DESCRIPTION
Some devices may give an error stating that INTERACT_ACROSS_USERS_FULL
permission is neeced. This permission can only be achieved by signing the
application with the same key as the system, which is never going to happen so
deal with it by catching any exceptions setting the mode may cause and failing
as gracefully as we can.

Ref:
http://stackoverflow.com/questions/34172575/audiomanager-setmode-securityexception-on-huawei-android-4