### PR TITLE
[RN] Fix full-screen mode when a dialog is opened on Android

### DIFF
--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -10,6 +10,7 @@ import {
     CONFERENCE_WILL_JOIN,
     SET_AUDIO_ONLY
 } from '../../base/conference';
+import { HIDE_DIALOG } from '../../base/dialog';
 import { Platform } from '../../base/react';
 import { MiddlewareRegistry } from '../../base/redux';
 
@@ -51,6 +52,14 @@ MiddlewareRegistry.register(store => next => action => {
     case CONFERENCE_LEFT:
         fullScreen = false;
         break;
+
+    case HIDE_DIALOG: {
+        const { audioOnly, conference }
+            = store.getState()['features/base/conference'];
+
+        fullScreen = conference ? !audioOnly : false;
+        break;
+    }
 
     case SET_AUDIO_ONLY:
         fullScreen = !action.audioOnly;


### PR DESCRIPTION
When a dialog is opened on Android, full-screen mode is exited but we (the app)
know nothing about this. Make sure we re-enter full-screen mode once a dialog is
closed, if the conditions to be in such mode are still met.