### PR TITLE
fix(tracks): remove mute and type change listeners on track remove

### DIFF
--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -179,6 +179,9 @@ export function trackMutedChanged(track) {
  * @returns {{ type: TRACK_REMOVED, track: Track }}
  */
 export function trackRemoved(track) {
+    track.removeAllListeners(JitsiTrackEvents.TRACK_MUTE_CHANGED);
+    track.removeAllListeners(JitsiTrackEvents.TRACK_VIDEOTYPE_CHANGED);
+
     return {
         type: TRACK_REMOVED,
         track: {


### PR DESCRIPTION
Listeners were set for when a track muted or changed its video
type, but the listeners were never removed. This would could
cause events to keep firing on the removed tracks, which would
cause redux to fire and error because the tracks were no longer
known. That the tracks still fire events after removal is
another issue...