### PR TITLE
fix(screen-sharing) Enable it by default on Firefox

### DIFF
--- a/config.js
+++ b/config.js
@@ -41,7 +41,7 @@ var config = { // eslint-disable-line no-unused-vars
     // extension is required.
     desktopSharingFirefoxExtId: null,
     // Whether desktop sharing should be disabled on Firefox.
-    desktopSharingFirefoxDisabled: true,
+    desktopSharingFirefoxDisabled: false,
     // The maximum version of Firefox which requires a jidesha extension.
     // Example: if set to 41, we will require the extension for Firefox versions
     // up to and including 41. On Firefox 42 and higher, we will run without the


### PR DESCRIPTION
Starting with Firefox 51 the extension is no longer mandatory, so make sure the
feature is not desabled by default.