### PR TITLE
[RN] Polyfill window.location.search

### DIFF
--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -259,7 +259,11 @@ function _visitNode(node, callback) {
     // location
     if (typeof global.location === 'undefined') {
         global.location = {
-            href: ''
+            href: '',
+
+            // Required by:
+            // - lib-jitsi-meet/modules/xmpp/xmpp.js
+            search: ''
         };
     }
 


### PR DESCRIPTION
Currently lib-jitsi-meet looks there in case the `anonymousdomain` config option
was specified.

While this commit alone doesn't add support for authenticated deployments, it
avoids a failure if `anonymousdomain` was set, regardless of authentication being
turned on or not.

Fixes: https://github.com/jitsi/jitsi-meet/issues/1858