### PR TITLE
[RN] Alternative to JitsiMeetView.loadURL w/o URL

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -93,10 +93,6 @@ See JitsiMeetView.getWelcomePageEnabled.
 
 See JitsiMeetView.loadURL.
 
-#### loadURLString(String)
-
-See JitsiMeetView.loadURLString.
-
 #### setWelcomePageEnabled(boolean)
 
 See JitsiMeetView.setWelcomePageEnabled.
@@ -118,12 +114,22 @@ empty view will be rendered when not in a conference. Defaults to false.
 #### loadURL(URL)
 
 Loads a specific URL which may identify a conference to join. If the specified
-URL is null, the Welcome page is displayed instead.
+URL is null and the Welcome page is enabled, the Welcome page is displayed
+instead.
 
 #### loadURLString(String)
 
 Loads a specific URL which may identify a conference to join. If the specified
-URL is null, the Welcome page is displayed instead.
+URL is null and the Welcome page is enabled, the Welcome page is displayed
+instead.
+
+#### loadURLObject(Bundle)
+
+Loads a specific URL which may identify a conference to join. The URL is
+specified in the form of a Bundle of properties which (1) internally are
+sufficient to construct a URL (string) while (2) abstracting the specifics of
+constructing the URL away from API clients/consumers. If the specified URL is
+null and the Welcome page is enabled, the Welcome page is displayed instead.
 
 #### setListener(listener)
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -233,21 +233,24 @@ public class JitsiMeetView extends FrameLayout {
     }
 
     /**
-     * Loads a specific URL {@link String} which may identify a conference to
-     * join. If the specified URL {@code String} is {@code null}, the Welcome
-     * page is displayed instead.
+     * Loads a specific URL which may identify a conference to join. The URL is
+     * specified in the form of a {@link Bundle} of properties which (1)
+     * internally are sufficient to construct a URL {@code String} while (2)
+     * abstracting the specifics of constructing the URL away from API
+     * clients/consumers. If the specified URL is {@code null} and the Welcome
+     * page is enabled, the Welcome page is displayed instead.
      *
-     * @param urlString - The URL {@code String} to load which may identify a
-     * conference to join.
+     * @param urlObject - The URL to load which may identify a conference to
+     * join.
      */
-    public void loadURLString(@Nullable String urlString) {
+    public void loadURLObject(@Nullable Bundle urlObject) {
         Bundle props = new Bundle();
 
         // externalAPIScope
         props.putString("externalAPIScope", externalAPIScope);
         // url
-        if (urlString != null) {
-            props.putString("url", urlString);
+        if (urlObject != null) {
+            props.putBundle("url", urlObject);
         }
         // welcomePageEnabled
         props.putBoolean("welcomePageEnabled", welcomePageEnabled);
@@ -264,6 +267,26 @@ public class JitsiMeetView extends FrameLayout {
             .startReactApplication(reactInstanceManager, "App", props);
         reactRootView.setBackgroundColor(BACKGROUND_COLOR);
         addView(reactRootView);
+    }
+
+    /**
+     * Loads a specific URL {@link String} which may identify a conference to
+     * join. If the specified URL {@code String} is {@code null}, the Welcome
+     * page is displayed instead.
+     *
+     * @param urlString - The URL {@code String} to load which may identify a
+     * conference to join.
+     */
+    public void loadURLString(@Nullable String urlString) {
+        Bundle urlObject;
+
+        if (urlString == null) {
+            urlObject = null;
+        } else {
+            urlObject = new Bundle();
+            urlObject.putString("url", urlString);
+        }
+        loadURLObject(urlObject);
     }
 
     /**

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -222,8 +222,8 @@ public class JitsiMeetView extends FrameLayout {
 
     /**
      * Loads a specific {@link URL} which may identify a conference to join. If
-     * the specified {@code URL} is {@code null}, the Welcome page is displayed
-     * instead.
+     * the specified {@code URL} is {@code null} and the Welcome page is
+     * enabled, the Welcome page is displayed instead.
      *
      * @param url - The {@code URL} to load which may identify a conference to
      * join.
@@ -263,16 +263,15 @@ public class JitsiMeetView extends FrameLayout {
         }
 
         reactRootView = new ReactRootView(getContext());
-        reactRootView
-            .startReactApplication(reactInstanceManager, "App", props);
+        reactRootView.startReactApplication(reactInstanceManager, "App", props);
         reactRootView.setBackgroundColor(BACKGROUND_COLOR);
         addView(reactRootView);
     }
 
     /**
      * Loads a specific URL {@link String} which may identify a conference to
-     * join. If the specified URL {@code String} is {@code null}, the Welcome
-     * page is displayed instead.
+     * join. If the specified URL {@code String} is {@code null} and the Welcome
+     * page is enabled, the Welcome page is displayed instead.
      *
      * @param urlString - The URL {@code String} to load which may identify a
      * conference to join.

--- a/ios/README.md
+++ b/ios/README.md
@@ -20,10 +20,10 @@ To get started:
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  JitsiMeetView *view = (JitsiMeetView *) self.view;
+  JitsiMeetView *jitsiMeetView = (JitsiMeetView *) self.view;
 
-  view.delegate = self;
-  [view loadURL:nil];
+  jitsiMeetView.delegate = self;
+  [jitsiMeetView loadURL:nil];
 }
 ```
 
@@ -46,20 +46,40 @@ NOTE: Must be set before `loadURL:`/`loadURLString:` for it to take effect.
 #### loadURL:NSURL
 
 ```objc
-[meetView loadURL:[NSURL URLWithString:@"https://meet.jit.si/test123"]];
+[jitsiMeetView loadURL:[NSURL URLWithString:@"https://meet.jit.si/test123"]];
 ```
 
 Loads a specific URL which may identify a conference to join. If the specified
-URL is `nil`, the Welcome page is displayed instead.
+URL is `nil` and the Welcome page is enabled, the Welcome page is displayed
+instead.
+
+#### loadURLObject:NSDictionary
+
+```objc
+[jitsiMeetView loadURLObject:@{
+    @"url": @"https://meet.jit.si/test123",
+    @"configOverwrite": @{
+        @"startWithAudioMuted": @YES,
+        @"startWithVideoMuted": @NO
+    }
+}];
+```
+
+Loads a specific URL which may identify a conference to join. The URL is
+specified in the form of an `NSDictionary` of properties which (1) internally
+are sufficient to construct a URL (string) while (2) abstracting the specifics
+of constructing the URL away from API clients/consumers. If the specified URL is
+`nil` and the Welcome page is enabled, the Welcome page is displayed instead.
 
 #### loadURLString:NSString
 
 ```objc
-[meetView loadURLString:@"https://meet.jit.si/test123"];
+[jitsiMeetView loadURLString:@"https://meet.jit.si/test123"];
 ```
 
 Loads a specific URL which may identify a conference to join. If the specified
-URL is `nil`, the Welcome page is displayed instead.
+URL is `nil` and the Welcome page is enabled, the Welcome page is displayed
+instead.
 
 #### Universal / deep linking
 

--- a/ios/app/src/ViewController.m
+++ b/ios/app/src/ViewController.m
@@ -32,10 +32,10 @@
     JitsiMeetView *view = (JitsiMeetView *) self.view;
 
     view.delegate = self;
-    // As this is the Jitsi Meet app (i.e. not the Jitsi Meet SDK), we do
-    // want the Welcome page to be enabled. It defaults to disabled in the
-    // SDK at the time of this writing but it is clearer to be explicit
-    // about what we want anyway.
+    // As this is the Jitsi Meet app (i.e. not the Jitsi Meet SDK), we do want
+    // the Welcome page to be enabled. It defaults to disabled in the SDK at the
+    // time of this writing but it is clearer to be explicit about what we want
+    // anyway.
     view.welcomePageEnabled = YES;
     [view loadURL:nil];
 }

--- a/ios/sdk/src/JitsiMeetView.h
+++ b/ios/sdk/src/JitsiMeetView.h
@@ -39,6 +39,8 @@
 
 - (void)loadURL:(NSURL * _Nullable)url;
 
+- (void)loadURLObject:(NSDictionary * _Nullable)urlObject;
+
 - (void)loadURLString:(NSString * _Nullable)urlString;
 
 @end

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -156,6 +156,15 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
 
 #pragma mark Initializers
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [self initWithXXX];
+    }
+
+    return self;
+}
+
 - (instancetype)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
@@ -264,8 +273,10 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
     });
 
     // Hook this JitsiMeetView into ExternalAPI.
-    externalAPIScope = [NSUUID UUID].UUIDString;
-    [views setObject:self forKey:externalAPIScope];
+    if (!externalAPIScope) {
+        externalAPIScope = [NSUUID UUID].UUIDString;
+        [views setObject:self forKey:externalAPIScope];
+    }
 
     // Set a background color which is in accord with the JavaScript and
     // Android parts of the application and causes less perceived visual

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -178,8 +178,8 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
 
 /**
  * Loads a specific {@link NSURL} which may identify a conference to join. If
- * the specified {@code NSURL} is {@code nil}, the Welcome page is displayed
- * instead.
+ * the specified {@code NSURL} is {@code nil} and the Welcome page is enabled,
+ * the Welcome page is displayed instead.
  *
  * @param url - The {@code NSURL} to load which may identify a conference to
  * join.
@@ -223,8 +223,8 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
 
 /**
  * Loads a specific URL {@link NSString} which may identify a conference to
- * join. If the specified URL {@code NSString} is {@code nil}, the Welcome page
- * is displayed instead.
+ * join. If the specified URL {@code NSString} is {@code nil} and the Welcome
+ * page is enabled, the Welcome page is displayed instead.
  *
  * @param urlString - The URL {@code NSString} to load which may identify a
  * conference to join.

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -185,28 +185,25 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
  * join.
  */
 - (void)loadURL:(NSURL *)url {
-    [self loadURLString:(url ? url.absoluteString : nil)];
+    [self loadURLString:url ? url.absoluteString : nil];
 }
 
 /**
- * Loads a specific URL {@link NSString} which may identify a conference to
- * join. If the specified URL {@code NSString} is {@code nil}, the Welcome page
- * is displayed instead.
+ * Loads a specific URL which may identify a conference to join. The URL is
+ * specified in the form of an {@link NSDictionary} of properties which (1)
+ * internally are sufficient to construct a URL {@code NSString} while (2)
+ * abstracting the specifics of constructing the URL away from API
+ * clients/consumers. If the specified URL is {@code nil} and the Welcome page
+ * is enabled, the Welcome page is displayed instead.
  *
- * @param urlString - The URL {@code NSString} to load which may identify a
- * conference to join.
+ * @param urlObject - The URL to load which may identify a conference to join.
  */
-- (void)loadURLString:(NSString *)urlString {
-    NSMutableDictionary *props = [[NSMutableDictionary alloc] init];
-
-    // externalAPIScope
-    [props setObject:externalAPIScope forKey:@"externalAPIScope"];
-    // url
-    if (urlString) {
-        [props setObject:urlString forKey:@"url"];
-    }
-    // welcomePageEnabled
-    [props setObject:@(self.welcomePageEnabled) forKey:@"welcomePageEnabled"];
+- (void)loadURLObject:(NSDictionary *)urlObject {
+    NSDictionary *props = @{
+        @"externalAPIScope": externalAPIScope,
+        @"url": urlObject,
+        @"welcomePageEnabled": @(self.welcomePageEnabled)
+    };
 
     if (rootView == nil) {
         rootView
@@ -222,6 +219,18 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
         // Update props with the new URL.
         rootView.appProperties = props;
     }
+}
+
+/**
+ * Loads a specific URL {@link NSString} which may identify a conference to
+ * join. If the specified URL {@code NSString} is {@code nil}, the Welcome page
+ * is displayed instead.
+ *
+ * @param urlString - The URL {@code NSString} to load which may identify a
+ * conference to join.
+ */
+- (void)loadURLString:(NSString *)urlString {
+    [self loadURLObject:urlString ? @{ @"url": urlString } : nil];
 }
 
 #pragma mark Private methods

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -13,11 +13,7 @@ import { RouteRegistry } from '../../base/react';
 import { MiddlewareRegistry, ReducerRegistry } from '../../base/redux';
 import { toURLString } from '../../base/util';
 
-import {
-    appNavigate,
-    appWillMount,
-    appWillUnmount
-} from '../actions';
+import { appNavigate, appWillMount, appWillUnmount } from '../actions';
 
 declare var APP: Object;
 
@@ -34,7 +30,7 @@ const DEFAULT_URL = 'https://meet.jit.si';
  */
 export class AbstractApp extends Component {
     /**
-     * AbstractApp component's property types.
+     * {@code AbstractApp} component's property types.
      *
      * @static
      */
@@ -46,7 +42,7 @@ export class AbstractApp extends Component {
         defaultURL: React.PropTypes.string,
 
         /**
-         * (Optional) Redux store for this app.
+         * (Optional) redux store for this app.
          */
         store: React.PropTypes.object,
 
@@ -60,24 +56,24 @@ export class AbstractApp extends Component {
     };
 
     /**
-     * Initializes a new AbstractApp instance.
+     * Initializes a new {@code AbstractApp} instance.
      *
-     * @param {Object} props - The read-only React Component props with which
-     * the new instance is to be initialized.
+     * @param {Object} props - The read-only React {@code Component} props with
+     * which the new instance is to be initialized.
      */
     constructor(props) {
         super(props);
 
         this.state = {
             /**
-             * The Route rendered by this AbstractApp.
+             * The Route rendered by this {@code AbstractApp}.
              *
              * @type {Route}
              */
             route: undefined,
 
             /**
-             * The Redux store used by this AbstractApp.
+             * The redux store used by this {@code AbstractApp}.
              *
              * @type {Store}
              */
@@ -118,23 +114,23 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Notifies this mounted React Component that it will receive new props.
-     * Makes sure that this AbstractApp has a Redux store to use.
+     * Notifies this mounted React {@code Component} that it will receive new
+     * props. Makes sure that this {@code AbstractApp} has a redux store to use.
      *
      * @inheritdoc
-     * @param {Object} nextProps - The read-only React Component props that this
-     * instance will receive.
+     * @param {Object} nextProps - The read-only React {@code Component} props
+     * that this instance will receive.
      * @returns {void}
      */
     componentWillReceiveProps(nextProps) {
-        // The consumer of this AbstractApp did not provide a Redux store.
+        // The consumer of this AbstractApp did not provide a redux store.
         if (typeof nextProps.store === 'undefined'
 
-                // The consumer of this AbstractApp did provide a Redux store
+                // The consumer of this AbstractApp did provide a redux store
                 // before. Which means that the consumer changed their mind. In
                 // such a case this instance should create its own internal
-                // Redux store. If the consumer did not provide a Redux store
-                // before, then this instance is using its own internal Redux
+                // redux store. If the consumer did not provide a redux store
+                // before, then this instance is using its own internal redux
                 // store already.
                 && typeof this.props.store !== 'undefined') {
             this.setState({
@@ -166,15 +162,16 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Gets a Location object from the window with information about the current
-     * location of the document. Explicitly defined to allow extenders to
-     * override because React Native does not usually have a location property
-     * on its window unless debugging remotely in which case the browser that is
-     * the remote debugger will provide a location property on the window.
+     * Gets a {@code Location} object from the window with information about the
+     * current location of the document. Explicitly defined to allow extenders
+     * to override because React Native does not usually have a location
+     * property on its window unless debugging remotely in which case the
+     * browser that is the remote debugger will provide a location property on
+     * the window.
      *
      * @public
-     * @returns {Location} A Location object with information about the current
-     * location of the document.
+     * @returns {Location} A {@code Location} object with information about the
+     * current location of the document.
      */
     getWindowLocation() {
         return undefined;
@@ -205,14 +202,14 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Create a ReactElement from the specified component, the specified props
-     * and the props of this AbstractApp which are suitable for propagation to
-     * the children of this Component.
+     * Creates a {@link ReactElement} from the specified component, the
+     * specified props and the props of this {@code AbstractApp} which are
+     * suitable for propagation to the children of this {@code Component}.
      *
-     * @param {Component} component - The component from which the ReactElement
-     * is to be created.
-     * @param {Object} props - The read-only React Component props with which
-     * the ReactElement is to be initialized.
+     * @param {Component} component - The component from which the
+     * {@code ReactElement} is to be created.
+     * @param {Object} props - The read-only React {@code Component} props with
+     * which the {@code ReactElement} is to be initialized.
      * @returns {ReactElement}
      * @protected
      */
@@ -245,12 +242,12 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Initializes a new Redux store instance suitable for use by
-     * this AbstractApp.
+     * Initializes a new redux store instance suitable for use by this
+     * {@code AbstractApp}.
      *
      * @private
-     * @returns {Store} - A new Redux store instance suitable for use by
-     * this AbstractApp.
+     * @returns {Store} - A new redux store instance suitable for use by
+     * this {@code AbstractApp}.
      */
     _createStore() {
         // Create combined reducer from all reducers in ReducerRegistry.
@@ -275,10 +272,11 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Gets the default URL to be opened when this App mounts.
+     * Gets the default URL to be opened when this {@code App} mounts.
      *
      * @protected
-     * @returns {string} The default URL to be opened when this App mounts.
+     * @returns {string} The default URL to be opened when this {@code App}
+     * mounts.
      */
     _getDefaultURL() {
         // If the execution environment provides a Location abstraction, then
@@ -298,10 +296,10 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Gets the Redux store used by this AbstractApp.
+     * Gets the redux store used by this {@code AbstractApp}.
      *
      * @protected
-     * @returns {Store} - The Redux store used by this AbstractApp.
+     * @returns {Store} - The redux store used by this {@code AbstractApp}.
      */
     _getStore() {
         let store = this.state.store;
@@ -314,20 +312,21 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Creates a Redux store to be used by this AbstractApp if such as store is
-     * not defined by the consumer of this AbstractApp through its
-     * read-only React Component props.
+     * Creates a redux store to be used by this {@code AbstractApp} if such as a
+     * store is not defined by the consumer of this {@code AbstractApp} through
+     * its read-only React {@code Component} props.
      *
-     * @param {Object} props - The read-only React Component props that will
-     * eventually be received by this AbstractApp.
+     * @param {Object} props - The read-only React {@code Component} props that
+     * will eventually be received by this {@code AbstractApp}.
      * @private
-     * @returns {Store} - The Redux store to be used by this AbstractApp.
+     * @returns {Store} - The redux store to be used by this
+     * {@code AbstractApp}.
      */
     _maybeCreateStore(props) {
-        // The application Jitsi Meet is architected with Redux. However, I do
+        // The application Jitsi Meet is architected with redux. However, I do
         // not want consumers of the App React Component to be forced into
-        // dealing with Redux. If the consumer did not provide an external Redux
-        // store, utilize an internal Redux store.
+        // dealing with redux. If the consumer did not provide an external redux
+        // store, utilize an internal redux store.
         let store = props.store;
 
         if (typeof store === 'undefined') {
@@ -380,7 +379,7 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Notifies this App that a specific Route is about to be rendered.
+     * Notifies this {@code App} that a specific Route is about to be rendered.
      *
      * @param {Route} route - The Route that is about to be rendered.
      * @private
@@ -394,10 +393,10 @@ export class AbstractApp extends Component {
     }
 
     /**
-     * Navigates this AbstractApp to (i.e. opens) a specific URL.
+     * Navigates this {@code AbstractApp} to (i.e. opens) a specific URL.
      *
-     * @param {string|Object} url - The URL to navigate this AbstractApp to
-     * (i.e. the URL to open).
+     * @param {string|Object} url - The URL to navigate this {@code AbstractApp}
+     * to (i.e. the URL to open).
      * @protected
      * @returns {void}
      */

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -11,6 +11,7 @@ import {
 } from '../../base/participants';
 import { RouteRegistry } from '../../base/react';
 import { MiddlewareRegistry, ReducerRegistry } from '../../base/redux';
+import { toURLString } from '../../base/util';
 
 import {
     appNavigate,
@@ -52,7 +53,10 @@ export class AbstractApp extends Component {
         /**
          * The URL, if any, with which the app was launched.
          */
-        url: React.PropTypes.string
+        url: React.PropTypes.oneOfType([
+            React.PropTypes.object,
+            React.PropTypes.string
+        ])
     };
 
     /**
@@ -110,7 +114,7 @@ export class AbstractApp extends Component {
 
         // If a URL was explicitly specified to this React Component, then open
         // it; otherwise, use a default.
-        this._openURL(this.props.url || this._getDefaultURL());
+        this._openURL(toURLString(this.props.url) || this._getDefaultURL());
     }
 
     /**
@@ -139,9 +143,10 @@ export class AbstractApp extends Component {
         }
 
         // Deal with URL changes.
-        const { url } = nextProps;
+        let { url } = nextProps;
 
-        if (this.props.url !== url) {
+        url = toURLString(url);
+        if (toURLString(this.props.url) !== url) {
             this._openURL(url || this._getDefaultURL());
         }
     }
@@ -391,12 +396,12 @@ export class AbstractApp extends Component {
     /**
      * Navigates this AbstractApp to (i.e. opens) a specific URL.
      *
-     * @param {string} url - The URL to which to navigate this AbstractApp (i.e.
-     * the URL to open).
+     * @param {string|Object} url - The URL to navigate this AbstractApp to
+     * (i.e. the URL to open).
      * @protected
      * @returns {void}
      */
     _openURL(url) {
-        this._getStore().dispatch(appNavigate(url));
+        this._getStore().dispatch(appNavigate(toURLString(url)));
     }
 }

--- a/react/features/app/reducer.js
+++ b/react/features/app/reducer.js
@@ -16,8 +16,8 @@ ReducerRegistry.register('features/app', (state = {}, action) => {
                 ...state,
 
                 /**
-                 * The one and only (i.e. singleton) App instance which is
-                 * currently mounted.
+                 * The one and only (i.e. singleton) {@link App} instance which
+                 * is currently mounted.
                  *
                  * @type {App}
                  */

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -262,3 +262,53 @@ export function parseURIString(uri: ?string) {
 
     return obj;
 }
+
+/**
+ * Attempts to return a {@code String} representation of a specific
+ * {@code Object} which is supposed to represent a URL. Obviously, if a
+ * {@code String} is specified, it is returned. If a {@code URL} is specified,
+ * its {@code URL#href} is returned. Additionally, an {@code Object} similar to
+ * the one accepted by the constructor of Web's ExternalAPI is supported on both
+ * mobile/React Native and Web/React.
+ *
+ * @param {string|Object} obj - The URL to return a {@code String}
+ * representation of.
+ * @returns {string} - A {@code String} representation of the specified
+ * {@code obj} which is supposed to represent a URL.
+ */
+export function toURLString(obj: ?(string | Object)): ?string {
+    let str;
+
+    switch (typeof obj) {
+    case 'object':
+        if (obj) {
+            if (obj instanceof URL) {
+                str = obj.href;
+            } else {
+                str = _urlObjectToString(obj);
+            }
+        }
+        break;
+
+    case 'string':
+        str = String(obj);
+        break;
+    }
+
+    return str;
+}
+
+/**
+ * Attempts to return a {@code String} representation of a specific
+ * {@code Object} similar to the one accepted by the constructor
+ * of Web's ExternalAPI.
+ *
+ * @param {Object} obj - The URL to return a {@code String} representation of.
+ * @returns {string} - A {@code String} representation of the specified
+ * {@code obj}.
+ */
+function _urlObjectToString({ url }: Object): ?string {
+    // TODO Support properties other than url. Support (pretty much) all
+    // properties accepted by the constructor of Web's ExternalAPI.
+    return url;
+}


### PR DESCRIPTION
Introduces `loadURLObject` in JitsiMeetView on Android and iOS which accepts a `Bundle` and `NSDictionary`, respectively, similar in structure to the JS object accepted by the constructor of Web's ExternalAPI. At this time, only the property `url` of the bundle/dictionary is supported. However,  it allows the public API of `loadURLObject` to be consumed. The property `url` will be made optional in the future and other properties will be supported from which a URL will be constructed.