### PR TITLE
[Android] Specify build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -130,7 +130,8 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 25
+    buildToolsVersion = "26.0.2"
+    compileSdkVersion = 26
     minSdkVersion    = 16
     targetSdkVersion = 25
 


### PR DESCRIPTION
Android Studio won't build the app otherwise. Since the gradle plugin 3.0 beta7,
the minimum supported build tools version is 26.0.2, so set it to that. Also
bump compileSdkVersion to 26 since they need to match (in the major number, that
is).

The target API is still 25. Android Oreo (26) brought some changes in overlay
permissions which I haven't figured out yet.