### PR TITLE
feat(device-error): Convert device error dialog to react 

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -43,6 +43,7 @@ import {
     participantRoleChanged,
     participantUpdated
 } from './react/features/base/participants';
+import { createLocalTracksFailed } from './react/features/base/tracks';
 import {
     showDesktopPicker
 } from  './react/features/desktop-picker';
@@ -162,12 +163,14 @@ function createInitialLocalTracksAndConnect(roomName) {
                     // If both requests for 'audio' + 'video' and 'audio' only
                     // failed, we assume that there is some problems with user's
                     // microphone and show corresponding dialog.
-                    APP.UI.showDeviceErrorDialog(audioOnlyError, null);
+                    APP.store.dispatch(createLocalTracksFailed(
+                        null, audioOnlyError));
                 } else {
                     // If request for 'audio' + 'video' failed, but request for
                     // 'audio' only was OK, we assume that we had problems with
                     // camera and show corresponding dialog.
-                    APP.UI.showDeviceErrorDialog(null, audioAndVideoError);
+                    APP.store.dispatch(createLocalTracksFailed(
+                        audioAndVideoError, null));
                 }
             }
 
@@ -1666,7 +1669,7 @@ export default {
                     APP.settings.setCameraDeviceId(cameraDeviceId, true);
                 })
                 .catch((err) => {
-                    APP.UI.showDeviceErrorDialog(null, err);
+                    APP.store.dispatch(createLocalTracksFailed(err, null));
                 });
             }
         );
@@ -1687,7 +1690,7 @@ export default {
                     APP.settings.setMicDeviceId(micDeviceId, true);
                 })
                 .catch((err) => {
-                    APP.UI.showDeviceErrorDialog(err, null);
+                    APP.store.dispatch(createLocalTracksFailed(null, err));
                 });
             }
         );

--- a/css/main.scss
+++ b/css/main.scss
@@ -38,6 +38,7 @@
 @import 'inlay';
 @import 'reload_overlay/reload_overlay';
 @import 'modals/desktop-picker/desktop-picker';
+@import 'modals/device-error/device-error';
 @import 'modals/device-selection/device-selection';
 @import 'modals/dialog';
 @import 'modals/feedback/feedback';

--- a/css/modals/device-error/_device-error.scss
+++ b/css/modals/device-error/_device-error.scss
@@ -1,0 +1,7 @@
+.device-error-do-not-show {
+    margin-top: 10px;
+
+    input {
+        margin-right: 5px;
+    }
+}

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -1,4 +1,4 @@
-/* global APP, JitsiMeetJS, $, config, interfaceConfig, toastr */
+/* global APP, $, config, interfaceConfig, toastr */
 
 const logger = require("jitsi-meet-logger").getLogger(__filename);
 
@@ -72,38 +72,6 @@ let etherpadManager;
 let sharedVideoManager;
 
 let followMeHandler;
-
-let deviceErrorDialog;
-
-const TrackErrors = JitsiMeetJS.errors.track;
-
-const JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP = {
-    microphone: {},
-    camera: {}
-};
-
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.UNSUPPORTED_RESOLUTION]
-    = "dialog.cameraUnsupportedResolutionError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.GENERAL]
-    = "dialog.cameraUnknownError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.PERMISSION_DENIED]
-    = "dialog.cameraPermissionDeniedError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.NOT_FOUND]
-    = "dialog.cameraNotFoundError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.CONSTRAINT_FAILED]
-    = "dialog.cameraConstraintFailedError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.NO_DATA_FROM_SOURCE]
-    = "dialog.cameraNotSendingData";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.GENERAL]
-    = "dialog.micUnknownError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.PERMISSION_DENIED]
-    = "dialog.micPermissionDeniedError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.NOT_FOUND]
-    = "dialog.micNotFoundError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.CONSTRAINT_FAILED]
-    = "dialog.micConstraintFailedError";
-JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.NO_DATA_FROM_SOURCE]
-    = "dialog.micNotSendingData";
 
 /**
  * Toggles the application in and out of full screen mode
@@ -1145,117 +1113,6 @@ UI.showExtensionExternalInstallationDialog = function (url) {
         loadedFunction: $.noop,
         closeFunction
     });
-};
-
-
-/**
- * Shows dialog with combined information about camera and microphone errors.
- * @param {JitsiTrackError} micError
- * @param {JitsiTrackError} cameraError
- */
-UI.showDeviceErrorDialog = function (micError, cameraError) {
-    let dontShowAgain = {
-        id: "doNotShowWarningAgain",
-        localStorageKey: "doNotShowErrorAgain",
-        textKey: "dialog.doNotShowWarningAgain"
-    };
-    let isMicJitsiTrackErrorAndHasName = micError && micError.name &&
-        micError instanceof JitsiMeetJS.errorTypes.JitsiTrackError;
-    let isCameraJitsiTrackErrorAndHasName = cameraError && cameraError.name &&
-        cameraError instanceof JitsiMeetJS.errorTypes.JitsiTrackError;
-    let showDoNotShowWarning = false;
-
-    if (micError && cameraError && isMicJitsiTrackErrorAndHasName &&
-        isCameraJitsiTrackErrorAndHasName) {
-        showDoNotShowWarning =  true;
-    } else if (micError && isMicJitsiTrackErrorAndHasName && !cameraError) {
-        showDoNotShowWarning =  true;
-    } else if (cameraError && isCameraJitsiTrackErrorAndHasName && !micError) {
-        showDoNotShowWarning =  true;
-    }
-
-    if (micError) {
-        dontShowAgain.localStorageKey += "-mic-" + micError.name;
-    }
-
-    if (cameraError) {
-        dontShowAgain.localStorageKey += "-camera-" + cameraError.name;
-    }
-
-    let cameraJitsiTrackErrorMsg = cameraError
-        ? JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[cameraError.name]
-        : undefined;
-    let micJitsiTrackErrorMsg = micError
-        ? JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[micError.name]
-        : undefined;
-    let cameraErrorMsg = cameraError
-        ? cameraJitsiTrackErrorMsg ||
-            JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[TrackErrors.GENERAL]
-        : "";
-    let micErrorMsg = micError
-        ? micJitsiTrackErrorMsg ||
-            JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.microphone[TrackErrors.GENERAL]
-        : "";
-    let additionalCameraErrorMsg = !cameraJitsiTrackErrorMsg && cameraError &&
-        cameraError.message
-            ? `<div>${cameraError.message}</div>`
-            : ``;
-    let additionalMicErrorMsg = !micJitsiTrackErrorMsg && micError &&
-        micError.message
-            ? `<div>${micError.message}</div>`
-            : ``;
-    let message = '';
-
-    if (micError) {
-        message = `
-            ${message}
-            <h3 data-i18n='dialog.micErrorPresent'></h3>
-            <h4 data-i18n='${micErrorMsg}'></h4>
-            ${additionalMicErrorMsg}`;
-    }
-
-    if (cameraError) {
-        message = `
-            ${message}
-            <h3 data-i18n='dialog.cameraErrorPresent'></h3>
-            <h4 data-i18n='${cameraErrorMsg}'></h4>
-            ${additionalCameraErrorMsg}`;
-    }
-
-    // To make sure we don't have multiple error dialogs open at the same time,
-    // we will just close the previous one if we are going to show a new one.
-    deviceErrorDialog && deviceErrorDialog.close();
-
-    deviceErrorDialog = messageHandler.openDialog(
-        getTitleKey(),
-        message,
-        false,
-        {Ok: true},
-        function () {},
-        null,
-        function () {
-            // Reset dialog reference to null to avoid memory leaks when
-            // user closed the dialog manually.
-            deviceErrorDialog = null;
-        },
-        showDoNotShowWarning ? dontShowAgain : undefined
-    );
-
-    function getTitleKey() {
-        let title = "dialog.error";
-
-        if (micError && micError.name === TrackErrors.PERMISSION_DENIED) {
-            if (!cameraError
-                    || cameraError.name === TrackErrors.PERMISSION_DENIED) {
-                title = "dialog.permissionDenied";
-            }
-        } else if (cameraError
-                && cameraError.name === TrackErrors.PERMISSION_DENIED) {
-            title = "dialog.permissionDenied";
-        }
-
-        return title;
-    }
 };
 
 /**

--- a/modules/devices/mediaDeviceHelper.js
+++ b/modules/devices/mediaDeviceHelper.js
@@ -1,5 +1,7 @@
 /* global APP, JitsiMeetJS */
 
+import { createLocalTracksFailed } from './../../react/features/base/tracks';
+
 let currentAudioInputDevices,
     currentVideoInputDevices,
     currentAudioOutputDevices;
@@ -203,8 +205,8 @@ export default {
                     ]))
                     .then(tracks => {
                         if (audioTrackError || videoTrackError) {
-                            APP.UI.showDeviceErrorDialog(
-                                audioTrackError, videoTrackError);
+                            APP.store.dispatch(createLocalTracksFailed(
+                                videoTrackError, audioTrackError));
                         }
 
                         return tracks.filter(t => typeof t !== 'undefined');
@@ -225,7 +227,9 @@ export default {
                 })
                 .catch(err => {
                     audioTrackError = err;
-                    showError && APP.UI.showDeviceErrorDialog(err, null);
+                    if (showError) {
+                        APP.store.dispatch(createLocalTracksFailed(null, err));
+                    }
                     return [];
                 });
         }
@@ -238,7 +242,9 @@ export default {
                 })
                 .catch(err => {
                     videoTrackError = err;
-                    showError && APP.UI.showDeviceErrorDialog(null, err);
+                    if (showError) {
+                        APP.store.dispatch(createLocalTracksFailed(err, null));
+                    }
                     return [];
                 });
         }

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -1,6 +1,7 @@
 import { appInit } from '../actions';
 import { AbstractApp } from './AbstractApp';
 
+import '../../device-error';
 import '../../room-lock';
 
 /**

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -1,6 +1,18 @@
 import { Symbol } from '../react';
 
 /**
+ * The type of Redux action which signals a device error occurred while creating
+ * a local track.
+ *
+ * {
+ *     type: CREATE_LOCAL_TRACKS_FAILED,
+ *     cameraError: JitsiTrackError,
+ *     micError: JitsiTrackError
+ * }
+ */
+export const CREATE_LOCAL_TRACKS_FAILED = Symbol('CREATE_LOCAL_TRACKS_FAILED');
+
+/**
  * Action for when a track has been added to the conference,
  * local or remote.
  *

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -9,6 +9,7 @@ import {
 import { getLocalParticipant } from '../participants';
 
 import {
+    CREATE_LOCAL_TRACKS_FAILED,
     TRACK_ADDED,
     TRACK_REMOVED,
     TRACK_UPDATED
@@ -35,6 +36,28 @@ export function createLocalTracks(options = {}) {
                 `JitsiMeetJS.createLocalTracks.catch rejection reason: ${err}`);
         });
 }
+
+/**
+ * Signals to display a device error notification with the passed in errors.
+ *
+ * @param {JitsiTrackError} cameraError - The error, if any, from attempting to
+ * use a camera.
+ * @param {JitsiTrackError} micError - The error, if any, from attempting to use
+ * a microphone.
+ * @returns {{
+ *     type: CREATE_LOCAL_TRACKS_FAILED,
+ *     cameraError: JitsiTrackError,
+ *     micError: JitsiTrackError
+ * }}
+ */
+export function createLocalTracksFailed(cameraError, micError) {
+    return {
+        type: CREATE_LOCAL_TRACKS_FAILED,
+        cameraError,
+        micError
+    };
+}
+
 
 /**
  * Calls JitsiLocalTrack#dispose() on all local tracks ignoring errors when

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -25,6 +25,7 @@ import {
 import { getLocalTrack, setTrackMuted } from './functions';
 
 declare var APP: Object;
+declare var interfaceConfig: Object;
 
 /**
  * Middleware that captures LIB_DID_DISPOSE and LIB_DID_INIT actions and,
@@ -37,7 +38,7 @@ declare var APP: Object;
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
     case CREATE_LOCAL_TRACKS_FAILED: {
-        if (typeof APP !== 'undefined') {
+        if (typeof APP !== 'undefined' && !interfaceConfig.filmStripOnly) {
             APP.UI.showDeviceErrorDialog(action.micError, action.cameraError);
         }
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -18,14 +18,8 @@ import {
     createLocalTracks,
     destroyLocalTracks
 } from './actions';
-import {
-    CREATE_LOCAL_TRACKS_FAILED,
-    TRACK_UPDATED
-} from './actionTypes';
+import { TRACK_UPDATED } from './actionTypes';
 import { getLocalTrack, setTrackMuted } from './functions';
-
-declare var APP: Object;
-declare var interfaceConfig: Object;
 
 /**
  * Middleware that captures LIB_DID_DISPOSE and LIB_DID_INIT actions and,
@@ -37,13 +31,6 @@ declare var interfaceConfig: Object;
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-    case CREATE_LOCAL_TRACKS_FAILED: {
-        if (typeof APP !== 'undefined' && !interfaceConfig.filmStripOnly) {
-            APP.UI.showDeviceErrorDialog(action.micError, action.cameraError);
-        }
-
-        break;
-    }
     case LIB_DID_DISPOSE:
         store.dispatch(destroyLocalTracks());
         break;

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -18,8 +18,13 @@ import {
     createLocalTracks,
     destroyLocalTracks
 } from './actions';
-import { TRACK_UPDATED } from './actionTypes';
+import {
+    CREATE_LOCAL_TRACKS_FAILED,
+    TRACK_UPDATED
+} from './actionTypes';
 import { getLocalTrack, setTrackMuted } from './functions';
+
+declare var APP: Object;
 
 /**
  * Middleware that captures LIB_DID_DISPOSE and LIB_DID_INIT actions and,
@@ -31,6 +36,13 @@ import { getLocalTrack, setTrackMuted } from './functions';
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
+    case CREATE_LOCAL_TRACKS_FAILED: {
+        if (typeof APP !== 'undefined') {
+            APP.UI.showDeviceErrorDialog(action.micError, action.cameraError);
+        }
+
+        break;
+    }
     case LIB_DID_DISPOSE:
         store.dispatch(destroyLocalTracks());
         break;

--- a/react/features/device-error/actionTypes.js
+++ b/react/features/device-error/actionTypes.js
@@ -1,0 +1,14 @@
+import { Symbol } from '../base/react';
+
+/**
+ * The type of the action which signals to update whether or not the device
+ * error dialog should open for the passed in errorType.
+ *
+ * {
+ *     type: SET_DEVICE_ERROR_DIALOG_PREFERENCE,
+ *     errorType: string,
+ *.    doNotShow: boolean
+ * }
+ */
+export const SET_DEVICE_ERROR_DIALOG_PREFERENCE
+    = Symbol('SET_DEVICE_ERROR_DIALOG_PREFERENCE');

--- a/react/features/device-error/actions.js
+++ b/react/features/device-error/actions.js
@@ -1,0 +1,36 @@
+import { openDialog } from '../base/dialog';
+
+import { SET_DEVICE_ERROR_DIALOG_PREFERENCE } from './actionTypes';
+import { DeviceErrorDialog } from './components';
+
+/**
+ * Opens {@code DeviceErrorDialog} with the passed in props.
+ *
+ * @param {Object} dialogProps - The props to pass into the dialog.
+ * @returns {Function}
+ */
+export function openDeviceErrorDialog(dialogProps) {
+    return openDialog(DeviceErrorDialog, dialogProps);
+}
+
+/**
+ * Signals to save the preference for whether or not an error dialog should
+ * display again for the given errorType.
+ *
+ * @param {string} errorType - The type of device error to save the preference
+ * for.
+ * @param {boolean} doNotShow - The value to be stored into local storage. If
+ * true, the dialog for the given errorType will not display again.
+ * @returns {{
+ *     type: SET_DEVICE_ERROR_DIALOG_PREFERENCE,
+ *     doNotShow: boolean,
+ *     errorType: string
+ * }}
+ */
+export function setDeviceErrorDialogPreference(errorType, doNotShow) {
+    return {
+        type: SET_DEVICE_ERROR_DIALOG_PREFERENCE,
+        doNotShow,
+        errorType
+    };
+}

--- a/react/features/device-error/components/DeviceErrorDialog.js
+++ b/react/features/device-error/components/DeviceErrorDialog.js
@@ -1,0 +1,291 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { Dialog } from '../../base/dialog';
+import { translate } from '../../base/i18n';
+
+import { setDeviceErrorDialogPreference } from '../actions';
+
+// FIXME The global reference to JitsiMeetJS is being used because at this
+// module's loading the imported JitsiMeetJS returns undefined.
+declare var JitsiMeetJS: Object;
+
+const TrackErrors = JitsiMeetJS.errors.track;
+const ERROR_MESSAGE_MAP = {
+    camera: {
+        [TrackErrors.CONSTRAINT_FAILED]: 'dialog.cameraConstraintFailedError',
+        [TrackErrors.GENERAL]: 'dialog.cameraUnknownError',
+        [TrackErrors.NO_DATA_FROM_SOURCE]: 'dialog.cameraNotSendingData',
+        [TrackErrors.NOT_FOUND]: 'dialog.cameraNotFoundError',
+        [TrackErrors.PERMISSION_DENIED]: 'dialog.cameraPermissionDeniedError',
+        [TrackErrors.UNSUPPORTED_RESOLUTION]:
+            'dialog.cameraUnsupportedResolutionError'
+    },
+    microphone: {
+        [TrackErrors.CONSTRAINT_FAILED]: 'dialog.micConstraintFailedError',
+        [TrackErrors.GENERAL]: 'dialog.micUnknownError',
+        [TrackErrors.NO_DATA_FROM_SOURCE]: 'dialog.micNotSendingData',
+        [TrackErrors.NOT_FOUND]: 'dialog.micNotFoundError',
+        [TrackErrors.PERMISSION_DENIED]: 'dialog.micPermissionDeniedError'
+    }
+};
+const { PERMISSION_DENIED } = TrackErrors;
+
+/**
+ * React {@code Component} for displaying an error dialog about a failed attempt
+ * to use a media device. On close, dispatches an action to save the preference
+ * for never displaying the dialog again for the given error types.
+ *
+ * @extends Component
+ */
+class DeviceErrorDialog extends Component {
+    /**
+     * {@code DeviceErrorDialog}'s property types.
+     *
+     * @static
+     */
+    static propTypes = {
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * @type {JitsiTrackError}
+         */
+        cameraError: React.PropTypes.object,
+
+        /**
+         * Invoked to update the preference of whether or not the dialog should
+         * display again.
+         */
+        dispatch: React.PropTypes.func,
+
+        /**
+         * The key used to save whether or not the dialog for the given errors
+         * should display again.
+         */
+        localStorageKey: React.PropTypes.string,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * @type {JitsiTrackError}
+         */
+        micError: React.PropTypes.object,
+
+        /**
+         * Invoked to obtain translated strings.
+         */
+        t: React.PropTypes.func
+    }
+
+    /**
+     * Initializes a new {@code DeviceErrorDialog} instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            /**
+             * An internal reference for whether or not the checkbox for never
+             * showing the error dialog again is checked. This preference is
+             * used to determine if future errors of the same types will display
+             * a dialog or not. On submission of this dialog, the preference
+             * will be saved into local storage.
+             *
+             * @private
+             * @type {boolean}
+             */
+            checked: false
+        };
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onCheckboxChange = this._onCheckboxChange.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <Dialog
+                isModal = { true }
+                onSubmit = { this._onSubmit }
+                titleKey = { this._createTitle() }
+                width = 'small' >
+                <div>
+                    { this._renderMicErrorMessage() }
+                    { this._renderCameraErrorMessage() }
+                    { this._renderDoNoShowMessage() }
+                </div>
+            </Dialog>
+        );
+    }
+
+    /**
+     * Returns which translation key should be used as the overlay's title based
+     * on the types of errors present.
+     *
+     * @private
+     * @returns {string}
+     */
+    _createTitle() {
+        const { cameraError, micError } = this.props;
+
+        let title = 'dialog.error';
+
+        if (micError && micError.name === PERMISSION_DENIED) {
+            if (!cameraError || cameraError.name === PERMISSION_DENIED) {
+                title = 'dialog.permissionDenied';
+            }
+        } else if (cameraError && cameraError.name === PERMISSION_DENIED) {
+            title = 'dialog.permissionDenied';
+        }
+
+        return title;
+    }
+
+    /**
+     * Updates the internal state with the current checked state of the "do not
+     * show" checkbox.
+     *
+     * @param {Event} event - The event from the checkbox changing its checked
+     * state.
+     * @private
+     * @returns {void}
+     */
+    _onCheckboxChange(event) {
+        this.setState({ checked: event.target.checked });
+    }
+
+    /**
+     * Dispatches an action to persistswhether or not, based on the "checked"
+     * state, future errors of the same types should display a dialog.
+     *
+     * @private
+     * @returns {boolean} True is returned to close the dialog.
+     */
+    _onSubmit() {
+        this.props.dispatch(setDeviceErrorDialogPreference(
+            this.props.localStorageKey,
+            this.state.checked));
+
+        return true;
+    }
+
+    /**
+     * Creates a ReactElement to display the passed in camera error. Will match
+     * the camera error type to a pre-existing error message or will use the
+     * message provided by the error itself if no match is found.
+     *
+     * @private
+     * @returns {ReactElement|null} Returns null if no camera error is present.
+     */
+    _renderCameraErrorMessage() {
+        const { cameraError } = this.props;
+
+        if (!cameraError) {
+            return null;
+        }
+
+        const jitsiCameraErrorMessage
+            = ERROR_MESSAGE_MAP.camera[cameraError.name];
+        const errorMessage = jitsiCameraErrorMessage
+                || ERROR_MESSAGE_MAP.camera[TrackErrors.GENERAL];
+        const additionalInfo = !jitsiCameraErrorMessage && cameraError.message;
+
+        return (
+            <div>
+                <h3>{ this.props.t('dialog.cameraErrorPresent') }</h3>
+                <h4>{ this.props.t(errorMessage) }</h4>
+                { additionalInfo }
+            </div>
+        );
+    }
+
+    /**
+     * Creates a ReactElement to display a checkbox for setting whether or not
+     * a dialog of the same passed in error types should ever display again.
+     *
+     * @private
+     * @returns {ReactElement|null}
+     */
+    _renderDoNoShowMessage() {
+        if (!this._shouldRenderDoNotShowMessage()) {
+            return null;
+        }
+
+        return (
+            <div className = 'device-error-do-not-show'>
+                <input
+                    checked = { this.state.checked }
+                    id = 'doNotShowWarningAgain'
+                    onChange = { this._onCheckboxChange }
+                    type = 'checkbox' />
+                <span>
+                    { this.props.t('dialog.doNotShowWarningAgain') }
+                </span>
+            </div>
+        );
+    }
+
+    /**
+     * Creates a ReactElement to display the passed in mic error. Will match the
+     * mic error type to a pre-existing error message or will use the message
+     * provided by the error itself if no match is found.
+     *
+     * @private
+     * @returns {ReactElement|null} Returns null if no mic error is present.
+     */
+    _renderMicErrorMessage() {
+        const { micError } = this.props;
+
+        if (!micError) {
+            return null;
+        }
+
+        const jitsiMicErrorMessage
+            = ERROR_MESSAGE_MAP.microphone[micError.name];
+        const errorMessage = jitsiMicErrorMessage
+                || ERROR_MESSAGE_MAP.microphone[TrackErrors.GENERAL];
+        const additionalInfo = !jitsiMicErrorMessage && micError.message;
+
+        return (
+            <div>
+                <h3>{ this.props.t('dialog.micErrorPresent') }</h3>
+                <h4>{ this.props.t(errorMessage) }</h4>
+                { additionalInfo }
+            </div>
+        );
+    }
+
+    /**
+     * Checks whether or not the ReactElement for setting a "do not show"
+     * preference should be rendered. True is returned if both camera and mic
+     * errors are JitsiTrackErrors or if only one JitsiTrackError is present.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _shouldRenderDoNotShowMessage() {
+        const { cameraError, micError } = this.props;
+        const isCameraJitsiTrackErrorWithName = cameraError
+            && cameraError.name
+            && cameraError instanceof JitsiMeetJS.errorTypes.JitsiTrackError;
+        const isMicJitsiTrackErrorWithName = micError
+            && micError.name
+            && micError instanceof JitsiMeetJS.errorTypes.JitsiTrackError;
+
+        return (isMicJitsiTrackErrorWithName && isCameraJitsiTrackErrorWithName)
+            || (isMicJitsiTrackErrorWithName && !cameraError)
+            || (isCameraJitsiTrackErrorWithName && !micError);
+
+    }
+}
+
+export default translate(connect()(DeviceErrorDialog));

--- a/react/features/device-error/components/index.js
+++ b/react/features/device-error/components/index.js
@@ -1,0 +1,1 @@
+export { default as DeviceErrorDialog } from './DeviceErrorDialog';

--- a/react/features/device-error/index.js
+++ b/react/features/device-error/index.js
@@ -1,0 +1,5 @@
+export * from './actions';
+export * from './actionTypes';
+export * from './components';
+
+import './middleware';

--- a/react/features/device-error/middleware.js
+++ b/react/features/device-error/middleware.js
@@ -1,0 +1,106 @@
+import jitsiLocalStorage from '../../../modules/util/JitsiLocalStorage';
+
+import { MiddlewareRegistry } from '../base/redux';
+import { CREATE_LOCAL_TRACKS_FAILED } from '../base/tracks';
+
+import { openDeviceErrorDialog } from './actions';
+import { SET_DEVICE_ERROR_DIALOG_PREFERENCE } from './actionTypes';
+
+declare var interfaceConfig: Object;
+
+const LOCAL_STORAGE_KEY = 'doNotShowErrorAgain';
+
+/**
+ * Implements middleware that captures actions related to displaying dialogs
+ * when an error occurs while creating a local media track.
+ *
+ * @param {Store} store - Redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case CREATE_LOCAL_TRACKS_FAILED: {
+        const { cameraError, micError } = action;
+
+        if (!interfaceConfig.filmStripOnly
+            && (cameraError || micError)) {
+            const localStorageKey = _getLocalStorageKey(cameraError, micError);
+
+            if (_shouldShowDeviceErrorDialog(localStorageKey)) {
+                store.dispatch(openDeviceErrorDialog({
+                    cameraError,
+                    localStorageKey,
+                    micError
+                }));
+            }
+
+        }
+
+        break;
+    }
+
+    case SET_DEVICE_ERROR_DIALOG_PREFERENCE: {
+        _setDeviceErrorDialogPreference(action.errorType, action.doNotShow);
+
+        break;
+    }
+    }
+
+    return next(action);
+});
+
+/**
+ * Returns the local storage key used to persist whether or not a dialog should
+ * display for future errors with the same types.
+ *
+ * @param {JitsiTrackError} cameraError - The error, if any, from attempting
+ * to use a camera.
+ * @param {JitsiTrackError} micError - The error, if any, from attempting to
+ * use a microphone.
+ * @private
+ * @returns {string}
+ */
+function _getLocalStorageKey(cameraError, micError) {
+    let localStorageKey = LOCAL_STORAGE_KEY;
+
+    if (micError) {
+        localStorageKey += `-mic-${micError.name}`;
+    }
+
+    if (cameraError) {
+        localStorageKey += `-camera-${cameraError.name}`;
+    }
+
+    return localStorageKey;
+}
+
+/**
+ * Persists into local storage whether or not the given errorType should display
+ * a dialog if encountered again.
+ *
+ * @param {string} errorType - The type of device error to save the preference
+ * for.
+ * @param {boolean} doNotShow - The value to be stored into local storage. If
+ * true, the dialog for the given errorType will not display again.
+ * @private
+ * @returns {void}
+ */
+function _setDeviceErrorDialogPreference(errorType, doNotShow) {
+    if (typeof doNotShow === 'boolean') {
+        jitsiLocalStorage.setItem(errorType, doNotShow);
+    }
+}
+
+/**
+ * Returns whether or not a device error dialog associated with the local
+ * storage key should be displayed.
+ *
+ * @param {string} localStorageKey - The local storage key to check.
+ * @private
+ * @returns {boolean} True if the device error dialog should display.
+ */
+function _shouldShowDeviceErrorDialog(localStorageKey) {
+    const localStorageValue = jitsiLocalStorage.getItem(localStorageKey);
+
+    return !localStorageValue || localStorageValue === 'false';
+}

--- a/react/features/overlay/actionTypes.js
+++ b/react/features/overlay/actionTypes.js
@@ -1,6 +1,17 @@
 import { Symbol } from '../base/react';
 
 /**
+ * The type of Redux action which signals to remove cached device errors from
+ * the store.
+ *
+ * {
+ *     type: CLEAR_DEVICE_ERRORS
+ * }
+ * @public
+ */
+export const CLEAR_DEVICE_ERRORS = Symbol('CLEAR_DEVICE_ERRORS');
+
+/**
  * The type of the Redux action which signals that the prompt for media
  * permission is visible or not.
  *

--- a/react/features/overlay/actions.js
+++ b/react/features/overlay/actions.js
@@ -1,7 +1,22 @@
 import {
+    CLEAR_DEVICE_ERRORS,
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
     SUSPEND_DETECTED
 } from './actionTypes';
+
+/**
+ * Signals to remove cached device errors from the store.
+ *
+ * @returns {{
+ *     type: CLEAR_DEVICE_ERRORS
+ * }}
+ * @public
+ */
+export function clearDeviceErrors() {
+    return {
+        type: CLEAR_DEVICE_ERRORS
+    };
+}
 
 /**
  * Signals that the prompt for media permission is visible or not.

--- a/react/features/overlay/components/DeviceErrorFilmstripOnlyOverlay.js
+++ b/react/features/overlay/components/DeviceErrorFilmstripOnlyOverlay.js
@@ -1,0 +1,135 @@
+import AKButton from '@atlaskit/button';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../base/i18n';
+import { JitsiTrackErrors } from '../../base/lib-jitsi-meet';
+
+import { clearDeviceErrors } from '../actions';
+
+import FilmstripOnlyOverlayFrame from './FilmstripOnlyOverlayFrame';
+
+/**
+ * React {@code Component} for an overlay informing an error occurred while
+ * attempting to use a camera and/or microphone. This component will be
+ * displayed only for filmstrip only mode. Due to space limitations, verbose
+ * error messaging is not displayed.
+ *
+ * @extends Component
+ */
+class DeviceErrorFilmstripOnlyOverlay extends Component {
+    /**
+     * {@code DeviceErrorFilmstripOnlyOverlay}'s property types.
+     *
+     * @static
+     */
+    static propTypes = {
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * @type {JitsiTrackError}
+         */
+        cameraError: React.PropTypes.object,
+
+        /**
+         * Invoked to clear known device errors.
+         */
+        dispatch: React.PropTypes.func,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * @type {JitsiTrackError}
+         */
+        micError: React.PropTypes.object,
+
+        /**
+         * Invoked to obtain translated strings.
+         */
+        t: React.PropTypes.func
+    }
+
+    /**
+     * Initializes a new {@code DeviceErrorFilmstripOnlyOverlay} instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onDismiss = this._onDismiss.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <FilmstripOnlyOverlayFrame
+                isLightOverlay = { true }>
+                <div className = 'inlay-filmstrip-only__container'>
+                    <div className = 'inlay-filmstrip-only__title'>
+                        { this.props.t(this._getTitleKey()) }
+                    </div>
+                    <div className = 'inlay-filmstrip-only__text'>
+                        <div>
+                            { this.props.cameraError
+                                && this.props.t('dialog.cameraErrorPresent') }
+                        </div>
+                        <div>
+                            { this.props.micError
+                                && this.props.t('dialog.micErrorPresent') }
+                        </div>
+                    </div>
+                    <AKButton
+                        appearance = 'primary'
+                        onClick = { this._onDismiss }>
+                        { this.props.t('dialog.Ok') }
+                    </AKButton>
+                </div>
+            </FilmstripOnlyOverlayFrame>
+        );
+    }
+
+    /**
+     * Determines which translation key should be used as the overlay's title
+     * based on the types of errors present.
+     *
+     * @private
+     * @returns {string} The translation key to use as an overlay title.
+     */
+    _getTitleKey() {
+        const { cameraError, micError } = this.props;
+        const { PERMISSION_DENIED } = JitsiTrackErrors;
+
+        let title = 'dialog.error';
+
+        if (micError && micError.name === PERMISSION_DENIED) {
+            if (!cameraError || cameraError.name === PERMISSION_DENIED) {
+                title = 'dialog.permissionDenied';
+            }
+        } else if (cameraError && cameraError.name === PERMISSION_DENIED) {
+            title = 'dialog.permissionDenied';
+        }
+
+        return title;
+    }
+
+    /**
+     * Dispatches an action to clear device error messages to hide the error
+     * overlay.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onDismiss() {
+        this.props.dispatch(clearDeviceErrors());
+    }
+}
+
+export default translate(connect()(DeviceErrorFilmstripOnlyOverlay));

--- a/react/features/overlay/components/OverlayContainer.js
+++ b/react/features/overlay/components/OverlayContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import DeviceErrorFilmstripOnlyOverlay from './DeviceErrorFilmstripOnlyOverlay';
 import PageReloadFilmstripOnlyOverlay from './PageReloadFilmstripOnlyOverlay';
 import PageReloadOverlay from './PageReloadOverlay';
 import SuspendedFilmstripOnlyOverlay from './SuspendedFilmstripOnlyOverlay';
@@ -32,6 +33,16 @@ class OverlayContainer extends Component {
          * @type {string}
          */
         _browser: React.PropTypes.string,
+
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _cameraError: React.PropTypes.object,
 
         /**
          * The indicator which determines whether the status of the
@@ -76,6 +87,16 @@ class OverlayContainer extends Component {
          * @type {boolean}
          */
         _isNetworkFailure: React.PropTypes.bool,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _micError: React.PropTypes.object,
 
         /**
          * The reason for the error that will cause the reload.
@@ -165,6 +186,13 @@ class OverlayContainer extends Component {
                     ? UserMediaPermissionsFilmstripOnlyOverlay
                     : UserMediaPermissionsOverlay;
             props = { browser: this.props._browser };
+        } else if (this.props._micError || this.props._cameraError) {
+            overlayComponent = filmstripOnly
+                ? DeviceErrorFilmstripOnlyOverlay : null;
+            props = {
+                cameraError: this.props._cameraError,
+                micError: this.props._micError
+            };
         }
 
         return (
@@ -202,6 +230,16 @@ function _mapStateToProps(state) {
          * @type {string}
          */
         _browser: stateFeaturesOverlay.browser,
+
+        /**
+         * The JitsiTrackError returned from failing to use a camera.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _cameraError: stateFeaturesOverlay.cameraError,
 
         /**
          * The indicator which determines whether the status of the
@@ -247,6 +285,16 @@ function _mapStateToProps(state) {
          * @type {boolean}
          */
         _isNetworkFailure: stateFeaturesOverlay.isNetworkFailure,
+
+        /**
+         * The JitsiTrackError returned from failing to use a microphone.
+         *
+         * NOTE: Used by DeviceErrorFilmstripOnlyOverlay only.
+         *
+         * @private
+         * @type {JitsiTrackError}
+         */
+        _micError: stateFeaturesOverlay.micError,
 
         /**
          * The reason for the error that will cause the reload.

--- a/react/features/overlay/reducer.js
+++ b/react/features/overlay/reducer.js
@@ -6,6 +6,7 @@ import {
     JitsiConnectionErrors
 } from '../base/lib-jitsi-meet';
 import { assign, ReducerRegistry, set } from '../base/redux';
+import { CREATE_LOCAL_TRACKS_FAILED } from '../base/tracks';
 
 import {
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
@@ -27,6 +28,9 @@ ReducerRegistry.register('features/overlay', (state = {}, action) => {
 
     case CONNECTION_FAILED:
         return _connectionFailed(state, action);
+
+    case CREATE_LOCAL_TRACKS_FAILED:
+        return _createLocalTracksFailed(state, action);
 
     case MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED:
         return _mediaPermissionPromptVisibilityChanged(state, action);
@@ -104,6 +108,23 @@ function _connectionFailed(state, action) {
     }
 
     return state;
+}
+
+/**
+ * Reduces a specific Redux action CREATE_LOCAL_TRACKS_FAILED for the feature
+ * overlay.
+ *
+ * @param {Object} state - The Redux state of the feature overlay.
+ * @param {Action} action - The Redux action to reduce.
+ * @returns {Object} The new state of the feature overlay after the reduction of
+ * the specified action.
+ * @private
+ */
+function _createLocalTracksFailed(state, action) {
+    return assign(state, {
+        cameraError: action.cameraError,
+        micError: action.micError
+    });
 }
 
 /**

--- a/react/features/overlay/reducer.js
+++ b/react/features/overlay/reducer.js
@@ -9,6 +9,7 @@ import { assign, ReducerRegistry, set } from '../base/redux';
 import { CREATE_LOCAL_TRACKS_FAILED } from '../base/tracks';
 
 import {
+    CLEAR_DEVICE_ERRORS,
     MEDIA_PERMISSION_PROMPT_VISIBILITY_CHANGED,
     SUSPEND_DETECTED
 } from './actionTypes';
@@ -20,6 +21,9 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  */
 ReducerRegistry.register('features/overlay', (state = {}, action) => {
     switch (action.type) {
+    case CLEAR_DEVICE_ERRORS:
+        return _clearDeviceErrors(state, action);
+
     case CONFERENCE_FAILED:
         return _conferenceFailed(state, action);
 
@@ -41,6 +45,22 @@ ReducerRegistry.register('features/overlay', (state = {}, action) => {
 
     return state;
 });
+
+
+/**
+ * Reduces a specific Redux action CLEAR_DEVICE_ERRORS for the feature overlay.
+ *
+ * @param {Object} state - The Redux state of the feature overlay.
+ * @returns {Object} The new state of the feature overlay after the reduction of
+ * the specified action.
+ * @private
+ */
+function _clearDeviceErrors(state) {
+    return assign(state, {
+        cameraError: null,
+        micError: null
+    });
+}
 
 /**
  * Reduces a specific Redux action CONFERENCE_FAILED of the feature overlay.


### PR DESCRIPTION
Move the device error dialog out of UI and messageHandler and
instead use a DeviceErrorDialog component. Its opening is
handled through middleware listening for track failure events.

These changes are built on top of https://github.com/jitsi/jitsi-meet/pull/1558.