### PR TITLE
fix(filmstrip): re-adjust z-indexes for tooltip display

### DIFF
--- a/css/_vertical_filmstrip_overrides.scss
+++ b/css/_vertical_filmstrip_overrides.scss
@@ -22,7 +22,7 @@
          * clickable but its inline dialogs must display over the video state
          * indicator when videos are displayed.
          */
-        z-index: calc(#{$tooltipsZ} + 1);
+        z-index: $tooltipsZ;
 
         &.hide-videos {
             z-index: calc(#{$tooltipsZ} - 1);


### PR DESCRIPTION
Filmstrip cannot be higher than tooltip-z or else it'll cover up tipsy tooltip. The z-index change wasn't even needed. What was I doing?