### PR TITLE
fix(filmstrip): adjust filmstrip remote videos positioning

### DIFF
--- a/css/_filmstrip.scss
+++ b/css/_filmstrip.scss
@@ -51,10 +51,8 @@
         height:196px;
         padding: 0;
         /* The filmstrip should not be covered by the left toolbar. */
-        padding-left: $defaultToolbarSize + 5;
         bottom: 0;
         width:auto;
-        border: $thumbnailsBorder solid transparent;
         z-index: $filmstripVideosZ;
         transition: bottom 2s;
         overflow: visible !important;
@@ -62,9 +60,10 @@
         videos. */
         font-size: 0pt;
 
-        #filmstripLocalVideo {
-            padding-left: 0;
-        }
+        &#remoteVideos {
+            border: $thumbnailsBorder solid transparent;
+            padding-left: $defaultToolbarSize + 5;
+       }
 
         &.hidden {
             bottom: -196px;

--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -70,7 +70,7 @@
 
         #remoteVideos {
             flex-direction: column-reverse;
-            height: 100%;
+            flex-grow: 1;
         }
 
         .videocontainer {


### PR DESCRIPTION
- For horizontal mode, remove extra spacing created by borders
  around local video and remote videos.
- For vertical mode, ensure remote videos grow only to fill the
  parent height (Firefox issue)