### PR TITLE
[Android] Use target API 23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ ext {
     compileSdkVersion = 25
     buildToolsVersion = "25.0.3"
     minSdkVersion    = 16
-    targetSdkVersion = 22
+    targetSdkVersion = 23
 }
 
 // Force the version of the Android build tools we have chosen on all

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -106,7 +106,7 @@ gradle.projectsEvaluated {
                 '--reset-cache')
 
             // Disable bundling on dev builds
-            //enabled !devEnabled
+            enabled !devEnabled
         }
 
         // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -17,7 +17,10 @@
 package org.jitsi.meet.sdk;
 
 import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
@@ -35,6 +38,13 @@ import java.net.URL;
  * <tt>JKConferenceView</tt> static methods.
  */
 public class JitsiMeetActivity extends AppCompatActivity {
+    /**
+     * Code for identifying the permission to draw on top of other apps. The
+     * number is chosen arbitrarily and used to correlate the intent with its
+     * result.
+     */
+    public static final int OVERLAY_PERMISSION_REQ_CODE = 4242;
+
     /**
      * Instance of the {@link JitsiMeetView} which this activity will display.
      */
@@ -68,6 +78,26 @@ public class JitsiMeetActivity extends AppCompatActivity {
      * {@inheritDoc}
      */
     @Override
+    protected void onActivityResult(
+            int requestCode,
+            int resultCode,
+            Intent data) {
+        if (requestCode == OVERLAY_PERMISSION_REQ_CODE) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                if (!Settings.canDrawOverlays(this)) {
+                    // Permission not granted.
+                    return;
+                }
+            }
+
+            setupView();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void onBackPressed() {
         if (!JitsiMeetView.onBackPressed()) {
             // Invoke the default handler if it wasn't handled by React.
@@ -82,15 +112,21 @@ public class JitsiMeetActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        view = new JitsiMeetView(this);
+        // In debug mode React needs permission to write over other apps in
+        // order to display the warning and error overlays.
+        if (BuildConfig.DEBUG
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                && !Settings.canDrawOverlays(this)) {
+            Intent intent
+                = new Intent(
+                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                        Uri.parse("package:" + getPackageName()));
 
-        // In order to have the desired effect
-        // JitsiMeetView#setWelcomePageEnabled(boolean) must be invoked before
-        // JitsiMeetView#loadURL(URL).
-        view.setWelcomePageEnabled(welcomePageEnabled);
-        view.loadURL(null);
+            startActivityForResult(intent, OVERLAY_PERMISSION_REQ_CODE);
+            return;
+        }
 
-        setContentView(view);
+        setupView();
     }
 
     /**
@@ -129,6 +165,18 @@ public class JitsiMeetActivity extends AppCompatActivity {
         super.onResume();
 
         JitsiMeetView.onHostResume(this);
+    }
+
+    private void setupView() {
+        view = new JitsiMeetView(this);
+
+        // In order to have the desired effect
+        // JitsiMeetView#setWelcomePageEnabled(boolean) must be invoked before
+        // JitsiMeetView#loadURL(URL).
+        view.setWelcomePageEnabled(welcomePageEnabled);
+        view.loadURL(null);
+
+        setContentView(view);
     }
 
     /**

--- a/react/features/base/media/reducer.js
+++ b/react/features/base/media/reducer.js
@@ -63,9 +63,9 @@ function _audio(state = AUDIO_INITIAL_MEDIA_STATE, action) {
  * @type {VideoMediaState}
  */
 const VIDEO_INITIAL_MEDIA_STATE = {
+    available: true,
     facingMode: CAMERA_FACING_MODE.USER,
-    muted: true,
-    available: true
+    muted: false
 };
 
 /**


### PR DESCRIPTION
This reverts commit c9a29153ddf55fb9021000696e71b4e4f04b302b.

Now that react-native-webrtc supports the permissions system in 23, use it since
it provides a more pleasant experience to users.

In addition, fix a bug in the previous code: the React Native view must be
loaded after we have acquired the permission to draw on top of other apps,
otherwise our app may crash while we accept the permission, since React may try
to draw.