### PR TITLE
feat(info): automatically show the info dialog

### DIFF
--- a/css/modals/invite/_info.scss
+++ b/css/modals/invite/_info.scss
@@ -1,4 +1,5 @@
 .info-dialog {
+    cursor: default;
     display: flex;
 
     .info-dialog-action-link {

--- a/react/features/invite/actionTypes.js
+++ b/react/features/invite/actionTypes.js
@@ -1,4 +1,15 @@
 /**
+ * The type of the action which signals a request to display the inline
+ * conference info dialog.
+ *
+ * {
+ *     type: SET_INFO_DIALOG_VISIBILITY,
+ *     visible: boolean
+ * }
+ */
+export const SET_INFO_DIALOG_VISIBILITY = Symbol('SET_INFO_DIALOG_VISIBILITY');
+
+/**
  * The type of the action which signals an error occurred while requesting dial-
  * in numbers.
  *

--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -1,13 +1,13 @@
 import { openDialog } from '../../features/base/dialog';
 
 import {
+    SET_INFO_DIALOG_VISIBILITY,
     UPDATE_DIAL_IN_NUMBERS_FAILED,
     UPDATE_DIAL_IN_NUMBERS_SUCCESS
 } from './actionTypes';
 import { AddPeopleDialog, InviteDialog } from './components';
 
 declare var $: Function;
-declare var APP: Object;
 
 /**
  * Opens the Invite Dialog.
@@ -25,6 +25,22 @@ export function openInviteDialog() {
  */
 export function openAddPeopleDialog() {
     return openDialog(AddPeopleDialog);
+}
+
+/**
+ * Opens the inline conference info dialog.
+ *
+ * @param {boolean} visible - Whether or not the dialog should be displayed.
+ * @returns {{
+ *     type: SET_INFO_DIALOG_VISIBILITY,
+ *     visible: boolean
+ * }}
+ */
+export function setInfoDialogVisibility(visible) {
+    return {
+        type: SET_INFO_DIALOG_VISIBILITY,
+        visible
+    };
 }
 
 /**

--- a/react/features/invite/components/InfoDialog.web.js
+++ b/react/features/invite/components/InfoDialog.web.js
@@ -46,6 +46,11 @@ class InfoDialog extends Component {
         onClose: PropTypes.func,
 
         /**
+         * Callback invoked when a mouse-related event has been detected.
+         */
+        onMouseOver: PropTypes.func,
+
+        /**
          * Invoked to obtain translated strings.
          */
         t: PropTypes.func
@@ -84,7 +89,9 @@ class InfoDialog extends Component {
      */
     render() {
         return (
-            <div className = 'info-dialog'>
+            <div
+                className = 'info-dialog'
+                onMouseOver = { this.props.onMouseOver } >
                 <div className = 'info-dialog-column'>
                     <h4 className = 'info-dialog-icon'>
                         <i className = 'icon-info' />

--- a/react/features/invite/components/InfoDialogButton.web.js
+++ b/react/features/invite/components/InfoDialogButton.web.js
@@ -46,10 +46,10 @@ class InfoDialogButton extends Component {
         _showDialog: PropTypes.bool,
 
         /**
-         * Whether or not the toolbars, in which this component exists, are
+         * Whether or not the toolbox, in which this component exists, are
          * visible.
          */
-        _visible: PropTypes.bool,
+        _toolboxVisible: PropTypes.bool,
 
         /**
          * Invoked to toggle display of the info dialog
@@ -107,8 +107,7 @@ class InfoDialogButton extends Component {
     }
 
     /**
-     * Update the state when the {@code InfoDialog} visibility has been updated
-     * for the first time.
+     * Update the state when the {@code InfoDialog} visibility has been updated.
      *
      * @inheritdoc
      */
@@ -118,7 +117,7 @@ class InfoDialogButton extends Component {
             this.setState({ hasInteractedWithDialog: true });
         }
 
-        if (!nextProps._visible && this.props._visible) {
+        if (!nextProps._toolboxVisible && this.props._toolboxVisible) {
             this._onDialogClose();
         }
     }
@@ -139,7 +138,7 @@ class InfoDialogButton extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const { _showDialog, _visible, tooltipPosition } = this.props;
+        const { _showDialog, _toolboxVisible, tooltipPosition } = this.props;
         const buttonConfiguration = {
             ...DEFAULT_BUTTON_CONFIGURATION,
             classNames: [
@@ -153,7 +152,7 @@ class InfoDialogButton extends Component {
                 content = { <InfoDialog
                     onClose = { this._onDialogClose }
                     onMouseOver = { this._onDialogMouseOver } /> }
-                isOpen = { _visible && _showDialog }
+                isOpen = { _toolboxVisible && _showDialog }
                 onClose = { this._onDialogClose }
                 onContentClick = { this._onDialogInteract }
                 position = { TOOLTIP_TO_POPUP_POSITION[tooltipPosition] }>
@@ -221,13 +220,13 @@ class InfoDialogButton extends Component {
  * @private
  * @returns {{
  *     _showDialog: boolean,
- *     _visible: boolean
+ *     _toolboxVisible: boolean
  * }}
  */
 function _mapStateToProps(state) {
     return {
         _showDialog: state['features/invite'].infoDialogVisible,
-        _visible: state['features/toolbox'].visible
+        _toolboxVisible: state['features/toolbox'].visible
     };
 }
 

--- a/react/features/invite/components/InfoDialogButton.web.js
+++ b/react/features/invite/components/InfoDialogButton.web.js
@@ -1,6 +1,11 @@
+import InlineDialog from '@atlaskit/inline-dialog';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-import { ToolbarButtonWithDialog } from '../../toolbox';
+import { ToolbarButton, TOOLTIP_TO_POPUP_POSITION } from '../../toolbox';
+
+import { setInfoDialogVisibility } from '../actions';
 
 import InfoDialog from './InfoDialog';
 
@@ -26,19 +31,115 @@ const DEFAULT_BUTTON_CONFIGURATION = {
  */
 class InfoDialogButton extends Component {
     /**
+     * {@code InfoDialogButton} component's property types.
+     *
+     * @static
+     */
+    static propTypes = {
+        /**
+         * Whether or not {@code InfoDialog} should be displayed.
+         */
+        _showDialog: PropTypes.bool,
+
+        /**
+         * Whether or not the toolbars, in which this component exists, are
+         * visible.
+         */
+        _visible: PropTypes.bool,
+
+        /**
+         * Invoked to toggle display of the info dialog
+         */
+        dispatch: PropTypes.func,
+
+        /**
+         * From which side tooltips should display. Will be re-used for
+         * displaying the inline dialog for video quality adjustment.
+         */
+        tooltipPosition: PropTypes.string
+    };
+
+    /**
+     * Initializes new {@code ToolbarButtonWithDialog} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onDialogClose = this._onDialogClose.bind(this);
+        this._onDialogToggle = this._onDialogToggle.bind(this);
+    }
+
+    /**
      * Implements React's {@link Component#render()}.
      *
      * @inheritdoc
      * @returns {ReactElement}
      */
     render() {
+        const { _showDialog, _visible, tooltipPosition } = this.props;
+        const buttonConfiguration = {
+            ...DEFAULT_BUTTON_CONFIGURATION,
+            classNames: [
+                ...DEFAULT_BUTTON_CONFIGURATION.classNames,
+                _showDialog ? 'toggled button-active' : ''
+            ]
+        };
+
         return (
-            <ToolbarButtonWithDialog
-                { ...this.props }
-                button = { DEFAULT_BUTTON_CONFIGURATION }
-                content = { InfoDialog } />
+            <InlineDialog
+                content = { <InfoDialog onClose = { this._onDialogClose } /> }
+                isOpen = { _visible && _showDialog }
+                onClose = { this._onDialogClose }
+                position = { TOOLTIP_TO_POPUP_POSITION[tooltipPosition] }>
+                <ToolbarButton
+                    button = { buttonConfiguration }
+                    onClick = { this._onDialogToggle }
+                    tooltipPosition = { tooltipPosition } />
+            </InlineDialog>
         );
+    }
+
+    /**
+     * Hides {@code InfoDialog}.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onDialogClose() {
+        this.props.dispatch(setInfoDialogVisibility(false));
+    }
+
+    /**
+     * Toggles the display of {@code InfoDialog}.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onDialogToggle() {
+        this.props.dispatch(setInfoDialogVisibility(!this.props._showDialog));
     }
 }
 
-export default InfoDialogButton;
+/**
+ * Maps (parts of) the Redux state to the associated {@code InfoDialogButton}
+ * component's props.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {{
+ *     _showDialog: boolean,
+ *     _visible: boolean
+ * }}
+ */
+function _mapStateToProps(state) {
+    return {
+        _showDialog: state['features/invite'].infoDialogVisible,
+        _visible: state['features/toolbox'].visible
+    };
+}
+
+export default connect(_mapStateToProps)(InfoDialogButton);

--- a/react/features/invite/reducer.js
+++ b/react/features/invite/reducer.js
@@ -7,7 +7,10 @@ import {
 } from './actionTypes';
 
 const DEFAULT_STATE = {
-    infoDialogVisible: false,
+
+    // By default show the info dialog when joining the conference.
+    infoDialogVisible: true,
+
     numbersEnabled: true
 };
 

--- a/react/features/invite/reducer.js
+++ b/react/features/invite/reducer.js
@@ -1,16 +1,24 @@
 import { ReducerRegistry } from '../base/redux';
 
 import {
+    SET_INFO_DIALOG_VISIBILITY,
     UPDATE_DIAL_IN_NUMBERS_FAILED,
     UPDATE_DIAL_IN_NUMBERS_SUCCESS
 } from './actionTypes';
 
 const DEFAULT_STATE = {
+    infoDialogVisible: false,
     numbersEnabled: true
 };
 
 ReducerRegistry.register('features/invite', (state = DEFAULT_STATE, action) => {
     switch (action.type) {
+    case SET_INFO_DIALOG_VISIBILITY:
+        return {
+            ...state,
+            infoDialogVisible: action.visible
+        };
+
     case UPDATE_DIAL_IN_NUMBERS_FAILED:
         return {
             ...state,

--- a/react/features/toolbox/components/ToolbarButton.web.js
+++ b/react/features/toolbox/components/ToolbarButton.web.js
@@ -6,23 +6,12 @@ import React, { Component } from 'react';
 
 import { translate } from '../../base/i18n';
 
+import { TOOLTIP_TO_POPUP_POSITION } from '../constants';
 import { isButtonEnabled } from '../functions';
 
 import StatelessToolbarButton from './StatelessToolbarButton';
 
 declare var APP: Object;
-
-/**
- * Mapping of tooltip positions to equivalent {@code AKInlineDialog} positions.
- *
- * @private
- */
-const TOOLTIP_TO_POPUP_POSITION = {
-    bottom: 'bottom center',
-    left: 'left middle',
-    top: 'top center',
-    right: 'right middle'
-};
 
 /**
  * Represents a button in Toolbar on React.

--- a/react/features/toolbox/components/ToolbarButtonWithDialog.web.js
+++ b/react/features/toolbox/components/ToolbarButtonWithDialog.web.js
@@ -3,20 +3,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { TOOLTIP_TO_POPUP_POSITION } from '../constants';
 import ToolbarButton from './ToolbarButton';
-
-/**
- * Maps AtlasKit {@code Tooltip} positions to equivalent {@code InlineDialog}
- * positions. The {@code InlineDialog} will appear from the the same side of
- * the button as the tooltip.
- *
- */
-const TOOLTIP_TO_DIALOG_POSITION = {
-    bottom: 'bottom center',
-    left: 'left middle',
-    right: 'right middle',
-    top: 'top center'
-};
 
 /**
  * React {@code Component} for displaying a button which will open an inline
@@ -113,7 +101,7 @@ class ToolbarButtonWithDialog extends Component {
                 content = { <Content onClose = { this._onDialogClose } /> }
                 isOpen = { _visible && this.state.showDialog }
                 onClose = { this._onDialogClose }
-                position = { TOOLTIP_TO_DIALOG_POSITION[tooltipPosition] }>
+                position = { TOOLTIP_TO_POPUP_POSITION[tooltipPosition] }>
                 <ToolbarButton
                     button = { buttonConfiguration }
                     onClick = { this._onDialogToggle }

--- a/react/features/toolbox/constants.js
+++ b/react/features/toolbox/constants.js
@@ -1,0 +1,11 @@
+/**
+ * Mapping of tooltip positions to equivalent {@code AKInlineDialog} positions.
+ *
+ * @private
+ */
+export const TOOLTIP_TO_POPUP_POSITION = {
+    bottom: 'bottom center',
+    left: 'left middle',
+    top: 'top center',
+    right: 'right middle'
+};

--- a/react/features/toolbox/index.js
+++ b/react/features/toolbox/index.js
@@ -1,6 +1,7 @@
 export * from './actions';
 export * from './actionTypes';
 export * from './components';
+export * from './constants';
 export * from './functions';
 
 import './middleware';


### PR DESCRIPTION
I'm not confident about the implementation here but it meets the absolute bare minimum of the happy flow working.

A couple things bothering me:
- I'm still not sure a good way to abstract a toolbar/box button with an inline dialog.
- The inline dialogs don't dock the toolbar and I'm not sure if that's good or bad.
- The relationship between toolbox and these other features seems off to me, maybe the features are circularly dependent but at least on different files.