### PR TITLE
fix(toolbox): move default toolbox buttons logic to web only

### DIFF
--- a/react/features/toolbox/actions.native.js
+++ b/react/features/toolbox/actions.native.js
@@ -4,7 +4,6 @@ import type { Dispatch } from 'redux-thunk';
 
 import {
     CLEAR_TOOLBOX_TIMEOUT,
-    SET_DEFAULT_TOOLBOX_BUTTONS,
     SET_SUBJECT,
     SET_SUBJECT_SLIDE_IN,
     SET_TOOLBAR_BUTTON,
@@ -15,7 +14,6 @@ import {
     SET_TOOLBOX_TIMEOUT_MS,
     SET_TOOLBOX_VISIBLE
 } from './actionTypes';
-import { getDefaultToolboxButtons } from './functions';
 
 /**
  * Event handler for local raise hand changed event.
@@ -67,22 +65,6 @@ export function setAudioIconEnabled(enabled: boolean = false): Function {
         };
 
         dispatch(setToolbarButton('microphone', button));
-    };
-}
-
-/**
- * Sets the default toolbar buttons of the Toolbox.
- *
- * @returns {{
- *     type: SET_DEFAULT_TOOLBOX_BUTTONS,
- *     primaryToolbarButtons: Map,
- *     secondaryToolbarButtons: Map
- * }}
- */
-export function setDefaultToolboxButtons(): Object {
-    return {
-        type: SET_DEFAULT_TOOLBOX_BUTTONS,
-        ...getDefaultToolboxButtons()
     };
 }
 

--- a/react/features/toolbox/actions.web.js
+++ b/react/features/toolbox/actions.web.js
@@ -3,8 +3,8 @@
 import Recording from '../../../modules/UI/recording/Recording';
 import SideContainerToggler
     from '../../../modules/UI/side_pannels/SideContainerToggler';
-import UIUtil from '../../../modules/UI/util/UIUtil';
 import UIEvents from '../../../service/UI/UIEvents';
+import UIUtil from '../../../modules/UI/util/UIUtil';
 
 import {
     clearToolboxTimeout,
@@ -15,13 +15,15 @@ import {
     setToolboxVisible,
     toggleToolbarButton
 } from './actions.native';
-
-export * from './actions.native';
+import { SET_DEFAULT_TOOLBOX_BUTTONS } from './actionTypes';
+import { getDefaultToolboxButtons } from './functions';
 
 declare var $: Function;
 declare var APP: Object;
 declare var config: Object;
 declare var interfaceConfig: Object;
+
+export * from './actions.native';
 
 /**
  * Checks whether desktop sharing is enabled and whether
@@ -106,6 +108,22 @@ export function hideToolbox(force: boolean = false): Function {
             dispatch(setToolboxVisible(false));
             dispatch(setSubjectSlideIn(false));
         }
+    };
+}
+
+/**
+ * Sets the default toolbar buttons of the Toolbox.
+ *
+ * @returns {{
+ *     type: SET_DEFAULT_TOOLBOX_BUTTONS,
+ *     primaryToolbarButtons: Map,
+ *     secondaryToolbarButtons: Map
+ * }}
+ */
+export function setDefaultToolboxButtons(): Object {
+    return {
+        type: SET_DEFAULT_TOOLBOX_BUTTONS,
+        ...getDefaultToolboxButtons()
     };
 }
 

--- a/react/features/toolbox/functions.native.js
+++ b/react/features/toolbox/functions.native.js
@@ -1,0 +1,102 @@
+/* @flow */
+
+import type { Dispatch } from 'redux';
+
+import { appNavigate } from '../app';
+import { toggleAudioMuted, toggleVideoMuted } from '../base/media';
+
+/**
+ * Maps (redux) actions to React component props.
+ *
+ * @param {Function} dispatch - Redux action dispatcher.
+ * @returns {{
+ *     _onHangup: Function,
+ *     _onToggleAudio: Function,
+ *     _onToggleVideo: Function
+ * }}
+ * @private
+ */
+export function abstractMapDispatchToProps(dispatch: Dispatch<*>): Object {
+    return {
+        /**
+         * Dispatches action to leave the current conference.
+         *
+         * @private
+         * @returns {void}
+         * @type {Function}
+         */
+        _onHangup() {
+            // XXX We don't know here which value is effectively/internally
+            // used when there's no valid room name to join. It isn't our
+            // business to know that anyway. The undefined value is our
+            // expression of (1) the lack of knowledge & (2) the desire to no
+            // longer have a valid room name to join.
+            return dispatch(appNavigate(undefined));
+        },
+
+        /**
+         * Dispatches an action to toggle the mute state of the
+         * audio/microphone.
+         *
+         * @private
+         * @returns {Object} - Dispatched action.
+         * @type {Function}
+         */
+        _onToggleAudio() {
+            return dispatch(toggleAudioMuted());
+        },
+
+        /**
+         * Dispatches an action to toggle the mute state of the video/camera.
+         *
+         * @private
+         * @returns {Object} - Dispatched action.
+         * @type {Function}
+         */
+        _onToggleVideo() {
+            return dispatch(toggleVideoMuted());
+        }
+    };
+}
+
+/**
+ * Maps parts of media state to component props.
+ *
+ * @param {Object} state - Redux state.
+ * @protected
+ * @returns {{
+ *     _audioMuted: boolean,
+ *     _videoMuted: boolean,
+ *     _visible: boolean
+ * }}
+ */
+export function abstractMapStateToProps(state: Object): Object {
+    const media = state['features/base/media'];
+    const { visible } = state['features/toolbox'];
+
+    return {
+        /**
+         * Flag showing that audio is muted.
+         *
+         * @protected
+         * @type {boolean}
+         */
+        _audioMuted: media.audio.muted,
+
+        /**
+         * Flag showing whether video is muted.
+         *
+         * @protected
+         * @type {boolean}
+         */
+        _videoMuted: media.video.muted,
+
+        /**
+         * Flag showing whether toolbox is visible.
+         *
+         * @protected
+         * @type {boolean}
+         */
+        _visible: visible
+    };
+}

--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -1,14 +1,7 @@
-/* @flow */
-
 import SideContainerToggler
     from '../../../modules/UI/side_pannels/SideContainerToggler';
 
-import { appNavigate } from '../app';
-import { toggleAudioMuted, toggleVideoMuted } from '../base/media';
-
 import defaultToolbarButtons from './defaultToolbarButtons';
-
-import type { Dispatch } from 'redux-thunk';
 
 type MapOfAttributes = { [key: string]: * };
 
@@ -16,101 +9,7 @@ declare var $: Function;
 declare var AJS: Object;
 declare var interfaceConfig: Object;
 
-/**
- * Maps (redux) actions to React component props.
- *
- * @param {Function} dispatch - Redux action dispatcher.
- * @returns {{
- *     _onHangup: Function,
- *     _onToggleAudio: Function,
- *     _onToggleVideo: Function
- * }}
- * @private
- */
-export function abstractMapDispatchToProps(dispatch: Dispatch<*>): Object {
-    return {
-        /**
-         * Dispatches action to leave the current conference.
-         *
-         * @private
-         * @returns {void}
-         * @type {Function}
-         */
-        _onHangup() {
-            // XXX We don't know here which value is effectively/internally
-            // used when there's no valid room name to join. It isn't our
-            // business to know that anyway. The undefined value is our
-            // expression of (1) the lack of knowledge & (2) the desire to no
-            // longer have a valid room name to join.
-            return dispatch(appNavigate(undefined));
-        },
-
-        /**
-         * Dispatches an action to toggle the mute state of the
-         * audio/microphone.
-         *
-         * @private
-         * @returns {Object} - Dispatched action.
-         * @type {Function}
-         */
-        _onToggleAudio() {
-            return dispatch(toggleAudioMuted());
-        },
-
-        /**
-         * Dispatches an action to toggle the mute state of the video/camera.
-         *
-         * @private
-         * @returns {Object} - Dispatched action.
-         * @type {Function}
-         */
-        _onToggleVideo() {
-            return dispatch(toggleVideoMuted());
-        }
-    };
-}
-
-/**
- * Maps parts of media state to component props.
- *
- * @param {Object} state - Redux state.
- * @protected
- * @returns {{
- *     _audioMuted: boolean,
- *     _videoMuted: boolean,
- *     _visible: boolean
- * }}
- */
-export function abstractMapStateToProps(state: Object): Object {
-    const media = state['features/base/media'];
-    const { visible } = state['features/toolbox'];
-
-    return {
-        /**
-         * Flag showing that audio is muted.
-         *
-         * @protected
-         * @type {boolean}
-         */
-        _audioMuted: media.audio.muted,
-
-        /**
-         * Flag showing whether video is muted.
-         *
-         * @protected
-         * @type {boolean}
-         */
-        _videoMuted: media.video.muted,
-
-        /**
-         * Flag showing whether toolbox is visible.
-         *
-         * @protected
-         * @type {boolean}
-         */
-        _visible: visible
-    };
-}
+export { abstractMapStateToProps } from './functions.native';
 
 /* eslint-disable flowtype/space-before-type-colon */
 


### PR DESCRIPTION
toolbox/functions has functions that are specific only to web,
specifically defaultToolbarButtons. This has caused the native
build to attempt to bring in a web dependency which leads to a
build error. The fix for now is splitting web functions from
native functions to resolve the build error.