### PR TITLE
feat(small-video): convert the "toolbar" to react

### DIFF
--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -82,6 +82,7 @@
 
                 .toolbar-icon {
                     float: none;
+                    margin: auto;
                 }
             }
         }

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-unused-vars */
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 import {
     MuteButton,
@@ -514,6 +515,13 @@ RemoteVideo.prototype.remove = function () {
     logger.log("Remove thumbnail", this.id);
 
     this.removeAudioLevelIndicator();
+
+    const toolbarContainer
+        = this.container.querySelector('.videocontainer__toolbar');
+
+    if (toolbarContainer) {
+        ReactDOM.unmountComponentAtNode(toolbarContainer);
+    }
 
     this.removeConnectionIndicator();
 

--- a/react/features/filmstrip/components/_.web.js
+++ b/react/features/filmstrip/components/_.web.js
@@ -1,0 +1,1 @@
+export * from './web';

--- a/react/features/filmstrip/components/index.js
+++ b/react/features/filmstrip/components/index.js
@@ -1,1 +1,3 @@
+export * from './_';
+
 export { default as Filmstrip } from './Filmstrip';

--- a/react/features/filmstrip/components/web/AudioMutedIndicator.js
+++ b/react/features/filmstrip/components/web/AudioMutedIndicator.js
@@ -1,0 +1,24 @@
+import BaseIndicator from './BaseIndicator';
+
+/**
+ * React {@code Component} for showing an audio muted icon with a tooltip.
+ *
+ * @extends BaseIndicator
+ */
+class AudioMutedIndicator extends BaseIndicator {
+    /**
+     * Initializes a new AudioMutedIcon instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._classNames = 'audioMuted toolbar-icon';
+        this._iconClass = 'icon-mic-disabled';
+        this._tooltipKey = 'videothumbnail.mute';
+    }
+}
+
+export default AudioMutedIndicator;

--- a/react/features/filmstrip/components/web/BaseIndicator.js
+++ b/react/features/filmstrip/components/web/BaseIndicator.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+
+import UIUtil from '../../../../../modules/UI/util/UIUtil';
+
+/**
+ * React {@code Component} for showing an icon with a tooltip.
+ *
+ * @extends Component
+ */
+class BaseIndicator extends Component {
+    /**
+     * Initializes a new {@code BaseIndicator} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        /**
+         * The CSS classes to apply to the root HTML element of the component.
+         *
+         * @type {string}
+         */
+        this._classNames = '';
+
+        /**
+         * The CSS class which will display an icon.
+         *
+         * @type {string}
+         */
+        this._iconClass = '';
+
+        /**
+         * An internal reference to the HTML element at the top of the
+         * component's DOM hierarchy. The reference is needed for attaching a
+         * tooltip.
+         *
+         * @type {HTMLElement}
+         */
+        this._rootElement = null;
+
+        /**
+         * The translation key for the text to display in the tooltip.
+         *
+         * @type {string}
+         */
+        this._tooltipKey = '';
+
+        // Bind event handler so it is only bound once for every instance.
+        this._setRootElementRef = this._setRootElementRef.bind(this);
+    }
+
+    /**
+     * Sets a tooltip which will display when hovering over the component.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    componentDidMount() {
+        this._setTooltip();
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <span className = { this._classNames }>
+                <i
+                    className = { this._iconClass }
+                    ref = { this._setRootElementRef } />
+            </span>
+        );
+    }
+
+    /**
+     * Sets the internal reference to the root HTML element for the component.
+     *
+     * @param {HTMLIconElement} element - The root HTML element of the
+     * component.
+     * @private
+     * @returns {void}
+     */
+    _setRootElementRef(element) {
+        this._rootElement = element;
+    }
+
+    /**
+     * Associate the component as a tooltip trigger so a tooltip may display on
+     * hover.
+     *
+     * @private
+     * @returns {void}
+     */
+    _setTooltip() {
+        // TODO Replace UIUtil with an AtlasKit component when a suitable one
+        // becomes available for tooltips.
+        UIUtil.setTooltip(
+            this._rootElement,
+            this._tooltipKey,
+            'top'
+        );
+    }
+}
+
+export default BaseIndicator;

--- a/react/features/filmstrip/components/web/ModeratorIndicator.js
+++ b/react/features/filmstrip/components/web/ModeratorIndicator.js
@@ -1,0 +1,24 @@
+import BaseIndicator from './BaseIndicator';
+
+/**
+ * React {@code Component} for showing a moderator icon with a tooltip.
+ *
+ * @extends BaseIndicator
+ */
+class ModeratorIndicator extends BaseIndicator {
+    /**
+     * Initializes a new ModeratorIndicator instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._classNames = 'focusindicator toolbar-icon right';
+        this._iconClass = 'icon-star';
+        this._tooltipKey = 'videothumbnail.moderator';
+    }
+}
+
+export default ModeratorIndicator;

--- a/react/features/filmstrip/components/web/VideoMutedIndicator.js
+++ b/react/features/filmstrip/components/web/VideoMutedIndicator.js
@@ -1,0 +1,24 @@
+import BaseIndicator from './BaseIndicator';
+
+/**
+ * React {@code Component} for showing a video muted icon with a tooltip.
+ *
+ * @extends BaseIndicator
+ */
+class VideoMutedIndicator extends BaseIndicator {
+    /**
+     * Initializes a new VideoMutedIndicator instance.
+     *
+     * @param {Object} props - The read-only React Component props with which
+     * the new instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._classNames = 'videoMuted toolbar-icon';
+        this._iconClass = 'icon-camera-disabled';
+        this._tooltipKey = 'videothumbnail.videomute';
+    }
+}
+
+export default VideoMutedIndicator;

--- a/react/features/filmstrip/components/web/index.js
+++ b/react/features/filmstrip/components/web/index.js
@@ -1,0 +1,3 @@
+export { default as AudioMutedIndicator } from './AudioMutedIndicator';
+export { default as ModeratorIndicator } from './ModeratorIndicator';
+export { default as VideoMutedIndicator } from './VideoMutedIndicator';


### PR DESCRIPTION
Move display of audio muted, video muted, and moderator icons,
which make up the elements of the small video toolbar, into React
Components.

jitsi-meet-torture tests had to be updated as the icons are now
removed from the dom when they should be hidden instead of
visibility being set to hidden. https://github.com/jitsi/jitsi-meet-torture/pull/86