### PR TITLE
fix(config): override config values instead of merging

### DIFF
--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -175,9 +175,16 @@ export function overrideConfigJSON(
 
             if (!_.isEmpty(configJSON)) {
                 logger.info(
-                    `Extending ${configName} `
-                    + `with: ${JSON.stringify(configJSON)}`);
-                _.merge(configObj, configJSON);
+                    `Extending ${configName} with: ${
+                        JSON.stringify(configJSON)}`);
+
+                // eslint-disable-next-line arrow-body-style
+                _.mergeWith(configObj, configJSON, (oldValue, newValue) => {
+
+                    // XXX We don't want to merge the arrays, we want to
+                    // overwrite them.
+                    return Array.isArray(oldValue) ? newValue : undefined;
+                });
             }
         }
     }


### PR DESCRIPTION
Iterate over objects and copy over primitives and arrays
instead of using _.merge, as merge will not replace a config
entry completely. For arrays in a target object, the arrays
will have its indices replaced. This means if a source array
is empty, the target array will be left alone. Similarly,
if the target array is longer than a source array, there
will be indices not touched in the target array.

This commit fixes #1863.