### PR TITLE
[RN] Fix setting full-screen when joining a conference

### DIFF
--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -43,10 +43,10 @@ MiddlewareRegistry.register(({ getState }) => next => action => {
             break;
         }
 
-        const { audioOnly, conference }
+        const { audioOnly, conference, joining }
             = getState()['features/base/conference'];
 
-        fullScreen = conference || action.conference ? !audioOnly : false;
+        fullScreen = conference || joining ? !audioOnly : false;
         break;
     }
 


### PR DESCRIPTION
HIDE_DIALOG happens between WILL_JOIN and JOINED so get the joining conference
from the state instead of the action.