### PR TITLE
jwt updates

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -1,18 +1,10 @@
 -- Token authentication
 -- Copyright (C) 2015 Atlassian
 
-local basexx = require "basexx";
-local have_async, async = pcall(require, "util.async");
-local hex = require "util.hex";
 local formdecode = require "util.http".formdecode;
 local generate_uuid = require "util.uuid".generate;
-local http = require "net.http";
-local json = require "cjson";
 local new_sasl = require "util.sasl".new;
-local path = require "util.paths";
 local sasl = require "util.sasl";
-local sha256 = require "util.hashes".sha256;
-local timer = require "util.timer";
 local token_util = module:require "token/util";
 
 -- define auth provider
@@ -20,33 +12,9 @@ local provider = {};
 
 local host = module.host;
 
-local appId = module:get_option_string("app_id");
-local appSecret = module:get_option_string("app_secret");
-local asapKeyServer = module:get_option_string("asap_key_server");
-local allowEmptyToken = module:get_option_boolean("allow_empty_token");
-local disableRoomNameConstraints = module:get_option_boolean("disable_room_name_constraints");
-
--- TODO: Figure out a less arbitrary default cache size.
-local cacheSize = module:get_option_number("jwt_pubkey_cache_size", 128);
-local cache = require"util.cache".new(cacheSize);
-
-if allowEmptyToken == true then
-	module:log("warn", "WARNING - empty tokens allowed");
-end
-
-if appId == nil then
-	module:log("error", "'app_id' must not be empty");
-	return;
-end
-
-if appSecret == nil and asapKeyServer == nil then
-	module:log("error", "'app_secret' or 'asap_key_server' must be specified");
-	return;
-end
-
-if asapKeyServer and not have_async then
-	module:log("error", "requires a version of Prosody with util.async");
-	return;
+-- stop loading module for current host if misconfigured
+if token_util.check_config() then
+    return;
 end
 
 -- Extract 'token' param from BOSH URL when session is created
@@ -82,104 +50,13 @@ function provider.delete_user(username)
 	return nil;
 end
 
-local http_timeout = 30;
-local http_headers = {
-	["User-Agent"] = "Prosody ("..prosody.version.."; "..prosody.platform..")"
-};
-
-function get_public_key(keyId)
-	local content = cache:get(keyId);
-	if content == nil then
-		-- If the key is not found in the cache.
-		module:log("debug", "Cache miss for key: "..keyId);
-		local code;
-		local wait, done = async.waiter();
-		local function cb(content_, code_, response_, request_)
-			content, code = content_, code_;
-			if code == 200 or code == 204 then
-				cache:set(keyId, content);
-			end
-			done();
-		end
-		local keyurl = path.join(asapKeyServer, hex.to(sha256(keyId))..'.pem');
-		module:log("debug", "Fetching public key from: "..keyurl);
-
-		-- We hash the key ID to work around some legacy behavior and make
-		-- deployment easier. It also helps prevent directory
-		-- traversal attacks (although path cleaning could have done this too).
-		local request = http.request(keyurl, {
-			headers = http_headers or {},
-			method = "GET"
-		}, cb);
-
-		-- TODO: Is the done() call racey? Can we cancel this if the request
-		--       succeedes?
-		local function cancel()
-			-- TODO: This check is racey. Not likely to be a problem, but we should
-			--       still stick a mutex on content / code at some point.
-			if code == nil then
-				http.destroy_request(request);
-				done();
-			end
-		end
-		timer.add_task(http_timeout, cancel);
-		wait();
-
-		if code == 200 or code == 204 then
-			return content;
-		end
-	else
-		-- If the key is in the cache, use it.
-		module:log("debug", "Cache hit for key: "..keyId);
-		return content;
-	end
-
-	return nil;
-end
-
 function provider.get_sasl_handler(session)
 	-- JWT token extracted from BOSH URL
 	local token = session.auth_token;
 
 	local function get_username_from_token(self, message)
 
-		if token == nil then
-			if allowEmptyToken then
-				return true;
-			else
-				return false, "not-allowed", "token required";
-			end
-		end
-
-		local pubKey;
-		if asapKeyServer and session.auth_token ~= nil then
-			local dotFirst = session.auth_token:find("%.");
-			if not dotFirst then return nil, "Invalid token" end
-			local header = json.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
-			local kid = header["kid"];
-			if kid == nil then
-				return false, "not-allowed", "'kid' claim is missing";
-			end
-			pubKey = get_public_key(kid);
-			if pubKey == nil then
-				return false, "not-allowed", "could not obtain public key";
-			end
-		end
-
-		-- now verify the whole token
-		local claims, msg;
-		if asapKeyServer then
-			claims, msg = token_util.verify_token(token, appId, pubKey, disableRoomNameConstraints);
-		else
-			claims, msg = token_util.verify_token(token, appId, appSecret, disableRoomNameConstraints);
-		end
-		if claims ~= nil then
-			-- Binds room name to the session which is later checked on MUC join
-			session.jitsi_meet_room = claims["room"];
-			return true;
-		else
-			return false, "not-allowed", msg;
-		end
+		return token_util.verify_token(session, token);
 	end
 
 	return new_sasl(host, { anonymous = get_username_from_token });

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -1,11 +1,108 @@
 -- Token authentication
 -- Copyright (C) 2015 Atlassian
 
+local basexx = require "basexx";
+local have_async, async = pcall(require, "util.async");
+local hex = require "util.hex";
+local http = require "net.http";
+local json = require "cjson";
+local path = require "util.paths";
+local sha256 = require "util.hashes".sha256;
+local timer = require "util.timer";
+
 local jwt = require "luajwtjitsi";
 
 local _M = {};
 
-local function _verify_token(token, appId, appSecret, disableRoomNameConstraints)
+local appId = module:get_option_string("app_id");
+local appSecret = module:get_option_string("app_secret");
+local asapKeyServer = module:get_option_string("asap_key_server");
+local allowEmptyToken = module:get_option_boolean("allow_empty_token");
+local disableRoomNameConstraints = module:get_option_boolean("disable_room_name_constraints");
+
+-- TODO: Figure out a less arbitrary default cache size.
+local cacheSize = module:get_option_number("jwt_pubkey_cache_size", 128);
+local cache = require"util.cache".new(cacheSize);
+
+local function _check_config()
+    if allowEmptyToken == true then
+        module:log("warn", "WARNING - empty tokens allowed");
+    end
+
+    if appId == nil then
+        module:log("error", "'app_id' must not be empty");
+        return true;
+    end
+
+    if appSecret == nil and asapKeyServer == nil then
+        module:log("error", "'app_secret' or 'asap_key_server' must be specified");
+        return true;
+    end
+
+    if asapKeyServer and not have_async then
+        module:log("error", "requires a version of Prosody with util.async");
+        return true;
+    end
+
+    return false;
+end
+
+local http_timeout = 30;
+local http_headers = {
+    ["User-Agent"] = "Prosody ("..prosody.version.."; "..prosody.platform..")"
+};
+
+function get_public_key(keyId)
+    local content = cache:get(keyId);
+    if content == nil then
+        -- If the key is not found in the cache.
+        module:log("debug", "Cache miss for key: "..keyId);
+        local code;
+        local wait, done = async.waiter();
+        local function cb(content_, code_, response_, request_)
+            content, code = content_, code_;
+            if code == 200 or code == 204 then
+                cache:set(keyId, content);
+            end
+            done();
+        end
+        local keyurl = path.join(asapKeyServer, hex.to(sha256(keyId))..'.pem');
+        module:log("debug", "Fetching public key from: "..keyurl);
+
+        -- We hash the key ID to work around some legacy behavior and make
+        -- deployment easier. It also helps prevent directory
+        -- traversal attacks (although path cleaning could have done this too).
+        local request = http.request(keyurl, {
+            headers = http_headers or {},
+            method = "GET"
+        }, cb);
+
+        -- TODO: Is the done() call racey? Can we cancel this if the request
+        --       succeedes?
+        local function cancel()
+            -- TODO: This check is racey. Not likely to be a problem, but we should
+            --       still stick a mutex on content / code at some point.
+            if code == nil then
+                http.destroy_request(request);
+                done();
+            end
+        end
+        timer.add_task(http_timeout, cancel);
+        wait();
+
+        if code == 200 or code == 204 then
+            return content;
+        end
+    else
+        -- If the key is in the cache, use it.
+        module:log("debug", "Cache hit for key: "..keyId);
+        return content;
+    end
+
+    return nil;
+end
+
+local function _verify_jwt_token(token, appId, appSecret, disableRoomNameConstraints)
 
 	local claims, err = jwt.decode(token, appSecret, true);
 	if claims == nil then
@@ -30,11 +127,62 @@ local function _verify_token(token, appId, appSecret, disableRoomNameConstraints
 		return nil, "'room' claim is missing";
 	end
 
+    local audClaim = claims["aud"];
+    if audClaim == nil then
+        return nil, "'aud' claim is missing";
+    end
+
 	return claims;
 end
 
-function _M.verify_token(token, appId, appSecret, disableRoomNameConstraints)
-	return _verify_token(token, appId, appSecret, disableRoomNameConstraints);
+local function _verify_token(session, token)
+
+    if token == nil then
+        if allowEmptyToken then
+            return true;
+        else
+            return false, "not-allowed", "token required";
+        end
+    end
+
+    local pubKey;
+    if asapKeyServer and session.auth_token ~= nil then
+        local dotFirst = session.auth_token:find("%.");
+        if not dotFirst then return nil, "Invalid token" end
+        local header = json.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
+        local kid = header["kid"];
+        if kid == nil then
+            return false, "not-allowed", "'kid' claim is missing";
+        end
+        pubKey = get_public_key(kid);
+        if pubKey == nil then
+            return false, "not-allowed", "could not obtain public key";
+        end
+    end
+
+    -- now verify the whole token
+    local claims, msg;
+    if asapKeyServer then
+        claims, msg = _verify_jwt_token(token, appId, pubKey, disableRoomNameConstraints);
+    else
+        claims, msg = _verify_jwt_token(token, appId, appSecret, disableRoomNameConstraints);
+    end
+    if claims ~= nil then
+        -- Binds room name to the session which is later checked on MUC join
+        session.jitsi_meet_room = claims["room"];
+        session.jitsi_meet_domain = claims["aud"];
+        return true;
+    else
+        return false, "not-allowed", msg;
+    end
+end
+
+function _M.verify_token(session, token)
+    return _verify_token(session, token);
+end
+
+function _M.check_config()
+    return _check_config();
 end
 
 return _M;


### PR DESCRIPTION
Moves all the jwt token verification logic inside token/util so it can be reused.
Adds the logic about room name and domain name verification to toke/util.
Adds some room_size API changes, that uses the token/util for room and domain verification and jwt verification. Also, changes mod_room_size from global to host specific module. 
Everything is split in different commits but I can extract the room_size changes in separate commit if considered to be easier.