### PR TITLE
jwt updates

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -1,58 +1,27 @@
 -- Token authentication
 -- Copyright (C) 2015 Atlassian
 
-local basexx = require "basexx";
-local have_async, async = pcall(require, "util.async");
-local hex = require "util.hex";
 local formdecode = require "util.http".formdecode;
 local generate_uuid = require "util.uuid".generate;
-local http = require "net.http";
-local json = require "cjson";
 local new_sasl = require "util.sasl".new;
-local path = require "util.paths";
 local sasl = require "util.sasl";
-local sha256 = require "util.hashes".sha256;
-local timer = require "util.timer";
-local token_util = module:require "token/util";
+local token_util = module:require "token/util".new(module);
+
+-- no token configuration
+if token_util == nil then
+    return;
+end
 
 -- define auth provider
 local provider = {};
 
 local host = module.host;
 
-local appId = module:get_option_string("app_id");
-local appSecret = module:get_option_string("app_secret");
-local asapKeyServer = module:get_option_string("asap_key_server");
-local allowEmptyToken = module:get_option_boolean("allow_empty_token");
-local disableRoomNameConstraints = module:get_option_boolean("disable_room_name_constraints");
-
--- TODO: Figure out a less arbitrary default cache size.
-local cacheSize = module:get_option_number("jwt_pubkey_cache_size", 128);
-local cache = require"util.cache".new(cacheSize);
-
-if allowEmptyToken == true then
-	module:log("warn", "WARNING - empty tokens allowed");
-end
-
-if appId == nil then
-	module:log("error", "'app_id' must not be empty");
-	return;
-end
-
-if appSecret == nil and asapKeyServer == nil then
-	module:log("error", "'app_secret' or 'asap_key_server' must be specified");
-	return;
-end
-
-if asapKeyServer and not have_async then
-	module:log("error", "requires a version of Prosody with util.async");
-	return;
-end
-
 -- Extract 'token' param from BOSH URL when session is created
 module:hook("bosh-session", function(event)
 	local session, request = event.session, event.request;
 	local query = request.url.query;
+
 	if query ~= nil then
 		session.auth_token = query and formdecode(query).token or nil;
 	end
@@ -82,104 +51,12 @@ function provider.delete_user(username)
 	return nil;
 end
 
-local http_timeout = 30;
-local http_headers = {
-	["User-Agent"] = "Prosody ("..prosody.version.."; "..prosody.platform..")"
-};
-
-function get_public_key(keyId)
-	local content = cache:get(keyId);
-	if content == nil then
-		-- If the key is not found in the cache.
-		module:log("debug", "Cache miss for key: "..keyId);
-		local code;
-		local wait, done = async.waiter();
-		local function cb(content_, code_, response_, request_)
-			content, code = content_, code_;
-			if code == 200 or code == 204 then
-				cache:set(keyId, content);
-			end
-			done();
-		end
-		local keyurl = path.join(asapKeyServer, hex.to(sha256(keyId))..'.pem');
-		module:log("debug", "Fetching public key from: "..keyurl);
-
-		-- We hash the key ID to work around some legacy behavior and make
-		-- deployment easier. It also helps prevent directory
-		-- traversal attacks (although path cleaning could have done this too).
-		local request = http.request(keyurl, {
-			headers = http_headers or {},
-			method = "GET"
-		}, cb);
-
-		-- TODO: Is the done() call racey? Can we cancel this if the request
-		--       succeedes?
-		local function cancel()
-			-- TODO: This check is racey. Not likely to be a problem, but we should
-			--       still stick a mutex on content / code at some point.
-			if code == nil then
-				http.destroy_request(request);
-				done();
-			end
-		end
-		timer.add_task(http_timeout, cancel);
-		wait();
-
-		if code == 200 or code == 204 then
-			return content;
-		end
-	else
-		-- If the key is in the cache, use it.
-		module:log("debug", "Cache hit for key: "..keyId);
-		return content;
-	end
-
-	return nil;
-end
-
 function provider.get_sasl_handler(session)
 	-- JWT token extracted from BOSH URL
 	local token = session.auth_token;
 
 	local function get_username_from_token(self, message)
-
-		if token == nil then
-			if allowEmptyToken then
-				return true;
-			else
-				return false, "not-allowed", "token required";
-			end
-		end
-
-		local pubKey;
-		if asapKeyServer and session.auth_token ~= nil then
-			local dotFirst = session.auth_token:find("%.");
-			if not dotFirst then return nil, "Invalid token" end
-			local header = json.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
-			local kid = header["kid"];
-			if kid == nil then
-				return false, "not-allowed", "'kid' claim is missing";
-			end
-			pubKey = get_public_key(kid);
-			if pubKey == nil then
-				return false, "not-allowed", "could not obtain public key";
-			end
-		end
-
-		-- now verify the whole token
-		local claims, msg;
-		if asapKeyServer then
-			claims, msg = token_util.verify_token(token, appId, pubKey, disableRoomNameConstraints);
-		else
-			claims, msg = token_util.verify_token(token, appId, appSecret, disableRoomNameConstraints);
-		end
-		if claims ~= nil then
-			-- Binds room name to the session which is later checked on MUC join
-			session.jitsi_meet_room = claims["room"];
-			return true;
-		else
-			return false, "not-allowed", msg;
-		end
+        return token_util:process_and_verify_token(session, token);
 	end
 
 	return new_sasl(host, { anonymous = get_username_from_token });

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -52,11 +52,9 @@ function provider.delete_user(username)
 end
 
 function provider.get_sasl_handler(session)
-	-- JWT token extracted from BOSH URL
-	local token = session.auth_token;
 
 	local function get_username_from_token(self, message)
-        return token_util:process_and_verify_token(session, token);
+        return token_util:process_and_verify_token(session);
 	end
 
 	return new_sasl(host, { anonymous = get_username_from_token });

--- a/resources/prosody-plugins/mod_muc_size.lua
+++ b/resources/prosody-plugins/mod_muc_size.lua
@@ -1,16 +1,10 @@
 -- Prosody IM
 -- Copyright (C) 2017 Atlassian
 --
--- This project is MIT/X11 licensed. Please see the
--- COPYING file in the source package for more information.
---
 -- This module requires net-url module
 -- Install it using #luarocks install net-url
 
-module:set_global(); -- Global module
-
-local split_jid = require "util.jid".split;
-local st = require "util.stanza";
+local jid = require "util.jid";
 local it = require "util.iterators";
 local json = require "util.json";
 local iterators = require "util.iterators";
@@ -20,28 +14,99 @@ local tostring = tostring;
 local neturl = require "net.url";
 local parse = neturl.parseQuery;
 
-function get_room_from_jid(jid)
-	local node, host = split_jid(jid);
+-- option to enable/disable room API token verifications
+local enableTokenVerification
+    = module:get_option_boolean("enable_roomsize_token_verification", false);
+
+local token_util = module:require "token/util".new(module);
+
+-- no token configuration but required
+if token_util == nil and enableTokenVerification then
+    log("error", "no token configuration but it is required");
+    return;
+end
+
+-- required parameter for custom muc component prefix,
+-- defaults to "conference"
+local muc_domain_prefix
+    = module:get_option_string("muc_mapper_domain_prefix", "conference");
+
+--- Finds and returns room by its jid
+-- @param room_jid the room jid to search in the muc component
+-- @return returns room if found or nil
+function get_room_from_jid(room_jid)
+	local _, host = jid.split(room_jid);
 	local component = hosts[host];
 	if component then
 		local muc = component.modules.muc
 		if muc and rawget(muc,"rooms") then
 			-- We're running 0.9.x or 0.10 (old MUC API)
-			return muc.rooms[jid];
+			return muc.rooms[room_jid];
 		elseif muc and rawget(muc,"get_room_from_jid") then
 			-- We're running >0.10 (new MUC API)
-			return muc.get_room_from_jid(jid);
+			return muc.get_room_from_jid(room_jid);
 		else
 			return
 		end
 	end
 end
 
+--- Verifies room name, domain name with the values in the token
+-- @param token the token we received
+-- @param room_address the full room address jid
+-- @return true if values are ok or false otherwise
+function verify_token(token, room_address)
+    if not enableTokenVerification then
+        return true;
+    end
+
+    -- if enableTokenVerification is enabled and we do not have token
+    -- stop here, cause the main virtual host can have guest access enabled
+    -- (allowEmptyToken = true) and we will allow access to rooms info without
+    -- a token
+    if token == nil then
+        log("warn", "no token provided");
+        return false;
+    end
+
+    local session = {};
+    session.auth_token = token;
+    local verified, reason = token_util:process_and_verify_token(session);
+    if not verified then
+        log("warn", "not a valid token %s", tostring(reason));
+        return false;
+    end
+
+    if not token_util:verify_room(session, room_address) then
+        log("warn", "Token %s not allowed to join: %s",
+            tostring(token), tostring(room_address));
+        return false;
+    end
+
+    return true;
+end
+
+--- Handles request for retrieving the room size
+-- @param event the http event, holds the request query
+-- @return GET response, containing a json with participants count,
+--         tha value is without counting the focus.
 function handle_get_room_size(event)
 	local params = parse(event.request.url.query);
 	local room_name = params["room"];
 	local domain_name = params["domain"];
-	local room_address = room_name .. "@" .. "conference." .. domain_name;
+    local subdomain = params["subdomain"];
+
+    local room_address
+        = jid.join(room_name, muc_domain_prefix.."."..domain_name);
+
+    if subdomain and subdomain ~= "" then
+        room_address = "["..subdomain.."]"..room_address;
+    end
+
+    if not verify_token(params["token"], room_address) then
+        return 403;
+    end
+
 	local room = get_room_from_jid(room_address);
 	local participant_count = 0;
 
@@ -52,7 +117,8 @@ function handle_get_room_size(event)
 		if occupants then
 			participant_count = iterators.count(room:each_occupant());
 		end
-		log("debug", "there are %s occupants in room", tostring(participant_count));
+		log("debug",
+            "there are %s occupants in room", tostring(participant_count));
 	else
 		log("debug", "no such room exists");
 	end
@@ -70,11 +136,25 @@ function handle_get_room_size(event)
 	return GET_response;
 end
 
+--- Handles request for retrieving the room participants details
+-- @param event the http event, holds the request query
+-- @return GET response, containing a json with participants details
 function handle_get_room (event)
 	local params = parse(event.request.url.query);
 	local room_name = params["room"];
 	local domain_name = params["domain"];
-	local room_address = room_name .. "@" .. "conference." .. domain_name;
+    local subdomain = params["subdomain"];
+    local room_address
+        = jid.join(room_name, muc_domain_prefix.."."..domain_name);
+
+    if subdomain ~= "" then
+        room_address = "["..subdomain.."]"..room_address;
+    end
+
+    if not verify_token(params["token"], room_address) then
+        return 403;
+    end
+
 	local room = get_room_from_jid(room_address);
 	local participant_count = 0;
 	local occupants_json = array();
@@ -99,7 +179,8 @@ function handle_get_room (event)
 			    end
 			end
 		end
-		log("debug", "there are %s occupants in room", tostring(participant_count));
+		log("debug",
+            "there are %s occupants in room", tostring(participant_count));
 	else
 		log("debug", "no such room exists");
 	end
@@ -117,8 +198,8 @@ function handle_get_room (event)
 	return GET_response;
 end;
 
-function module.add_host(module)
-	module:depends("http");
+function module.load()
+    module:depends("http");
 	module:provides("http", {
 		default_path = "/";
 		route = {

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -36,7 +36,6 @@ function Util.new(module)
     self.appSecret = module:get_option_string("app_secret");
     self.asapKeyServer = module:get_option_string("asap_key_server");
     self.allowEmptyToken = module:get_option_boolean("allow_empty_token");
-    self.disableRoomNameConstraints = module:get_option_boolean("disable_room_name_constraints");
 
     if self.allowEmptyToken == true then
         module:log("warn", "WARNING - empty tokens allowed");
@@ -136,7 +135,7 @@ function Util:verify_token(token)
     end
 
     local roomClaim = claims["room"];
-    if roomClaim == nil and self.disableRoomNameConstraints ~= true then
+    if roomClaim == nil then
         return nil, "'room' claim is missing";
     end
 
@@ -214,7 +213,7 @@ function Util:verify_room(session, room_address)
     end
 
     local auth_room = session.jitsi_meet_room;
-    if self.disableRoomNameConstraints ~= true and room ~= string.lower(auth_room) then
+    if room ~= string.lower(auth_room) then
         return false;
     end
 

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -1,40 +1,224 @@
 -- Token authentication
 -- Copyright (C) 2015 Atlassian
 
+local basexx = require "basexx";
+local have_async, async = pcall(require, "util.async");
+local hex = require "util.hex";
 local jwt = require "luajwtjitsi";
+local http = require "net.http";
+local json = require "cjson";
+local path = require "util.paths";
+local sha256 = require "util.hashes".sha256;
+local timer = require "util.timer";
 
-local _M = {};
+local http_timeout = 30;
+local http_headers = {
+    ["User-Agent"] = "Prosody ("..prosody.version.."; "..prosody.platform..")"
+};
 
-local function _verify_token(token, appId, appSecret, disableRoomNameConstraints)
+-- TODO: Figure out a less arbitrary default cache size.
+local cacheSize = module:get_option_number("jwt_pubkey_cache_size", 128);
+local cache = require"util.cache".new(cacheSize);
 
-	local claims, err = jwt.decode(token, appSecret, true);
-	if claims == nil then
-		return nil, err;
-	end
+local Util = {}
+Util.__index = Util
 
-	local alg = claims["alg"];
-	if alg ~= nil and (alg == "none" or alg == "") then
-		return nil, "'alg' claim must not be empty";
-	end
+--- Constructs util class for token verifications.
+-- Constructor that uses the passed module to extract all the
+-- needed configurations.
+-- If confuguration is missing returns nil
+-- @param module the module in which options to check for configs.
+-- @return the new instance or nil
+function Util.new(module)
+    local self = setmetatable({}, Util)
 
-	local issClaim = claims["iss"];
-	if issClaim == nil then
-		return nil, "'iss' claim is missing";
-	end
-	if issClaim ~= appId then
-		return nil, "Invalid application ID('iss' claim)";
-	end
+    self.appId = module:get_option_string("app_id");
+    self.appSecret = module:get_option_string("app_secret");
+    self.asapKeyServer = module:get_option_string("asap_key_server");
+    self.allowEmptyToken = module:get_option_boolean("allow_empty_token");
+    self.disableRoomNameConstraints = module:get_option_boolean("disable_room_name_constraints");
 
-	local roomClaim = claims["room"];
-	if roomClaim == nil and disableRoomNameConstraints ~= true then
-		return nil, "'room' claim is missing";
-	end
+    if self.allowEmptyToken == true then
+        module:log("warn", "WARNING - empty tokens allowed");
+    end
 
-	return claims;
+    if self.appId == nil then
+        module:log("error", "'app_id' must not be empty");
+        return nil;
+    end
+
+    if self.appSecret == nil and self.asapKeyServer == nil then
+        module:log("error", "'app_secret' or 'asap_key_server' must be specified");
+        return nil;
+    end
+
+    if self.asapKeyServer and not have_async then
+        module:log("error", "requires a version of Prosody with util.async");
+        return nil;
+    end
+
+    return self
 end
 
-function _M.verify_token(token, appId, appSecret, disableRoomNameConstraints)
-	return _verify_token(token, appId, appSecret, disableRoomNameConstraints);
+--- Returns the public key by keyID
+-- @param keyId the key ID to request
+-- @return the public key (the content of requested resource) or nil
+function Util:get_public_key(keyId)
+    local content = cache:get(keyId);
+    if content == nil then
+        -- If the key is not found in the cache.
+        module:log("debug", "Cache miss for key: "..keyId);
+        local code;
+        local wait, done = async.waiter();
+        local function cb(content_, code_, response_, request_)
+            content, code = content_, code_;
+            if code == 200 or code == 204 then
+                cache:set(keyId, content);
+            end
+            done();
+        end
+        local keyurl = path.join(self.asapKeyServer, hex.to(sha256(keyId))..'.pem');
+        module:log("debug", "Fetching public key from: "..keyurl);
+
+        -- We hash the key ID to work around some legacy behavior and make
+        -- deployment easier. It also helps prevent directory
+        -- traversal attacks (although path cleaning could have done this too).
+        local request = http.request(keyurl, {
+            headers = http_headers or {},
+            method = "GET"
+        }, cb);
+
+        -- TODO: Is the done() call racey? Can we cancel this if the request
+        --       succeedes?
+        local function cancel()
+            -- TODO: This check is racey. Not likely to be a problem, but we should
+            --       still stick a mutex on content / code at some point.
+            if code == nil then
+                http.destroy_request(request);
+                done();
+            end
+        end
+        timer.add_task(http_timeout, cancel);
+        wait();
+
+        if code == 200 or code == 204 then
+            return content;
+        end
+    else
+        -- If the key is in the cache, use it.
+        module:log("debug", "Cache hit for key: "..keyId);
+        return content;
+    end
+
+    return nil;
 end
 
-return _M;
+--- Verifies token
+-- @param token the token to verify
+-- @return nil and error or the extracted claims from the token
+function Util:verify_token(token)
+    local claims, err = jwt.decode(token, self.appSecret, true);
+    if claims == nil then
+        return nil, err;
+    end
+
+    local alg = claims["alg"];
+    if alg ~= nil and (alg == "none" or alg == "") then
+        return nil, "'alg' claim must not be empty";
+    end
+
+    local issClaim = claims["iss"];
+    if issClaim == nil then
+        return nil, "'iss' claim is missing";
+    end
+    if issClaim ~= self.appId then
+        return nil, "Invalid application ID('iss' claim)";
+    end
+
+    local roomClaim = claims["room"];
+    if roomClaim == nil and self.disableRoomNameConstraints ~= true then
+        return nil, "'room' claim is missing";
+    end
+
+    return claims;
+end
+
+--- Verifies token and process needed values to be stored in the session.
+-- Stores in session the following values:
+-- session.jitsi_meet_room - the room name value from the token
+-- @param session the current session
+-- @param token the token to verify
+-- @return false and error
+function Util:process_and_verify_token(session, token)
+
+    if token == nil then
+        if self.allowEmptyToken then
+            return true;
+        else
+            return false, "not-allowed", "token required";
+        end
+    end
+
+    local pubKey;
+    if self.asapKeyServer and session.auth_token ~= nil then
+        local dotFirst = session.auth_token:find("%.");
+        if not dotFirst then return nil, "Invalid token" end
+        local header = json.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
+        local kid = header["kid"];
+        if kid == nil then
+            return false, "not-allowed", "'kid' claim is missing";
+        end
+        pubKey = self:get_public_key(kid);
+        if pubKey == nil then
+            return false, "not-allowed", "could not obtain public key";
+        end
+    end
+
+    -- now verify the whole token
+    local claims, msg;
+    if self.asapKeyServer then
+        claims, msg = self:verify_token(token);
+    else
+        claims, msg = self:verify_token(token);
+    end
+    if claims ~= nil then
+        -- Binds room name to the session which is later checked on MUC join
+        session.jitsi_meet_room = claims["room"];
+        return true;
+    else
+        return false, "not-allowed", msg;
+    end
+end
+
+--- Verifies room name if necesarry.
+-- Checks configs and if necessary checks the room name extracted from
+-- room_address against the one saved in the session when token was verified
+-- @param session the current session
+-- @param room_address the whole room address as received
+-- @return returns true in case room was verified or there is no need to verify
+--         it and returns false in case verification was processed
+--         and was not successful
+function Util:verify_room(session, room_address)
+    if self.allowEmptyToken and session.auth_token == nil then
+        module:log(
+            "debug",
+            "Skipped room token verification - empty tokens are allowed");
+        return true;
+    end
+
+    local room = string.match(room_address, "^(%w+)@");
+    if room == nil then
+        log("error",
+            "Unable to get name of the MUC room ? to: %s", room_address);
+        return true;
+    end
+
+    local auth_room = session.jitsi_meet_room;
+    if self.disableRoomNameConstraints ~= true and room ~= string.lower(auth_room) then
+        return false;
+    end
+
+    return true;
+end
+
+return Util;

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -183,15 +183,15 @@ function Util:verify_token(token)
 end
 
 --- Verifies token and process needed values to be stored in the session.
+-- Token is obtained from session.auth_token.
 -- Stores in session the following values:
 -- session.jitsi_meet_room - the room name value from the token
 -- session.jitsi_meet_domain - the domain name value from the token
 -- @param session the current session
--- @param token the token to verify
 -- @return false and error
-function Util:process_and_verify_token(session, token)
+function Util:process_and_verify_token(session)
 
-    if token == nil then
+    if session.auth_token == nil then
         if self.allowEmptyToken then
             return true;
         else
@@ -217,9 +217,9 @@ function Util:process_and_verify_token(session, token)
     -- now verify the whole token
     local claims, msg;
     if self.asapKeyServer then
-        claims, msg = self:verify_token(token);
+        claims, msg = self:verify_token(session.auth_token);
     else
-        claims, msg = self:verify_token(token);
+        claims, msg = self:verify_token(session.auth_token);
     end
     if claims ~= nil then
         -- Binds room name to the session which is later checked on MUC join


### PR DESCRIPTION
Opening a second PR about jwt changes.

Moves all the jwt token verification logic inside token/util so it can be reused.
Adds domain name verification and multidomain support. 
Updates room size API to work with multiple domains.