### PR TITLE
Fix toggled state in secondary toolbar

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -174,8 +174,7 @@
         width: $defaultToolbarSize;
         -webkit-transform: translateX(-100%);
 
-        .button.toggled:not(.icon-raised-hand):not(.button-active) {
-            background: $toolbarSelectBackground;
+        .button.toggled {
             cursor: pointer;
             text-decoration: none;
 
@@ -186,6 +185,10 @@
                     background: none;
                     cursor: default;
                 }
+            }
+
+            &.expandable {
+                background: $toolbarSelectBackground;
             }
         }
     }

--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -29,6 +29,7 @@ export function getButtonAttributesByProps(props: Object = {})
         classNames = [ ...classNames ];
     }
 
+    props.sideContainerId && classNames.push('expandable');
     props.toggled && classNames.push('toggled');
     props.unclickable && classNames.push('unclickable');
 


### PR DESCRIPTION
Toggled state of buttons w/o sidebar in the secondary toolbar was broken. This PR is intended to fix this bug.

<img width="142" alt="screen shot 2017-04-28 at 4 54 18 pm" src="https://cloud.githubusercontent.com/assets/5806075/25532312/a83f9862-2c35-11e7-87e4-1c009ea60d8c.png">
