### PR TITLE
[RN] Lower Android target SDK version to 22

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,5 +29,5 @@ ext {
     compileSdkVersion = 23
     buildToolsVersion = "23.0.1"
     minSdkVersion    = 16
-    targetSdkVersion = 23
+    targetSdkVersion = 22
 }

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -17,10 +17,7 @@
 package org.jitsi.meet.sdk;
 
 import android.content.Intent;
-import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
@@ -38,13 +35,6 @@ import java.net.URL;
  * <tt>JKConferenceView</tt> static methods.
  */
 public class JitsiMeetActivity extends AppCompatActivity {
-    /**
-     * Code for identifying the permission to draw on top of other apps. The
-     * number is chosen arbitrarily and used to correlate the intent with its
-     * result.
-     */
-    public static final int OVERLAY_PERMISSION_REQ_CODE = 4242;
-
     /**
      * Instance of the {@link JitsiMeetView} which this activity will display.
      */
@@ -78,26 +68,6 @@ public class JitsiMeetActivity extends AppCompatActivity {
      * {@inheritDoc}
      */
     @Override
-    protected void onActivityResult(
-            int requestCode,
-            int resultCode,
-            Intent data) {
-        if (requestCode == OVERLAY_PERMISSION_REQ_CODE) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (!Settings.canDrawOverlays(this)) {
-                    // Permission not granted.
-                    return;
-                }
-            }
-
-            setContentView(view);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void onBackPressed() {
         if (!JitsiMeetView.onBackPressed()) {
             // Invoke the default handler if it wasn't handled by React.
@@ -119,20 +89,6 @@ public class JitsiMeetActivity extends AppCompatActivity {
         // JitsiMeetView#loadURL(URL).
         view.setWelcomePageEnabled(welcomePageEnabled);
         view.loadURL(null);
-
-        // In debug mode React needs permission to write over other apps in
-        // order to display the warning and error overlays.
-        if (BuildConfig.DEBUG
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                && !Settings.canDrawOverlays(this)) {
-            Intent intent
-                = new Intent(
-                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                        Uri.parse("package:" + getPackageName()));
-
-            startActivityForResult(intent, OVERLAY_PERMISSION_REQ_CODE);
-            return;
-        }
 
         setContentView(view);
     }


### PR DESCRIPTION
API level 22 is below 23 (aka Marshmallow), which included an overhaul in the
permissions system. React Native recommends 22 (it's the default when you create
a new app) and there have been reports when set higher [0] and [1].

This also fixes a critical bug, wherein Jitsi Meet wouldn't request permissions
for the camera and microphone.

Last, this change also allows us to get rid of the overlay checking code,
because it was only needed for API level 23 or higher.

[0]: https://github.com/facebook/react-native/pull/10479
[1]: https://github.com/facebook/react-native/issues/10587