### PR TITLE
[Android] Don't mute the microphone under any circumstance

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/audiomode/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/audiomode/AudioModeModule.java
@@ -300,7 +300,6 @@ public class AudioModeModule extends ReactContextBaseJavaModule {
             audioManager.setMode(AudioManager.MODE_NORMAL);
             audioManager.abandonAudioFocus(null);
             audioManager.setSpeakerphoneOn(false);
-            audioManager.setMicrophoneMute(true);
             setBluetoothAudioRoute(false);
 
             return true;


### PR DESCRIPTION
It's a global action, and if we do that other applications won't be able to use
it. I experienced this with the system camera. We do, however, make sure to
enable it when we need to.

Note that enabling it doesn't mean we are *using* it. It just means we *can*,
and that we will get actual audio when we do.