### PR TITLE
feat(external_api): set permissions for cross-origin iframe

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -245,6 +245,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
+        this._frame.allow = 'camera; microphone';
         this._frame.src = this._url;
         this._frame.name = frameName;
         this._frame.id = frameName;


### PR DESCRIPTION
In Chrome M63 a warning is shown, permissions won't be automatically allowed
afterwards. Reference:
https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes

Setting this early makes us future proof, while working with current versions
too: Chrome < 63 gives an error because it doesn't understand the option and
Firefox seems to ignore it, so both continue to work as before.