### PR TITLE
[RN] Don't open the camera on startup when there is no welcome page

### DIFF
--- a/react/features/app/middleware.js
+++ b/react/features/app/middleware.js
@@ -76,22 +76,31 @@ function _navigate({ dispatch, getState }) {
     const { app, getRouteToRender } = state['features/app'];
     const routeToRender = getRouteToRender && getRouteToRender(state);
 
-    // Create/destroy the local tracks as needed: create them the first time we
-    // are going to render an actual route (be that the WelcomePage or the
-    // Conference).
-    //
-    // When the WelcomePage is disabled, the app will transition to the
-    // null/undefined route. Detect these transitions and create/destroy the
-    // local tracks so the camera doesn't stay open if the app is not rendering
-    // any component.
-    if (typeof routeToRender === 'undefined' || routeToRender === null) {
-        // Destroy the local tracks if there is no route to render and there is
-        // no welcome page.
-        app.props.welcomePageEnabled || dispatch(destroyLocalTracks());
-    } else {
-        // Create the local tracks if they haven't been created yet.
-        state['features/base/tracks'].some(t => t.local)
-            || dispatch(createInitialLocalTracks());
+    // FIXME The following is logic specific to the user experience of the
+    // mobile/React Native app. Firstly, I don't like that it's here at all.
+    // Secondly, I copied the mobile/React Native detection from
+    // react/features/base/config/reducer.js because I couldn't iron out an
+    // abstraction. Because of the first point, I'm leaving the second point
+    // unresolved to attract attention to the fact that the following needs more
+    // thinking.
+    if (navigator.userAgent.match(/react[ \s-]*native/i)) {
+        // Create/destroy the local tracks as needed: create them the first time
+        // we are going to render an actual route (be that the WelcomePage or
+        // the Conference).
+        //
+        // When the WelcomePage is disabled, the app will transition to the
+        // null/undefined route. Detect these transitions and create/destroy the
+        // local tracks so the camera doesn't stay open if the app is not
+        // rendering any component.
+        if (typeof routeToRender === 'undefined' || routeToRender === null) {
+            // Destroy the local tracks if there is no route to render and there
+            // is no WelcomePage.
+            app.props.welcomePageEnabled || dispatch(destroyLocalTracks());
+        } else {
+            // Create the local tracks if they haven't been created yet.
+            state['features/base/tracks'].some(t => t.local)
+                || dispatch(createInitialLocalTracks());
+        }
     }
 
     app._navigate(routeToRender);

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import { LIB_DID_DISPOSE, LIB_DID_INIT } from '../lib-jitsi-meet';
 import {
     CAMERA_FACING_MODE,
     MEDIA_TYPE,
@@ -14,10 +13,6 @@ import {
 } from '../media';
 import { MiddlewareRegistry } from '../redux';
 
-import {
-    createInitialLocalTracks,
-    destroyLocalTracks
-} from './actions';
 import { TRACK_ADDED, TRACK_REMOVED, TRACK_UPDATED } from './actionTypes';
 import { getLocalTrack, setTrackMuted } from './functions';
 
@@ -33,14 +28,6 @@ declare var APP: Object;
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-    case LIB_DID_DISPOSE:
-        store.dispatch(destroyLocalTracks());
-        break;
-
-    case LIB_DID_INIT:
-        store.dispatch(createInitialLocalTracks());
-        break;
-
     case SET_AUDIO_MUTED:
         _setMuted(store, action, MEDIA_TYPE.AUDIO);
         break;


### PR DESCRIPTION
The end goal of this patch was to avoid opening the camera when there is no
welcome page.

In order to achieve this, the logic for creating the local tracks was
refactored:

Before this patch local tracks were created when lib-jitsi-meet was initialized,
and destroyed when it was deinitialized. As a side note, this meant that when a
conference in a non-default domain was joined, local tracks were destroyed and
recreated in quick succession.

Now, local trans are created and destroyed based on what the next route will be,
and this happens when the target room has been decided. This allows us to create
local tracks the moment we need to render any route, and destroy them when there
is no route to be rendered. As an interesting byproduct, this refactor also
avoids the destruction + recreation of local tracks when a conference in a
non-default domain was left.