### PR TITLE
Installs required basexx when token package is installed. Fixes #1870.

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -64,6 +64,11 @@ case "$1" in
                    echo "Failed to install luajwtjitsi - try installing it manually"
                 fi
 
+                # Install basexx
+                if ! luarocks install basexx; then
+                   echo "Failed to install basexx - try installing it manually"
+                fi
+
                 if [ -x "/etc/init.d/prosody" ]; then
                     invoke-rc.d prosody restart
                 fi

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -58,7 +58,12 @@ end
 function provider.get_sasl_handler(session)
 
 	local function get_username_from_token(self, message)
-        local res = token_util:process_and_verify_token(session);
+        local res, error, reason = token_util:process_and_verify_token(session);
+
+        if (res == false) then
+            log("warn",
+                "Error verifying token err:%s, reason:%s", error, reason);
+        end
 
         local customUsername
             = prosody.events.fire_event("pre-jitsi-authentication", session);

--- a/resources/prosody-plugins/mod_muc_size.lua
+++ b/resources/prosody-plugins/mod_muc_size.lua
@@ -1,8 +1,6 @@
 -- Prosody IM
 -- Copyright (C) 2017 Atlassian
 --
--- This module requires net-url module
--- Install it using #luarocks install net-url
 
 local jid = require "util.jid";
 local it = require "util.iterators";


### PR DESCRIPTION
Adds some debug messages when token verification fails for some reason.