### PR TITLE
[Android] Update gradle plugin version

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-milestone-1-all.zip


### PR DESCRIPTION
A problem occurred evaluating project ':app'.
> Failed to apply plugin [id 'com.android.application']
   > Minimum supported Gradle version is 4.1-milestone-1. Current version is 4.0. If using the gradle wrapper, try editing the distributionUrl in /Users/scorretge/work/jitsi-meet/android/gradle/wrapper/gradle-wrapper.properties to gradle-4.1-milestone-1-all.zip