### PR TITLE
ref(stats): do not modify stats object from lib

### DIFF
--- a/react/features/connection-indicator/statsEmitter.js
+++ b/react/features/connection-indicator/statsEmitter.js
@@ -108,20 +108,19 @@ const statsEmitter = {
      * @returns {void}
      */
     _onStatsUpdated(currentUserId, stats) {
-        const allUserFramerates = stats.framerate;
-        const allUserResolutions = stats.resolution;
-
-        const currentUserFramerate = allUserFramerates[currentUserId];
-        const currentUserResolution = allUserResolutions[currentUserId];
+        const allUserFramerates = stats.framerate || {};
+        const allUserResolutions = stats.resolution || {};
 
         // FIXME resolution and framerate are hashes keyed off of user ids with
         // stat values. Receivers of stats expect resolution and framerate to
         // be primatives, not hashes, so overwrites the 'lib-jitsi-meet' stats
         // objects.
-        stats.framerate = currentUserFramerate;
-        stats.resolution = currentUserResolution;
+        const modifiedLocalStats = Object.assign({}, stats, {
+            framerate: allUserFramerates[currentUserId],
+            resolution: allUserResolutions[currentUserId]
+        });
 
-        this._emitStatsUpdate(currentUserId, stats);
+        this._emitStatsUpdate(currentUserId, modifiedLocalStats);
 
         // Get all the unique user ids from the framerate and resolution stats
         // and update remote user stats as needed.


### PR DESCRIPTION
This is more of a principle change than a necessary one.
In lib-jitsi-meet, when a getStats call finishes, the
stats are processed and first emitted (and received by
jitsi-meet) and then processed again for sending to
remote participants. Modifying the stats in place changes
the structure of stats before the second processing,
which maybe be unexpected.