### PR TITLE
fix(JitsiLocalStorage): Handle local storage error

### DIFF
--- a/modules/util/JitsiLocalStorage.js
+++ b/modules/util/JitsiLocalStorage.js
@@ -1,3 +1,7 @@
+import Logger from 'jitsi-meet-logger';
+
+const logger = Logger.getLogger(__filename);
+
 /**
  * Dummy implementation of Storage interface with empty methods.
  */
@@ -26,8 +30,15 @@ class JitsiLocalStorage extends DummyLocalStorage {
      * @constructor
      * @param {Storage} storage browser's local storage object.
      */
-    constructor(storage) {
+    constructor() {
         super();
+        let storage;
+
+        try {
+            storage = window.localStorage;
+        } catch (error) {
+            logger.error(error);
+        }
         this.storage = storage || new DummyLocalStorage();
     }
 
@@ -61,4 +72,4 @@ class JitsiLocalStorage extends DummyLocalStorage {
     }
 }
 
-export default new JitsiLocalStorage(window.localStorage);
+export default new JitsiLocalStorage();


### PR DESCRIPTION
Fixes an issue with Jitsi Meet when the local storage is disabled. 

Accessing `window.localStorage` was causing an error which was stopping the JS execution before anything on the page was loaded.