### PR TITLE
Adapt Jitsi-meet client to be usable with others xmpp client

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -183,6 +183,9 @@ function getDisplayName(id) {
     if (participant && participant.getDisplayName()) {
         return participant.getDisplayName();
     }
+    else if(participant){
+        return id;
+    }
 }
 
 /**


### PR DESCRIPTION
Use id (which is in reality XMPP resource) to have correct display name of user from other xmpp clients which does not use XEP-0172 for muc (https://xmpp.org/extensions/xep-0172.html#former : this XEP is now discouraged for this kind of use) instead of nothing at all.

This patch is just a try to repair this kind of problem. It doesn't modify now "fellow jitser" texts in UI, and don't add "resource as id" nickname (which should be done in lib-jitsi-meet probably).

Issue here : https://github.com/jitsi/jitsi-meet/issues/1270