### PR TITLE
ref(toolbar): replace custom debounce with lodash throttle

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -4,6 +4,8 @@ const logger = require("jitsi-meet-logger").getLogger(__filename);
 
 var UI = {};
 
+import _ from 'lodash';
+
 import Chat from "./side_pannels/chat/Chat";
 import SidePanels from "./side_pannels/SidePanels";
 import Avatar from "./avatar/Avatar";
@@ -20,7 +22,6 @@ import Filmstrip from "./videolayout/Filmstrip";
 import SettingsMenu from "./side_pannels/settings/SettingsMenu";
 import Profile from "./side_pannels/profile/Profile";
 import Settings from "./../settings/Settings";
-import { debounce } from "../util/helpers";
 
 import { updateDeviceList } from '../../react/features/base/devices';
 import {
@@ -278,13 +279,13 @@ UI.start = function () {
 
     sharedVideoManager = new SharedVideoManager(eventEmitter);
     if (!interfaceConfig.filmStripOnly) {
-        let debouncedShowToolbar
-            = debounce(
+        let throttledShowToolbar
+            = _.throttle(
                     () => UI.showToolbar(),
                     100,
                     { leading: true, trailing: false });
 
-        $("#videoconference_page").mousemove(debouncedShowToolbar);
+        $("#videoconference_page").mousemove(throttledShowToolbar);
 
         // Initialise the recording module.
         if (config.enableRecording) {

--- a/modules/util/helpers.js
+++ b/modules/util/helpers.js
@@ -17,36 +17,6 @@ export function createDeferred() {
 }
 
 /**
- * Creates a debounced function that delays invoking func until after wait
- * milliseconds have elapsed since the last time the debounced function was
- * invoked.
- *
- * @param fn
- * @param wait
- * @param options
- * @returns {function(...[*])}
- */
-export function debounce(fn, wait = 0, options = {}) {
-    const leading = options.leading || false;
-    const trailing
-        = (typeof options.trailing === 'undefined') || options.trailing;
-    let called = false;
-
-    return (...args) => {
-        if (!called) {
-            leading && fn(...args);
-
-            setTimeout(() => {
-                called = false;
-                trailing && fn(...args);
-            }, wait);
-
-            called = true;
-        }
-    };
-}
-
-/**
  * Returns the namespace for all global variables, functions, etc that we need.
  *
  * @returns {Object} the namespace.


### PR DESCRIPTION
The current custom debounce function sets a timeout and ensures
additional calls are not executed while the timeout is pending.
Regulating the call of a function while also ensuring it gets
called at a certain time is a throttle.