### PR TITLE
fix(popover): z-index should be greater than toasts

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -128,9 +128,9 @@ $toolbarZ: 400;
 $tooltipsZ: 401;
 $dropdownMaskZ: 900;
 $dropdownZ: 901;
-$jitsipopoverZ: 1010;
-$centeredVideoLabelZ: 1011;
-$notificationZ: 1012;
+$centeredVideoLabelZ: 1010;
+$notificationZ: 1011;
+$jitsipopoverZ: 1012;
 $popoverZ: 1015;
 $overlayZ: 1016;
 


### PR DESCRIPTION
Currently, the JitsiPopover z-index will cause it to display below
any toast notifications so this changes modifies the z-index
values so JitsiPopover is higher than the notification toasts.