### PR TITLE
fix(icons): set a size prop for AtlasKit icons

### DIFF
--- a/react/features/dial-out/components/DialOutNumbersForm.web.js
+++ b/react/features/dial-out/components/DialOutNumbersForm.web.js
@@ -24,13 +24,6 @@ const DEFAULT_COUNTRY = {
 };
 
 /**
- * The expand icon of the dropdown menu.
- *
- * @type {ReactElement}
- */
-const EXPAND_ICON = <ExpandIcon label = 'expand' />;
-
-/**
  * React {@code Component} responsible for fetching and displaying dial-out
  * country codes, as well as dialing a phone number.
  *
@@ -208,7 +201,9 @@ class DialOutNumbersForm extends Component {
                     type = 'text'
                     value = { dialCode || '' } />
                 <span className = 'dropdown-trigger-icon'>
-                    { EXPAND_ICON }
+                    <ExpandIcon
+                        label = 'expand'
+                        size = 'medium' />
                 </span>
             </div>
         );

--- a/react/features/invite/components/DialInNumbersForm.js
+++ b/react/features/invite/components/DialInNumbersForm.js
@@ -210,7 +210,9 @@ class DialInNumbersForm extends Component {
                     type = 'text'
                     value = { triggerText || '' } />
                 <span className = 'dial-in-numbers-trigger-icon'>
-                    <ExpandIcon label = 'expand' />
+                    <ExpandIcon
+                        label = 'expand'
+                        size = 'medium' />
                 </span>
             </div>
         );


### PR DESCRIPTION
With the upgarde of @atlaskit/icon to 7.0.0, the size prop
essentially became required to maintain its appearance in the
jitsi app, otherwise it'll unexpectedly try to take up the
available space and cause minor display issues.