### PR TITLE
fix(css): load css before jitsi-meet js

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,9 +132,10 @@
     <script><!--#include virtual="/interface_config.js" --></script>
     <script><!--#include virtual="/logging_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
+    <!-- load css before jitsi-meet javascript so any dom size querying can take into account CSS sizing -->
+    <link rel="stylesheet" href="css/all.css">
     <script src="libs/app.bundle.min.js?v=139"></script>
     <!--#include virtual="title.html" -->
-    <link rel="stylesheet" href="css/all.css">
     <!--#include virtual="plugin.head.html" -->
   </head>
   <body>


### PR DESCRIPTION
Some parts of jits-meet js query the dom for size measurements.
Measurements can be affected by css, so css that loads after the
measurements are taken can affect display. Put css loading
before jitsi-meet js loading to ensure the browser will finish
loading the css before executing the js.