### PR TITLE
ref(1-on-1): move remote video visibility to a selector

### DIFF
--- a/react/features/filmstrip/actionTypes.js
+++ b/react/features/filmstrip/actionTypes.js
@@ -1,16 +1,4 @@
 /**
- * The type of action which signals to change the visibility of remote videos in
- * the filmstrip.
- *
- * {
- *     type: SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
- *     remoteVideosVisible: boolean
- * }
- */
-export const SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY
-    = Symbol('SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY');
-
-/**
  * The type of action sets the visibility of the entire filmstrip;
  *
  * {

--- a/react/features/filmstrip/actions.js
+++ b/react/features/filmstrip/actions.js
@@ -1,24 +1,6 @@
 import {
-    SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
-
-/**
- * Sets the visibility of remote videos in the filmstrip.
- *
- * @param {boolean} remoteVideosVisible - Whether or not remote videos in the
- * filmstrip should be visible.
- * @returns {{
- *     type: SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
- *     remoteVideosVisible: boolean
- * }}
- */
-export function setFilmstripRemoteVideosVisibility(remoteVideosVisible) {
-    return {
-        type: SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
-        remoteVideosVisible
-    };
-}
 
 /**
  * Sets if the entire filmstrip should be visible.

--- a/react/features/filmstrip/components/Filmstrip.web.js
+++ b/react/features/filmstrip/components/Filmstrip.web.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import { Toolbox } from '../../toolbox';
 
-import { shouldShowRemoteVideos } from '../functions';
+import { shouldRemoteVideosBeVisible } from '../functions';
 
 /**
  * Implements a React {@link Component} which represents the filmstrip on
@@ -92,7 +92,7 @@ class Filmstrip extends Component {
  */
 function _mapStateToProps(state) {
     return {
-        _remoteVideosVisible: shouldShowRemoteVideos(state)
+        _remoteVideosVisible: shouldRemoteVideosBeVisible(state)
     };
 }
 

--- a/react/features/filmstrip/components/Filmstrip.web.js
+++ b/react/features/filmstrip/components/Filmstrip.web.js
@@ -5,6 +5,8 @@ import { connect } from 'react-redux';
 
 import { Toolbox } from '../../toolbox';
 
+import { shouldShowRemoteVideos } from '../functions';
+
 /**
  * Implements a React {@link Component} which represents the filmstrip on
  * Web/React.
@@ -89,11 +91,8 @@ class Filmstrip extends Component {
  * }}
  */
 function _mapStateToProps(state) {
-    const { remoteVideosVisible } = state['features/filmstrip'];
-    const { disable1On1Mode } = state['features/base/config'];
-
     return {
-        _remoteVideosVisible: Boolean(remoteVideosVisible || disable1On1Mode)
+        _remoteVideosVisible: shouldShowRemoteVideos(state)
     };
 }
 

--- a/react/features/filmstrip/functions.js
+++ b/react/features/filmstrip/functions.js
@@ -1,0 +1,34 @@
+declare var interfaceConfig: Object;
+
+import {
+    getPinnedParticipant,
+    getLocalParticipant
+} from '../base/participants';
+
+/**
+ * A selector for determining whether or not remote video thumbnails should be
+ * displayed in the filmstrip.
+ *
+ * @param {Object} state - The full redux state.
+ * @returns {boolean} - True if remote video thumbnails should be displayed.
+ */
+export function shouldShowRemoteVideos(state) {
+    const participants = state['features/base/participants'];
+
+    const shouldShowVideos
+        = state['features/base/config'].disable1On1Mode
+
+        || interfaceConfig.filmStripOnly
+
+        // This is not a 1-on-1 call.
+        || participants.length > 2
+
+        // There is another participant and the local participant is pinned.
+        || (participants.length > 1
+            && getLocalParticipant(state) === getPinnedParticipant(state))
+
+        // There is any non-person participant, like a shared video.
+        || participants.find(participant => participant.isBot);
+
+    return Boolean(shouldShowVideos);
+}

--- a/react/features/filmstrip/functions.js
+++ b/react/features/filmstrip/functions.js
@@ -12,7 +12,7 @@ import {
  * @param {Object} state - The full redux state.
  * @returns {boolean} - True if remote video thumbnails should be displayed.
  */
-export function shouldShowRemoteVideos(state) {
+export function shouldRemoteVideosBeVisible(state) {
     const participants = state['features/base/participants'];
 
     const shouldShowVideos

--- a/react/features/filmstrip/index.js
+++ b/react/features/filmstrip/index.js
@@ -1,6 +1,7 @@
 export * from './actions';
 export * from './actionTypes';
 export * from './components';
+export * from './functions';
 
 import './middleware';
 import './reducer';

--- a/react/features/filmstrip/reducer.js
+++ b/react/features/filmstrip/reducer.js
@@ -1,16 +1,9 @@
 import { ReducerRegistry } from '../base/redux';
 import {
-    SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
 
 const DEFAULT_STATE = {
-    /**
-     * By default start with remote videos hidden for 1-on-1 mode and rely on
-     * other logic to invoke an action to make them visible when needed.
-     */
-    remoteVideosVisible: false,
-
     visible: true
 };
 
@@ -18,11 +11,6 @@ ReducerRegistry.register(
     'features/filmstrip',
     (state = DEFAULT_STATE, action) => {
         switch (action.type) {
-        case SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY:
-            return {
-                ...state,
-                remoteVideosVisible: action.remoteVideosVisible
-            };
         case SET_FILMSTRIP_VISIBILITY:
             return {
                 ...state,

--- a/react/features/recording/components/RecordingLabel.web.js
+++ b/react/features/recording/components/RecordingLabel.web.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
+import { shouldShowRemoteVideos } from '../../filmstrip';
 
 /**
  * Implements a React {@link Component} which displays the current state of
@@ -140,7 +141,7 @@ class RecordingLabel extends Component {
  * }}
  */
 function _mapStateToProps(state) {
-    const { remoteVideosVisible, visible } = state['features/filmstrip'];
+    const { visible } = state['features/filmstrip'];
     const { labelDisplayConfiguration } = state['features/recording'];
 
     return {
@@ -164,7 +165,7 @@ function _mapStateToProps(state) {
          *
          * @type {boolean}
          */
-        _remoteVideosVisible: remoteVideosVisible
+        _remoteVideosVisible: shouldShowRemoteVideos(state)
     };
 }
 

--- a/react/features/recording/components/RecordingLabel.web.js
+++ b/react/features/recording/components/RecordingLabel.web.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
-import { shouldShowRemoteVideos } from '../../filmstrip';
+import { shouldRemoteVideosBeVisible } from '../../filmstrip';
 
 /**
  * Implements a React {@link Component} which displays the current state of
@@ -165,7 +165,7 @@ function _mapStateToProps(state) {
          *
          * @type {boolean}
          */
-        _remoteVideosVisible: shouldShowRemoteVideos(state)
+        _remoteVideosVisible: shouldRemoteVideosBeVisible(state)
     };
 }
 

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { Popover } from '../../base/popover';
+import { shouldShowRemoteVideos } from '../../filmstrip';
+
 import { VideoQualityDialog } from './';
 
 import {
@@ -209,24 +211,15 @@ export class VideoQualityLabel extends Component {
  * }}
  */
 function _mapStateToProps(state) {
-    const {
-        audioOnly,
-        conference
-    } = state['features/base/conference'];
-    const { disable1On1Mode } = state['features/base/config'];
-    const {
-        remoteVideosVisible,
-        visible
-    } = state['features/filmstrip'];
-    const {
-        resolution
-    } = state['features/large-video'];
+    const { audioOnly, conference } = state['features/base/conference'];
+    const { visible } = state['features/filmstrip'];
+    const { resolution } = state['features/large-video'];
 
     return {
         _audioOnly: audioOnly,
         _conferenceStarted: Boolean(conference),
         _filmstripVisible: visible,
-        _remoteVideosVisible: Boolean(remoteVideosVisible || disable1On1Mode),
+        _remoteVideosVisible: shouldShowRemoteVideos(state),
         _resolution: resolution
     };
 }

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { Popover } from '../../base/popover';
-import { shouldShowRemoteVideos } from '../../filmstrip';
+import { shouldRemoteVideosBeVisible } from '../../filmstrip';
 
 import { VideoQualityDialog } from './';
 
@@ -219,7 +219,7 @@ function _mapStateToProps(state) {
         _audioOnly: audioOnly,
         _conferenceStarted: Boolean(conference),
         _filmstripVisible: visible,
-        _remoteVideosVisible: shouldShowRemoteVideos(state),
+        _remoteVideosVisible: shouldRemoteVideosBeVisible(state),
         _resolution: resolution
     };
 }


### PR DESCRIPTION
Derive whether or not remote videos should display using a selector
to look across different states. A selector was chosen over using
memoized selectors (reselect) or subscribers as a first step
approach, avoiding additional mutations caused by a subscriber
updating the filmstrip state and avoiding additional api overhead
introduced by reselect.

This commit was made on top of https://github.com/jitsi/jitsi-meet/pull/1915. This commit will rely on the lib-jitsi-changes from that pull request, and tests will fail until those lib changes are merged in.