### PR TITLE
misc: fix dispatching actions twice when mapDispatchToProps is used

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -228,7 +228,7 @@ function _mapDispatchToProps(dispatch) {
          * @private
          */
         _onConnect() {
-            return dispatch(connect());
+            dispatch(connect());
         },
 
         /**
@@ -238,7 +238,7 @@ function _mapDispatchToProps(dispatch) {
          * @private
          */
         _onDisconnect() {
-            return dispatch(disconnect());
+            dispatch(disconnect());
         },
 
         /**
@@ -250,7 +250,7 @@ function _mapDispatchToProps(dispatch) {
          * @private
          */
         _setToolboxVisible(visible: boolean) {
-            return dispatch(setToolboxVisible(visible));
+            dispatch(setToolboxVisible(visible));
         }
     };
 }

--- a/react/features/overlay/components/ReloadButton.js
+++ b/react/features/overlay/components/ReloadButton.js
@@ -79,7 +79,7 @@ function _mapDispatchToProps(dispatch: Function): Object {
          * @returns {Object} Dispatched action.
          */
         _reloadNow() {
-            return dispatch(_reloadNow());
+            dispatch(_reloadNow());
         }
     };
 }

--- a/react/features/toolbox/components/SecondaryToolbar.web.js
+++ b/react/features/toolbox/components/SecondaryToolbar.web.js
@@ -121,7 +121,7 @@ function _mapDispatchToProps(dispatch: Function): Object {
          * @returns {Object} Dispatched action.
          */
         _onSideToolbarContainerToggled(containerId: string) {
-            return dispatch(toggleSideToolbarContainer(containerId));
+            dispatch(toggleSideToolbarContainer(containerId));
         }
     };
 }

--- a/react/features/toolbox/components/Toolbox.native.js
+++ b/react/features/toolbox/components/Toolbox.native.js
@@ -268,7 +268,7 @@ function _mapDispatchToProps(dispatch) {
          * @type {Function}
          */
         _onRoomLock() {
-            return dispatch(beginRoomLockRequest());
+            dispatch(beginRoomLockRequest());
         },
 
         /**
@@ -279,7 +279,7 @@ function _mapDispatchToProps(dispatch) {
          * @type {Function}
          */
         _onShareRoom() {
-            return dispatch(beginShareRoom());
+            dispatch(beginShareRoom());
         },
 
         /**
@@ -290,7 +290,7 @@ function _mapDispatchToProps(dispatch) {
          * @type {Function}
          */
         _onToggleAudioOnly() {
-            return dispatch(toggleAudioOnly());
+            dispatch(toggleAudioOnly());
         },
 
         /**
@@ -302,7 +302,7 @@ function _mapDispatchToProps(dispatch) {
          * @type {Function}
          */
         _onToggleCameraFacingMode() {
-            return dispatch(toggleCameraFacingMode());
+            dispatch(toggleCameraFacingMode());
         }
     };
 }

--- a/react/features/toolbox/functions.native.js
+++ b/react/features/toolbox/functions.native.js
@@ -31,7 +31,7 @@ export function abstractMapDispatchToProps(dispatch: Dispatch<*>): Object {
             // business to know that anyway. The undefined value is our
             // expression of (1) the lack of knowledge & (2) the desire to no
             // longer have a valid room name to join.
-            return dispatch(appNavigate(undefined));
+            dispatch(appNavigate(undefined));
         },
 
         /**
@@ -43,7 +43,7 @@ export function abstractMapDispatchToProps(dispatch: Dispatch<*>): Object {
          * @type {Function}
          */
         _onToggleAudio() {
-            return dispatch(toggleAudioMuted());
+            dispatch(toggleAudioMuted());
         },
 
         /**
@@ -54,7 +54,7 @@ export function abstractMapDispatchToProps(dispatch: Dispatch<*>): Object {
          * @type {Function}
          */
         _onToggleVideo() {
-            return dispatch(toggleVideoMuted());
+            dispatch(toggleVideoMuted());
         }
     };
 }


### PR DESCRIPTION
The functions need not return anything, or it will be dispatched as another
action.