### PR TITLE
fix(toolbox): Do not create toolbar button if not configured to display

### DIFF
--- a/react/features/toolbox/reducer.js
+++ b/react/features/toolbox/reducer.js
@@ -217,22 +217,23 @@ function _setButton(state, { button, buttonName }): Object {
         place = 'secondaryToolbarButtons';
     }
 
-    selectedButton = {
-        ...selectedButton,
-        ...button
-    };
-
     // In filmstrip-only mode we only show buttons if they're filmstrip-only
     // enabled, so we don't need to update if this isn't the case.
     // FIXME A reducer should be a pure function of the current state and the
     // specified action so it should not use the global variable
     // interfaceConfig. Anyway, we'll move interfaceConfig into the (redux)
     // store so we'll surely revisit the source code bellow.
-    if (interfaceConfig.filmStripOnly && !selectedButton.filmstripOnlyEnabled) {
+    if ((interfaceConfig.filmStripOnly && !selectedButton.filmstripOnlyEnabled)
+        || !selectedButton) {
         return {
             ...state
         };
     }
+
+    selectedButton = {
+        ...selectedButton,
+        ...button
+    };
 
     const updatedToolbar = state[place].set(buttonName, selectedButton);
 


### PR DESCRIPTION
The action setToolbarButton triggers a toolbox reducer to update the button
state. If the button being modified is not present in the primary toolbar
configuration, the secondary toolbar configuration is checked. If the button
is not present in the configuration, the button is still set in the
redux store for secondary toolbar buttons but with an undefined configuration.
This causes the SecondaryToolbar to render the button without any content,
making it practically invisible.

This fix prevents the invisible buttons from being created but would also
cause the SecondaryToolbar not to display at all if
interfaceConfig.TOOLBAR_BUTTONS is empty.