### PR TITLE
fixed not being able to scroll on jitsi main page

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -14,11 +14,13 @@ body {
     height: 100%;
     font-size: 12px;
     font-weight: 400;
-    overflow: hidden;
     color: $defaultColor;
     background: $defaultBackground;
     &.filmstrip-only {
         background: transparent;
+    }
+    &.filmstrip-only, &.vertical-filmstrip {
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
The overflow:hidden prevents scrolling on the main page thus not being able to see all the content. We can apply it afterwards.