### PR TITLE
accept 'avatar' as well as 'avatarUrl' for avatar field

### DIFF
--- a/react/features/conference/route.js
+++ b/react/features/conference/route.js
@@ -114,10 +114,10 @@ function _setTokenData() {
     const { caller } = state['features/jwt'];
 
     if (caller) {
-        const { avatarUrl, email, name } = caller;
+        const { avatarUrl, avatar, email, name } = caller;
 
         APP.settings.setEmail((email || '').trim(), true);
-        APP.settings.setAvatarUrl((avatarUrl || '').trim());
+        APP.settings.setAvatarUrl((avatarUrl || avatar || '').trim());
         APP.settings.setDisplayName((name || '').trim(), true);
     }
 }

--- a/react/features/jwt/components/CallOverlay.js
+++ b/react/features/jwt/components/CallOverlay.js
@@ -158,7 +158,7 @@ class CallOverlay extends Component {
      */
     render() {
         const { className, ringing } = this.state;
-        const { avatarUrl, name } = this.props._callee;
+        const { avatarUrl, avatar, name } = this.props._callee;
 
         return (
             <Container
@@ -171,7 +171,7 @@ class CallOverlay extends Component {
                     </Text>
                     <Avatar
                         { ...this._style('ringing__avatar') }
-                        uri = { avatarUrl } />
+                        uri = { avatarUrl || avatar } />
                     <Container
                         { ...this._style('ringing__caller-info') }>
                         <Text


### PR DESCRIPTION
New token scheme has slightly simplified field names, so use them if available