### PR TITLE
feat(invite): Add conference id to dial-in numbers display

### DIFF
--- a/css/modals/invite/_invite.scss
+++ b/css/modals/invite/_invite.scss
@@ -8,17 +8,22 @@
 
 .invite-dialog {
     .dial-in-numbers {
+        .dial-in-numbers-conference-id {
+            color: orange;
+            margin-left: 3px;
+        }
+
+        /*
+         * dial-in-numbers-copy styling is needed for the feature of copying
+         * text to the clipboard. The styling keeps the element invisible
+         * to the user but still programmatically selectable for copying.
+         */
         .dial-in-numbers-copy {
             opacity: 0;
             pointer-events: none;
             position: fixed;
-            user-select: text;
             -webkit-user-select: text;
-        }
-
-        .dial-in-numbers-conference-id {
-            color: orange;
-            margin-left: 3px;
+            user-select: text;
         }
 
         .dial-in-numbers-trigger {

--- a/css/modals/invite/_invite.scss
+++ b/css/modals/invite/_invite.scss
@@ -8,6 +8,19 @@
 
 .invite-dialog {
     .dial-in-numbers {
+        .dial-in-numbers-copy {
+            opacity: 0;
+            pointer-events: none;
+            position: fixed;
+            user-select: text;
+            -webkit-user-select: text;
+        }
+
+        .dial-in-numbers-conference-id {
+            color: orange;
+            margin-left: 3px;
+        }
+
         .dial-in-numbers-trigger {
             position: relative;
             width: 100%;

--- a/lang/main.json
+++ b/lang/main.json
@@ -437,14 +437,13 @@
     },
     "invite": {
         "addPassword": "Add password",
-        "dialInNumbers": "Dial-in telephone numbers",
-        "errorFetchingNumbers": "Failed to obtain dial-in numbers",
+        "callNumber": "Call __number__",
+        "enterId": "Enter Meeting ID: __meetingId__ following by # to dial in from a phone",
+        "howToDialIn": "To dial in, use one of the following numbers and meeting ID",
         "hidePassword": "Hide password",
         "inviteTo": "Invite people to __conferenceName__",
-        "loadingNumbers": "Loading...",
+        "invitedYouTo": "__userName__ has invited you to the __meetingUrl__ conference",
         "locked": "This call is locked. New callers must have the link and enter the password to join.",
-        "noNumbers": "No numbers available",
-        "numbersDisabled": "Dialing in has been disabled",
         "showPassword": "Show password",
         "unlocked": "This call is unlocked. Any new caller with the link may join the call."
     }

--- a/react/features/invite/actionTypes.js
+++ b/react/features/invite/actionTypes.js
@@ -13,17 +13,6 @@ export const UPDATE_DIAL_IN_NUMBERS_FAILED
     = Symbol('UPDATE_DIAL_IN_NUMBERS_FAILED');
 
 /**
- * The type of the action which signals a request for dial-in numbers has been
- * started.
- *
- * {
- *     type: UPDATE_DIAL_IN_NUMBERS_REQUEST
- * }
- */
-export const UPDATE_DIAL_IN_NUMBERS_REQUEST
-    = Symbol('UPDATE_DIAL_IN_NUMBERS_REQUEST');
-
-/**
  * The type of the action which signals a request for dial-in numbers has
  * succeeded.
  *

--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -2,7 +2,6 @@ import { openDialog } from '../../features/base/dialog';
 
 import {
     UPDATE_DIAL_IN_NUMBERS_FAILED,
-    UPDATE_DIAL_IN_NUMBERS_REQUEST,
     UPDATE_DIAL_IN_NUMBERS_SUCCESS
 } from './actionTypes';
 import { InviteDialog } from './components';
@@ -11,6 +10,10 @@ declare var $: Function;
 declare var APP: Object;
 declare var config: Object;
 
+const CONFERENCE_ID_ENDPOINT = config.conferenceMapperUrl;
+const DIAL_IN_NUMBERS_ENDPOINT = config.dialInNumbersUrl;
+const MUC_URL = config && config.hosts && config.hosts.muc;
+
 /**
  * Opens the Invite Dialog.
  *
@@ -18,34 +21,46 @@ declare var config: Object;
  */
 export function openInviteDialog() {
     return openDialog(InviteDialog, {
-        conferenceUrl: encodeURI(APP.ConferenceUrl.getInviteUrl()),
-        dialInNumbersUrl: config.dialInNumbersUrl
+        conferenceUrl: encodeURI(APP.ConferenceUrl.getInviteUrl())
     });
 }
 
 /**
- * Sends an ajax request for dial-in numbers.
+ * Sends an ajax requests for dial-in numbers and conference id.
  *
- * @param {string} dialInNumbersUrl - The endpoint for retrieving json that
- * includes numbers for dialing in to a conference.
  * @returns {Function}
  */
-export function updateDialInNumbers(dialInNumbersUrl) {
-    return dispatch => {
-        dispatch({
-            type: UPDATE_DIAL_IN_NUMBERS_REQUEST
+export function updateDialInNumbers() {
+    return (dispatch, getState) => {
+
+        if (!CONFERENCE_ID_ENDPOINT || !DIAL_IN_NUMBERS_ENDPOINT || !MUC_URL) {
+            return;
+        }
+
+        const { room } = getState()['features/base/conference'];
+        const conferenceIdUrl
+            = `${CONFERENCE_ID_ENDPOINT}?conference=${room}@${MUC_URL}`;
+
+        Promise.all([
+            $.getJSON(DIAL_IN_NUMBERS_ENDPOINT),
+            $.getJSON(conferenceIdUrl)
+        ]).then(([ numbersResponse, idResponse ]) => {
+            if (!idResponse.conference || !idResponse.id) {
+                return Promise.reject(idResponse.message);
+            }
+
+            dispatch({
+                type: UPDATE_DIAL_IN_NUMBERS_SUCCESS,
+                conferenceId: idResponse,
+                dialInNumbers: numbersResponse
+            });
+        })
+        .catch(error => {
+            dispatch({
+                type: UPDATE_DIAL_IN_NUMBERS_FAILED,
+                error
+            });
         });
 
-        $.getJSON(dialInNumbersUrl)
-            .success(response =>
-                dispatch({
-                    type: UPDATE_DIAL_IN_NUMBERS_SUCCESS,
-                    response
-                }))
-            .error(error =>
-                dispatch({
-                    type: UPDATE_DIAL_IN_NUMBERS_FAILED,
-                    error
-                }));
     };
 }

--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -8,29 +8,6 @@ import { InviteDialog } from './components';
 
 declare var $: Function;
 declare var APP: Object;
-declare var config: Object;
-
-/**
- * The url for the api that matches a conference name and muc to an id.
- *
- * @type {string}
- */
-const DIAL_IN_CONF_CODE_URL = config.dialInConfCodeUrl;
-
-/**
- * The url for the api that returns phone numbers to dial in to the conference
- * and join using the conference id.
- *
- * @type {string}
- */
-const DIAL_IN_NUMBERS_URLS = config.dialInNumbersUrl;
-
-/**
- * The url for the MUC component joined for the conference.
- *
- * @type {string}
- */
-const MUC_URL = config.hosts && config.hosts.muc;
 
 /**
  * Opens the Invite Dialog.
@@ -50,8 +27,11 @@ export function openInviteDialog() {
  */
 export function updateDialInNumbers() {
     return (dispatch, getState) => {
+        const { dialInConfCodeUrl, dialInNumbersUrl, hosts }
+            = getState()['features/base/config'];
+        const mucUrl = hosts && hosts.muc;
 
-        if (!DIAL_IN_CONF_CODE_URL || !DIAL_IN_NUMBERS_URLS || !MUC_URL) {
+        if (!dialInConfCodeUrl || !dialInNumbersUrl || !mucUrl) {
             dispatch({
                 type: UPDATE_DIAL_IN_NUMBERS_FAILED,
                 error: 'URLs for fetching dial in numbers not properly defined'
@@ -62,10 +42,10 @@ export function updateDialInNumbers() {
 
         const { room } = getState()['features/base/conference'];
         const conferenceIdUrl
-            = `${DIAL_IN_CONF_CODE_URL}?conference=${room}@${MUC_URL}`;
+            = `${dialInConfCodeUrl}?conference=${room}@${mucUrl}`;
 
         Promise.all([
-            $.getJSON(DIAL_IN_NUMBERS_URLS),
+            $.getJSON(dialInNumbersUrl),
             $.getJSON(conferenceIdUrl)
         ]).then(([ numbersResponse, idResponse ]) => {
             if (!idResponse.conference || !idResponse.id) {

--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -10,9 +10,27 @@ declare var $: Function;
 declare var APP: Object;
 declare var config: Object;
 
-const CONFERENCE_ID_ENDPOINT = config.conferenceMapperUrl;
-const DIAL_IN_NUMBERS_ENDPOINT = config.dialInNumbersUrl;
-const MUC_URL = config && config.hosts && config.hosts.muc;
+/**
+ * The url for the api that matches a conference name and muc to an id.
+ *
+ * @type {string}
+ */
+const DIAL_IN_CONF_CODE_URL = config.dialInConfCodeUrl;
+
+/**
+ * The url for the api that returns phone numbers to dial in to the conference
+ * and join using the conference id.
+ *
+ * @type {string}
+ */
+const DIAL_IN_NUMBERS_URLS = config.dialInNumbersUrl;
+
+/**
+ * The url for the MUC component joined for the conference.
+ *
+ * @type {string}
+ */
+const MUC_URL = config.hosts && config.hosts.muc;
 
 /**
  * Opens the Invite Dialog.
@@ -33,16 +51,21 @@ export function openInviteDialog() {
 export function updateDialInNumbers() {
     return (dispatch, getState) => {
 
-        if (!CONFERENCE_ID_ENDPOINT || !DIAL_IN_NUMBERS_ENDPOINT || !MUC_URL) {
+        if (!DIAL_IN_CONF_CODE_URL || !DIAL_IN_NUMBERS_URLS || !MUC_URL) {
+            dispatch({
+                type: UPDATE_DIAL_IN_NUMBERS_FAILED,
+                error: 'URLs for fetching dial in numbers not properly defined'
+            });
+
             return;
         }
 
         const { room } = getState()['features/base/conference'];
         const conferenceIdUrl
-            = `${CONFERENCE_ID_ENDPOINT}?conference=${room}@${MUC_URL}`;
+            = `${DIAL_IN_CONF_CODE_URL}?conference=${room}@${MUC_URL}`;
 
         Promise.all([
-            $.getJSON(DIAL_IN_NUMBERS_ENDPOINT),
+            $.getJSON(DIAL_IN_NUMBERS_URLS),
             $.getJSON(conferenceIdUrl)
         ]).then(([ numbersResponse, idResponse ]) => {
             if (!idResponse.conference || !idResponse.id) {

--- a/react/features/invite/components/DialInNumbersForm.js
+++ b/react/features/invite/components/DialInNumbersForm.js
@@ -27,14 +27,14 @@ class DialInNumbersForm extends Component {
      */
     static propTypes = {
         /**
-         * The name of the current user.
-         */
-        _currentUserName: React.PropTypes.string,
-
-        /**
          * The redux state representing the dial-in numbers feature.
          */
         _dialIn: React.PropTypes.object,
+
+        /**
+         * The display name of the local user.
+         */
+        _localUserDisplayName: React.PropTypes.string,
 
         /**
          * The url for the JitsiConference.
@@ -292,7 +292,7 @@ class DialInNumbersForm extends Component {
     _generateCopyText() {
         const welcome = this.props.t('invite.invitedYouTo', {
             meetingUrl: this.props.conferenceUrl,
-            userName: this.props._currentUserName
+            userName: this.props._localUserDisplayName
         });
 
         const callNumber = this.props.t('invite.callNumber',
@@ -390,7 +390,7 @@ class DialInNumbersForm extends Component {
  * @param {Object} state - The Redux state.
  * @private
  * @returns {{
- *     _currentUserName: React.PropTypes.string,
+ *     _localUserDisplayName: React.PropTypes.string,
  *     _dialIn: React.PropTypes.object
  * }}
  */
@@ -399,7 +399,7 @@ function _mapStateToProps(state) {
         = getLocalParticipant(state['features/base/participants']);
 
     return {
-        _currentUserName: name,
+        _localUserDisplayName: name,
         _dialIn: state['features/invite/dial-in']
     };
 }

--- a/react/features/invite/components/InviteDialog.js
+++ b/react/features/invite/components/InviteDialog.js
@@ -42,11 +42,6 @@ class InviteDialog extends Component {
         conferenceUrl: React.PropTypes.string,
 
         /**
-         * The url for retrieving dial-in numbers.
-         */
-        dialInNumbersUrl: React.PropTypes.string,
-
-        /**
          * Invoked to obtain translated strings.
          */
         t: React.PropTypes.func
@@ -68,7 +63,7 @@ class InviteDialog extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const { _conference } = this.props;
+        const { _conference, conferenceUrl } = this.props;
         const titleString
             = this.props.t(
                 'invite.inviteTo',
@@ -80,8 +75,8 @@ class InviteDialog extends Component {
                 okTitleKey = 'dialog.done'
                 titleString = { titleString }>
                 <div className = 'invite-dialog'>
-                    <ShareLinkForm toCopy = { this.props.conferenceUrl } />
-                    { this._renderDialInNumbersForm() }
+                    <ShareLinkForm toCopy = { conferenceUrl } />
+                    <DialInNumbersForm conferenceUrl = { conferenceUrl } />
                     <PasswordContainer
                         conference = { _conference.conference }
                         locked = { _conference.locked }
@@ -89,22 +84,6 @@ class InviteDialog extends Component {
                         showPasswordEdit = { this.props._isModerator } />
                 </div>
             </Dialog>
-        );
-    }
-
-    /**
-     * Creates a React {@code Component} for displaying and copying to clipboard
-     * telephone numbers for dialing in to the conference.
-     *
-     * @private
-     * @returns {ReactElement|null}
-     */
-    _renderDialInNumbersForm() {
-        return (
-            this.props.dialInNumbersUrl
-                ? <DialInNumbersForm
-                    dialInNumbersUrl = { this.props.dialInNumbersUrl } />
-                : null
         );
     }
 }

--- a/react/features/invite/index.js
+++ b/react/features/invite/index.js
@@ -2,3 +2,4 @@ export * from './actions';
 export * from './components';
 
 import './reducer';
+import './middleware';

--- a/react/features/invite/middleware.js
+++ b/react/features/invite/middleware.js
@@ -1,0 +1,25 @@
+import { MiddlewareRegistry } from '../base/redux';
+
+import { UPDATE_DIAL_IN_NUMBERS_FAILED } from './actionTypes';
+
+const logger = require('jitsi-meet-logger').getLogger(__filename);
+
+/**
+ * Middleware that catches actions fetching dial-in numbers.
+ *
+ * @param {Store} store - Redux store.
+ * @returns {Function}
+ */
+// eslint-disable-next-line no-unused-vars
+MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case UPDATE_DIAL_IN_NUMBERS_FAILED:
+        logger.error('Error encountered while fetching dial-in numbers:',
+           action.error);
+        break;
+    }
+
+    return result;
+});

--- a/react/features/invite/reducer.js
+++ b/react/features/invite/reducer.js
@@ -4,7 +4,6 @@ import {
 
 import {
     UPDATE_DIAL_IN_NUMBERS_FAILED,
-    UPDATE_DIAL_IN_NUMBERS_REQUEST,
     UPDATE_DIAL_IN_NUMBERS_SUCCESS
 } from './actionTypes';
 
@@ -19,24 +18,16 @@ ReducerRegistry.register(
         case UPDATE_DIAL_IN_NUMBERS_FAILED: {
             return {
                 ...state,
-                error: action.error,
-                loading: false
+                error: action.error
             };
         }
 
-        case UPDATE_DIAL_IN_NUMBERS_REQUEST: {
-            return {
-                ...state,
-                error: null,
-                loading: true
-            };
-        }
         case UPDATE_DIAL_IN_NUMBERS_SUCCESS: {
-            const { numbers, numbersEnabled } = action.response;
+            const { numbers, numbersEnabled } = action.dialInNumbers;
 
             return {
+                conferenceId: action.conferenceId.id,
                 error: null,
-                loading: false,
                 numbers,
                 numbersEnabled
             };


### PR DESCRIPTION
DialInNumbersForm has been modified to display a conference id to be used for
dialing into the conference. The changes include:
- Requesting the conference id and adding the conference id to the redux store
- Displaying the conference id in DialInNumbersForm
- Modifying the copy behavior to support copying the new message to clipboard
- DialInNumbersForm does not display until all ajax requests have completed
  successfully. This eliminates the need for the REQUESTING state.