### PR TITLE
[iOS] Fix joining initial URL if app was closed

### DIFF
--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -22,7 +22,8 @@
 
 -             (BOOL)application:(UIApplication *)application
   didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    return YES;
+  return [JitsiMeetView application:application
+      didFinishLaunchingWithOptions:launchOptions];
 }
 
 #pragma mark Linking delegate methods

--- a/ios/sdk/src/JitsiMeetView.h
+++ b/ios/sdk/src/JitsiMeetView.h
@@ -25,6 +25,9 @@
 
 @property (nonatomic) BOOL welcomePageEnabled;
 
++             (BOOL)application:(UIApplication *_Nullable)application
+  didFinishLaunchingWithOptions:(NSDictionary *_Nullable)launchOptions;
+
 +    (BOOL)application:(UIApplication * _Nonnull)application
   continueUserActivity:(NSUserActivity * _Nonnull)userActivity
     restorationHandler:(void (^ _Nullable)(NSArray * _Nullable))restorationHandler;

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -111,10 +111,26 @@ void registerFatalErrorHandler() {
 static RCTBridgeWrapper *bridgeWrapper;
 
 /**
+ * Copy of the {@code launchOptions} dictionary that the application was started
+ * with. This is required for the initial URL to be used if a link was followed
+ * while the application was not started.
+ */
+static NSDictionary *_launchOptions;
+
+/**
  * The {@code JitsiMeetView}s associated with their {@code ExternalAPI} scopes
  * (i.e. unique identifiers within the process).
  */
 static NSMapTable<NSString *, JitsiMeetView *> *views;
+
+
++             (BOOL)application:(UIApplication *)application
+  didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Store launch options, will be used when we create the bridge.
+    _launchOptions = [launchOptions copy];
+
+    return YES;
+}
 
 #pragma mark Linking delegate helpers
 // https://facebook.github.io/react-native/docs/linking.html
@@ -211,7 +227,8 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
 
     dispatch_once(&dispatchOncePredicate, ^{
         // Initialize the static state of JitsiMeetView.
-        bridgeWrapper = [[RCTBridgeWrapper alloc] init];
+        bridgeWrapper
+            = [[RCTBridgeWrapper alloc] initWithLaunchOptions:_launchOptions];
         views = [NSMapTable strongToWeakObjectsMapTable];
 
         // Dynamically load custom bundled fonts.

--- a/ios/sdk/src/RCTBridgeWrapper.h
+++ b/ios/sdk/src/RCTBridgeWrapper.h
@@ -34,4 +34,6 @@
 
 @property (nonatomic, readonly, strong)  RCTBridge *bridge;
 
+- (instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions;
+
 @end

--- a/ios/sdk/src/RCTBridgeWrapper.m
+++ b/ios/sdk/src/RCTBridgeWrapper.m
@@ -22,10 +22,11 @@
  */
 @implementation RCTBridgeWrapper
 
-- (instancetype)init {
+- (instancetype)initWithLaunchOptions:(NSDictionary *)launchOptions {
     self = [super init];
     if (self) {
-        _bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:nil];
+        _bridge = [[RCTBridge alloc] initWithDelegate:self
+                                        launchOptions:launchOptions];
     }
 
     return self;


### PR DESCRIPTION
On iOS, if the app is closed the startup options are only passed as the
`launchOptions` dictionary of `applicationDidFinishLaunching`. Thus add a helper
method to be called from there by embedding applications so we can copy that
dictionary.