### PR TITLE
fix(filmstrip): Set avatar container height within inlay

### DIFF
--- a/css/_inlay.scss
+++ b/css/_inlay.scss
@@ -93,6 +93,7 @@
         }
 
         &__avatar-container {
+            height: 100%;
             position: relative;
             > img {
                 height: 100%;


### PR DESCRIPTION
In the filmstrip inlay, the avatar container holds the avatar
image. The image is set to 100% height, so it displays entirely
in the container. However, this does not adjust the horizontal
space created by the image in firefox, leaving whitespace to the
right of the avatar. The fix is to set the container height to
100% so that all its content will fit inside, automatically
adjusting the space created by the image width.