### PR TITLE
fix(quality-slider): prevent resizing by making p2p warning hidden

### DIFF
--- a/css/modals/video-quality/_video-quality.scss
+++ b/css/modals/video-quality/_video-quality.scss
@@ -2,7 +2,12 @@
     color: $modalTextColor;
 
     .hide-warning {
+        height: 0;
         visibility: hidden;
+    }
+
+    .video-quality-dialog-title {
+        margin-bottom: 10px;
     }
 
     .video-quality-dialog-contents {
@@ -10,7 +15,7 @@
         color: $modalTextColor;
         display: flex;
         flex-direction: column;
-        padding: 0 10px 10px;
+        padding: 10px;
         min-width: 250px;
 
         .video-quality-dialog-slider-container {

--- a/css/modals/video-quality/_video-quality.scss
+++ b/css/modals/video-quality/_video-quality.scss
@@ -1,8 +1,8 @@
 .video-quality-dialog {
     color: $modalTextColor;
 
-    .video-quality-dialog-title {
-        margin-bottom: 10px;
+    .hide-warning {
+        visibility: hidden;
     }
 
     .video-quality-dialog-contents {
@@ -10,7 +10,7 @@
         color: $modalTextColor;
         display: flex;
         flex-direction: column;
-        padding: 10px;
+        padding: 0 10px 10px;
         min-width: 250px;
 
         .video-quality-dialog-slider-container {

--- a/react/features/video-quality/components/VideoQualityDialog.web.js
+++ b/react/features/video-quality/components/VideoQualityDialog.web.js
@@ -123,12 +123,7 @@ class VideoQualityDialog extends Component {
                     { t('videoStatus.callQuality') }
                 </h3>
                 <div className = { showP2PWarning ? '' : 'hide-warning' }>
-                    <InlineMessage
-                        secondaryText
-                            = { t('videoStatus.recHighDefinitionOnly') }
-                        title = { t('videoStatus.p2pEnabled') }>
-                        { t('videoStatus.p2pVideoQualityDescription') }
-                    </InlineMessage>
+                    { this._renderP2PMessage() }
                 </div>
                 <div className = 'video-quality-dialog-contents'>
                     <div className = 'video-quality-dialog-slider-container'>
@@ -153,6 +148,24 @@ class VideoQualityDialog extends Component {
                     </div>
                 </div>
             </div>
+        );
+    }
+
+    /**
+     * Creates React Elements for notifying that peer to peer is enabled.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderP2PMessage() {
+        const { t } = this.props;
+
+        return (
+            <InlineMessage
+                secondaryText = { t('videoStatus.recHighDefinitionOnly') }
+                title = { t('videoStatus.p2pEnabled') }>
+                { t('videoStatus.p2pVideoQualityDescription') }
+            </InlineMessage>
         );
     }
 

--- a/react/features/video-quality/components/VideoQualityDialog.web.js
+++ b/react/features/video-quality/components/VideoQualityDialog.web.js
@@ -115,13 +115,21 @@ class VideoQualityDialog extends Component {
     render() {
         const { _audioOnly, _p2p, t } = this.props;
         const activeSliderOption = this._mapCurrentQualityToSliderValue();
+        const showP2PWarning = _p2p && !_audioOnly;
 
         return (
             <div className = 'video-quality-dialog'>
                 <h3 className = 'video-quality-dialog-title'>
                     { t('videoStatus.callQuality') }
                 </h3>
-                { !_audioOnly && _p2p ? this._renderP2PMessage() : null }
+                <div className = { showP2PWarning ? '' : 'hide-warning' }>
+                    <InlineMessage
+                        secondaryText
+                            = { t('videoStatus.recHighDefinitionOnly') }
+                        title = { t('videoStatus.p2pEnabled') }>
+                        { t('videoStatus.p2pVideoQualityDescription') }
+                    </InlineMessage>
+                </div>
                 <div className = 'video-quality-dialog-contents'>
                     <div className = 'video-quality-dialog-slider-container'>
                         { /* FIXME: onChange and onMouseUp are both used for
@@ -145,24 +153,6 @@ class VideoQualityDialog extends Component {
                     </div>
                 </div>
             </div>
-        );
-    }
-
-    /**
-     * Creates React Elements for notifying that peer to peer is enabled.
-     *
-     * @private
-     * @returns {ReactElement}
-     */
-    _renderP2PMessage() {
-        const { t } = this.props;
-
-        return (
-            <InlineMessage
-                secondaryText = { t('videoStatus.recHighDefinitionOnly') }
-                title = { t('videoStatus.p2pEnabled') }>
-                { t('videoStatus.p2pVideoQualityDescription') }
-            </InlineMessage>
         );
     }
 


### PR DESCRIPTION
Instead of removing and appending the p2p warning, make it always
appended but toggle visibility so it always takes up space. This
should prevent resizing when the warning appears. Margin and
padding were adjusted to account for the empty space displayed
by a hidden p2p warning.