### PR TITLE
feat(filmstrip): Display device errors in an overlay 

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -43,6 +43,7 @@ import {
     participantRoleChanged,
     participantUpdated
 } from './react/features/base/participants';
+import { createLocalTracksFailed } from './react/features/base/tracks';
 import {
     showDesktopPicker
 } from  './react/features/desktop-picker';
@@ -162,12 +163,14 @@ function createInitialLocalTracksAndConnect(roomName) {
                     // If both requests for 'audio' + 'video' and 'audio' only
                     // failed, we assume that there is some problems with user's
                     // microphone and show corresponding dialog.
-                    APP.UI.showDeviceErrorDialog(audioOnlyError, null);
+                    APP.store.dispatch(createLocalTracksFailed(
+                        null, audioOnlyError));
                 } else {
                     // If request for 'audio' + 'video' failed, but request for
                     // 'audio' only was OK, we assume that we had problems with
                     // camera and show corresponding dialog.
-                    APP.UI.showDeviceErrorDialog(null, audioAndVideoError);
+                    APP.store.dispatch(createLocalTracksFailed(
+                        audioAndVideoError, null));
                 }
             }
 
@@ -1666,7 +1669,7 @@ export default {
                     APP.settings.setCameraDeviceId(cameraDeviceId, true);
                 })
                 .catch((err) => {
-                    APP.UI.showDeviceErrorDialog(null, err);
+                    APP.store.dispatch(createLocalTracksFailed(err, null));
                 });
             }
         );
@@ -1687,7 +1690,7 @@ export default {
                     APP.settings.setMicDeviceId(micDeviceId, true);
                 })
                 .catch((err) => {
-                    APP.UI.showDeviceErrorDialog(err, null);
+                    APP.store.dispatch(createLocalTracksFailed(null, err));
                 });
             }
         );

--- a/modules/devices/mediaDeviceHelper.js
+++ b/modules/devices/mediaDeviceHelper.js
@@ -1,5 +1,7 @@
 /* global APP, JitsiMeetJS */
 
+import { createLocalTracksFailed } from './../../react/features/base/tracks';
+
 let currentAudioInputDevices,
     currentVideoInputDevices,
     currentAudioOutputDevices;
@@ -203,8 +205,8 @@ export default {
                     ]))
                     .then(tracks => {
                         if (audioTrackError || videoTrackError) {
-                            APP.UI.showDeviceErrorDialog(
-                                audioTrackError, videoTrackError);
+                            APP.store.dispatch(createLocalTracksFailed(
+                                videoTrackError, audioTrackError));
                         }
 
                         return tracks.filter(t => typeof t !== 'undefined');
@@ -225,7 +227,9 @@ export default {
                 })
                 .catch(err => {
                     audioTrackError = err;
-                    showError && APP.UI.showDeviceErrorDialog(err, null);
+                    if (showError) {
+                        APP.store.dispatch(createLocalTracksFailed(null, err));
+                    }
                     return [];
                 });
         }
@@ -238,7 +242,9 @@ export default {
                 })
                 .catch(err => {
                     videoTrackError = err;
-                    showError && APP.UI.showDeviceErrorDialog(null, err);
+                    if (showError) {
+                        APP.store.dispatch(createLocalTracksFailed(err, null));
+                    }
                     return [];
                 });
         }

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -1,6 +1,18 @@
 import { Symbol } from '../react';
 
 /**
+ * The type of Redux action which signals a device error occurred while creating
+ * a local track.
+ *
+ * {
+ *     type: CREATE_LOCAL_TRACKS_FAILED,
+ *     cameraError: JitsiTrackError,
+ *     micError: JitsiTrackError
+ * }
+ */
+export const CREATE_LOCAL_TRACKS_FAILED = Symbol('CREATE_LOCAL_TRACKS_FAILED');
+
+/**
  * Action for when a track has been added to the conference,
  * local or remote.
  *

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -9,6 +9,7 @@ import {
 import { getLocalParticipant } from '../participants';
 
 import {
+    CREATE_LOCAL_TRACKS_FAILED,
     TRACK_ADDED,
     TRACK_REMOVED,
     TRACK_UPDATED
@@ -35,6 +36,28 @@ export function createLocalTracks(options = {}) {
                 `JitsiMeetJS.createLocalTracks.catch rejection reason: ${err}`);
         });
 }
+
+/**
+ * Signals to display a device error notification with the passed in errors.
+ *
+ * @param {JitsiTrackError} cameraError - The error, if any, from attempting to
+ * use a camera.
+ * @param {JitsiTrackError} micError - The error, if any, from attempting to use
+ * a microphone.
+ * @returns {{
+ *     type: CREATE_LOCAL_TRACKS_FAILED,
+ *     cameraError: JitsiTrackError,
+ *     micError: JitsiTrackError
+ * }}
+ */
+export function createLocalTracksFailed(cameraError, micError) {
+    return {
+        type: CREATE_LOCAL_TRACKS_FAILED,
+        cameraError,
+        micError
+    };
+}
+
 
 /**
  * Calls JitsiLocalTrack#dispose() on all local tracks ignoring errors when

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -25,6 +25,7 @@ import {
 import { getLocalTrack, setTrackMuted } from './functions';
 
 declare var APP: Object;
+declare var interfaceConfig: Object;
 
 /**
  * Middleware that captures LIB_DID_DISPOSE and LIB_DID_INIT actions and,
@@ -37,7 +38,7 @@ declare var APP: Object;
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
     case CREATE_LOCAL_TRACKS_FAILED: {
-        if (typeof APP !== 'undefined') {
+        if (typeof APP !== 'undefined' && !interfaceConfig.filmStripOnly) {
             APP.UI.showDeviceErrorDialog(action.micError, action.cameraError);
         }
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -18,8 +18,13 @@ import {
     createLocalTracks,
     destroyLocalTracks
 } from './actions';
-import { TRACK_UPDATED } from './actionTypes';
+import {
+    CREATE_LOCAL_TRACKS_FAILED,
+    TRACK_UPDATED
+} from './actionTypes';
 import { getLocalTrack, setTrackMuted } from './functions';
+
+declare var APP: Object;
 
 /**
  * Middleware that captures LIB_DID_DISPOSE and LIB_DID_INIT actions and,
@@ -31,6 +36,13 @@ import { getLocalTrack, setTrackMuted } from './functions';
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
+    case CREATE_LOCAL_TRACKS_FAILED: {
+        if (typeof APP !== 'undefined') {
+            APP.UI.showDeviceErrorDialog(action.micError, action.cameraError);
+        }
+
+        break;
+    }
     case LIB_DID_DISPOSE:
         store.dispatch(destroyLocalTracks());
         break;

--- a/react/features/overlay/actionTypes.js
+++ b/react/features/overlay/actionTypes.js
@@ -1,6 +1,17 @@
 import { Symbol } from '../base/react';
 
 /**
+ * The type of Redux action which signals to remove cached device errors from
+ * the store.
+ *
+ * {
+ *     type: CLEAR_DEVICE_ERRORS
+ * }
+ * @public
+ */
+export const CLEAR_DEVICE_ERRORS = Symbol('CLEAR_DEVICE_ERRORS');
+
+/**
  * The type of the Redux action which signals that the prompt for media
  * permission is visible or not.
  *

--- a/react/features/overlay/actions.js
+++ b/react/features/overlay/actions.js
@@ -1,7 +1,22 @@
 import {
+    CLEAR_DEVICE_ERRORS,
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
     SUSPEND_DETECTED
 } from './actionTypes';
+
+/**
+ * Signals to remove cached device errors from the store.
+ *
+ * @returns {{
+ *     type: CLEAR_DEVICE_ERRORS
+ * }}
+ * @public
+ */
+export function clearDeviceErrors() {
+    return {
+        type: CLEAR_DEVICE_ERRORS
+    };
+}
 
 /**
  * Signals that the prompt for media permission is visible or not.

--- a/react/features/overlay/components/DeviceErrorFilmstripOnlyOverlay.js
+++ b/react/features/overlay/components/DeviceErrorFilmstripOnlyOverlay.js
@@ -1,0 +1,135 @@
+import AKButton from '@atlaskit/button';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../base/i18n';
+import { JitsiTrackErrors } from '../../base/lib-jitsi-meet';
+
+import { clearDeviceErrors } from '../actions';
+
+import FilmstripOnlyOverlayFrame from './FilmstripOnlyOverlayFrame';
+
+/**
+ * React {@code Component} for an overlay informing an error occurred while
+ * attempting to use a camera and/or microphone. This component will be
+ * displayed only for filmstrip only mode. Due to space limitations, verbose
+ * error messaging is not displayed.
+ *
+ * @extends Component
+ */
+class DeviceErrorFilmstripOnlyOverlay extends Component {
+    /**
+     * {@code DeviceErrorFilmstripOnlyOverlay}'s property types.
+     *
+     * @static
+     */
+    static propTypes = {
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * @type {JitsiTrackError}
+         */
+        cameraError: React.PropTypes.object,
+
+        /**
+         * Invoked to clear known device errors.
+         */
+        dispatch: React.PropTypes.func,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * @type {JitsiTrackError}
+         */
+        micError: React.PropTypes.object,
+
+        /**
+         * Invoked to obtain translated strings.
+         */
+        t: React.PropTypes.func
+    }
+
+    /**
+     * Initializes a new {@code DeviceErrorFilmstripOnlyOverlay} instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onDismiss = this._onDismiss.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <FilmstripOnlyOverlayFrame
+                isLightOverlay = { true }>
+                <div className = 'inlay-filmstrip-only__container'>
+                    <div className = 'inlay-filmstrip-only__title'>
+                        { this.props.t(this._getTitleKey()) }
+                    </div>
+                    <div className = 'inlay-filmstrip-only__text'>
+                        <div>
+                            { this.props.cameraError
+                                && this.props.t('dialog.cameraErrorPresent') }
+                        </div>
+                        <div>
+                            { this.props.micError
+                                && this.props.t('dialog.micErrorPresent') }
+                        </div>
+                    </div>
+                    <AKButton
+                        appearance = 'primary'
+                        onClick = { this._onDismiss }>
+                        { this.props.t('dialog.Ok') }
+                    </AKButton>
+                </div>
+            </FilmstripOnlyOverlayFrame>
+        );
+    }
+
+    /**
+     * Determines which translation key should be used as the overlay's title
+     * based on the types of errors present.
+     *
+     * @private
+     * @returns {string} The translation key to use as an overlay title.
+     */
+    _getTitleKey() {
+        const { cameraError, micError } = this.props;
+        const { PERMISSION_DENIED } = JitsiTrackErrors;
+
+        let title = 'dialog.error';
+
+        if (micError && micError.name === PERMISSION_DENIED) {
+            if (!cameraError || cameraError.name === PERMISSION_DENIED) {
+                title = 'dialog.permissionDenied';
+            }
+        } else if (cameraError && cameraError.name === PERMISSION_DENIED) {
+            title = 'dialog.permissionDenied';
+        }
+
+        return title;
+    }
+
+    /**
+     * Dispatches an action to clear device error messages to hide the error
+     * overlay.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onDismiss() {
+        this.props.dispatch(clearDeviceErrors());
+    }
+}
+
+export default translate(connect()(DeviceErrorFilmstripOnlyOverlay));

--- a/react/features/overlay/components/OverlayContainer.js
+++ b/react/features/overlay/components/OverlayContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import DeviceErrorFilmstripOnlyOverlay from './DeviceErrorFilmstripOnlyOverlay';
 import PageReloadFilmstripOnlyOverlay from './PageReloadFilmstripOnlyOverlay';
 import PageReloadOverlay from './PageReloadOverlay';
 import SuspendedFilmstripOnlyOverlay from './SuspendedFilmstripOnlyOverlay';
@@ -32,6 +33,16 @@ class OverlayContainer extends Component {
          * @type {string}
          */
         _browser: React.PropTypes.string,
+
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _cameraError: React.PropTypes.object,
 
         /**
          * The indicator which determines whether the status of the
@@ -76,6 +87,16 @@ class OverlayContainer extends Component {
          * @type {boolean}
          */
         _isNetworkFailure: React.PropTypes.bool,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _micError: React.PropTypes.object,
 
         /**
          * The reason for the error that will cause the reload.
@@ -165,6 +186,13 @@ class OverlayContainer extends Component {
                     ? UserMediaPermissionsFilmstripOnlyOverlay
                     : UserMediaPermissionsOverlay;
             props = { browser: this.props._browser };
+        } else if (this.props._micError || this.props._cameraError) {
+            overlayComponent = filmstripOnly
+                ? DeviceErrorFilmstripOnlyOverlay : null;
+            props = {
+                cameraError: this.props._cameraError,
+                micError: this.props._micError
+            };
         }
 
         return (
@@ -202,6 +230,16 @@ function _mapStateToProps(state) {
          * @type {string}
          */
         _browser: stateFeaturesOverlay.browser,
+
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _cameraError: stateFeaturesOverlay.cameraError,
 
         /**
          * The indicator which determines whether the status of the
@@ -247,6 +285,16 @@ function _mapStateToProps(state) {
          * @type {boolean}
          */
         _isNetworkFailure: stateFeaturesOverlay.isNetworkFailure,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _micError: stateFeaturesOverlay.micError,
 
         /**
          * The reason for the error that will cause the reload.

--- a/react/features/overlay/reducer.js
+++ b/react/features/overlay/reducer.js
@@ -6,6 +6,7 @@ import {
     JitsiConnectionErrors
 } from '../base/lib-jitsi-meet';
 import { assign, ReducerRegistry, set } from '../base/redux';
+import { CREATE_LOCAL_TRACKS_FAILED } from '../base/tracks';
 
 import {
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
@@ -27,6 +28,9 @@ ReducerRegistry.register('features/overlay', (state = {}, action) => {
 
     case CONNECTION_FAILED:
         return _connectionFailed(state, action);
+
+    case CREATE_LOCAL_TRACKS_FAILED:
+        return _createLocalTracksFailed(state, action);
 
     case MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED:
         return _mediaPermissionPromptVisibilityChanged(state, action);
@@ -104,6 +108,23 @@ function _connectionFailed(state, action) {
     }
 
     return state;
+}
+
+/**
+ * Reduces a specific Redux action CREATE_LOCAL_TRACKS_FAILED for the feature
+ * overlay.
+ *
+ * @param {Object} state - The Redux state of the feature overlay.
+ * @param {Action} action - The Redux action to reduce.
+ * @returns {Object} The new state of the feature overlay after the reduction of
+ * the specified action.
+ * @private
+ */
+function _createLocalTracksFailed(state, action) {
+    return assign(state, {
+        cameraError: action.cameraError,
+        micError: action.micError
+    });
 }
 
 /**

--- a/react/features/overlay/reducer.js
+++ b/react/features/overlay/reducer.js
@@ -9,6 +9,7 @@ import { assign, ReducerRegistry, set } from '../base/redux';
 import { CREATE_LOCAL_TRACKS_FAILED } from '../base/tracks';
 
 import {
+    CLEAR_DEVICE_ERRORS,
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
     SUSPEND_DETECTED
 } from './actionTypes';
@@ -20,6 +21,9 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  */
 ReducerRegistry.register('features/overlay', (state = {}, action) => {
     switch (action.type) {
+    case CLEAR_DEVICE_ERRORS:
+        return _clearDeviceErrors(state, action);
+
     case CONFERENCE_FAILED:
         return _conferenceFailed(state, action);
 
@@ -41,6 +45,22 @@ ReducerRegistry.register('features/overlay', (state = {}, action) => {
 
     return state;
 });
+
+
+/**
+ * Reduces a specific Redux action CLEAR_DEVICE_ERRORS for the feature overlay.
+ *
+ * @param {Object} state - The Redux state of the feature overlay.
+ * @returns {Object} The new state of the feature overlay after the reduction of
+ * the specified action.
+ * @private
+ */
+function _clearDeviceErrors(state) {
+    return assign(state, {
+        cameraError: null,
+        micError: null
+    });
+}
 
 /**
  * Reduces a specific Redux action CONFERENCE_FAILED of the feature overlay.


### PR DESCRIPTION
This series of commits places errors from createLocalTracks into the redux store for the overlays feature to pick up and subsequently display an overlay. A device-error folder has been created with only an actions and middleware file, with the intent of moving the device error modal to react in a future commit.