### PR TITLE
fix(large-video): ensure switch to local video when all others leave 

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -263,7 +263,8 @@ var VideoLayout = {
      * otherwise elects new video, in this order.
      */
     updateAfterThumbRemoved (id) {
-        if (!this.isCurrentlyOnLarge(id)) {
+        // Always trigger an update if large video is empty.
+        if (this.getLargeVideoID() && !this.isCurrentlyOnLarge(id)) {
             return;
         }
 
@@ -859,20 +860,6 @@ var VideoLayout = {
         }
 
         VideoLayout.resizeThumbnails();
-
-        const remoteVideosCount = Object.keys(remoteVideos).length;
-
-        if (!remoteVideosCount) {
-            window.setTimeout(() => {
-                const updatedRemoteVideosCount
-                    = Object.keys(remoteVideos).length;
-
-                if (!updatedRemoteVideosCount) {
-                    this._maybePlaceParticipantOnLargeVideo(
-                        APP.conference.getMyUserId());
-                }
-            }, 3000);
-        }
     },
 
     onVideoTypeChanged (id, newVideoType) {

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -859,6 +859,20 @@ var VideoLayout = {
         }
 
         VideoLayout.resizeThumbnails();
+
+        const remoteVideosCount = Object.keys(remoteVideos).length;
+
+        if (!remoteVideosCount) {
+            window.setTimeout(() => {
+                const updatedRemoteVideosCount
+                    = Object.keys(remoteVideos).length;
+
+                if (!updatedRemoteVideosCount) {
+                    this._maybePlaceParticipantOnLargeVideo(
+                        APP.conference.getMyUserId());
+                }
+            }, 3000);
+        }
     },
 
     onVideoTypeChanged (id, newVideoType) {

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -264,7 +264,8 @@ var VideoLayout = {
      */
     updateAfterThumbRemoved (id) {
         // Always trigger an update if large video is empty.
-        if (this.getLargeVideoID() && !this.isCurrentlyOnLarge(id)) {
+        if (!largeVideo
+            || (this.getLargeVideoID() && !this.isCurrentlyOnLarge(id))) {
             return;
         }
 


### PR DESCRIPTION
This handles the case where User A and B are in a call and B has no audio or video. Then B leaves. User A would see User B left on large video. Instead, User A should see self view on large.

This change is branched from https://github.com/jitsi/jitsi-meet/pull/1599, which needs to be merged in first.