### PR TITLE
Remove primary toolbar splitter

### DIFF
--- a/css/themes/_light.scss
+++ b/css/themes/_light.scss
@@ -94,7 +94,6 @@ $popupMenuSelectedItemBackground: rgba(256, 256, 256, .2);
 $secondaryToolbarBg: rgba(0, 0, 0, 0.5);
 // TOFIX: Once moved to react rename to match the side panel class name.
 $sideToolbarContainerBg: rgba(0, 0, 0, 0.75);
-$splitterColor: #ccc;
 $toolbarBackground: rgba(0, 0, 0, 0.5);
 $toolbarBadgeBackground: #165ECC;
 $toolbarBadgeColor: #FFFFFF;

--- a/interface_config.js
+++ b/interface_config.js
@@ -28,12 +28,6 @@ var interfaceConfig = { // eslint-disable-line no-unused-vars
      */
     AUTHENTICATION_ENABLE: true,
     /**
-     * The index of the splitter button in the main toolbar. The splitter
-     * button is a button in the toolbar that will be applied a special styling
-     * visually dividing the toolbar buttons.
-     */
-    //MAIN_TOOLBAR_SPLITTER_INDEX: -1,
-    /**
      * the toolbar buttons line is intentionally left in one line, to be able
      * to easily override values or remove them using regex
      */

--- a/react/features/toolbox/components/PrimaryToolbar.web.js
+++ b/react/features/toolbox/components/PrimaryToolbar.web.js
@@ -31,28 +31,6 @@ class PrimaryToolbar extends Component {
     state: Object;
 
     /**
-     * Constructs instance of primary toolbar React component.
-     *
-     * @param {Object} props - React component's properties.
-     */
-    constructor(props) {
-        super(props);
-
-        const splitterIndex = interfaceConfig.MAIN_TOOLBAR_SPLITTER_INDEX;
-
-        this.state = {
-
-            /**
-             * If deployment supports toolbar splitter this value contains its
-             * index.
-             *
-             * @type {number}
-             */
-            splitterIndex
-        };
-    }
-
-    /**
      * Renders primary toolbar component.
      *
      * @returns {ReactElement}
@@ -67,7 +45,6 @@ class PrimaryToolbar extends Component {
             return null;
         }
 
-        const { splitterIndex } = this.state;
         const { primaryToolbarClassName } = getToolbarClassNames(this.props);
         const tooltipPosition
             = interfaceConfig.filmStripOnly ? 'left' : 'bottom';
@@ -75,7 +52,6 @@ class PrimaryToolbar extends Component {
         return (
             <Toolbar
                 className = { primaryToolbarClassName }
-                splitterIndex = { splitterIndex }
                 toolbarButtons = { _primaryToolbarButtons }
                 tooltipPosition = { tooltipPosition } />
         );

--- a/react/features/toolbox/components/Toolbar.web.js
+++ b/react/features/toolbox/components/Toolbar.web.js
@@ -45,12 +45,6 @@ class Toolbar extends Component {
         className: React.PropTypes.string,
 
         /**
-         * If the toolbar requires splitter this property defines splitter
-         * index.
-         */
-        splitterIndex: React.PropTypes.number,
-
-        /**
          * Map with toolbar buttons.
          */
         toolbarButtons: React.PropTypes.instanceOf(Map),
@@ -105,12 +99,11 @@ class Toolbar extends Component {
      * @param {Array} acc - Toolbar buttons array.
      * @param {Array} keyValuePair - Key value pair containing button and its
      * key.
-     * @param {number} index - Index of the key value pair in the array.
      * @private
-     * @returns {Array} Array of toolbar buttons and splitter if it's on.
+     * @returns {Array} Array of toolbar buttons.
      */
-    _renderToolbarButton(acc: Array<*>, keyValuePair: Array<*>,
-                         index: number): Array<ReactElement<*>> {
+    _renderToolbarButton(acc: Array<*>,
+                         keyValuePair: Array<*>): Array<ReactElement<*>> {
         const [ key, button ] = keyValuePair;
 
         if (button.component) {
@@ -123,13 +116,7 @@ class Toolbar extends Component {
             return acc;
         }
 
-        const { splitterIndex, tooltipPosition } = this.props;
-
-        if (splitterIndex && index === splitterIndex) {
-            const splitter = <span className = 'toolbar__splitter' />;
-
-            acc.push(splitter);
-        }
+        const { tooltipPosition } = this.props;
 
         const { onClick, onMount, onUnmount } = button;
 


### PR DESCRIPTION
The primary toolbar splitter isn't used anymore and only adds complexity to the code.