### PR TITLE
Fixes chat when on join we receive messages.

### DIFF
--- a/modules/UI/side_pannels/chat/Chat.js
+++ b/modules/UI/side_pannels/chat/Chat.js
@@ -57,7 +57,7 @@ function updateVisualNotification() {
     const unreadMsgElement
         = unreadMsgSelector.length > 0 ? unreadMsgSelector[0] : undefined;
 
-    if (unreadMessages) {
+    if (unreadMessages && unreadMsgElement) {
         unreadMsgElement.innerHTML = unreadMessages.toString();
 
         APP.store.dispatch(dockToolbox(true));


### PR DESCRIPTION
Fixes a TypeError: Cannot set property 'innerHTML' of undefined
                    at o (Chat.js:61)
                    at Object.updateChatConversation (Chat.js:271)
that is thrown when joining a conference with messages already set to the chat. The error used to remove a strophe handler and chat was not working at all for those seeing the error.