### PR TITLE
[RN] Use JWT callee name in CallKit

### DIFF
--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -209,18 +209,22 @@ function _conferenceLeft(store, next, action) {
 function _conferenceWillJoin({ getState }, next, action) {
     const result = next(action);
 
+    const state = getState();
     const conference = action.conference;
-    const url = getInviteURL(getState);
-    const hasVideo = !isVideoMutedByAudioOnly(getState);
+    const url = getInviteURL(state);
+    const hasVideo = !isVideoMutedByAudioOnly(state);
 
     // When assigning the call UUID, do so in upper case, since iOS will
     // return it upper cased.
     conference.callUUID = uuid.v4().toUpperCase();
     CallKit.startCall(conference.callUUID, url.toString(), hasVideo)
         .then(() => {
-            const { room } = getState()['features/base/conference'];
+            const { room } = state['features/base/conference'];
+            const { callee } = state['features/jwt'];
 
-            CallKit.updateCall(conference.callUUID, { displayName: room });
+            CallKit.updateCall(
+                conference.callUUID,
+                { displayName: (callee && callee.name) || room });
         });
 
     return result;


### PR DESCRIPTION
Fallback to the room name otherwise. This allows us to have better entries in
the phone history.