### PR TITLE
[RN] Make sure the jwt module is imported

### DIFF
--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -3,6 +3,7 @@
 import { Linking } from 'react-native';
 
 import { Platform } from '../../base/react';
+import '../../jwt';
 import '../../mobile/audio-mode';
 import '../../mobile/background';
 import '../../mobile/full-screen';


### PR DESCRIPTION
On native we rely on the middleware / reducer to do the work, and yet the module
was not imported anywhere, so they were not registered and this led to errors
because there was no default state for that feature.

Prior to 320e67baa1d3b78229daa2331a5917cc8b63a5a5 the module was imported,
albeit in another (arguably bogus) place.