### PR TITLE
fix(vertical-filmstrip): enable hardware acceleration for icons

### DIFF
--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -65,7 +65,7 @@
             left: 0;
             top: auto;
             right: auto;
-            transform: rotate(-90deg);
+            transform: translate3d(0,0,0) rotate(-90deg);
         }
 
         #remoteVideos {
@@ -74,6 +74,11 @@
         }
 
         .videocontainer {
+            &__toolbar,
+            &__toptoolbar {
+                transform: translate3d(0,0,0);
+            }
+
             /**
              * Move status icons to the bottom right of the thumbnail.
              */


### PR DESCRIPTION
Icons on the thumbnails can flicker when scrolling through videos.
To give rendering a bit more power, and thereby help with rendering
icons without flickering, force hardware acceleration.