### PR TITLE
feat(p2p): enable H.264 for P2P by default

### DIFF
--- a/config.js
+++ b/config.js
@@ -102,7 +102,7 @@ var config = { // eslint-disable-line no-unused-vars
         ],
         // If set to true, it will prefer to use H.264 for P2P calls (if H.264
         // is supported).
-        preferH264: false
+        preferH264: true
         // How long we're going to wait, before going back to P2P after
         // the 3rd participant has left the conference (to filter out page reload)
         //backToP2PDelay: 5

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { JitsiConferenceEvents } from '../lib-jitsi-meet';
 import { setVideoMuted } from '../media';
 import {
@@ -255,22 +256,20 @@ export function createConference() {
         dispatch(_conferenceWillJoin(room));
 
         const config = state['features/base/config'];
+        const configOverride = {
+            p2p: {
+                preferH264: true
+            }
+        };
         const conference
             = connection.initJitsiConference(
 
                 // XXX Lib-jitsi-meet does not accept uppercase letters.
                 room.toLowerCase(),
-                {
-                    ...config,
 
-                    openSctp: true
-
-                    // FIXME I tested H.264 from iPhone 6S during a morning
-                    // standup but, unfortunately, the other participants who
-                    // happened to be running the Web app saw only black.
-                    //
-                    // preferH264: true
-                });
+                // We use lodash's merge here because it will recursively merge
+                // objects allowing partial overrides.
+                _.merge({}, config, configOverride));
 
         _addConferenceListeners(conference, dispatch);
 


### PR DESCRIPTION
~Note: this PR sits atop #1710~

Rebased.