### PR TITLE
ref(filmstrip): move toggling to react and redux

### DIFF
--- a/modules/FollowMe.js
+++ b/modules/FollowMe.js
@@ -1,3 +1,4 @@
+/* global APP */
 /*
  * Copyright @ 2015 Atlassian Pty Ltd
  *
@@ -14,6 +15,8 @@
  * limitations under the License.
  */
 const logger = require("jitsi-meet-logger").getLogger(__filename);
+
+import { setFilmstripVisibility } from '../react/features/filmstrip';
 
 import UIEvents from '../service/UI/UIEvents';
 import VideoLayout from './UI/videolayout/VideoLayout';
@@ -143,7 +146,9 @@ class FollowMe {
      * @private
      */
     _setFollowMeInitialState() {
-        this._filmstripToggled.bind(this, this._UI.isFilmstripVisible());
+        const { visible } = APP.store.getState()['features/filmstrip'];
+
+        this._filmstripToggled.bind(this, visible);
 
         const pinnedId = VideoLayout.getPinnedId();
 
@@ -330,12 +335,7 @@ class FollowMe {
             // receipt.
             filmstripVisible = (filmstripVisible == 'true');
 
-            // FIXME The UI (module) very likely doesn't (want to) expose its
-            // eventEmitter as a public field. I'm not sure at the time of this
-            // writing whether calling UI.toggleFilmstrip() is acceptable (from
-            // a design standpoint) either.
-            if (filmstripVisible !== this._UI.isFilmstripVisible())
-                this._UI.eventEmitter.emit(UIEvents.TOGGLE_FILMSTRIP);
+            APP.store.dispatch(setFilmstripVisibility(filmstripVisible));
         }
     }
 

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -27,6 +27,7 @@ import {
     openDeviceSelectionDialog
 } from '../../react/features/device-selection';
 import { openDisplayNamePrompt } from '../../react/features/display-name';
+import { setFilmstripVisibility } from '../../react/features/filmstrip';
 import {
     checkAutoEnableDesktopSharing,
     clearButtonPopup,
@@ -244,7 +245,7 @@ UI.mucJoined = function () {
 /***
  * Handler for toggling filmstrip
  */
-UI.handleToggleFilmstrip = () => UI.toggleFilmstrip();
+UI.handleToggleFilmstrip = () => VideoLayout.resizeVideoArea(true, false);
 
 /**
  * Returns the shared document manager object.
@@ -295,7 +296,6 @@ UI.start = function () {
     } else {
         $("body").addClass("filmstrip-only");
         UI.showToolbar();
-        Filmstrip.setFilmstripOnly();
         APP.store.dispatch(setNotificationsEnabled(false));
     }
 
@@ -553,16 +553,11 @@ UI.toggleSmileys = () => Chat.toggleSmileys();
  * Toggles filmstrip.
  */
 UI.toggleFilmstrip = function () {
-    var self = Filmstrip;
-    self.toggleFilmstrip.apply(self, arguments);
-    VideoLayout.resizeVideoArea(true, false);
-};
+    const { visible } = APP.store.getState()['features/filmstrip'];
 
-/**
- * Indicates if the filmstrip is currently visible or not.
- * @returns {true} if the filmstrip is currently visible, otherwise
- */
-UI.isFilmstripVisible = () => Filmstrip.isFilmstripVisible();
+    APP.store.dispatch(setFilmstripVisibility(!visible));
+    UI.handleToggleFilmstrip();
+};
 
 /**
  * Toggles chat panel.
@@ -1263,7 +1258,7 @@ const UIListeners = new Map([
             isGuest && UI.toggleSidePanel('profile_container');
         }
     ], [
-        UIEvents.TOGGLE_FILMSTRIP,
+        UIEvents.TOGGLED_FILMSTRIP,
         UI.handleToggleFilmstrip
     ], [
         UIEvents.FOLLOW_ME_ENABLED,

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -73,7 +73,7 @@ class Conference extends Component {
             <div id = 'videoconference_page'>
                 <div id = 'videospace'>
                     <LargeVideo />
-                    <Filmstrip displayToolbox = { filmStripOnly } />
+                    <Filmstrip filmstripOnly = { filmStripOnly } />
                 </div>
 
                 { filmStripOnly ? null : <Toolbox /> }

--- a/react/features/filmstrip/actions.js
+++ b/react/features/filmstrip/actions.js
@@ -3,6 +3,10 @@ import {
     SET_FILMSTRIP_VISIBILITY
 } from './actionTypes';
 
+import UIEvents from '../../../service/UI/UIEvents';
+
+declare var APP: Object;
+
 /**
  * Sets the visibility of remote videos in the filmstrip.
  *
@@ -21,17 +25,21 @@ export function setFilmstripRemoteVideosVisibility(remoteVideosVisible) {
 }
 
 /**
- * Sets if the entire filmstrip should be visible.
+ * Sets whether or not the entire filmstrip should be visible. Emits out to
+ * non-reduxified UI of the filmstrip visibility change.
  *
  * @param {boolean} visible - Whether not the filmstrip is visible.
- * @returns {{
- *     type: SET_FILMSTRIP_VISIBILITY,
- *     visible: boolean
- * }}
+ * @returns {Function}
  */
 export function setFilmstripVisibility(visible) {
-    return {
-        type: SET_FILMSTRIP_VISIBILITY,
-        visible
+    return dispatch => {
+        dispatch({
+            type: SET_FILMSTRIP_VISIBILITY,
+            visible
+        });
+
+        if (typeof APP !== 'undefined') {
+            APP.UI.emitEvent(UIEvents.TOGGLED_FILMSTRIP, visible);
+        }
     };
 }

--- a/react/features/filmstrip/middleware.js
+++ b/react/features/filmstrip/middleware.js
@@ -3,9 +3,9 @@
 import { MiddlewareRegistry } from '../base/redux';
 import { SET_CALL_OVERLAY_VISIBLE } from '../jwt';
 
-import Filmstrip from '../../../modules/UI/videolayout/Filmstrip';
 import UIEvents from '../../../service/UI/UIEvents';
 
+import { setFilmstripVisibility } from './actions';
 import {
     SET_FILMSTRIP_REMOTE_VIDEOS_VISIBLITY,
     SET_FILMSTRIP_VISIBILITY
@@ -13,26 +13,14 @@ import {
 
 declare var APP: Object;
 
-// eslint-disable-next-line no-unused-vars
-MiddlewareRegistry.register(({ getState }) => next => action => {
+MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
     case SET_CALL_OVERLAY_VISIBLE:
         if (typeof APP !== 'undefined') {
-            const oldValue
-                = Boolean(getState()['features/jwt'].callOverlayVisible);
             const result = next(action);
-            const newValue
-                = Boolean(getState()['features/jwt'].callOverlayVisible);
+            const { callOverlayVisible } = store.getState()['features/jwt'];
 
-            oldValue === newValue
-
-                // FIXME The following accesses the private state filmstrip of
-                // Filmstrip. It is written with the understanding that
-                // Filmstrip will be rewritten in React and, consequently, will
-                // not need the middleware implemented here, Filmstrip.init, and
-                // UI.start.
-                || (Filmstrip.filmstrip
-                    && Filmstrip.toggleFilmstrip(!newValue, false));
+            store.dispatch(setFilmstripVisibility(!callOverlayVisible));
 
             return result;
         }

--- a/service/UI/UIEvents.js
+++ b/service/UI/UIEvents.js
@@ -45,18 +45,7 @@ export default {
      * Notifies that the profile toolbar button has been clicked.
      */
     TOGGLE_PROFILE: "UI.toggle_profile",
-    /**
-     * Notifies that a command to toggle the filmstrip has been issued. The
-     * event may optionally specify a {Boolean} (primitive) value to assign to
-     * the visibility of the filmstrip (i.e. the event may act as a setter).
-     * The very toggling of the filmstrip may or may not occurred at the time
-     * of the receipt of the event depending on the position of the receiving
-     * event listener in relation to the event listener which carries out the
-     * command to toggle the filmstrip.
-     *
-     * @see {TOGGLED_FILMSTRIP}
-     */
-    TOGGLE_FILMSTRIP: "UI.toggle_filmstrip",
+
     /**
      * Notifies that the filmstrip was (actually) toggled. The event supplies a
      * {Boolean} (primitive) value indicating the visibility of the filmstrip


### PR DESCRIPTION
- Create the toggle button in the react filmstrip component.
  Remove toggle button initialization from Filmstrip.
- Replace calls to Filmstrip.toggleFilmstrip() to an action
  that sets filmstrip visibility.
- Hook the react filmstrip to redux to listen for visibility
  changes.
- Remove TOGGLE_FILMSTRIP event so the non-react UI is only
  reactive to toggle changes. This includes making video
  layout resizing occur on TOGGLED_FILMSTRIP.
- Move Filmstrip.isFilmstripVisible calls to look ups in the
  redux store to use redux as the source of truth.