### PR TITLE
ref(stats): process stats through one pub/sub

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -48,6 +48,7 @@ import {
     trackAdded,
     trackRemoved
 } from './react/features/base/tracks';
+import { statsEmitter } from './react/features/connection-indicator';
 import { showDesktopPicker } from  './react/features/desktop-picker';
 import {
     mediaPermissionPromptVisibilityChanged,
@@ -63,8 +64,6 @@ const ConferenceErrors = JitsiMeetJS.errors.conference;
 
 const TrackEvents = JitsiMeetJS.events.track;
 const TrackErrors = JitsiMeetJS.errors.track;
-
-const ConnectionQualityEvents = JitsiMeetJS.events.connectionQuality;
 
 const eventEmitter = new EventEmitter();
 
@@ -1726,16 +1725,7 @@ export default {
             }
         });
 
-        room.on(ConnectionQualityEvents.LOCAL_STATS_UPDATED,
-            (stats) => {
-                APP.UI.updateLocalStats(stats.connectionQuality, stats);
-
-        });
-
-        room.on(ConnectionQualityEvents.REMOTE_STATS_UPDATED,
-            (id, stats) => {
-                APP.UI.updateRemoteStats(id, stats.connectionQuality, stats);
-        });
+        statsEmitter.startListeningForStats(room);
 
         room.addCommandListener(this.commands.defaults.ETHERPAD, ({value}) => {
             APP.UI.initEtherpad(value);

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -973,25 +973,6 @@ UI.hideStats = function () {
 };
 
 /**
- * Update local connection quality statistics.
- * @param {number} percent
- * @param {object} stats
- */
-UI.updateLocalStats = function (percent, stats) {
-    VideoLayout.updateLocalConnectionStats(percent, stats);
-};
-
-/**
- * Update connection quality statistics for remote user.
- * @param {string} id user id
- * @param {number} percent
- * @param {object} stats
- */
-UI.updateRemoteStats = function (id, percent, stats) {
-    VideoLayout.updateConnectionStats(id, percent, stats);
-};
-
-/**
  * Mark video as interrupted or not.
  * @param {boolean} interrupted if video is interrupted
  */

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -37,7 +37,7 @@ function LocalVideo(VideoLayout, emitter) {
     this.setDisplayName();
 
     this.addAudioLevelIndicator();
-    this.updateConnectionIndicator();
+    this.updateIndicators();
 }
 
 LocalVideo.prototype = Object.create(SmallVideo.prototype);

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -48,7 +48,7 @@ function RemoteVideo(user, VideoLayout, emitter) {
     this.hasRemoteVideoMenu = false;
     this._supportsRemoteControl = false;
     this.addRemoteVideoContainer();
-    this.updateConnectionIndicator();
+    this.updateIndicators();
     this.setDisplayName();
     this.bindHoverHandler();
     this.flipX = false;
@@ -630,18 +630,6 @@ RemoteVideo.prototype.addRemoteStreamElement = function (stream) {
     if (!isVideo) {
         this._audioStreamElement = streamElement;
     }
-};
-
-RemoteVideo.prototype.updateResolution = function (resolution) {
-    this.updateConnectionIndicator({ resolution });
-};
-
-/**
- * Updates this video framerate indication.
- * @param framerate the value to update
- */
-RemoteVideo.prototype.updateFramerate = function (framerate) {
-    this.updateConnectionIndicator({ framerate });
 };
 
 /**

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -84,13 +84,14 @@ function SmallVideo(VideoLayout) {
     this.disableUpdateView = false;
 
     /**
-     * Statistics to display within the connection indicator. With new updates,
-     * only changed values are updated through assignment to a new reference.
+     * The current state of the user's bridge connection. The value should be
+     * a string as enumerated in the library's participantConnectionStatus
+     * constants.
      *
      * @private
-     * @type {object}
+     * @type {string|null}
      */
-    this._cachedConnectionStats = {};
+    this._connectionStatus = null;
 
     /**
      * Whether or not the ConnectionIndicator's popover is hovered. Modifies
@@ -261,18 +262,6 @@ SmallVideo.prototype.bindHoverHandler = function () {
 };
 
 /**
- * Updates the data for the indicator
- * @param id the id of the indicator
- * @param percent the percent for connection quality
- * @param object the data
- */
-SmallVideo.prototype.updateConnectionStats = function (percent, object) {
-    const newStats = Object.assign({}, object, { percent });
-
-    this.updateConnectionIndicator(newStats);
-};
-
-/**
  * Unmounts the ConnectionIndicator component.
 
  * @returns {void}
@@ -289,7 +278,8 @@ SmallVideo.prototype.removeConnectionIndicator = function () {
  * @returns {void}
  */
 SmallVideo.prototype.updateConnectionStatus = function (connectionStatus) {
-    this.updateConnectionIndicator({ connectionStatus });
+    this._connectionStatus = connectionStatus;
+    this.updateIndicators();
 };
 
 /**
@@ -742,21 +732,6 @@ SmallVideo.prototype.initBrowserSpecificProperties = function() {
 };
 
 /**
- * Creates or updates the connection indicator. Updates the previously known
- * statistics about the participant's connection.
- *
- * @param {Object} newStats - New statistics to merge with previously known
- * statistics about the participant's connection.
- * @returns {void}
- */
-SmallVideo.prototype.updateConnectionIndicator = function (newStats = {}) {
-    this._cachedConnectionStats
-        = Object.assign({}, this._cachedConnectionStats, newStats);
-
-    this.updateIndicators();
-};
-
-/**
  * Updates the React element responsible for showing connection status, dominant
  * speaker, and raised hand icons. Uses instance variables to get the necessary
  * state to display. Will create the React element if not already created.
@@ -775,11 +750,12 @@ SmallVideo.prototype.updateIndicators = function () {
         <div>
             { this._showConnectionIndicator
                 ? <ConnectionIndicator
+                    connectionStatus = { this._connectionStatus }
                     iconSize = { iconSize }
                     isLocalVideo = { this.isLocal }
                     onHover = { this._onPopoverHover }
                     showMoreLink = { this.isLocal }
-                    stats = { this._cachedConnectionStats } />
+                    userID = { this.id } />
                 : null }
             { this._showRaisedHand
                 ? <RaisedHandIndicator iconSize = { iconSize } /> : null }

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -211,6 +211,11 @@ var VideoLayout = {
         if (largeVideo && !largeVideo.id) {
             this.updateLargeVideo(APP.conference.getMyUserId(), true);
         }
+
+        // FIXME: replace this call with a generic update call once SmallVideo
+        // only contains a ReactElement. Then remove this call once the
+        // Filmstrip is fully in React.
+        localVideoThumbnail.updateIndicators();
     },
 
     /**
@@ -763,60 +768,6 @@ var VideoLayout = {
             if (remoteVideo.isCurrentlyOnLargeVideo()) {
                 this.updateLargeVideo(id);
             }
-        }
-    },
-
-    /**
-     * Updates local stats
-     * @param percent
-     * @param object
-     */
-    updateLocalConnectionStats (percent, object) {
-        const { framerate, resolution } = object;
-
-        // FIXME overwrites 'lib-jitsi-meet' internal object
-        // Why library internal objects are passed as event's args ?
-        object.resolution = resolution[APP.conference.getMyUserId()];
-        object.framerate = framerate[APP.conference.getMyUserId()];
-        localVideoThumbnail.updateConnectionStats(percent, object);
-
-        Object.keys(resolution).forEach(function (id) {
-            if (APP.conference.isLocalId(id)) {
-                return;
-            }
-
-            let resolutionValue = resolution[id];
-            let remoteVideo = remoteVideos[id];
-
-            if (resolutionValue && remoteVideo) {
-                remoteVideo.updateResolution(resolutionValue);
-            }
-        });
-
-        Object.keys(framerate).forEach(function (id) {
-            if (APP.conference.isLocalId(id)) {
-                return;
-            }
-
-            const framerateValue = framerate[id];
-            const remoteVideo = remoteVideos[id];
-
-            if (framerateValue && remoteVideo) {
-                remoteVideo.updateFramerate(framerateValue);
-            }
-        });
-    },
-
-    /**
-     * Updates remote stats.
-     * @param id the id associated with the stats
-     * @param percent the connection quality percent
-     * @param object the stats data
-     */
-    updateConnectionStats (id, percent, object) {
-        let remoteVideo = remoteVideos[id];
-        if (remoteVideo) {
-            remoteVideo.updateConnectionStats(percent, object);
         }
     },
 

--- a/react/features/connection-indicator/components/ConnectionIndicator.js
+++ b/react/features/connection-indicator/components/ConnectionIndicator.js
@@ -168,7 +168,7 @@ class ConnectionIndicator extends Component {
     componentDidUpdate(prevProps) {
         if (prevProps.userID !== this.props.userID) {
             statsEmitter.unsubscribeToClientStats(
-                this.props.userID, this._onStatsUpdated);
+                prevProps.userID, this._onStatsUpdated);
             statsEmitter.subscribeToClientStats(
                 this.props.userID, this._onStatsUpdated);
         }

--- a/react/features/connection-indicator/index.js
+++ b/react/features/connection-indicator/index.js
@@ -1,1 +1,3 @@
 export * from './components';
+
+export { default as statsEmitter } from './statsEmitter';

--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -1,0 +1,147 @@
+import JitsiMeetJS from '../base/lib-jitsi-meet';
+
+declare var APP: Object;
+
+/**
+ * Contains all the callbacks to be notified when stats are updated.
+ *
+ * {
+ *     userId: Function[]
+ * }
+ */
+const subscribers = {};
+
+/**
+ * A singleton that acts as a pub/sub service for connection stat updates.
+ */
+const statsEmitter = {
+    /**
+     * Have {@code statsEmitter} subscribe to stat updates from a given
+     * conference.
+     *
+     * @param {JitsiConference} conference - The conference for which
+     * {@code statsEmitter} should subscribe for stat updates.
+     * @returns {void}
+     */
+    startListeningForStats(conference) {
+        const { connectionQuality } = JitsiMeetJS.events;
+
+        conference.on(connectionQuality.LOCAL_STATS_UPDATED,
+            stats => this._onStatsUpdated(stats));
+
+        conference.on(connectionQuality.REMOTE_STATS_UPDATED,
+            (id, stats) => this._emitStatsUpdate(id, stats));
+    },
+
+    /**
+     * Add a subscriber to be notified when stats are updated for a specified
+     * user id.
+     *
+     * @param {string} id - The user id whose stats updates are of interest.
+     * @param {Function} callback - The function to invoke when stats for the
+     * user have been updated.
+     * @returns {void}
+     */
+    subscribeToClientStats(id, callback) {
+        if (!id) {
+            return;
+        }
+
+        if (!subscribers[id]) {
+            subscribers[id] = [];
+        }
+
+        subscribers[id].push(callback);
+    },
+
+    /**
+     * Remove a subscriber that is listening for stats updates for a specified
+     * user id.
+     *
+     * @param {string} id - The user id whose stats updates are no longer of
+     * interest.
+     * @param {Function} callback - The function that is currently subscribed to
+     * stat updates for the specified user id.
+     * @returns {void}
+     */
+    unsubscribeToClientStats(id, callback) {
+        if (!subscribers[id]) {
+            return;
+        }
+
+        const filteredSubscribers = subscribers[id].filter(
+            subscriber => subscriber !== callback);
+
+        if (filteredSubscribers.length) {
+            subscribers[id] = filteredSubscribers;
+        } else {
+            delete subscribers[id];
+        }
+    },
+
+    /**
+     * Emit a stat update to all those listening for a specific user's
+     * connection stats.
+     *
+     * @param {string} id - The user id the stats are associated with.
+     * @param {Object} stats - New connection stats for the user.
+     * @returns {void}
+     */
+    _emitStatsUpdate(id, stats = {}) {
+        const callbacks = subscribers[id] || [];
+
+        callbacks.forEach(callback => {
+            callback(stats);
+        });
+    },
+
+    /**
+     * Emit a stat update to all those listening for local stat updates. Will
+     * also update listeners of remote user stats of changes related to their
+     * stats.
+     *
+     * @param {Object} stats - Connection stats for the local user as provided
+     * by the library.
+     * @returns {void}
+     */
+    _onStatsUpdated(stats) {
+        const allUserFramerates = stats.framerate;
+        const allUserResolutions = stats.resolution;
+
+        const currentUserId = APP.conference.getMyUserId();
+        const currentUserFramerate = allUserFramerates[currentUserId];
+        const currentUserResolution = allUserResolutions[currentUserId];
+
+        // FIXME resolution and framerate are hashes keyed off of user ids with
+        // stat values. Receivers of stats expect resolution and framerate to
+        // be primatives, not hashes, so overwrites the 'lib-jitsi-meet' stats
+        // objects.
+        stats.framerate = currentUserFramerate;
+        stats.resolution = currentUserResolution;
+
+        this._emitStatsUpdate(currentUserId, stats);
+
+        Object.keys(allUserFramerates)
+            .filter(id => id !== currentUserId)
+            .forEach(id => {
+                const framerate = allUserFramerates[id];
+
+                if (framerate) {
+                    this._emitStatsUpdate(id, { framerate });
+                }
+            });
+
+        Object.keys(allUserResolutions)
+            .filter(id => id !== currentUserId)
+            .forEach(id => {
+                const resolution = allUserResolutions[id];
+
+                if (resolution) {
+                    this._emitStatsUpdate(id, { resolution });
+                }
+            });
+
+    }
+};
+
+export default statsEmitter;


### PR DESCRIPTION
Instead of passing stats through UI then VideoLayout then the
SmallVideo, pass stats directly to what uses it--ConnectionIndicator.
This also bypasses adding the stats to the store, as they do not
seem to be something that needs to be shared or stored app-wide
just yet.