### PR TITLE
[RN] Create tracks right when they are required

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -51,7 +51,7 @@ import {
     participantUpdated
 } from './react/features/base/participants';
 import {
-    createLocalTracks,
+    _createLocalTracks,
     replaceLocalTrack,
     trackAdded,
     trackRemoved
@@ -548,7 +548,7 @@ export default {
                         return [desktopStream];
                     }
 
-                    return createLocalTracks({ devices: ['audio'] }, true)
+                    return _createLocalTracks({ devices: ['audio'] }, true)
                         .then(([audioStream]) => {
                             return [desktopStream, audioStream];
                         })
@@ -560,7 +560,7 @@ export default {
                     logger.error('Failed to obtain desktop stream', error);
                     screenSharingError = error;
                     return requestedAudio
-                        ? createLocalTracks({ devices: ['audio'] }, true)
+                        ? _createLocalTracks({ devices: ['audio'] }, true)
                         : [];
                 }).catch(error => {
                     audioOnlyError = error;
@@ -570,7 +570,7 @@ export default {
             // Resolve with no tracks
             tryCreateLocalTracks = Promise.resolve([]);
         } else {
-            tryCreateLocalTracks = createLocalTracks(
+            tryCreateLocalTracks = _createLocalTracks(
                 { devices: initialDevices }, true)
                 .catch(err => {
                     if (requestedAudio && requestedVideo) {
@@ -578,7 +578,7 @@ export default {
                         // Try audio only...
                         audioAndVideoError = err;
 
-                        return createLocalTracks({devices: ['audio']}, true);
+                        return _createLocalTracks({devices: ['audio']}, true);
                     } else if (requestedAudio && !requestedVideo) {
                         audioOnlyError = err;
 
@@ -598,7 +598,7 @@ export default {
 
                     // Try video only...
                     return requestedVideo
-                        ? createLocalTracks({devices: ['video']}, true)
+                        ? _createLocalTracks({devices: ['video']}, true)
                         : [];
                 })
                 .catch(err => {
@@ -779,7 +779,7 @@ export default {
         };
 
         if (!localAudio && this.audioMuted && !mute) {
-            createLocalTracks({ devices: ['audio'] }, false)
+            _createLocalTracks({ devices: ['audio'] }, false)
                 .then(([audioTrack]) => audioTrack)
                 .catch(error => {
                     maybeShowErrorDialog(error);
@@ -847,7 +847,7 @@ export default {
             //
             // FIXME when local track creation is moved to react/redux
             // it should take care of the use case described above
-            createLocalTracks({ devices: ['video'] }, false)
+            _createLocalTracks({ devices: ['video'] }, false)
                 .then(([videoTrack]) => videoTrack)
                 .catch(error => {
                     // FIXME should send some feedback to the API on error ?
@@ -1330,7 +1330,7 @@ export default {
         let promise = null;
 
         if (didHaveVideo) {
-            promise = createLocalTracks({ devices: ['video'] })
+            promise = _createLocalTracks({ devices: ['video'] })
                 .then(([stream]) => this.useVideoStream(stream))
                 .then(() => {
                     JitsiMeetJS.analytics.sendEvent(
@@ -1416,7 +1416,7 @@ export default {
         const didHaveVideo = Boolean(localVideo);
         const wasVideoMuted = this.videoMuted;
 
-        return createLocalTracks({
+        return _createLocalTracks({
             desktopSharingSources: options.desktopSharingSources,
             devices: ['desktop'],
             desktopSharingExtensionExternalInstallation: {
@@ -2004,7 +2004,7 @@ export default {
             UIEvents.VIDEO_DEVICE_CHANGED,
             (cameraDeviceId) => {
                 JitsiMeetJS.analytics.sendEvent('settings.changeDevice.video');
-                createLocalTracks({
+                _createLocalTracks({
                     devices: ['video'],
                     cameraDeviceId: cameraDeviceId,
                     micDeviceId: null
@@ -2033,7 +2033,7 @@ export default {
             (micDeviceId) => {
                 JitsiMeetJS.analytics.sendEvent(
                     'settings.changeDevice.audioIn');
-                createLocalTracks({
+                _createLocalTracks({
                     devices: ['audio'],
                     cameraDeviceId: null,
                     micDeviceId: micDeviceId
@@ -2260,7 +2260,7 @@ export default {
 
         promises.push(
             mediaDeviceHelper.createLocalTracksAfterDeviceListChanged(
-                    createLocalTracks,
+                    _createLocalTracks,
                     newDevices.videoinput,
                     newDevices.audioinput)
                 .then(tracks =>

--- a/react/features/app/functions.native.js
+++ b/react/features/app/functions.native.js
@@ -1,7 +1,7 @@
 import { isRoomValid } from '../base/conference';
 import { RouteRegistry } from '../base/react';
 import { Conference } from '../conference';
-import { WelcomePage } from '../welcome';
+import { BlankWelcomePage, WelcomePage } from '../welcome';
 
 /**
  * Determines which route is to be rendered in order to depict a specific Redux
@@ -28,7 +28,8 @@ export function _getRouteToRender(stateOrGetState) {
         // React-ive way anyway so it's all the same difference.
         const { app } = state['features/app'];
 
-        component = app && app.props.welcomePageEnabled ? WelcomePage : null;
+        component = app && app.props.welcomePageEnabled
+            ? WelcomePage : BlankWelcomePage;
     }
 
     return RouteRegistry.getRouteByComponent(component);

--- a/react/features/app/middleware.js
+++ b/react/features/app/middleware.js
@@ -5,7 +5,7 @@ import {
     SET_LOCATION_URL
 } from '../base/connection';
 import { MiddlewareRegistry } from '../base/redux';
-import { createInitialLocalTracks, destroyLocalTracks } from '../base/tracks';
+import { createLocalTracks, destroyLocalTracks } from '../base/tracks';
 
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
@@ -99,7 +99,7 @@ function _navigate({ dispatch, getState }) {
         } else {
             // Create the local tracks if they haven't been created yet.
             state['features/base/tracks'].some(t => t.local)
-                || dispatch(createInitialLocalTracks());
+                || dispatch(createLocalTracks());
         }
     }
 

--- a/react/features/app/middleware.js
+++ b/react/features/app/middleware.js
@@ -5,7 +5,6 @@ import {
     SET_LOCATION_URL
 } from '../base/connection';
 import { MiddlewareRegistry } from '../base/redux';
-import { createLocalTracks, destroyLocalTracks } from '../base/tracks';
 
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
@@ -71,37 +70,10 @@ function _connectionEstablished(store, next, action) {
  * @private
  * @returns {void}
  */
-function _navigate({ dispatch, getState }) {
+function _navigate({ getState }) {
     const state = getState();
     const { app, getRouteToRender } = state['features/app'];
     const routeToRender = getRouteToRender && getRouteToRender(state);
-
-    // FIXME The following is logic specific to the user experience of the
-    // mobile/React Native app. Firstly, I don't like that it's here at all.
-    // Secondly, I copied the mobile/React Native detection from
-    // react/features/base/config/reducer.js because I couldn't iron out an
-    // abstraction. Because of the first point, I'm leaving the second point
-    // unresolved to attract attention to the fact that the following needs more
-    // thinking.
-    if (navigator.product === 'ReactNative') {
-        // Create/destroy the local tracks as needed: create them the first time
-        // we are going to render an actual route (be that the WelcomePage or
-        // the Conference).
-        //
-        // When the WelcomePage is disabled, the app will transition to the
-        // null/undefined route. Detect these transitions and create/destroy the
-        // local tracks so the camera doesn't stay open if the app is not
-        // rendering any component.
-        if (typeof routeToRender === 'undefined' || routeToRender === null) {
-            // Destroy the local tracks if there is no route to render and there
-            // is no WelcomePage.
-            app.props.welcomePageEnabled || dispatch(destroyLocalTracks());
-        } else {
-            // Create the local tracks if they haven't been created yet.
-            state['features/base/tracks'].some(t => t.local)
-                || dispatch(createLocalTracks());
-        }
-    }
 
     return app._navigate(routeToRender);
 }

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -243,7 +243,9 @@ function _setAudioOnly({ dispatch, getState }, next, action) {
     dispatch(setLastN(audioOnly ? 0 : undefined));
 
     // Mute/unmute the local video.
-    dispatch(setVideoMuted(audioOnly, VIDEO_MUTISM_AUTHORITY.AUDIO_ONLY));
+    dispatch(setVideoMuted(audioOnly,
+                           VIDEO_MUTISM_AUTHORITY.AUDIO_ONLY,
+                           /* ensureTrack */ true));
 
     if (typeof APP !== 'undefined') {
         // TODO This should be a temporary solution that lasts only until

--- a/react/features/base/media/actions.js
+++ b/react/features/base/media/actions.js
@@ -34,15 +34,20 @@ export function setAudioAvailable(available: boolean) {
  *
  * @param {boolean} muted - True if the local audio is to be muted or false if
  * the local audio is to be unmuted.
+ * @param {boolean} ensureTrack - True if we want to ensure that a new track is
+ * created if missing.
  * @returns {{
  *     type: SET_AUDIO_MUTED,
- *     muted: boolean
+ *     muted: boolean,
+ *     ensureTrack: boolean
  * }}
  */
-export function setAudioMuted(muted: boolean) {
+export function setAudioMuted(muted: boolean,
+                              ensureTrack: boolean = false) {
     return {
         type: SET_AUDIO_MUTED,
-        muted
+        muted,
+        ensureTrack
     };
 }
 
@@ -86,11 +91,14 @@ export function setVideoAvailable(available: boolean) {
  * the local video is to be unmuted.
  * @param {number} authority - The {@link VIDEO_MUTISM_AUTHORITY} which is
  * muting/unmuting the local video.
+ * @param {boolean} ensureTrack - True if we want to ensure that a new track is
+ * created if missing.
  * @returns {Function}
  */
 export function setVideoMuted(
         muted: boolean,
-        authority: number = VIDEO_MUTISM_AUTHORITY.USER) {
+        authority: number = VIDEO_MUTISM_AUTHORITY.USER,
+        ensureTrack: boolean = false) {
     return (dispatch: Dispatch<*>, getState: Function) => {
         const oldValue = getState()['features/base/media'].video.muted;
 
@@ -99,7 +107,8 @@ export function setVideoMuted(
 
         return dispatch({
             type: SET_VIDEO_MUTED,
-            muted: newValue
+            muted: newValue,
+            ensureTrack
         });
     };
 }

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -8,7 +8,7 @@ import {
 import { getLocalParticipant } from '../participants';
 
 import { TRACK_ADDED, TRACK_REMOVED, TRACK_UPDATED } from './actionTypes';
-import { createLocalTracks } from './functions';
+import { _createLocalTracks } from './functions';
 
 /**
  * Request to start capturing local audio and/or video. By default, the user
@@ -17,7 +17,7 @@ import { createLocalTracks } from './functions';
  * @param {Object} [options] - For info @see JitsiMeetJS.createLocalTracks.
  * @returns {Function}
  */
-export function createInitialLocalTracks(options = {}) {
+export function createLocalTracks(options = {}) {
     return (dispatch, getState) => {
         const devices
             = options.devices || [ MEDIA_TYPE.AUDIO, MEDIA_TYPE.VIDEO ];
@@ -28,7 +28,7 @@ export function createInitialLocalTracks(options = {}) {
 
         // The following executes on React Native only at the time of this
         // writing. The effort to port Web's createInitialLocalTracksAndConnect
-        // is significant and that's where the function createLocalTracks got
+        // is significant and that's where the function _createLocalTracks got
         // born. I started with the idea a porting so that we could inherit the
         // ability to getUserMedia for audio only or video only if getUserMedia
         // for audio and video fails. Eventually though, I realized that on
@@ -37,7 +37,7 @@ export function createInitialLocalTracks(options = {}) {
         // to implement them) and the right thing to do is to ask for each
         // device separately.
         for (const device of devices) {
-            createLocalTracks(
+            _createLocalTracks(
                 {
                     cameraDeviceId: options.cameraDeviceId,
                     devices: [ device ],
@@ -48,7 +48,7 @@ export function createInitialLocalTracks(options = {}) {
                 store)
             .then(localTracks => dispatch(_updateLocalTracks(localTracks)));
 
-            // TODO The function createLocalTracks logs the rejection reason of
+            // TODO The function _createLocalTracks logs the rejection reason of
             // JitsiMeetJS.createLocalTracks so there is no real benefit to
             // logging it here as well. Technically though,
             // _updateLocalTracks may cause a rejection so it may be nice to log

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -11,6 +11,37 @@ import { TRACK_ADDED, TRACK_REMOVED, TRACK_UPDATED } from './actionTypes';
 import { _createLocalTracks } from './functions';
 
 /**
+ * Requests the creating of the desired media type tracks. Desire is expressed
+ * by base/media. This function will dispatch a {@code createLocalTracks}
+ * action for the "missing" types, that is, the ones which base/media would
+ * like to have (unmuted tracks) but are not present yet.
+ *
+ * @returns {Function}
+ */
+export function createDesiredLocalTracks() {
+    return (dispatch, getState) => {
+        const state = getState();
+        const desiredTypes = [];
+
+        state['features/base/media'].audio.muted
+            || desiredTypes.push(MEDIA_TYPE.AUDIO);
+        Boolean(state['features/base/media'].video.muted)
+            || desiredTypes.push(MEDIA_TYPE.VIDEO);
+
+        const availableTypes
+            = state['features/base/tracks']
+                .filter(t => t.local).map(t => t.mediaType);
+
+        // We need to create the desired tracks which are not already available.
+        const createTypes
+            = desiredTypes.filter(type => availableTypes.indexOf(type) === -1);
+
+        createTypes.length
+            && dispatch(createLocalTracks({ devices: createTypes }));
+    };
+}
+
+/**
  * Request to start capturing local audio and/or video. By default, the user
  * facing camera will be selected.
  *

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -23,7 +23,7 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  * is to execute and from which state such as {@code config} is to be retrieved.
  * @returns {Promise<JitsiLocalTrack[]>}
  */
-export function createLocalTracks(
+export function _createLocalTracks(
         options,
         firePermissionPromptIsShownEvent,
         store) {

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -13,7 +13,7 @@ import {
 } from '../media';
 import { MiddlewareRegistry } from '../redux';
 
-import { setTrackMuted } from './actions';
+import { createLocalTracks, setTrackMuted } from './actions';
 import { TRACK_ADDED, TRACK_REMOVED, TRACK_UPDATED } from './actionTypes';
 import { getLocalTrack } from './functions';
 
@@ -166,10 +166,16 @@ function _getLocalTrack({ getState }, mediaType: MEDIA_TYPE) {
  * @private
  * @returns {void}
  */
-function _setMuted(store, { muted }, mediaType: MEDIA_TYPE) {
+function _setMuted(store, { ensureTrack, muted }, mediaType: MEDIA_TYPE) {
     const localTrack = _getLocalTrack(store, mediaType);
 
-    localTrack && store.dispatch(setTrackMuted(localTrack.jitsiTrack, muted));
+    if (localTrack) {
+        store.dispatch(setTrackMuted(localTrack.jitsiTrack, muted));
+    } else if (!muted && ensureTrack && typeof APP === 'undefined') {
+        // FIXME: This only runs on mobile now because web has its own way of
+        // creating local tracks. Adjust the check once they are unified.
+        store.dispatch(createLocalTracks({ devices: [ mediaType ] }));
+    }
 }
 
 /**

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -4,6 +4,7 @@ import { connect as reactReduxConnect } from 'react-redux';
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
 import { Container } from '../../base/react';
+import { createDesiredLocalTracks } from '../../base/tracks';
 import { Filmstrip } from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
 import { OverlayContainer } from '../../overlay';
@@ -222,19 +223,21 @@ class Conference extends Component {
 function _mapDispatchToProps(dispatch) {
     return {
         /**
-         * Dispatched an action connecting to the conference.
+         * Dispatches actions to create the desired local tracks and for
+         * connecting to the conference.
          *
-         * @returns {Object} Dispatched action.
+         * @returns {void}
          * @private
          */
         _onConnect() {
+            dispatch(createDesiredLocalTracks());
             dispatch(connect());
         },
 
         /**
          * Dispatches an action disconnecting from the conference.
          *
-         * @returns {Object} Dispatched action.
+         * @returns {void}
          * @private
          */
         _onDisconnect() {
@@ -246,7 +249,7 @@ function _mapDispatchToProps(dispatch) {
          *
          * @param {boolean} visible - True to show the Toolbox or false to hide
          * it.
-         * @returns {Object} Dispatched action.
+         * @returns {void}
          * @private
          */
         _setToolboxVisible(visible: boolean) {

--- a/react/features/toolbox/components/Toolbox.native.js
+++ b/react/features/toolbox/components/Toolbox.native.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { toggleAudioOnly } from '../../base/conference';
 import {
     MEDIA_TYPE,
+    VIDEO_MUTISM_AUTHORITY,
     setAudioMuted,
     setVideoMuted,
     toggleCameraFacingMode
@@ -167,7 +168,9 @@ class Toolbox extends Component {
         // sets the state of base/media. Whether the user's intention will turn
         // into reality is a whole different story which is of no concern to the
         // tapping.
-        this.props.dispatch(setAudioMuted(!this.props._audioMuted));
+        this.props.dispatch(setAudioMuted(!this.props._audioMuted,
+                                          VIDEO_MUTISM_AUTHORITY.USER,
+                                          /* ensureTrack */ true));
     }
 
     /**
@@ -182,7 +185,9 @@ class Toolbox extends Component {
         // sets the state of base/media. Whether the user's intention will turn
         // into reality is a whole different story which is of no concern to the
         // tapping.
-        this.props.dispatch(setVideoMuted(!this.props._videoMuted));
+        this.props.dispatch(setVideoMuted(!this.props._videoMuted,
+                                          VIDEO_MUTISM_AUTHORITY.USER,
+                                          /* ensureTrack */ true));
     }
 
     /**

--- a/react/features/welcome/components/BlankWelcomePage.js
+++ b/react/features/welcome/components/BlankWelcomePage.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { destroyLocalTracks } from '../../base/tracks';
+
+
+/**
+ * Component for rendering a blank welcome page. It renders absolutely nothing
+ * and destroys local tracks upon being mounted, since no media is desired when
+ * this component is rendered.
+ *
+ * The use case is mainly mobile, where SDK users probably disable the welcome
+ * page, but using it on the web in the future is not out of the question.
+ */
+class BlankWelcomePage extends Component {
+    /**
+     * {@code BlankWelcomePage} component's property types.
+     *
+     * @static
+     */
+    static propTypes = {
+        dispatch: PropTypes.func
+    };
+
+    /**
+     * Destroys the local tracks (if any) since no media is desired when this
+     * component is rendered.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    componentWillMount() {
+        this.props.dispatch(destroyLocalTracks());
+    }
+
+    /**
+     * Implements React's {@link Component#render()}. In this particular case
+     * we return null, because the entire purpose of this component is to render
+     * nothing.
+     *
+     * @inheritdoc
+     * @returns {null}
+     */
+    render() {
+        return null;
+    }
+}
+
+export default connect()(BlankWelcomePage);

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -3,8 +3,10 @@ import { TextInput, TouchableHighlight, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
+import { MEDIA_TYPE } from '../../base/media';
 import { Link, Text } from '../../base/react';
 import { ColorPalette } from '../../base/styles';
+import { createLocalTracks } from '../../base/tracks';
 
 import { AbstractWelcomePage, _mapStateToProps } from './AbstractWelcomePage';
 import styles from './styles';
@@ -35,7 +37,20 @@ class WelcomePage extends AbstractWelcomePage {
      *
      * @static
      */
-    static propTypes = AbstractWelcomePage.propTypes
+    static propTypes = AbstractWelcomePage.propTypes;
+
+    /**
+     * Creates a video track if not already available.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    componentWillMount() {
+        const { dispatch, _localVideoTrack } = this.props;
+
+        (typeof _localVideoTrack === 'undefined')
+            && dispatch(createLocalTracks({ devices: [ MEDIA_TYPE.VIDEO ] }));
+    }
 
     /**
      * Renders a prompt for entering a room name.

--- a/react/features/welcome/components/index.js
+++ b/react/features/welcome/components/index.js
@@ -1,1 +1,2 @@
+export { default as BlankWelcomePage } from './BlankWelcomePage';
 export { default as WelcomePage } from './WelcomePage';

--- a/react/features/welcome/route.js
+++ b/react/features/welcome/route.js
@@ -2,7 +2,7 @@
 
 import { RouteRegistry } from '../base/react';
 
-import { WelcomePage } from './components';
+import { BlankWelcomePage, WelcomePage } from './components';
 import { generateRoomWithoutSeparator } from './roomnameGenerator';
 
 declare var APP: Object;
@@ -46,3 +46,12 @@ function onEnter(nextState, replace) {
         replace(`/${room}`);
     }
 }
+
+/**
+ * Register route for BlankWelcomePage.
+ */
+RouteRegistry.register({
+    component: BlankWelcomePage,
+    undefined,
+    path: '/#blank'
+});


### PR DESCRIPTION
**NOTE**: This PR sits on top of https://github.com/jitsi/jitsi-meet/pull/1896

When do we need tracks?

- Welcome page (only the video track)
- Conference (depends if starting with audio / video muted is requested)

When do we need to destroy the tracks?

- When we are not in a conference and there is no welcome page

In order to accommodate all the above use cases, a new component is introduced:
BlankWelcomePage. Its purpose is to take the place of the welcome page when it
is disabled. When this component is mounted local tracks are destroyed.

Analogously, a video track is created when the (real) welcome page is created,
and all the desired tracks are created then the Conference component is created.
What are desired tracks? These are the tracks we'd like to use for the
conference that is about to happen. By default both audio and video are desired.
It's possible, however, the user requested to start the call with no
video/audio, in which case it's muted in base/media and a track is not created.

The first time the app starts (with the welcome page) it will request permission
for video only, since there is no need for audio in the welcome page. Later,
when a conference is joined permission for audio will be requested when an audio
track is to be created. The audio track is not destroyed when the conference
ends. Yours truly thinks this is not needed since it's a stopped track which is
not using system resources.