### PR TITLE
fix(vertical-filmstrip): do not move recording label if not in the co…

### DIFF
--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -91,7 +91,7 @@
      * For video labels that display on the top right to adjust its position as
      * the filmstrip itself or filmstrip remote videos appear and disappear.
      */
-    .video-state-indicator {
+    .video-state-indicator.moveToCorner {
         transition: right 2s;
 
         &.with-filmstrip {


### PR DESCRIPTION
…rner

For the video status in the corner, apply overrides only when the label is in the corner. This stops the styles from applying when the record status is not in the corner and therefore should not be manipulated to the left of the screen.