### PR TITLE
Reduce the dependencies of the Web ExternalAPI

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { urlObjectToString } from '../../../react/features/base/util';
+import { urlObjectToString } from '../../../react/features/base/util/uri.js';
 import {
     PostMessageTransportBackend,
     Transport

--- a/react/features/base/util/loadScript.web.js
+++ b/react/features/base/util/loadScript.web.js
@@ -1,4 +1,6 @@
-import JitsiMeetJS from '../lib-jitsi-meet';
+/* @flow */
+
+declare var JitsiMeetJS: Object;
 
 /**
  * Loads a script from a specific URL. The script will be interpreted upon load.
@@ -7,13 +9,13 @@ import JitsiMeetJS from '../lib-jitsi-meet';
  * @returns {Promise} Resolved with no arguments when the script is loaded and
  * rejected with the error from JitsiMeetJS.ScriptUtil.loadScript method.
  */
-export function loadScript(url) {
+export function loadScript(url: string) {
     return new Promise((resolve, reject) =>
         JitsiMeetJS.util.ScriptUtil.loadScript(
             url,
             /* async */ true,
             /* prepend */ false,
             /* relativeURL */ false,
-            /* loadCallback */ () => resolve(),
-            /* errorCallback */ error => reject(error)));
+            /* loadCallback */ resolve,
+            /* errorCallback */ reject));
 }


### PR DESCRIPTION
We broke external_api.min.js by `import`ing react/features/util which
`import`ed react/features/base/lib-jitsi-meet.

1. To reduce the risks of such a breakage until we add
   external_api.min.js to the torture tests, `import` as little as
   possible in modules/API/external/external_api.js.
2. Use the global `JitsiMeetJS` on Web in react/features/base/util.