### PR TITLE
[RN] Add support for callstats on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-i18next": "4.8.0",
     "react-native": "0.42.3",
     "react-native-background-timer": "1.2.0",
+    "react-native-callstats": "3.23.0",
     "react-native-fetch-blob": "0.10.8",
     "react-native-img-cache": "1.4.0",
     "react-native-immersive": "1.0.0",

--- a/react/features/base/config/reducer.js
+++ b/react/features/base/config/reducer.js
@@ -37,14 +37,6 @@ const INITIAL_RN_STATE = {
     // fastest to merely disable them.
     disableAudioLevels: true,
 
-    // FIXME Lib-jitsi-meet uses HTML script elements to asynchronously load
-    // certain pieces of JavaScript. Unfortunately, the technique doesn't work
-    // on React Native (because there are no HTML elements in the first place).
-    // Fortunately, these pieces of JavaScript currently involve third parties
-    // and we can temporarily disable them (until we implement an alternative to
-    // async script elements on React Native).
-    disableThirdPartyRequests: true,
-
     p2p: {
         preferH264: true
     }

--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -313,15 +313,6 @@ function _visitNode(node, callback) {
         })();
     }
 
-    // performance
-    if (typeof global.performance === 'undefined') {
-        global.performance = {
-            now() {
-                return 0;
-            }
-        };
-    }
-
     // sessionStorage
     //
     // Required by:
@@ -339,6 +330,7 @@ function _visitNode(node, callback) {
 
     // WebRTC
     require('./polyfills-webrtc');
+    require('react-native-callstats/csio-polyfill');
 
     // XMLHttpRequest
     if (global.XMLHttpRequest) {


### PR DESCRIPTION
The global.performance.now polyfill is removed since it's polyfilled by
react-native-callstats.