### PR TITLE
Fixes crashing jwt util for anonymous domains.

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -72,8 +72,6 @@ case "$1" in
                 echo "Use the following command, after this package has been installed and"
                 echo "after every prosody-trunk upgrade:"
                 echo "sudo patch -N /usr/lib/prosody/modules/mod_bosh.lua /usr/share/jitsi-meet/prosody-plugins/mod_bosh.lua.patch"
-            else
-                echo "Failed apply auto-config to $PROSODY_HOST_CONFIG which most likely comes from not supported version of jitsi-meet"
             fi
         else
             echo "Prosody config not found at $PROSODY_HOST_CONFIG - unable to auto-configure token authentication"

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -260,7 +260,9 @@ function Util:verify_room(session, room_address)
 
     local auth_room = session.jitsi_meet_room;
     if not self.enableDomainVerification then
-        if room ~= string.lower(auth_room) then
+        -- if auth_room is missing, this means user is anonymous (no token for
+        -- its domain) we let it through, jicofo is verifying creation domain
+        if auth_room and room ~= string.lower(auth_room) then
             return false;
         end
 


### PR DESCRIPTION
Room name verification crashes when we have a configured anonymousdomain as it doesn't have any token extracted data. It is safe to skip this check as room creation is verified by jicofo and we have the option restrict_room_creation to admin users.
Removes obsolete print when updating jitsi-meet-tokens.