### PR TITLE
Fixes display name for incoming chat messages, sender doesn't have nick.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1716,6 +1716,13 @@ export default {
             if (isButtonEnabled('chat')) {
                 room.on(JitsiConferenceEvents.MESSAGE_RECEIVED, (id, body, ts) => {
                     let nick = getDisplayName(id);
+
+                    if (!nick) {
+                        nick =
+                            `${interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME} (${
+                                id})`;
+                    }
+
                     APP.API.notifyReceivedChatMessage({
                         id,
                         nick,


### PR DESCRIPTION
If we join in a conference and there are messages from user who left before us joining(or they do not have display name set, missing nick extenasion in presence), now we see this:
<img width="274" alt="screen shot 2017-10-13 at 15 22 32" src="https://user-images.githubusercontent.com/3263098/31566819-ea33b110-b031-11e7-9f6f-dc8bd28a9a70.png">

This PR fixes like this:
<img width="282" alt="screen shot 2017-10-13 at 15 22 06" src="https://user-images.githubusercontent.com/3263098/31566827-f60faae8-b031-11e7-99a8-db0988781831.png">

It adds the resource of the user that sent the message, cause there may be multiple people who left/rejoined and we need to at least see the difference between messages, like:
<img width="302" alt="screen shot 2017-10-13 at 15 23 00" src="https://user-images.githubusercontent.com/3263098/31566843-10dcf63c-b032-11e7-909f-065aa13dec24.png">
