### PR TITLE
fix(toolbar): fix proptype warning

### DIFF
--- a/react/features/toolbox/components/ToolbarButtonWithDialog.web.js
+++ b/react/features/toolbox/components/ToolbarButtonWithDialog.web.js
@@ -48,7 +48,7 @@ class ToolbarButtonWithDialog extends Component {
         /**
          * The React Component to show within {@code InlineDialog}.
          */
-        content: PropTypes.object,
+        content: PropTypes.func,
 
         /**
          * From which side tooltips should display. Will be re-used for


### PR DESCRIPTION
The implementation of ToolbarButtonWithDialog expects a
constructor function for now, not the object returned
from calling a constructor function.