### PR TITLE
[Android] Fix resource leak when JitsiMeetView is destroyed

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -56,6 +56,9 @@ public class MainActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
 
+        view.dispose();
+        view = null;
+
         JitsiMeetView.onHostDestroy(this);
     }
 
@@ -105,6 +108,12 @@ See JitsiMeetView.setWelcomePageEnabled.
 
 The `JitsiMeetView` class is the core of Jitsi Meet SDK. It's designed to
 display a Jitsi Meet conference (or a welcome page).
+
+#### dispose()
+
+Releases all resources associated with this view. This method MUST be called
+when the Activity holding this view is going to be destroyed, usually in the
+`onDestroy()` method.
 
 #### getListener()
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -154,6 +154,11 @@ public class JitsiMeetActivity extends AppCompatActivity {
     protected void onDestroy() {
         super.onDestroy();
 
+        if (view != null) {
+            view.dispose();
+            view = null;
+        }
+
         JitsiMeetView.onHostDestroy(this);
     }
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -200,6 +200,21 @@ public class JitsiMeetView extends FrameLayout {
     }
 
     /**
+     * Releases the React resources (specifically the {@link ReactRootView})
+     * associated with this view.
+     *
+     * This method MUST be called when the Activity holding this view is destroyed, typically in the
+     * {@code onDestroy} method.
+     */
+    public void dispose() {
+        if (reactRootView != null) {
+            removeView(reactRootView);
+            reactRootView.unmountReactApplication();
+            reactRootView = null;
+        }
+    }
+
+    /**
      * Gets the {@link JitsiMeetViewListener} set on this {@code JitsiMeetView}.
      *
      * @return The {@code JitsiMeetViewListener} set on this
@@ -254,10 +269,7 @@ public class JitsiMeetView extends FrameLayout {
 
         // TODO: ReactRootView#setAppProperties is only available on React
         // Native 0.45, so destroy the current root view and create a new one.
-        if (reactRootView != null) {
-            removeView(reactRootView);
-            reactRootView = null;
-        }
+        dispose();
 
         reactRootView = new ReactRootView(getContext());
         reactRootView


### PR DESCRIPTION
In iOS this is automagically done in the view destructor, bunt we don't have
that luxury in Java we have to do it manually.

The new disponse() method MUST be called when the Activity holding the view is
going to be destroyed, typically in the onDestroy() handler.