### PR TITLE
ref(toolbar): add wrapper around buttons for torture tests

### DIFF
--- a/react/features/toolbox/components/ToolbarButton.web.js
+++ b/react/features/toolbox/components/ToolbarButton.web.js
@@ -156,13 +156,14 @@ class ToolbarButton extends Component {
                 <StatelessToolbarButton { ...props } />
             </Tooltip>
         );
+        let children = buttonComponent;
 
         const popupConfig = this._getPopupDisplayConfiguration();
 
         if (popupConfig) {
             const { dataAttr, dataInterpolate, position } = popupConfig;
 
-            return (
+            children = ( // eslint-disable-line no-extra-parens
                 <AKInlineDialog
                     content = { t(dataAttr, dataInterpolate) }
                     isOpen = { Boolean(popupConfig) }
@@ -172,7 +173,11 @@ class ToolbarButton extends Component {
             );
         }
 
-        return buttonComponent;
+        return (
+            <div className = { `toolbar-button-wrapper ${button.id}-wrapper` }>
+                { children }
+            </div>
+        );
     }
 
     /**


### PR DESCRIPTION
The torture tests were looking for the anchor tag within each
button. However, that anchor could get blown away from a react
re-render. So instead, expose a way for the torture tests
to find the root node of the button.