### PR TITLE
feat(pinning): move web pinning logic into redux

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -83,8 +83,6 @@ let room;
 let connection;
 let localAudio, localVideo;
 
-import {VIDEO_CONTAINER_TYPE} from "./modules/UI/videolayout/VideoContainer";
-
 /*
  * Logic to open a desktop picker put on the window global for
  * lib-jitsi-meet to detect and invoke
@@ -1777,37 +1775,9 @@ export default {
                 UIEvents.VIDEO_UNMUTING_WHILE_AUDIO_ONLY,
                 () => this._displayAudioOnlyTooltip('videoMute'));
 
-            APP.UI.addListener(UIEvents.PINNED_ENDPOINT,
-            (smallVideo, isPinned) => {
-                let smallVideoId = smallVideo.getId();
-                let isLocal = APP.conference.isLocalId(smallVideoId);
-
-                let eventName
-                    = (isPinned ? "pinned" : "unpinned") + "." +
-                            (isLocal ? "local" : "remote");
-                let participantCount = room.getParticipantCount();
-                JitsiMeetJS.analytics.sendEvent(
-                        eventName,
-                        { value: participantCount });
-
-                // FIXME why VIDEO_CONTAINER_TYPE instead of checking if
-                // the participant is on the large video ?
-                if (smallVideo.getVideoType() === VIDEO_CONTAINER_TYPE
-                    && !isLocal) {
-
-                    // When the library starts supporting multiple pins we
-                    // would pass the isPinned parameter together with the
-                    // identifier, but currently we send null to indicate that
-                    // we unpin the last pinned.
-                    try {
-                        room.pinParticipant(isPinned ? smallVideoId : null);
-                    } catch (e) {
-                        reportError(e);
-                    }
-                }
-
-                updateRemoteThumbnailsVisibility();
-            });
+            APP.UI.addListener(
+                UIEvents.PINNED_ENDPOINT,
+                updateRemoteThumbnailsVisibility);
         }
 
         room.on(ConferenceEvents.CONNECTION_INTERRUPTED, () => {

--- a/modules/FollowMe.js
+++ b/modules/FollowMe.js
@@ -145,15 +145,9 @@ class FollowMe {
     _setFollowMeInitialState() {
         this._filmstripToggled.bind(this, this._UI.isFilmstripVisible());
 
-        var pinnedId = VideoLayout.getPinnedId();
-        var isPinned = false;
-        var smallVideo;
-        if (pinnedId) {
-            isPinned = true;
-            smallVideo = VideoLayout.getSmallVideo(pinnedId);
-        }
+        const pinnedId = VideoLayout.getPinnedId();
 
-        this._nextOnStage(smallVideo.getId(), isPinned);
+        this._nextOnStage(pinnedId, Boolean(pinnedId));
 
         // check whether shared document is enabled/initialized
         if(this._UI.getSharedDocumentManager())

--- a/modules/FollowMe.js
+++ b/modules/FollowMe.js
@@ -153,7 +153,7 @@ class FollowMe {
             smallVideo = VideoLayout.getSmallVideo(pinnedId);
         }
 
-        this._nextOnStage(smallVideo, isPinned);
+        this._nextOnStage(smallVideo.getId(), isPinned);
 
         // check whether shared document is enabled/initialized
         if(this._UI.getSharedDocumentManager())
@@ -174,8 +174,8 @@ class FollowMe {
                             this.filmstripEventHandler);
 
         var self = this;
-        this.pinnedEndpointEventHandler = function (smallVideo, isPinned) {
-            self._nextOnStage(smallVideo, isPinned);
+        this.pinnedEndpointEventHandler = function (videoId, isPinned) {
+            self._nextOnStage(videoId, isPinned);
         };
         this._UI.addListener(UIEvents.PINNED_ENDPOINT,
                             this.pinnedEndpointEventHandler);
@@ -243,13 +243,13 @@ class FollowMe {
      * unpinned
      * @private
      */
-    _nextOnStage (smallVideo, isPinned) {
+    _nextOnStage (videoId, isPinned) {
         if (!this._conference.isModerator)
             return;
 
         var nextOnStage = null;
         if(isPinned)
-            nextOnStage = smallVideo.getId();
+            nextOnStage = videoId;
 
         this._local.nextOnStage = nextOnStage;
     }

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -10,6 +10,10 @@ import LargeContainer from '../videolayout/LargeContainer';
 import SmallVideo from '../videolayout/SmallVideo';
 import Filmstrip from '../videolayout/Filmstrip';
 
+import {
+    participantJoined,
+    participantLeft
+} from '../../../react/features/base/participants';
 import { dockToolbox, showToolbox } from '../../../react/features/toolbox';
 
 export const SHARED_VIDEO_CONTAINER_TYPE = "sharedvideo";
@@ -267,6 +271,13 @@ export default class SharedVideoManager {
 
             VideoLayout.addLargeVideoContainer(
                 SHARED_VIDEO_CONTAINER_TYPE, self.sharedVideo);
+
+            APP.store.dispatch(participantJoined({
+                id: self.url,
+                isBot: true,
+                name: player.getVideoData().title
+            }));
+
             VideoLayout.handleVideoThumbClicked(self.url);
 
             // If we are sending the command and we are starting the player
@@ -460,6 +471,8 @@ export default class SharedVideoManager {
                 this.emitter.emit(
                     UIEvents.UPDATE_SHARED_VIDEO, null, 'removed');
         });
+
+        APP.store.dispatch(participantLeft(this.url));
 
         this.url = null;
         this.isSharedVideoShown = false;

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -176,9 +176,7 @@ function _pinParticipant(store, next, action) {
     const participantById = getParticipantById(participants, id);
     let pin;
 
-    const shouldEmitToLegacyApp = typeof APP !== 'undefined';
-
-    if (shouldEmitToLegacyApp) {
+    if (typeof APP !== 'undefined') {
         const pinnedParticipant = getPinnedParticipant(participants);
         const actionName = action.participant.id ? 'pinned' : 'unpinned';
         let videoType;
@@ -216,10 +214,6 @@ function _pinParticipant(store, next, action) {
         } catch (err) {
             _handleParticipantError(err);
         }
-    }
-
-    if (shouldEmitToLegacyApp) {
-        APP.UI.emitEvent(UIEvents.PINNED_ENDPOINT, id, Boolean(id));
     }
 
     return next(action);

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -99,6 +99,38 @@ export function getParticipantById(stateOrGetState, id) {
 }
 
 /**
+ * Returns a count of the known participants in the passed in redux state,
+ * excluding any fake participants.
+ *
+ * @param {(Function|Object|Participant[])} stateOrGetState - The redux state
+ * features/base/participants, the (whole) redux state, or redux's
+ * {@code getState} function to be used to retrieve the
+ * features/base/participants state.
+ * @returns {number}
+ */
+export function getParticipantCount(stateOrGetState) {
+    const participants = _getParticipants(stateOrGetState);
+    const realParticipants = participants.filter(p => !p.isBot);
+
+    return realParticipants.length;
+}
+
+/**
+ * Returns the participant which has its pinned state set to truthy.
+ *
+ * @param {(Function|Object|Participant[])} stateOrGetState - The redux state
+ * features/base/participants, the (whole) redux state, or redux's
+ * {@code getState} function to be used to retrieve the
+ * features/base/participants state.
+ * @returns {(Participant|undefined)}
+ */
+export function getPinnedParticipant(stateOrGetState) {
+    const participants = _getParticipants(stateOrGetState);
+
+    return participants.find(p => p.pinned);
+}
+
+/**
  * Returns array of participants from Redux state.
  *
  * @param {(Function|Object|Participant[])} stateOrGetState - The redux state

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -73,6 +73,7 @@ function _participant(state, action) {
             connectionStatus,
             dominantSpeaker,
             email,
+            isBot,
             local,
             pinned,
             role
@@ -108,6 +109,7 @@ function _participant(state, action) {
             dominantSpeaker: dominantSpeaker || false,
             email,
             id,
+            isBot,
             local: local || false,
             name,
             pinned: pinned || false,

--- a/react/features/jwt/middleware.js
+++ b/react/features/jwt/middleware.js
@@ -9,7 +9,11 @@ import {
 import { SET_CONFIG } from '../base/config';
 import { SET_LOCATION_URL } from '../base/connection';
 import { LIB_INIT_ERROR } from '../base/lib-jitsi-meet';
-import { PARTICIPANT_JOINED } from '../base/participants';
+import {
+    getLocalParticipant,
+    getParticipantCount,
+    PARTICIPANT_JOINED
+} from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
 
 import { setCallOverlayVisible, setJWT } from './actions';
@@ -96,13 +100,8 @@ function _maybeSetCallOverlayVisible({ dispatch, getState }, next, action) {
             default: {
                 // The CallOverlay it to no longer be displayed/visible as soon
                 // as another participant joins.
-                const participants = state['features/base/participants'];
-
-                callOverlayVisible
-                    = Boolean(
-                        participants
-                            && participants.length === 1
-                            && participants[0].local);
+                callOverlayVisible = getParticipantCount(state) === 1
+                    && Boolean(getLocalParticipant(state));
 
                 // However, the CallDialog is not to be displayed/visible again
                 // after all remote participants leave.


### PR DESCRIPTION
- Re-use the native redux pinning implementation for web
- Remove pinning logic from conference.js
- To the native pinning add a check for sharedVideo so
  youtube videos do not send a pin event
- Add shared videos as a participant to enable pinning and
  so they can eventually get added to the filmstrip