### PR TITLE
[RN] Set iOS status bar style to light

### DIFF
--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -78,6 +78,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>


### PR DESCRIPTION
It will render as white in dark backgrounds. This is what FaceTime does and what
we already do on Android. The problem with the default look (black text) is
noticeable in audio only mode, since the background is dark.

Sample:

![img_0001](https://cloud.githubusercontent.com/assets/317464/25179391/fac04452-2509-11e7-9e90-b001b31ba08f.PNG)
![img_0002](https://cloud.githubusercontent.com/assets/317464/25179392/fac261ba-2509-11e7-93fc-b1ff9fa8571e.PNG)
