### PR TITLE
fix(toolbox): Defensively check classNames when mapping button attrib…

### DIFF
--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -21,13 +21,9 @@ export { abstractMapStateToProps } from './functions.native';
  */
 export function getButtonAttributesByProps(props: Object = {})
         : MapOfAttributes {
-    let classNames = props.classNames;
-
-    if (classNames) {
-        // XXX Make sure to not modify props.classNames because that'd be bad
-        // practice.
-        classNames = [ ...classNames ];
-    }
+    // XXX Make sure to not modify props.classNames because that'd be bad
+    // practice.
+    const classNames = (props.classNames && [ ...props.classNames ]) || [];
 
     props.toggled && classNames.push('toggled');
     props.unclickable && classNames.push('unclickable');


### PR DESCRIPTION
…utes

There looks to be a deeper underlying issue of the toolbar buttons being created when setToolbarButton is being called, even if the button is not in the config. That change will happen in the future after design discussion. However, this change to defensive checking should be done anyway to do a proper defensive check.