### PR TITLE
fix(vertical-filmstrip): different label animations for filmstrip states

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1844,11 +1844,12 @@ export default {
             const remoteVideosCount = APP.UI.getRemoteVideosCount();
 
             const shouldShowRemoteThumbnails = interfaceConfig.filmStripOnly
-                || APP.UI.isPinned(localUserId)
+                || (APP.UI.isPinned(localUserId) && remoteVideosCount)
                 || remoteVideosCount > 1
                 || remoteParticipantsCount !== remoteVideosCount;
 
-            APP.UI.setRemoteThumbnailsVisibility(shouldShowRemoteThumbnails);
+            APP.UI.setRemoteThumbnailsVisibility(
+                Boolean(shouldShowRemoteThumbnails));
         }
     },
     /**

--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -92,9 +92,9 @@
      * the filmstrip itself or filmstrip remote videos appear and disappear.
      */
     .video-state-indicator.moveToCorner {
-        transition: right 2s;
+        transition: right 0.5s;
 
-        &.with-filmstrip {
+        &.with-filmstrip.with-remote-videos {
             &#recordingLabel {
                 right: 200px;
             }
@@ -102,6 +102,20 @@
             &#videoResolutionLabel {
                 right: 150px;
             }
+        }
+
+        &.with-filmstrip.without-remote-videos {
+            transition-delay: 0.5s;
+        }
+
+        &.with-filmstrip.with-remote-videos.opening {
+            transition: 0.9s;
+            transition-timing-function: ease-in-out;
+        }
+
+        &.without-filmstrip {
+            transition: 1.2s ease-in-out;
+            transition-delay: 0.1s;
         }
     }
 

--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -88,8 +88,19 @@
     }
 
     /**
-     * For video labels that display on the top right to adjust its position as
-     * the filmstrip itself or filmstrip remote videos appear and disappear.
+     * These styles are for the video labels that display on the top right. The
+     * styles adjust the labels' positioning as the filmstrip itself or
+     * filmstrip's remote videos appear and disappear.
+     *
+     * The class with-filmstrip is for when the filmstrip is visible.
+     * The class without-filmstrip is for when the filmstrip has been toggled to
+     * be hidden.
+     * The class opening is for when the filmstrip is transitioning from hidden
+     * to visible.
+     * The class with-remote-videos is for when the filmstrip has remote videos
+     * displayed, as opposed to 1-on-1 mode where they might be hidden.
+     * The class without-remote-videos is for when the filmstrip is visible
+     * but it has no videos to display.
      */
     .video-state-indicator.moveToCorner {
         transition: right 0.5s;

--- a/modules/UI/recording/Recording.js
+++ b/modules/UI/recording/Recording.js
@@ -213,7 +213,6 @@ function moveToCorner(selector, move) {
         selector.removeClass(moveToCornerClass);
 
     const {
-        remoteVideosCount,
         remoteVideosVisible,
         visible
     } = APP.store.getState()['features/filmstrip'];
@@ -224,9 +223,8 @@ function moveToCorner(selector, move) {
     selector.toggleClass('with-filmstrip', visible);
     selector.toggleClass('without-filmstrip', !visible);
 
-    const oneOnOne = Boolean(remoteVideosVisible && remoteVideosCount);
-    selector.toggleClass('with-remote-videos', oneOnOne);
-    selector.toggleClass('without-remote-videos', !oneOnOne);
+    selector.toggleClass('with-remote-videos', remoteVideosVisible);
+    selector.toggleClass('without-remote-videos', !remoteVideosVisible);
 }
 
 /**

--- a/modules/UI/recording/Recording.js
+++ b/modules/UI/recording/Recording.js
@@ -196,20 +196,14 @@ function _showStopRecordingPrompt(recordingType) {
 
 /**
  * Moves the element given by {selector} to the top right corner of the screen.
+ * Set additional classes that can be used to style the selector relative to the
+ * state of the filmstrip.
+ *
  * @param selector the selector for the element to move
  * @param move {true} to move the element, {false} to move it back to its intial
  * position
  */
 function moveToCorner(selector, move) {
-    const {
-        remoteVideosCount,
-        remoteVideosVisible,
-        visible
-    } = APP.store.getState()['features/filmstrip'];
-    selector.toggleClass(
-        'with-filmstrip',
-        Boolean(remoteVideosCount && remoteVideosVisible && visible));
-
     let moveToCornerClass = "moveToCorner";
     let containsClass = selector.hasClass(moveToCornerClass);
 
@@ -217,6 +211,22 @@ function moveToCorner(selector, move) {
         selector.addClass(moveToCornerClass);
     else if (!move && containsClass)
         selector.removeClass(moveToCornerClass);
+
+    const {
+        remoteVideosCount,
+        remoteVideosVisible,
+        visible
+    } = APP.store.getState()['features/filmstrip'];
+    const filmstripWasHidden = selector.hasClass('without-filmstrip');
+    const filmstipIsOpening = filmstripWasHidden && visible;
+    selector.toggleClass('opening', filmstipIsOpening);
+
+    selector.toggleClass('with-filmstrip', visible);
+    selector.toggleClass('without-filmstrip', !visible);
+
+    const oneOnOne = Boolean(remoteVideosVisible && remoteVideosCount);
+    selector.toggleClass('with-remote-videos', oneOnOne);
+    selector.toggleClass('without-remote-videos', !oneOnOne);
 }
 
 /**

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -1,10 +1,6 @@
 /* global APP, $, interfaceConfig */
 const logger = require("jitsi-meet-logger").getLogger(__filename);
 
-import {
-    setFilmstripRemoteVideosCount
-} from '../../../react/features/filmstrip';
-
 import Filmstrip from "./Filmstrip";
 import UIEvents from "../../../service/UI/UIEvents";
 import UIUtil from "../util/UIUtil";
@@ -555,8 +551,6 @@ var VideoLayout = {
                     onComplete();
             });
 
-        APP.store.dispatch(
-            setFilmstripRemoteVideosCount(this.getRemoteVideosCount()));
         return { localVideo, remoteVideo };
     },
 

--- a/react/features/filmstrip/actionTypes.js
+++ b/react/features/filmstrip/actionTypes.js
@@ -18,7 +18,7 @@ export const SET_FILMSTRIP_REMOTE_VIDEOS_COUNT
  *
  * {
  *     type: SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
- *     removeVideosVisible: boolean
+ *     remoteVideosVisible: boolean
  * }
  */
 export const SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY

--- a/react/features/filmstrip/actionTypes.js
+++ b/react/features/filmstrip/actionTypes.js
@@ -1,18 +1,6 @@
 import { Symbol } from '../base/react';
 
 /**
- * The type of action which signals to change the count of known remote videos
- * displayed in the filmstrip.
- *
- * {
- *     type: SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
- *     remoteVideosCount: number
- * }
- */
-export const SET_FILMSTRIP_REMOTE_VIDEOS_COUNT
-    = Symbol('SET_FILMSTRIP_REMOTE_VIDEOS_COUNT');
-
-/**
  * The type of action which signals to change the visibility of remote videos in
  * the filmstrip.
  *

--- a/react/features/filmstrip/actions.js
+++ b/react/features/filmstrip/actions.js
@@ -1,5 +1,4 @@
 import {
-    SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
     SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
@@ -18,22 +17,6 @@ export function setFilmstripRemoteVideosVisibility(remoteVideosVisible) {
     return {
         type: SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
         remoteVideosVisible
-    };
-}
-
-/**
- * Sets how many remote videos are currently in the filmstrip.
- *
- * @param {number} remoteVideosCount - The number of remote videos.
- * @returns {{
- *     type: SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
- *     remoteVideosCount: number
- * }}
- */
-export function setFilmstripRemoteVideosCount(remoteVideosCount) {
-    return {
-        type: SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
-        remoteVideosCount
     };
 }
 

--- a/react/features/filmstrip/middleware.js
+++ b/react/features/filmstrip/middleware.js
@@ -3,7 +3,6 @@ import UIEvents from '../../../service/UI/UIEvents';
 import { MiddlewareRegistry } from '../base/redux';
 
 import {
-    SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
     SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
@@ -15,7 +14,6 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
-    case SET_FILMSTRIP_REMOTE_VIDEOS_COUNT:
     case SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY:
     case SET_FILMSTRIP_VISIBILITY: {
         if (typeof APP !== 'undefined') {

--- a/react/features/filmstrip/reducer.js
+++ b/react/features/filmstrip/reducer.js
@@ -1,12 +1,10 @@
 import { ReducerRegistry } from '../base/redux';
 import {
-    SET_FILMSTRIP_REMOTE_VIDEOS_COUNT,
     SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
 
 const DEFAULT_STATE = {
-    remoteVideosCount: 0,
     remoteVideosVisible: true,
     visible: true
 };
@@ -15,11 +13,6 @@ ReducerRegistry.register(
     'features/filmstrip',
     (state = DEFAULT_STATE, action) => {
         switch (action.type) {
-        case SET_FILMSTRIP_REMOTE_VIDEOS_COUNT:
-            return {
-                ...state,
-                remoteVideosCount: action.remoteVideosCount
-            };
         case SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY:
             return {
                 ...state,

--- a/react/features/video-status-label/components/VideoStatusLabel.js
+++ b/react/features/video-status-label/components/VideoStatusLabel.js
@@ -40,12 +40,6 @@ export class VideoStatusLabel extends Component {
         _largeVideoHD: React.PropTypes.bool,
 
         /**
-         * The number of remote video thumbnails in the filmstrip. Used to
-         * determine display classes to set.
-         */
-        _remoteVideosCount: React.PropTypes.number,
-
-        /**
          * Whether or note remote videos are visible in the filmstrip,
          * regardless of count. Used to determine display classes to set.
          */
@@ -108,7 +102,6 @@ export class VideoStatusLabel extends Component {
             _audioOnly,
             _conferenceStarted,
             _filmstripVisible,
-            _remoteVideosCount,
             _remoteVideosVisible,
             _largeVideoHD,
             t
@@ -135,11 +128,12 @@ export class VideoStatusLabel extends Component {
         const baseClasses = 'video-state-indicator moveToCorner';
         const filmstrip
             = _filmstripVisible ? 'with-filmstrip' : 'without-filmstrip';
-        const oneOnOne = _remoteVideosVisible && _remoteVideosCount
-            ? 'with-remote-videos' : 'without-remote-videos';
+        const remoteVideosVisible = _remoteVideosVisible
+            ? 'with-remote-videos'
+            : 'without-remote-videos';
         const opening = this.state.togglingToVisible ? 'opening' : '';
         const classNames
-            = `${baseClasses} ${filmstrip} ${oneOnOne} ${opening}`;
+            = `${baseClasses} ${filmstrip} ${remoteVideosVisible} ${opening}`;
 
         return (
             <div
@@ -204,7 +198,6 @@ export class VideoStatusLabel extends Component {
  *     _conferenceStarted: boolean,
  *     _filmstripVisible: true,
  *     _largeVideoHD: (boolean|undefined),
- *     _remoteVideosCount: number,
  *     _remoteVideosVisible: boolean
  * }}
  */
@@ -215,7 +208,6 @@ function _mapStateToProps(state) {
         isLargeVideoHD
     } = state['features/base/conference'];
     const {
-        remoteVideosCount,
         remoteVideosVisible,
         visible
     } = state['features/filmstrip'];
@@ -225,8 +217,7 @@ function _mapStateToProps(state) {
         _conferenceStarted: Boolean(conference),
         _filmstripVisible: visible,
         _largeVideoHD: isLargeVideoHD,
-        _remoteVideosVisible: remoteVideosVisible,
-        _remoteVideosCount: remoteVideosCount
+        _remoteVideosVisible: remoteVideosVisible
     };
 }
 


### PR DESCRIPTION
Instead of one timing for sliding the video status label left and right,
have different timings depending on the filmstrip state. To facilitate
triggering the different animations, add more classes to the labels
that need to move that specify the filmstrip state.

- Faster transition if focusing on self-view with videos present so
  the label does not overlap videos transitioning from 0 opacity.
- Transition delay when de-focusing on self-view with videos present
  so videos have time to go away before the label moves over them.
- Maintain no movement if there are no videos, regardless of
  filmstrip toggle state.
- Different delays for when the filmstrip is being toggled visible
  and hidden if there are remote videos visible.