### PR TITLE
fix(add-people): remove line break from searchPeople request

### DIFF
--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -12,8 +12,8 @@ export function searchPeople(serviceUrl, jwt, text) {
     const queryTypes = '["conferenceRooms","user","room"]';
 
     return new Promise((resolve, reject) => {
-        $.getJSON(`${serviceUrl}?query=${encodeURIComponent(text)}
-            &queryTypes=${queryTypes}&jwt=${jwt}`,
+        $.getJSON(`${serviceUrl}?query=${encodeURIComponent(text)}`
+            + `&queryTypes=${queryTypes}&jwt=${jwt}`,
         response => resolve(response)
         ).fail((jqxhr, textStatus, error) =>
             reject(error)


### PR DESCRIPTION
Chrome has deprecated line breaks in requests. The template
literal used for the searchPeople url has a line breaks. Instead
of line breaking the request url, concatenate it together.