### PR TITLE
Make Chinese(Simplified) selectable in settings

### DIFF
--- a/react/features/base/i18n/constants.js
+++ b/react/features/base/i18n/constants.js
@@ -22,7 +22,8 @@ export const LANGUAGES = [
     'sk',
     'sl',
     'sv',
-    'tr'
+    'tr',
+    'zhCN'
 ];
 
 /**


### PR DESCRIPTION
Hi,

I noticed that even though translation of Chinese(Simplified) has been almost complete at http://translate.jitsi.org/, the language is not selectable in the settings side panel. Could you add the language there?

Thank you.