### PR TITLE
mic error after used jitsi-meet on android 

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/audiomode/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/audiomode/AudioModeModule.java
@@ -300,7 +300,6 @@ public class AudioModeModule extends ReactContextBaseJavaModule {
             audioManager.setMode(AudioManager.MODE_NORMAL);
             audioManager.abandonAudioFocus(null);
             audioManager.setSpeakerphoneOn(false);
-            audioManager.setMicrophoneMute(true);
             setBluetoothAudioRoute(false);
 
             return true;


### PR DESCRIPTION
on some Android OS , for example OPPO (in China) , muted microphone will never unMute again , so we cannot mute mic when conference left