### PR TITLE
Get rid of 'audioMuted' and 'videoMuted' flags in conference.js

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -677,7 +677,8 @@ export default {
                 tracks.forEach(track => {
                     if (track.isAudioTrack() && this.isLocalAudioMuted()) {
                         track.mute();
-                    } else if (track.isVideoTrack() && this.isVideoMuted()) {
+                    } else if (track.isVideoTrack()
+                                    && this.isLocalVideoMuted()) {
                         track.mute();
                     }
                 });
@@ -747,7 +748,7 @@ export default {
      * Tells whether the local video is muted or not.
      * @return {boolean}
      */
-    isVideoMuted() {
+    isLocalVideoMuted() {
         // If the tracks are not ready, read from base/media state
         return this._localTracksInitialized
             ? isLocalTrackMuted(
@@ -825,7 +826,7 @@ export default {
             this.setVideoMuteStatus(mute);
 
             return;
-        } else if (this.isVideoMuted() === mute) {
+        } else if (this.isLocalVideoMuted() === mute) {
             // NO-OP
             return;
         }
@@ -869,7 +870,7 @@ export default {
      * dialogs in case of media permissions error.
      */
     toggleVideoMuted(showUI = true) {
-        this.muteVideo(!this.isVideoMuted(), showUI);
+        this.muteVideo(!this.isLocalVideoMuted(), showUI);
     },
     /**
      * Retrieve list of conference participants (without local user).
@@ -1222,7 +1223,7 @@ export default {
                 } else {
                     this.isSharingScreen = false;
                 }
-                this.setVideoMuteStatus(this.isVideoMuted());
+                this.setVideoMuteStatus(this.isLocalVideoMuted());
                 APP.UI.updateDesktopSharingButtons();
             });
     },
@@ -1402,7 +1403,7 @@ export default {
         let externalInstallation = false;
         let DSExternalInstallationInProgress = false;
         const didHaveVideo = Boolean(this.localVideo);
-        const wasVideoMuted = this.isVideoMuted();
+        const wasVideoMuted = this.isLocalVideoMuted();
 
         return createLocalTracks({
             desktopSharingSources: options.desktopSharingSources,
@@ -2239,7 +2240,7 @@ export default {
                 this.localAudio);
         let promises = [];
         let audioWasMuted = this.isLocalAudioMuted();
-        let videoWasMuted = this.isVideoMuted();
+        let videoWasMuted = this.isLocalVideoMuted();
         let availableAudioInputDevices =
             mediaDeviceHelper.getDevicesFromListByKind(devices, 'audioinput');
         let availableVideoInputDevices =

--- a/conference.js
+++ b/conference.js
@@ -135,7 +135,7 @@ function connect(roomName) {
  * @param {string} value new value
  */
 function sendData(command, value) {
-    if(!room) {
+    if (!room) {
         return;
     }
 
@@ -640,13 +640,13 @@ export default {
     init(options) {
         this.roomName = options.roomName;
         // attaches global error handler, if there is already one, respect it
-        if(JitsiMeetJS.getGlobalOnErrorHandler){
+        if (JitsiMeetJS.getGlobalOnErrorHandler){
             var oldOnErrorHandler = window.onerror;
             window.onerror = function (message, source, lineno, colno, error) {
                 JitsiMeetJS.getGlobalOnErrorHandler(
                     message, source, lineno, colno, error);
 
-                if(oldOnErrorHandler)
+                if (oldOnErrorHandler)
                     oldOnErrorHandler(message, source, lineno, colno, error);
             };
 
@@ -656,7 +656,7 @@ export default {
             JitsiMeetJS.getGlobalOnErrorHandler(
                     null, null, null, null, event.reason);
 
-                if(oldOnUnhandledRejection)
+                if (oldOnUnhandledRejection)
                     oldOnUnhandledRejection(event);
             };
         }
@@ -766,6 +766,8 @@ export default {
     muteAudio(mute, showUI = true) {
         // Not ready to modify track's state yet
         if (!this._localTracksInitialized) {
+            // This will only modify base/media.audio.muted which is then synced
+            // up with the track at the end of local tracks initialization.
             muteLocalAudio(mute);
             this.setAudioMuteStatus(mute);
 
@@ -822,6 +824,8 @@ export default {
     muteVideo(mute, showUI = true) {
         // If not ready to modify track's state yet adjust the base/media
         if (!this._localTracksInitialized) {
+            // This will only modify base/media.video.muted which is then synced
+            // up with the track at the end of local tracks initialization.
             muteLocalVideo(mute);
             this.setVideoMuteStatus(mute);
 
@@ -1195,7 +1199,7 @@ export default {
 
     _getConferenceOptions() {
         let options = config;
-        if(config.enableRecording && !config.recordingType) {
+        if (config.enableRecording && !config.recordingType) {
             options.recordingType = (config.hosts &&
                 (typeof config.hosts.jirecon != "undefined"))?
                 "jirecon" : "colibri";
@@ -1657,29 +1661,28 @@ export default {
         });
 
         room.on(ConferenceEvents.TRACK_ADDED, (track) => {
-            if(!track || track.isLocal())
+            if (!track || track.isLocal())
                 return;
 
             APP.store.dispatch(trackAdded(track));
         });
 
         room.on(ConferenceEvents.TRACK_REMOVED, (track) => {
-            if(!track || track.isLocal())
+            if (!track || track.isLocal())
                 return;
 
             APP.store.dispatch(trackRemoved(track));
         });
 
         room.on(ConferenceEvents.TRACK_AUDIO_LEVEL_CHANGED, (id, lvl) => {
-            if(this.isLocalId(id)
+            if (this.isLocalId(id)
                 && this.localAudio && this.localAudio.isMuted()) {
                 lvl = 0;
             }
 
-            if(config.debug)
-            {
+            if (config.debug) {
                 this.audioLevelsMap[id] = lvl;
-                if(config.debugAudioLevels)
+                if (config.debugAudioLevels)
                     logger.log("AudioLevel:" + id + "/" + lvl);
             }
 
@@ -2366,10 +2369,10 @@ export default {
      * NOTE: Should be used after conference.init
      */
     logEvent(name, value, label) {
-        if(JitsiMeetJS.analytics) {
+        if (JitsiMeetJS.analytics) {
             JitsiMeetJS.analytics.sendEvent(name, {value, label});
         }
-        if(room) {
+        if (room) {
             room.sendApplicationLog(JSON.stringify({name, value, label}));
         }
     },

--- a/conference.js
+++ b/conference.js
@@ -766,6 +766,7 @@ export default {
         // Not ready to modify track's state yet
         if (!this._localTracksInitialized) {
             muteLocalAudio(mute);
+            this.setAudioMuteStatus(mute);
 
             return;
         } else if (this.isLocalAudioMuted() === mute) {
@@ -821,6 +822,7 @@ export default {
         // If not ready to modify track's state yet adjust the base/media
         if (!this._localTracksInitialized) {
             muteLocalVideo(mute);
+            this.setVideoMuteStatus(mute);
 
             return;
         } else if (this.isVideoMuted() === mute) {

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -24,7 +24,6 @@ import Settings from "./../settings/Settings";
 import { debounce } from "../util/helpers";
 
 import { updateDeviceList } from '../../react/features/base/devices';
-import { setAudioMuted } from '../../react/features/base/media';
 import {
     openDeviceSelectionDialog
 } from '../../react/features/device-selection';
@@ -673,7 +672,6 @@ UI.askForNickname = function () {
 UI.setAudioMuted = function (id, muted) {
     VideoLayout.onAudioMute(id, muted);
     if (APP.conference.isLocalId(id)) {
-        APP.store.dispatch(setAudioMuted(muted));
         APP.conference.updateAudioIconEnabled();
     }
 };

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -24,7 +24,7 @@ import Settings from "./../settings/Settings";
 import { debounce } from "../util/helpers";
 
 import { updateDeviceList } from '../../react/features/base/devices';
-import { setAudioMuted, setVideoMuted } from '../../react/features/base/media';
+import { setAudioMuted } from '../../react/features/base/media';
 import {
     openDeviceSelectionDialog
 } from '../../react/features/device-selection';
@@ -684,7 +684,6 @@ UI.setAudioMuted = function (id, muted) {
 UI.setVideoMuted = function (id, muted) {
     VideoLayout.onVideoMute(id, muted);
     if (APP.conference.isLocalId(id)) {
-        APP.store.dispatch(setVideoMuted(muted));
         APP.conference.updateVideoIconEnabled();
     }
 };

--- a/react/features/base/media/functions.js
+++ b/react/features/base/media/functions.js
@@ -1,3 +1,5 @@
+import { VIDEO_MUTISM_AUTHORITY } from './constants';
+
 /**
  * Determines whether a specific videoTrack should be rendered.
  *
@@ -13,4 +15,16 @@ export function shouldRenderVideoTrack(videoTrack, waitForVideoStarted) {
         videoTrack
             && !videoTrack.muted
             && (!waitForVideoStarted || videoTrack.videoStarted));
+}
+
+/**
+ * Checks if video is currently muted by the user authority.
+ *
+ * @param {Object} store - The redux store instance.
+ * @returns {boolean}
+ */
+export function isVideoMutedByUser({ getState }) {
+    return Boolean(
+        getState()['features/base/media'] // eslint-disable-line no-bitwise
+            .video.muted & VIDEO_MUTISM_AUTHORITY.USER);
 }

--- a/react/features/base/media/middleware.js
+++ b/react/features/base/media/middleware.js
@@ -93,7 +93,7 @@ function _setRoom({ dispatch, getState }, next, action) {
  * @private
  * @returns {void}
  */
-function _syncTrackMutedState({ dispatch, getState }, track) {
+function _syncTrackMutedState({ getState }, track) {
     const state = getState()['features/base/media'];
     const muted = Boolean(state[track.mediaType].muted);
 
@@ -104,6 +104,6 @@ function _syncTrackMutedState({ dispatch, getState }, track) {
     // fired before track gets to state.
     if (track.muted !== muted) {
         track.muted = muted;
-        dispatch(setTrackMuted(track.jitsiTrack, muted));
+        setTrackMuted(track.jitsiTrack, muted);
     }
 }

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -349,35 +349,6 @@ function _getLocalTracksToChange(currentTracks, newTracks) {
 }
 
 /**
- * Mutes or unmutes a specific <tt>JitsiLocalTrack</tt>. If the muted state of
- * the specified <tt>track</tt> is already in accord with the specified
- * <tt>muted</tt> value, then does nothing.
- *
- * @param {JitsiLocalTrack} track - The <tt>JitsiLocalTrack</tt> to mute or
- * unmute.
- * @param {boolean} muted - If the specified <tt>track</tt> is to be muted, then
- * <tt>true</tt>; otherwise, <tt>false</tt>.
- * @returns {Promise}
- */
-export function setTrackMuted(track, muted) {
-    return () => {
-        muted = Boolean(muted); // eslint-disable-line no-param-reassign
-
-        if (track.isMuted() === muted) {
-            return Promise.resolve();
-        }
-
-        const f = muted ? 'mute' : 'unmute';
-
-        return track[f]().catch(error => {
-
-            // FIXME emit mute failed, so that the app can show error dialog
-            console.error(`set track ${f} failed`, error);
-        });
-    };
-}
-
-/**
  * Returns true if the provided JitsiTrack should be rendered as a mirror.
  *
  * We only want to show a video in mirrored mode when:

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -170,3 +170,30 @@ export function isLocalTrackMuted(tracks, mediaType) {
 
     return !track || track.muted;
 }
+
+/**
+ * Mutes or unmutes a specific <tt>JitsiLocalTrack</tt>. If the muted state of
+ * the specified <tt>track</tt> is already in accord with the specified
+ * <tt>muted</tt> value, then does nothing.
+ *
+ * @param {JitsiLocalTrack} track - The <tt>JitsiLocalTrack</tt> to mute or
+ * unmute.
+ * @param {boolean} muted - If the specified <tt>track</tt> is to be muted, then
+ * <tt>true</tt>; otherwise, <tt>false</tt>.
+ * @returns {Promise}
+ */
+export function setTrackMuted(track, muted) {
+    muted = Boolean(muted); // eslint-disable-line no-param-reassign
+
+    if (track.isMuted() === muted) {
+        return Promise.resolve();
+    }
+
+    const f = muted ? 'mute' : 'unmute';
+
+    return track[f]().catch(error => {
+
+        // FIXME emit mute failed, so that the app can show error dialog
+        console.error(`set track ${f} failed`, error);
+    });
+}

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -157,14 +157,16 @@ export function getTracksByMediaType(tracks, mediaType) {
 }
 
 /**
- * Checks if the first local video track in the given tracks set is muted.
+ * Checks if the first local track in the given tracks set is muted.
  *
  * @param {Track[]} tracks - List of all tracks.
- * @returns {boolean} True if local video track is muted or false if there are
- * no local video tracks in the given set of tracks.
+ * @param {MEDIA_TYPE} mediaType - The media type of tracks to be checked.
+ * @returns {boolean} True if local track is muted or false if the track is
+ * unmuted or if there are no local tracks of the given media type in the given
+ * set of tracks.
  */
-export function isLocalVideoTrackMuted(tracks) {
-    const videoTrack = getLocalVideoTrack(tracks);
+export function isLocalTrackMuted(tracks, mediaType) {
+    const track = getLocalTrack(tracks, mediaType);
 
-    return !videoTrack || videoTrack.muted;
+    return !track || track.muted;
 }

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -155,3 +155,16 @@ export function getTrackByJitsiTrack(tracks, jitsiTrack) {
 export function getTracksByMediaType(tracks, mediaType) {
     return tracks.filter(t => t.mediaType === mediaType);
 }
+
+/**
+ * Checks if the first local video track in the given tracks set is muted.
+ *
+ * @param {Track[]} tracks - List of all tracks.
+ * @returns {boolean} True if local video track is muted or false if there are
+ * no local video tracks in the given set of tracks.
+ */
+export function isLocalVideoTrackMuted(tracks) {
+    const videoTrack = getLocalVideoTrack(tracks);
+
+    return !videoTrack || videoTrack.muted;
+}

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -116,7 +116,12 @@ MiddlewareRegistry.register(store => next => action => {
                     participantID,
                     jitsiTrack.videoType);
             } else {
-                APP.UI.setAudioMuted(participantID, muted);
+                // eslint-disable-next-line no-lonely-if
+                if (jitsiTrack.isLocal()) {
+                    APP.conference.setAudioMuteStatus(muted);
+                } else {
+                    APP.UI.setAudioMuted(participantID, muted);
+                }
             }
         }
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -114,13 +114,10 @@ MiddlewareRegistry.register(store => next => action => {
                 APP.UI.onPeerVideoTypeChanged(
                     participantID,
                     jitsiTrack.videoType);
+            } else if (jitsiTrack.isLocal()) {
+                APP.conference.setAudioMuteStatus(muted);
             } else {
-                // eslint-disable-next-line no-lonely-if
-                if (jitsiTrack.isLocal()) {
-                    APP.conference.setAudioMuteStatus(muted);
-                } else {
-                    APP.UI.setAudioMuted(participantID, muted);
-                }
+                APP.UI.setAudioMuted(participantID, muted);
             }
         }
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -11,9 +11,8 @@ import {
 } from '../media';
 import { MiddlewareRegistry } from '../redux';
 
-import { setTrackMuted } from './actions';
 import { TRACK_ADDED, TRACK_REMOVED, TRACK_UPDATED } from './actionTypes';
-import { getLocalTrack } from './functions';
+import { getLocalTrack, setTrackMuted } from './functions';
 
 declare var APP: Object;
 
@@ -160,5 +159,5 @@ function _getLocalTrack({ getState }, mediaType: MEDIA_TYPE) {
 function _setMuted(store, { muted }, mediaType: MEDIA_TYPE) {
     const localTrack = _getLocalTrack(store, mediaType);
 
-    localTrack && store.dispatch(setTrackMuted(localTrack.jitsiTrack, muted));
+    localTrack && setTrackMuted(localTrack.jitsiTrack, muted);
 }

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -6,8 +6,6 @@ import {
     SET_AUDIO_MUTED,
     SET_CAMERA_FACING_MODE,
     SET_VIDEO_MUTED,
-    setAudioMuted,
-    setVideoMuted,
     TOGGLE_CAMERA_FACING_MODE,
     toggleCameraFacingMode
 } from '../media';
@@ -108,30 +106,18 @@ MiddlewareRegistry.register(store => next => action => {
             const participantID = jitsiTrack.getParticipantId();
             const isVideoTrack = jitsiTrack.isVideoTrack();
 
-            if (jitsiTrack.isLocal()) {
-                if (isVideoTrack) {
+            if (isVideoTrack) {
+                if (jitsiTrack.isLocal()) {
                     APP.conference.setVideoMuteStatus(muted);
                 } else {
-                    APP.conference.setAudioMuteStatus(muted);
+                    APP.UI.setVideoMuted(participantID, muted);
                 }
-            }
-
-            if (isVideoTrack) {
-                APP.UI.setVideoMuted(participantID, muted);
                 APP.UI.onPeerVideoTypeChanged(
                     participantID,
                     jitsiTrack.videoType);
             } else {
                 APP.UI.setAudioMuted(participantID, muted);
             }
-
-            // XXX The following synchronizes the state of base/tracks into the
-            // state of base/media. Which is not required in React (and,
-            // respectively, React Native) because base/media expresses the
-            // app's and the user's desires/expectations/intents and base/tracks
-            // expresses practice/reality. Unfortunately, the old Web does not
-            // comply and/or does the opposite. Hence, the following:
-            return _trackUpdated(store, next, action);
         }
 
     }
@@ -170,65 +156,4 @@ function _setMuted(store, { muted }, mediaType: MEDIA_TYPE) {
     const localTrack = _getLocalTrack(store, mediaType);
 
     localTrack && store.dispatch(setTrackMuted(localTrack.jitsiTrack, muted));
-}
-
-/**
- * Intercepts the action <tt>TRACK_UPDATED</tt> in order to synchronize the
- * muted states of the local tracks of features/base/tracks with the muted
- * states of features/base/media.
- *
- * @param {Store} store - The redux store in which the specified <tt>action</tt>
- * is being dispatched.
- * @param {Dispatch} next - The redux dispatch function to dispatch the
- * specified <tt>action</tt> to the specified <tt>store</tt>.
- * @param {Action} action - The redux action <tt>TRACK_UPDATED</tt> which is
- * being dispatched in the specified <tt>store</tt>.
- * @private
- * @returns {Object} The new state that is the result of the reduction of the
- * specified <tt>action</tt>.
- */
-function _trackUpdated(store, next, action) {
-    // Determine the muted state of the local track before the update.
-    const track = action.track;
-    let mediaType;
-    let oldMuted;
-
-    if ('muted' in track) {
-        // XXX The return value of JitsiTrack.getType() is of type MEDIA_TYPE
-        // that happens to be compatible with the type MEDIA_TYPE defined by
-        // jitsi-meet.
-        mediaType = track.jitsiTrack.getType();
-
-        const localTrack = _getLocalTrack(store, mediaType);
-
-        if (localTrack) {
-            oldMuted = localTrack.muted;
-        }
-    }
-
-    const result = next(action);
-
-    if (typeof oldMuted !== 'undefined') {
-        // Determine the muted state of the local track after the update. If the
-        // muted states before and after the update differ, then the respective
-        // media state should by synchronized.
-        const localTrack = _getLocalTrack(store, mediaType);
-
-        if (localTrack) {
-            const newMuted = localTrack.muted;
-
-            if (oldMuted !== newMuted) {
-                switch (mediaType) {
-                case MEDIA_TYPE.AUDIO:
-                    store.dispatch(setAudioMuted(newMuted));
-                    break;
-                case MEDIA_TYPE.VIDEO:
-                    store.dispatch(setVideoMuted(newMuted));
-                    break;
-                }
-            }
-        }
-    }
-
-    return result;
 }

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -39,13 +39,14 @@ const buttons: Object = {
         isDisplayed: () => true,
         id: 'toolbar_button_camera',
         onClick() {
-            if (APP.conference.videoMuted) {
+            const newState = !APP.conference.isVideoMuted();
+
+            if (newState) {
                 JitsiMeetJS.analytics.sendEvent('toolbar.video.enabled');
-                APP.UI.emitEvent(UIEvents.VIDEO_MUTED, false);
             } else {
                 JitsiMeetJS.analytics.sendEvent('toolbar.video.disabled');
-                APP.UI.emitEvent(UIEvents.VIDEO_MUTED, true);
             }
+            APP.UI.emitEvent(UIEvents.VIDEO_MUTED, newState);
         },
         popups: [
             {

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -290,7 +290,7 @@ const buttons: Object = {
         onClick() {
             const sharedVideoManager = APP.UI.getSharedVideoManager();
 
-            if (APP.conference.audioMuted) {
+            if (APP.conference.isLocalAudioMuted()) {
                 // If there's a shared video with the volume "on" and we aren't
                 // the video owner, we warn the user
                 // that currently it's not possible to unmute.

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -39,7 +39,7 @@ const buttons: Object = {
         isDisplayed: () => true,
         id: 'toolbar_button_camera',
         onClick() {
-            const newState = !APP.conference.isVideoMuted();
+            const newState = !APP.conference.isLocalVideoMuted();
 
             if (newState) {
                 JitsiMeetJS.analytics.sendEvent('toolbar.video.enabled');

--- a/react/features/toolbox/defaultToolbarButtons.js
+++ b/react/features/toolbox/defaultToolbarButtons.js
@@ -39,14 +39,14 @@ const buttons: Object = {
         isDisplayed: () => true,
         id: 'toolbar_button_camera',
         onClick() {
-            const newState = !APP.conference.isLocalVideoMuted();
+            const newVideoMutedState = !APP.conference.isLocalVideoMuted();
 
-            if (newState) {
+            if (newVideoMutedState) {
                 JitsiMeetJS.analytics.sendEvent('toolbar.video.enabled');
             } else {
                 JitsiMeetJS.analytics.sendEvent('toolbar.video.disabled');
             }
-            APP.UI.emitEvent(UIEvents.VIDEO_MUTED, newState);
+            APP.UI.emitEvent(UIEvents.VIDEO_MUTED, newVideoMutedState);
         },
         popups: [
             {

--- a/react/features/toolbox/functions.native.js
+++ b/react/features/toolbox/functions.native.js
@@ -3,7 +3,8 @@
 import type { Dispatch } from 'redux';
 
 import { appNavigate } from '../app';
-import { getLocalAudioTrack, isLocalVideoTrackMuted } from '../base/tracks';
+import { MEDIA_TYPE } from '../base/media';
+import { isLocalTrackMuted } from '../base/tracks';
 
 /**
  * Maps redux actions to {@link Toolbox} (React {@code Component}) props.
@@ -58,8 +59,6 @@ export function abstractMapStateToProps(state: Object): Object {
     const tracks = state['features/base/tracks'];
     const { visible } = state['features/toolbox'];
 
-    const audioTrack = getLocalAudioTrack(tracks);
-
     return {
         /**
          * Flag showing whether audio is muted.
@@ -67,7 +66,7 @@ export function abstractMapStateToProps(state: Object): Object {
          * @protected
          * @type {boolean}
          */
-        _audioMuted: !audioTrack || audioTrack.muted,
+        _audioMuted: isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO),
 
         /**
          * Flag showing whether video is muted.
@@ -75,7 +74,7 @@ export function abstractMapStateToProps(state: Object): Object {
          * @protected
          * @type {boolean}
          */
-        _videoMuted: isLocalVideoTrackMuted(tracks),
+        _videoMuted: isLocalTrackMuted(tracks, MEDIA_TYPE.VIDEO),
 
         /**
          * Flag showing whether toolbox is visible.

--- a/react/features/toolbox/functions.native.js
+++ b/react/features/toolbox/functions.native.js
@@ -3,7 +3,7 @@
 import type { Dispatch } from 'redux';
 
 import { appNavigate } from '../app';
-import { getLocalAudioTrack, getLocalVideoTrack } from '../base/tracks';
+import { getLocalAudioTrack, isLocalVideoTrackMuted } from '../base/tracks';
 
 /**
  * Maps redux actions to {@link Toolbox} (React {@code Component}) props.
@@ -59,7 +59,6 @@ export function abstractMapStateToProps(state: Object): Object {
     const { visible } = state['features/toolbox'];
 
     const audioTrack = getLocalAudioTrack(tracks);
-    const videoTrack = getLocalVideoTrack(tracks);
 
     return {
         /**
@@ -76,7 +75,7 @@ export function abstractMapStateToProps(state: Object): Object {
          * @protected
          * @type {boolean}
          */
-        _videoMuted: !videoTrack || videoTrack.muted,
+        _videoMuted: isLocalVideoTrackMuted(tracks),
 
         /**
          * Flag showing whether toolbox is visible.

--- a/react/features/toolbox/middleware.js
+++ b/react/features/toolbox/middleware.js
@@ -38,23 +38,16 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case SET_AUDIO_AVAILABLE: {
-        return _setMediaAvailableOrMuted(
-            store, next, action, MEDIA_TYPE.AUDIO);
+        return _setMediaAvailableOrMuted(store, next, action);
     }
 
     case SET_VIDEO_AVAILABLE: {
-        return _setMediaAvailableOrMuted(
-            store, next, action, MEDIA_TYPE.VIDEO);
+        return _setMediaAvailableOrMuted(store, next, action);
     }
 
     case TRACK_UPDATED: {
         if (action.track.jitsiTrack.isLocal()) {
-            return _setMediaAvailableOrMuted(
-                store,
-                next,
-                action,
-                action.track.jitsiTrack.isAudioTrack()
-                    ? MEDIA_TYPE.AUDIO : MEDIA_TYPE.VIDEO);
+            return _setMediaAvailableOrMuted(store, next, action);
         }
         break;
     }
@@ -64,8 +57,6 @@ MiddlewareRegistry.register(store => next => action => {
     return next(action);
 });
 
-/* eslint-disable max-params */
-
 /**
  * Adjusts the state of toolbar's microphone or camera button.
  *
@@ -74,14 +65,37 @@ MiddlewareRegistry.register(store => next => action => {
  * specified {@code action} in the specified {@code store}.
  * @param {Object} action - SET_AUDIO_AVAILABLE, SET_VIDEO_AVAILABLE or
  * TRACK_UPDATED.
- * @param {MEDIA_TYPE} mediaType - The type of the media which tells whether
- * it's the microphone or the camera button to be updated.
  *
  * @returns {*}
  */
-function _setMediaAvailableOrMuted(
-    { dispatch, getState }, next, action, mediaType) {
+function _setMediaAvailableOrMuted({ dispatch, getState }, next, action) {
     const result = next(action);
+
+    let mediaType;
+
+    switch (action.type) {
+    case SET_AUDIO_AVAILABLE: {
+        mediaType = MEDIA_TYPE.AUDIO;
+        break;
+    }
+
+    case SET_VIDEO_AVAILABLE: {
+        mediaType = MEDIA_TYPE.VIDEO;
+        break;
+    }
+
+    case TRACK_UPDATED: {
+        mediaType
+            = action.track.jitsiTrack.isAudioTrack()
+                ? MEDIA_TYPE.AUDIO : MEDIA_TYPE.VIDEO;
+        break;
+    }
+
+    default: {
+        throw new Error(`Unsupported action ${action}`);
+    }
+
+    }
 
     const mediaState = getState()['features/base/media'];
     const { available }
@@ -104,5 +118,3 @@ function _setMediaAvailableOrMuted(
 
     return result;
 }
-
-/* eslint-enable max-params */

--- a/react/features/toolbox/middleware.js
+++ b/react/features/toolbox/middleware.js
@@ -3,9 +3,9 @@
 import {
     SET_AUDIO_AVAILABLE,
     SET_AUDIO_MUTED,
-    SET_VIDEO_AVAILABLE,
-    SET_VIDEO_MUTED } from '../base/media';
+    SET_VIDEO_AVAILABLE } from '../base/media';
 import { MiddlewareRegistry } from '../base/redux';
+import { isLocalVideoTrackMuted, TRACK_UPDATED } from '../base/tracks';
 
 import { setToolbarButton } from './actions';
 import { CLEAR_TOOLBOX_TIMEOUT, SET_TOOLBOX_TIMEOUT } from './actionTypes';
@@ -43,7 +43,7 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case SET_VIDEO_AVAILABLE:
-    case SET_VIDEO_MUTED:
+    case TRACK_UPDATED:
         return _setVideoAvailableOrMuted(store, next, action);
     }
 
@@ -82,15 +82,17 @@ function _setAudioAvailableOrMuted({ dispatch, getState }, next, action) {
  * @param {Function} next - The redux function to continue dispatching the
  * specified {@code action} in the specified {@code store}.
  * @param {Object} action - Either {@link SET_VIDEO_AVAILABLE} or
- * {@link SET_VIDEO_MUTED}.
+ * {@link TRACK_UPDATED}.
  * @returns {Object} The new state that is the result of the reduction of the
  * specified {@code action}.
  */
 function _setVideoAvailableOrMuted({ dispatch, getState }, next, action) {
     const result = next(action);
 
-    const { available, muted } = getState()['features/base/media'].video;
+    const { available } = getState()['features/base/media'].video;
     const i18nKey = available ? 'videomute' : 'cameraDisabled';
+    const tracks = getState()['features/base/tracks'];
+    const muted = isLocalVideoTrackMuted(tracks);
 
     dispatch(setToolbarButton('camera', {
         enabled: available,


### PR DESCRIPTION
This PR fixes an issue where turning off audio only mode will not unmute local video (on Web).

Gets rid of flags in conference.js and figures out muted status based on redux track's state.

Next step would be to get rid of 'localAudio' and 'localVideo' fields in conference.js.