### PR TITLE
[RN] Display loading indicator while joining

### DIFF
--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -15,5 +15,18 @@ export default createStyleSheet({
         alignSelf: 'stretch',
         backgroundColor: ColorPalette.appBackground,
         flex: 1
-    })
+    }),
+
+    /**
+     * Style for the connecting indicator.
+     */
+    connectingIndicator: {
+        alignItems: 'center',
+        bottom: 0,
+        justifyContent: 'center',
+        left: 0,
+        position: 'absolute',
+        right: 0,
+        top: 0
+    }
 });

--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -22,9 +22,11 @@ export default createStyleSheet({
      */
     connectingIndicator: {
         alignItems: 'center',
+        backgroundColor: ColorPalette.white,
         bottom: 0,
         justifyContent: 'center',
         left: 0,
+        opacity: 0.6,
         position: 'absolute',
         right: 0,
         top: 0


### PR DESCRIPTION
See the individual commits for details. It's currently displayed in 2 places: 
- The join button.
- The middle of the screen while joining (in the conference view)

<hr/>

The implementation took an interesting turn when I was adding the indicator to the conference page. It started to flicker because there are many tiny network requests, with gaps in between. That made me realize that we have cases where we *know* we want to show the loading indicator, and thus `LoadingIndicator` was born.

This component displays the loading spinner unconditionally, and it's used within `NetworkActivityIndicator` to display it based on the presence of network activity.

So, turns out in the two cases where we wanted to show the indicators have defined lifetimes (while appNavigate is doing its thing, and while we are connecting, respectively), so we use `LoadingIndicator` on those instead.

In addition I added one last experimental commit: a while semi-translucent background for the conference view while loading. I think it looks nice, and the experience could be enhanced with some extra work:

- don't allow switching between toolbox and filmstrip while connecting
- hide the secondary toolbar while connecting

These 2 + the experimental commit can be combined in a separate PR, if we agree that's what we want to do.