### PR TITLE
fix(connection-indicator): rename calls to hiding the indicator

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -837,9 +837,9 @@ var VideoLayout = {
         for (var video in remoteVideos) {
             let remoteVideo = remoteVideos[video];
             if (remoteVideo)
-                remoteVideo.hideIndicator();
+                remoteVideo.removeConnectionIndicator();
         }
-        localVideoThumbnail.hideIndicator();
+        localVideoThumbnail.removeConnectionIndicator();
     },
 
     removeParticipantContainer (id) {


### PR DESCRIPTION
This broke because the method names changed when the top icons of the thumbnail got reactified. This likely broke because either I just missed it during initial development or missed the change while redoing the changes due to conflicts.

This mainly affected when someone got kicked out of the conference. That's when the indicators are hidden. However, another script error occurs when getting kicked out, and its origin is  seemingly unrelated to the indicator.