### PR TITLE
[Android] Destroy containes when they are not visible

### DIFF
--- a/react/features/base/react/components/native/Container.js
+++ b/react/features/base/react/components/native/Container.js
@@ -7,6 +7,7 @@ import {
     View
 } from 'react-native';
 
+import { Platform } from '../../';
 import AbstractContainer from '../AbstractContainer';
 
 /**
@@ -38,6 +39,12 @@ export default class Container extends AbstractContainer {
 
         // visible
         if (!visible) {
+            // FIXME: Whatever I try ends up failing somehow on Android, give up
+            // for now, hoping display: 'none' solves this.
+            if (Platform.OS === 'android') {
+                return null;
+            }
+
             // Intentionally hide this Container without destroying it.
             // TODO Replace with display: 'none' supported in RN >= 0.43.
             props.style = {


### PR DESCRIPTION
Whatever I've tried so far ends up failing in really weird ways, so let's admit
defeat, for now. Destroy containers only on Android.

This shall be revisited when we update RN to version >= 0.43 and we have
"display: 'none'" available.