### PR TITLE
fix(device-selection): show black background only when video muted

### DIFF
--- a/css/modals/device-selection/_device-selection.scss
+++ b/css/modals/device-selection/_device-selection.scss
@@ -41,11 +41,7 @@
     }
 
     .device-selection-video-container {
-        /* TOFIX: to be removed when we move out from muted preview */
-        background: black;
         border-radius: 3px;
-        /* TOFIX-END */
-        height: 160px;
         margin-bottom: 5px;
 
         .video-input-preview {
@@ -66,12 +62,18 @@
                 top: 50%;
             }
 
-            &.video-muted .video-input-preview-muted {
-                display: block;
+            &.video-muted {
+                /* TOFIX: to be removed when we move out from muted preview */
+                background: black;
+                /* TOFIX-END */
+
+                .video-input-preview-muted {
+                    display: block;
+                }
             }
 
             .video-input-preview-display {
-                height: 100%;
+                height: auto;
                 overflow: hidden;
                 width: 100%;
             }


### PR DESCRIPTION
On certain modal dimensions, the black background of the video
preview could peek through, making it look like the video has a
black line. The change is to remove the black background from
showing by default and having it only display when the video is
muted. Also, the video preview dimension stylings have been
changed to facilitiate smoother size adjusting with modal size
changes.