### PR TITLE
fix(defaultToolbarButtons): Fixes mute popup warning

### DIFF
--- a/react/features/toolbox/defaultToolbarButtons.web.js
+++ b/react/features/toolbox/defaultToolbarButtons.web.js
@@ -278,7 +278,7 @@ export default function getDefaultButtons() {
                         && sharedVideoManager.isSharedVideoVolumeOn()
                         && !sharedVideoManager.isSharedVideoOwner()) {
                         APP.UI.showCustomToolbarPopup(
-                            '#unableToUnmutePopup', true, 5000);
+                            'microphone', 'unableToUnmutePopup', true, 5000);
                     } else {
                         JitsiMeetJS.analytics
                             .sendEvent('toolbar.audio.unmuted');


### PR DESCRIPTION
Fixes exception when trying to unmute in the scenario, where someone else is sharing a video with you.