### PR TITLE
[RN] Fix passing url prop to Root and App components

### DIFF
--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -137,6 +137,11 @@ export class AbstractApp extends Component {
                 store: this._maybeCreateStore(nextProps)
             });
         }
+
+        // Deal with URL changes
+        if (typeof nextProps.url !== 'undefined') {
+            this._openURL(nextProps.url || this._getDefaultURL());
+        }
     }
 
     /**

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -395,6 +395,16 @@ export class AbstractApp extends Component {
      * @returns {void}
      */
     _openURL(url) {
-        this._getStore().dispatch(appNavigate(url));
+        const dispatch = this._getStore().dispatch;
+        const { conference, joining }
+            = this._getStore().getState()['features/base/conference'];
+
+        // FIXME: revisit this after the hangup sequence is fixed.
+        // Make sure we disconnect from the current conference.
+        if (conference || joining) {
+            dispatch(appNavigate(undefined));
+        }
+
+        dispatch(appNavigate(url));
     }
 }

--- a/react/features/base/conference/actionTypes.js
+++ b/react/features/base/conference/actionTypes.js
@@ -36,7 +36,8 @@ export const CONFERENCE_LEFT = Symbol('CONFERENCE_LEFT');
  *
  * {
  *     type: CONFERENCE_WILL_JOIN,
- *     room: string
+ *     room: string,
+ *     conference: JitsiConference
  * }
  */
 export const CONFERENCE_WILL_JOIN = Symbol('CONFERENCE_WILL_JOIN');

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -200,15 +200,19 @@ export function conferenceLeft(conference) {
  *
  * @param {string} room - The room (name) which identifies the conference the
  * local participant will (try to) join.
+ * @param {JitsiConference} conference - The JitsiConference instance the
+ * local participant will (try to) join.
  * @returns {{
  *     type: CONFERENCE_WILL_JOIN,
- *     room: string
+ *     room: string,
+*      conference: JitsiConference
  * }}
  */
-function _conferenceWillJoin(room) {
+function _conferenceWillJoin(room, conference) {
     return {
         type: CONFERENCE_WILL_JOIN,
-        room
+        room,
+        conference
     };
 }
 
@@ -252,14 +256,14 @@ export function createConference() {
             throw new Error('Cannot join conference without room name');
         }
 
-        dispatch(_conferenceWillJoin(room));
-
         const conference
             = connection.initJitsiConference(
 
                 // XXX Lib-jitsi-meet does not accept uppercase letters.
                 room.toLowerCase(),
                 state['features/base/config']);
+
+        dispatch(_conferenceWillJoin(room, conference));
 
         _addConferenceListeners(conference, dispatch);
 

--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -7,6 +7,7 @@ import {
     CONFERENCE_FAILED,
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
+    CONFERENCE_WILL_JOIN,
     CONFERENCE_WILL_LEAVE,
     LOCK_STATE_CHANGED,
     SET_AUDIO_ONLY,
@@ -31,6 +32,9 @@ ReducerRegistry.register('features/base/conference', (state = {}, action) => {
 
     case CONFERENCE_LEFT:
         return _conferenceLeft(state, action);
+
+    case CONFERENCE_WILL_JOIN:
+        return _conferenceWillJoin(state, action);
 
     case CONFERENCE_WILL_LEAVE:
         return _conferenceWillLeave(state, action);
@@ -84,6 +88,7 @@ function _conferenceFailed(state, action) {
             audioOnly: undefined,
             audioOnlyVideoMuted: undefined,
             conference: undefined,
+            joining: undefined,
             leaving: undefined,
 
             /**
@@ -133,6 +138,7 @@ function _conferenceJoined(state, action) {
              * @type {JitsiConference}
              */
             conference,
+            joining: undefined,
             leaving: undefined,
 
             /**
@@ -167,11 +173,26 @@ function _conferenceLeft(state, action) {
             audioOnly: undefined,
             audioOnlyVideoMuted: undefined,
             conference: undefined,
+            joining: undefined,
             leaving: undefined,
             locked: undefined,
             password: undefined,
             passwordRequired: undefined
         }));
+}
+
+/**
+ * Reduces a specific Redux action CONFERENCE_WILL_JOIN of the feature
+ * base/conference.
+ *
+ * @param {Object} state - The Redux state of the feature base/conference.
+ * @param {Action} action - The Redux action CONFERENCE_WILL_JOIN to reduce.
+ * @private
+ * @returns {Object} The new state of the feature base/conference after the
+ * reduction of the specified action.
+ */
+function _conferenceWillJoin(state, action) {
+    return set(state, 'joining', action.conference);
 }
 
 /**

--- a/react/features/base/connection/actionTypes.js
+++ b/react/features/base/connection/actionTypes.js
@@ -33,6 +33,16 @@ export const CONNECTION_ESTABLISHED = Symbol('CONNECTION_ESTABLISHED');
 export const CONNECTION_FAILED = Symbol('CONNECTION_FAILED');
 
 /**
+ * The type of (redux) action which signals that a connection will connect.
+ *
+ * {
+ *     type: CONNECTION_WILL_CONNECT,
+ *     connection: JitsiConnection
+ * }
+ */
+export const CONNECTION_WILL_CONNECT = Symbol('CONNECTION_WILL_CONNECT');
+
+/**
  * The type of (redux) action which sets the location URL of the application,
  * connection, conference, etc.
  *

--- a/react/features/base/connection/reducer.js
+++ b/react/features/base/connection/reducer.js
@@ -5,6 +5,8 @@ import { assign, ReducerRegistry, set } from '../redux';
 import {
     CONNECTION_DISCONNECTED,
     CONNECTION_ESTABLISHED,
+    CONNECTION_FAILED,
+    CONNECTION_WILL_CONNECT,
     SET_LOCATION_URL
 } from './actionTypes';
 
@@ -20,6 +22,12 @@ ReducerRegistry.register(
 
         case CONNECTION_ESTABLISHED:
             return _connectionEstablished(state, action);
+
+        case CONNECTION_FAILED:
+            return _connectionFailed(state, action);
+
+        case CONNECTION_WILL_CONNECT:
+            return _connectionWillConnect(state, action);
 
         case SET_LOCATION_URL:
             return _setLocationURL(state, action);
@@ -61,7 +69,42 @@ function _connectionDisconnected(
 function _connectionEstablished(
         state: Object,
         { connection }: { connection: Object }) {
-    return set(state, 'connection', connection);
+    return assign(state, {
+        connecting: undefined,
+        connection
+    });
+}
+
+/* eslint-disable no-unused-vars */
+
+/**
+ * Reduces a specific Redux action CONNECTION_FAILED of the feature
+ * base/connection.
+ *
+ * @param {Object} state - The Redux state of the feature base/connection.
+ * @param {Action} action - The Redux action CONNECTION_FAILED to reduce.
+ * @private
+ * @returns {Object} The new state of the feature base/connection after the
+ * reduction of the specified action.
+ */
+function _connectionFailed(state: Object, action: Object) {
+    return set(state, 'connecting', undefined);
+}
+
+/* eslint-enable no-unused-vars */
+
+/**
+ * Reduces a specific Redux action CONNECTION_WILL_CONNECT of the feature
+ * base/connection.
+ *
+ * @param {Object} state - The Redux state of the feature base/connection.
+ * @param {Action} action - The Redux action CONNECTION_WILL_CONNECT to reduce.
+ * @private
+ * @returns {Object} The new state of the feature base/connection after the
+ * reduction of the specified action.
+ */
+function _connectionWillConnect(state: Object, action: Object) {
+    return set(state, 'connecting', action.connection);
 }
 
 /**

--- a/react/index.native.js
+++ b/react/index.native.js
@@ -56,18 +56,37 @@ class Root extends Component {
             url: this.props.url
         };
 
-        // Handle the URL, if any, with which the app was launched.
-        Linking.getInitialURL()
-            .then(url => this.setState({ url }))
-            .catch(err => {
-                console.error('Failed to get initial URL', err);
+        // Handle the URL the application was launched with, but props have
+        // precedence.
+        if (typeof this.props.url === 'undefined') {
+            Linking.getInitialURL()
+                .then(url => {
+                    if (typeof this.state.url === 'undefined') {
+                        this.setState({ url });
+                    }
+                })
+                .catch(err => {
+                    console.error('Failed to get initial URL', err);
 
-                // XXX Start with an empty URL if getting the initial URL fails;
-                // otherwise, nothing will be rendered.
-                if (this.state.url !== null) {
-                    this.setState({ url: null });
-                }
-            });
+                    if (typeof this.state.url === 'undefined') {
+                        // Start with an empty URL if getting the initial URL
+                        // fails otherwise, nothing will be rendered.
+                        this.setState({ url: null });
+                    }
+                });
+        }
+    }
+
+    /**
+     * Implements React's {@link Component#componentWillReceiveProps()}.
+     *
+     * New props can be set from the native side by setting the appProperties
+     * property (on iOS) or calling setAppProperties (on Android).
+     *
+     * @inheritdoc
+     */
+    componentWillReceiveProps(nextProps) {
+        this.setState({ url: nextProps.url || null });
     }
 
     /**


### PR DESCRIPTION
React (pun intended) to prop changes, that is, load the new specified URL.

In addition, fix a hidden bug in loading the initial URL from the linking
module: we prefer a prop to the URL the app was launched with, in case somehow
both are specified. We (the Jitsi Meet app) are not going to run into this
corner case, but let's be defensive just in case.