### PR TITLE
fix(info): delay display to prevent misalignment

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -4,8 +4,6 @@ const logger = require("jitsi-meet-logger").getLogger(__filename);
 
 var UI = {};
 
-import _ from 'lodash';
-
 import Chat from "./side_pannels/chat/Chat";
 import SidePanels from "./side_pannels/SidePanels";
 import Avatar from "./avatar/Avatar";
@@ -273,14 +271,6 @@ UI.start = function () {
 
     sharedVideoManager = new SharedVideoManager(eventEmitter);
     if (!interfaceConfig.filmStripOnly) {
-        let throttledShowToolbar
-            = _.throttle(
-                    () => UI.showToolbar(),
-                    100,
-                    { leading: true, trailing: false });
-
-        $("#videoconference_page").mousemove(throttledShowToolbar);
-
         // Initialise the recording module.
         if (config.enableRecording) {
             Recording.init(eventEmitter, config.recordingType);

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
 import { Filmstrip } from '../../filmstrip';
+import { setInfoDialogVisibility } from '../../invite';
 import { LargeVideo } from '../../large-video';
 import { NotificationsContainer } from '../../notifications';
 import { OverlayContainer } from '../../overlay';
@@ -69,6 +70,13 @@ class Conference extends Component {
         APP.UI.bindEvents();
 
         this.props.dispatch(connect());
+
+        // Automatically show the {@code InfoDialog} but do so after a timeout
+        // to better ensure the relevant components have been attached to the
+        // dom, otherwise the dialog may display misaligned.
+        setTimeout(() => {
+            this.props.dispatch(setInfoDialogVisibility(true));
+        });
     }
 
     /**

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -3,6 +3,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect as reactReduxConnect } from 'react-redux';
+import _ from 'lodash';
 
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
@@ -21,6 +22,8 @@ declare var interfaceConfig: Object;
  * The conference page of the Web application.
  */
 class Conference extends Component {
+    _onShowToolbar: Function;
+    _originalOnShowToolbar: Function;
 
     /**
      * Conference component's property types.
@@ -30,6 +33,27 @@ class Conference extends Component {
     static propTypes = {
         dispatch: PropTypes.func
     };
+
+    /**
+     * Initializes a new Conference instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        // Throttle and bind this component's mousemove handler to prevent it
+        // from firing too often.
+        this._originalOnShowToolbar = this._onShowToolbar;
+        this._onShowToolbar = _.throttle(
+            () => this._originalOnShowToolbar(),
+            100,
+            {
+                leading: true,
+                trailing: false
+            });
+    }
 
     /**
      * Until we don't rewrite UI using react components
@@ -71,7 +95,9 @@ class Conference extends Component {
         const { filmStripOnly } = interfaceConfig;
 
         return (
-            <div id = 'videoconference_page'>
+            <div
+                id = 'videoconference_page'
+                onMouseMove = { this._onShowToolbar }>
                 <div id = 'videospace'>
                     <LargeVideo />
                     <Filmstrip filmstripOnly = { filmStripOnly } />
@@ -93,6 +119,16 @@ class Conference extends Component {
                 <HideNotificationBarStyle />
             </div>
         );
+    }
+
+    /**
+     * Displays the toolbar.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onShowToolbar() {
+        APP.UI.showToolbar();
     }
 }
 

--- a/react/features/invite/reducer.js
+++ b/react/features/invite/reducer.js
@@ -7,10 +7,6 @@ import {
 } from './actionTypes';
 
 const DEFAULT_STATE = {
-
-    // By default show the info dialog when joining the conference.
-    infoDialogVisible: true,
-
     numbersEnabled: true
 };
 


### PR DESCRIPTION
Renders can be trigger on the toolbars, causing the InfoButton to display its inline dialog InfoDialog before the InfoButton and toolbar have been properly attached to the dom. This is most easily reproducible by moving the mouse around while the conference is loading, thereby triggering additional toolbar re-renders. When that happens, the InfoDialog may not be placed in the correct location once the button and toolbar are put on the dom. The best "solution" I could come up with is triggering display of the InfoDialog after the conference has rendered and after it should have attached itself to the dom. I'm definitely open to changing this implementation.