### PR TITLE
fix(remote-video): update remote video menu if it exists

### DIFF
--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -436,8 +436,11 @@ RemoteVideo.prototype._setAudioVolume = function (scale, newVal) {
  * @param force to work even if popover is not visible
  */
 RemoteVideo.prototype.updateRemoteVideoMenu = function (isMuted, force) {
-
     this.isAudioMuted = isMuted;
+
+    if (!this.popover) {
+        return;
+    }
 
     // generate content, translate it and add it to document only if
     // popover is visible or we force to do so.


### PR DESCRIPTION
In RemoteVideo, creation of the RemoteVideoMenu (popover) is
skipped if in filmstrip only mode. However, updateRemoteVideoMenu
is called by other components, and that tries to access popover
and will error.

Add a defensive check for now as filmstrip is being rewritten
for react.