### PR TITLE
fix(video-quality): change click handler location on label

### DIFF
--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -163,14 +163,15 @@ export class VideoQualityLabel extends Component {
         return (
             <div
                 className = { classNames }
-                id = 'videoResolutionLabel'
-                onClick = { this._onDialogToggle }>
+                id = 'videoResolutionLabel'>
                 <AKInlineDialog
                     content = { <VideoQualityDialog /> }
                     isOpen = { this.state.showVideoQualityDialog }
                     onClose = { this._onDialogClose }
                     position = { 'left top' }>
-                    <div className = 'video-quality-label-status'>
+                    <div
+                        className = 'video-quality-label-status'
+                        onClick = { this._onDialogToggle }>
                         { _audioOnly
                             ? <i className = 'icon-visibility-off' />
                             : this._mapResolutionToTranslation(_resolution) }


### PR DESCRIPTION
This will prevent the quality dialog from closing when changing
desired quality level.