### PR TITLE
feat: add option to disable desktop sharing

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -544,7 +544,27 @@ export default {
     audioMuted: false,
     videoMuted: false,
     isSharingScreen: false,
+    /**
+     * Indicates if the desktop sharing functionality has been enabled.
+     * It takes into consideration {@link isDesktopSharingDisabledByConfig}
+     * as well as the status returned by
+     * {@link JitsiMeetJS.isDesktopSharingEnabled()}. The latter can be false
+     * either if the desktop sharing is not supported by the current browser
+     * or if it was disabled through lib-jitsi-meet specific options (check
+     * config.js for listed options).
+     */
     isDesktopSharingEnabled: false,
+    /**
+     * Set to <tt>true</tt> if the desktop sharing functionality has been
+     * explicitly disabled in the config.
+     */
+    isDesktopSharingDisabledByConfig: false,
+    /**
+     * The text displayed when the desktop sharing button is disabled through
+     * the config. The value is set through
+     * {@link interfaceConfig.DESKTOP_SHARING_BUTTON_DISABLED_TOOLTIP}.
+     */
+    desktopSharingDisabledTooltip: null,
     /*
      * Whether the local "raisedHand" flag is on.
      */
@@ -601,8 +621,15 @@ export default {
                     ConnectionEvents.CONNECTION_FAILED,
                     _connectionFailedHandler);
                 APP.connection = connection = con;
-                this.isDesktopSharingEnabled =
-                    JitsiMeetJS.isDesktopSharingEnabled();
+
+                // Desktop sharing related stuff:
+                this.isDesktopSharingDisabledByConfig
+                    = config.disableDesktopSharing;
+                this.isDesktopSharingEnabled
+                    = !this.isDesktopSharingDisabledByConfig
+                        && JitsiMeetJS.isDesktopSharingEnabled();
+                this.desktopSharingDisabledTooltip
+                    = interfaceConfig.DESKTOP_SHARING_BUTTON_DISABLED_TOOLTIP;
                 eventEmitter.emit(
                     JitsiMeetConferenceEvents.DESKTOP_SHARING_ENABLED_CHANGED,
                     this.isDesktopSharingEnabled);

--- a/config.js
+++ b/config.js
@@ -26,7 +26,10 @@ var config = { // eslint-disable-line no-unused-vars
     clientNode: 'http://jitsi.org/jitsimeet', // The name of client node advertised in XEP-0115 'c' stanza
     //focusUserJid: 'focus@auth.jitsi-meet.example.com', // The real JID of focus participant - can be overridden here
     //defaultSipNumber: '', // Default SIP number
-
+    /**
+     * Disables desktop sharing functionality.
+     */
+    disableDesktopSharing: false,
     // The ID of the jidesha extension for Chrome.
     desktopSharingChromeExtId: null,
     // Whether desktop sharing should be disabled on Chrome.

--- a/interface_config.js
+++ b/interface_config.js
@@ -2,6 +2,12 @@ var interfaceConfig = { // eslint-disable-line no-unused-vars
     // TO FIX: this needs to be handled from SASS variables. There are some
     // methods allowing to use variables both in css and js.
     DEFAULT_BACKGROUND: '#474747',
+    /**
+     * In case the desktop sharing is disabled through the config the button
+     * will not be hidden, but displayed as disabled with this text us as
+     * a tooltip.
+     */
+    DESKTOP_SHARING_BUTTON_DISABLED_TOOLTIP: null,
     INITIAL_TOOLBAR_TIMEOUT: 20000,
     TOOLBAR_TIMEOUT: 4000,
     DEFAULT_REMOTE_DISPLAY_NAME: "Fellow Jitster",

--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -168,6 +168,23 @@ const IndicatorFontSizes = {
     },
 
     /**
+     * Sets the tooltip to the given element, but instead of using translation
+     * key uses text value.
+     *
+     * @param element the element to set the tooltip to
+     * @param text the tooltip text
+     * @param position the position of the tooltip in relation to the element
+     */
+    setTooltipText(element, text, position) {
+        if (element) {
+            UIUtil.removeTooltip(element);
+
+            element.setAttribute('data-tooltip', TOOLTIP_POSITIONS[position]);
+            element.setAttribute('content', text);
+        }
+    },
+
+    /**
      * Removes the tooltip to the given element.
      *
      * @param element the element to remove the tooltip from

--- a/react/features/toolbox/actions.web.js
+++ b/react/features/toolbox/actions.web.js
@@ -235,13 +235,22 @@ export function setProfileButtonUnclickable(unclickable: boolean): Function {
 export function showDesktopSharingButton(): Function {
     return (dispatch: Dispatch<*>) => {
         const buttonName = 'desktop';
+        const disabledTooltipText
+            = APP.conference.desktopSharingDisabledTooltip;
+        const showTooltip
+            = disabledTooltipText
+                && APP.conference.isDesktopSharingDisabledByConfig;
         const visible
-            = APP.conference.isDesktopSharingEnabled
-                && UIUtil.isButtonEnabled(buttonName);
+            = UIUtil.isButtonEnabled(buttonName)
+                && (APP.conference.isDesktopSharingEnabled || showTooltip);
 
-        dispatch(setToolbarButton(buttonName, {
-            hidden: !visible
-        }));
+        const newState = {
+            enabled: APP.conference.isDesktopSharingEnabled,
+            hidden: !visible,
+            tooltipText: showTooltip ? disabledTooltipText : undefined
+        };
+
+        dispatch(setToolbarButton(buttonName, newState));
     };
 }
 

--- a/react/features/toolbox/components/ToolbarButton.web.js
+++ b/react/features/toolbox/components/ToolbarButton.web.js
@@ -221,9 +221,15 @@ class ToolbarButton extends AbstractToolbarButton {
         if (UIUtil.isButtonEnabled(name)) {
 
             if (!button.unclickable) {
-                UIUtil.setTooltip(this.button,
-                    button.tooltipKey,
-                    tooltipPosition);
+                if (button.tooltipText) {
+                    UIUtil.setTooltipText(this.button,
+                        button.tooltipText,
+                        tooltipPosition);
+                } else {
+                    UIUtil.setTooltip(this.button,
+                        button.tooltipKey,
+                        tooltipPosition);
+                }
             }
 
             if (button.shortcut) {

--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -43,6 +43,10 @@ export function getButtonAttributesByProps(props: Object = {})
         result.style = { display: 'none' };
     }
 
+    if (props.tooltipText) {
+        result.content = props.tooltipText;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Depends on https://github.com/jitsi/lib-jitsi-meet/pull/548

config.disableDesktopSharing - when set to false will disable desktop
sharing

interfaceConfig.DESKTOP_SHARING_BUTTON_DISABLED_TOOLTIP - when value is
assigned, will not hide the desktop sharing button completely, but show
as disabled with this value used as the tooltip text.