### PR TITLE
[Android] Update minimum and target SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ allprojects {
 ext {
     compileSdkVersion = 25
     buildToolsVersion = "25.0.3"
-    minSdkVersion    = 16
+    minSdkVersion    = 19
     targetSdkVersion = 25
 }
 


### PR DESCRIPTION
We don't really support API 16, those devices are really old and we cannot test
them. There are some crashes specific to those, but there is not much we can do,
so let's just stop pretending we support them.

In addition, since we compile with API level 25, there is no reason to not set
it as the target.