### PR TITLE
[RN] Fix/mitigate URL-related issues

### DIFF
--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -47,8 +47,8 @@ function _appNavigateToMandatoryLocation(
     const newHost = newLocation.host;
 
     if (oldHost === newHost) {
-        dispatchSetLocationURL();
-        dispatchSetRoom();
+        dispatchSetLocationURL()
+            .then(dispatchSetRoom);
     } else {
         // If the host has changed, we need to load the config of the new host
         // and set it, and only after that we can navigate to a different route.
@@ -80,8 +80,9 @@ function _appNavigateToMandatoryLocation(
             return;
         }
 
-        dispatchSetLocationURL();
-        dispatch(setConfig(config));
+        return (
+            dispatchSetLocationURL()
+                .then(() => dispatch(setConfig(config))));
     }
 
     /**
@@ -90,7 +91,7 @@ function _appNavigateToMandatoryLocation(
      * @returns {void}
      */
     function dispatchSetLocationURL() {
-        dispatch(setLocationURL(new URL(newLocation.toString())));
+        return dispatch(setLocationURL(new URL(newLocation.toString())));
     }
 
     /**
@@ -99,7 +100,7 @@ function _appNavigateToMandatoryLocation(
      * @returns {void}
      */
     function dispatchSetRoom() {
-        dispatch(setRoom(newLocation.room));
+        return dispatch(setRoom(newLocation.room));
     }
 }
 

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -84,18 +84,24 @@ export class App extends AbstractApp {
 
         // Navigate to the specified Route.
         const windowLocation = this.getWindowLocation();
+        let promise;
 
         if (!route || windowLocation.pathname === path) {
             // The browser is at the specified path already and what remains is
             // to make this App instance aware of the route to be rendered at
             // the current location.
-            super._navigate(route);
+
+            // XXX Refer to the super's _navigate for an explanation why a
+            // Promise is returned.
+            promise = super._navigate(route);
         } else {
             // The browser must go to the specified location. Once the specified
             // location becomes current, the App will be made aware of the route
             // to be rendered at it.
             windowLocation.pathname = path;
         }
+
+        return promise || Promise.resolve();
     }
 
     /**

--- a/react/features/app/middleware.js
+++ b/react/features/app/middleware.js
@@ -103,7 +103,7 @@ function _navigate({ dispatch, getState }) {
         }
     }
 
-    app._navigate(routeToRender);
+    return app._navigate(routeToRender);
 }
 
 /**
@@ -121,11 +121,9 @@ function _navigate({ dispatch, getState }) {
  * specified {@code action}.
  */
 function _setLocationURL({ getState }, next, action) {
-    const result = next(action);
-
-    getState()['features/app'].app._navigate(undefined);
-
-    return result;
+    return (
+        getState()['features/app'].app._navigate(undefined)
+            .then(() => next(action)));
 }
 
 /**

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -29,7 +29,8 @@ import {
 import {
     AVATAR_ID_COMMAND,
     AVATAR_URL_COMMAND,
-    EMAIL_COMMAND
+    EMAIL_COMMAND,
+    JITSI_CONFERENCE_URL_KEY
 } from './constants';
 import { _addLocalTracksToConference } from './functions';
 
@@ -239,7 +240,7 @@ export function conferenceWillLeave(conference) {
 export function createConference() {
     return (dispatch, getState) => {
         const state = getState();
-        const connection = state['features/base/connection'].connection;
+        const { connection, locationURL } = state['features/base/connection'];
 
         if (!connection) {
             throw new Error('Cannot create a conference without a connection!');
@@ -258,6 +259,7 @@ export function createConference() {
                 room.toLowerCase(),
                 state['features/base/config']);
 
+        conference[JITSI_CONFERENCE_URL_KEY] = locationURL;
         dispatch(_conferenceWillJoin(conference));
 
         _addConferenceListeners(conference, dispatch);

--- a/react/features/base/conference/constants.js
+++ b/react/features/base/conference/constants.js
@@ -18,3 +18,19 @@ export const AVATAR_URL_COMMAND = 'avatar-url';
  * @type {string}
  */
 export const EMAIL_COMMAND = 'email';
+
+/**
+ * The name of the {@code JitsiConference} property which identifies the URL of
+ * the conference represented by the {@code JitsiConference} instance.
+ *
+ * TODO It was introduced in a moment of desperation. Jitsi Meet SDK for Android
+ * and iOS needs to deliver events from the JavaScript side where they originate
+ * to the Java and Objective-C sides, respectively, where they are to be
+ * handled. The URL of the {@code JitsiConference} was chosen as the identifier
+ * because the Java and Objective-C sides join by URL through their respective
+ * loadURL methods. But features/base/connection's {@code locationURL} is not
+ * guaranteed at the time of this writing to match the {@code JitsiConference}
+ * instance when the events are to be fired. Patching {@code JitsiConference}
+ * from the outside is not cool but it should suffice for now.
+ */
+export const JITSI_CONFERENCE_URL_KEY = Symbol('url');

--- a/react/features/base/connection/functions.js
+++ b/react/features/base/connection/functions.js
@@ -35,10 +35,21 @@ export function getURLWithoutParams(url: URL): URL {
     const { hash, search } = url;
 
     if ((hash && hash.length > 1) || (search && search.length > 1)) {
-        // eslint-disable-next-line no-param-reassign
-        url = new URL(url.href);
+        url = new URL(url.href); // eslint-disable-line no-param-reassign
         url.hash = '';
         url.search = '';
+
+        // XXX The implementation of URL at least on React Native appends ? and
+        // # at the end of the href which is not desired.
+        let { href } = url;
+
+        if (href) {
+            href.endsWith('#') && (href = href.substring(0, href.length - 1));
+            href.endsWith('?') && (href = href.substring(0, href.length - 1));
+
+            // eslint-disable-next-line no-param-reassign
+            url.href === href || (url = new URL(href));
+        }
     }
 
     return url;

--- a/react/features/base/connection/functions.js
+++ b/react/features/base/connection/functions.js
@@ -13,7 +13,10 @@ export function getInviteURL(stateOrGetState: Function | Object): ?string {
         = typeof stateOrGetState === 'function'
             ? stateOrGetState()
             : stateOrGetState;
-    const { locationURL } = state['features/base/connection'];
+    const locationURL
+        = state instanceof URL
+            ? state
+            : state['features/base/connection'].locationURL;
     let inviteURL;
 
     if (locationURL) {

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -356,7 +356,7 @@ export function toURLString(obj: ?(string | Object)): ?string {
  * {@code Object}.
  */
 export function urlObjectToString(o: Object): ?string {
-    const url = parseStandardURIString(o.url || '');
+    const url = parseStandardURIString(_fixURIStringScheme(o.url || ''));
 
     // protocol
     if (!url.protocol) {

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -378,18 +378,22 @@ export function urlObjectToString(o: Object): ?string {
         //
         // It may be host/hostname and pathname with the latter denoting the
         // tenant.
-        const { host, hostname, pathname: contextRoot, port }
-            = parseStandardURIString(o.domain || o.host || o.hostname);
+        const domain = o.domain || o.host || o.hostname;
 
-        // authority
-        if (host) {
-            url.host = host;
-            url.hostname = hostname;
-            url.port = port;
+        if (domain) {
+            const { host, hostname, pathname: contextRoot, port }
+                = parseStandardURIString(domain);
+
+            // authority
+            if (host) {
+                url.host = host;
+                url.hostname = hostname;
+                url.port = port;
+            }
+
+            // pathname
+            pathname === '/' && contextRoot !== '/' && (pathname = contextRoot);
         }
-
-        // pathname
-        pathname === '/' && contextRoot !== '/' && (pathname = contextRoot);
     }
 
     // pathname


### PR DESCRIPTION
Fixes/mitigates multiple issues in Jitsi Meet SDK for Android and iOS related to URLs including but not limited to:
- `loadURL` results in black screen while in a conference (on the same Jitsi Meet deployment at least);
- `JitsiMeetView`'s listener gets the app's default URL as `data.url`.