### PR TITLE
fix(dominant-speaker): update dominant speaker in redux

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -46,6 +46,7 @@ import {
     setVideoMuted
 } from './react/features/base/media';
 import {
+    dominantSpeakerChanged,
     localParticipantConnectionStatusChanged,
     localParticipantRoleChanged,
     MAX_DISPLAY_NAME_LENGTH,
@@ -1714,6 +1715,8 @@ export default {
                 APP.UI.participantConnectionStatusChanged(id);
         });
         room.on(ConferenceEvents.DOMINANT_SPEAKER_CHANGED, (id) => {
+            APP.store.dispatch(dominantSpeakerChanged(id));
+
             if (this.isLocalId(id)) {
                 this.isDominantSpeaker = true;
                 this.setRaisedHand(false);


### PR DESCRIPTION
Without dominant speaker in redux, the wrong user will be
selected after an unpin event.