### PR TITLE
fixes authentication of rooms which do not contain the auth domain

### DIFF
--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -310,7 +310,7 @@ function Util:verify_room(session, room_address)
         -- we do not have a domain part (multidomain is not enabled)
         -- verify with info from the token
         return room_address_to_verify == jid.join(
-            string.lower(room_to_check), self.muc_domain_prefix.."."..auth_domain);
+            string.lower(room_to_check), self.muc_domain);
     end
 end
 


### PR DESCRIPTION
This PR fixes an issue with room verification when attempting to verify a room that does not include the tenant, when the token does include a tenant