### PR TITLE
[RN] Load config.js when the room is known

### DIFF
--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -37,11 +37,6 @@ export function appNavigate(uri: ?string) {
 function _appNavigateToMandatoryLocation(
         dispatch: Dispatch<*>, getState: Function,
         newLocation: Object) {
-    // TODO Kostiantyn Tsaregradskyi: We should probably detect if user is
-    // currently in a conference and ask her if she wants to close the
-    // current conference and start a new one with the new room name or
-    // domain.
-
     const oldLocationURL = getState()['features/base/connection'].locationURL;
     const oldHost = oldLocationURL ? oldLocationURL.host : undefined;
     const newHost = newLocation.host;

--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -30,32 +30,22 @@ export function appNavigate(uri: ?string) {
  * state.
  * @param {Object} newLocation - The location URI to navigate to. The value
  * cannot be undefined and is assumed to have all properties such as
- * {@code host} and {@code room} defined values.
+ * {@code host} and {@code room} defined. The values for these properties, may
+ * be undefined.
  * @private
  * @returns {void}
  */
 function _appNavigateToMandatoryLocation(
         dispatch: Dispatch<*>, getState: Function,
         newLocation: Object) {
-    const oldLocationURL = getState()['features/base/connection'].locationURL;
-    const oldHost = oldLocationURL ? oldLocationURL.host : undefined;
-    const newHost = newLocation.host;
-
-    if (oldHost === newHost) {
-        dispatchSetLocationURL()
-            .then(dispatchSetRoom);
-    } else {
-        // If the host has changed, we need to load the config of the new host
-        // and set it, and only after that we can navigate to a different route.
-        _loadConfig(newLocation)
-            .then(
-                config => configLoaded(/* err */ undefined, config),
-                err => configLoaded(err, /* config */ undefined))
-            .then(dispatchSetRoom);
-    }
+    _loadConfig(newLocation)
+        .then(
+            config => configLoaded(/* err */ undefined, config),
+            err => configLoaded(err, /* config */ undefined))
+        .then(dispatchSetRoom);
 
     /**
-     * Notifies that an attempt to load the config(uration) of domain has
+     * Notifies that an attempt to load the required configuration has
      * completed.
      *
      * @param {string|undefined} err - If the loading has failed, the error
@@ -189,6 +179,15 @@ export function appWillUnmount(app) {
  * @returns {Promise<Object>}
  */
 function _loadConfig(location: Object) {
+    // Here we 'fake' a configuration when the room is undefined. We cannot
+    // load a configuration from the server, but we need lib-jitsi-meet to be
+    // initialized in order to be able to create some local tracks for the
+    // welcome page.
+
+    if (typeof location.room === 'undefined') {
+        return Promise.resolve({});
+    }
+
     let protocol = location.protocol.toLowerCase();
 
     // The React Native app supports an app-specific scheme which is sure to not
@@ -199,5 +198,6 @@ function _loadConfig(location: Object) {
 
     return (
         loadConfig(
-            `${protocol}//${location.host}${location.contextRoot || '/'}`));
+            `${protocol}//${location.host}${location.contextRoot || '/'}`,
+            location.room));
 }

--- a/react/features/base/lib-jitsi-meet/functions.js
+++ b/react/features/base/lib-jitsi-meet/functions.js
@@ -55,15 +55,21 @@ export function isFatalJitsiConnectionError(error: string) {
  * Loads config.js from a specific remote server.
  *
  * @param {string} host - Host where config.js is hosted.
- * @param {string} path='config.js' - Relative pah to config.js file.
+ * @param {string} room - Room for which the configuration is being loaded.
  * @returns {Promise<Object>}
  */
-export function loadConfig(host: string, path: string = 'config.js') {
+export function loadConfig(host: string, room: string) {
     let promise;
 
     if (typeof APP === 'undefined') {
+        const url = new URL('config.js', host);
+
+        // XXX React Native doesn't support URLSearchParams
+        // https://github.com/facebook/react-native/issues/9596
+        const urlString = `${url.toString()}?room=${room}`;
+
         promise
-            = loadScript(new URL(path, host).toString())
+            = loadScript(urlString)
                 .then(() => {
                     const { config } = window;
 
@@ -77,7 +83,7 @@ export function loadConfig(host: string, path: string = 'config.js') {
                     return config;
                 })
                 .catch(err => {
-                    console.error(`Failed to load ${path} from ${host}`, err);
+                    console.error(`Failed to load config.js from ${host}`, err);
 
                     throw err;
                 });


### PR DESCRIPTION
    In order to load the configuration from the shard that will actually host the
    conference, it's imperative that we add the room= query parameter:

    https://meet.jit.si/config.js?room=example

    This implies a departure from our current model, where the config is loaded
    early, and discarded if the domain for the next conference is different, but
    kept otherwise.

    This patch loads the config later than we used to, that is, once we know the
    room the user is about to join.

    Due to architectural limitations in lib-jitsi-meet, it needs to be initialized
    with a configuration in order to properly function. This is unfortunate because
    we need to create a video track in the welcome page, but don't know the room
    (hence no config) yet. In order to circumvent this problem an empty
    configuration is used, which is later swapped with the appropriate one, once
    loaded.

    Some interesting side-effects of this change are a perceived speed increase when
    the app starts or a conference is hangup. They are both due to the fact that no
    config needs to be fetched from a remote server in those cases.