### PR TITLE
fix(conference): ensure avatar url and email changes act on strings

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2052,7 +2052,7 @@ export default {
      * @param email {string} the new email
      */
     changeLocalEmail(email = '') {
-        email = email.trim();
+        email = String(email).trim();
 
         if (email === APP.settings.getEmail()) {
             return;
@@ -2076,7 +2076,7 @@ export default {
      * @param url {string} the new url
      */
     changeLocalAvatarUrl(url = '') {
-        url = url.trim();
+        url = String(url).trim();
 
         if (url === APP.settings.getAvatarUrl()) {
             return;


### PR DESCRIPTION
Both conference.changeLocalEmail and conference.changeLocalAvatarUrl
are exposed in the external api. It is possible for users to then
pass in non-string values. To make it more visibly obvious of the
error and to prevent script errors, convert whatever is passed in
into a string.