### PR TITLE
[RN] Don't tell everyone we're called "me"

### DIFF
--- a/react/features/base/jwt/middleware.js
+++ b/react/features/base/jwt/middleware.js
@@ -14,7 +14,6 @@ import { LIB_INIT_ERROR } from '../lib-jitsi-meet';
 import {
     getLocalParticipant,
     getParticipantCount,
-    LOCAL_PARTICIPANT_DEFAULT_NAME,
     PARTICIPANT_JOINED,
     participantUpdated
 } from '../participants';
@@ -274,7 +273,7 @@ function _undoOverwriteLocalParticipant(
             newProperties.email = undefined;
         }
         if (name === localParticipant.name) {
-            newProperties.name = LOCAL_PARTICIPANT_DEFAULT_NAME;
+            newProperties.name = undefined;
         }
         dispatch(participantUpdated(newProperties));
     }

--- a/react/features/base/participants/constants.js
+++ b/react/features/base/participants/constants.js
@@ -22,15 +22,6 @@ export const DEFAULT_AVATAR_RELATIVE_PATH = 'images/avatar.png';
 export const LOCAL_PARTICIPANT_DEFAULT_ID = 'local';
 
 /**
- * The default display name of the local participant.
- *
- * TODO Get the display name from config and/or localized.
- *
- * @type {string}
- */
-export const LOCAL_PARTICIPANT_DEFAULT_NAME = 'me';
-
-/**
  * Max length of the display names.
  *
  * @type {string}

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -11,11 +11,7 @@ import {
     PARTICIPANT_UPDATED,
     PIN_PARTICIPANT
 } from './actionTypes';
-import {
-    LOCAL_PARTICIPANT_DEFAULT_ID,
-    LOCAL_PARTICIPANT_DEFAULT_NAME,
-    PARTICIPANT_ROLE
-} from './constants';
+import { LOCAL_PARTICIPANT_DEFAULT_ID, PARTICIPANT_ROLE } from './constants';
 
 /**
  * Participant object.
@@ -80,10 +76,11 @@ function _participant(state: Object = {}, action) {
             email,
             isBot,
             local,
+            name,
             pinned,
             role
         } = participant;
-        let { avatarID, id, name } = participant;
+        let { avatarID, id } = participant;
 
         // avatarID
         //
@@ -99,17 +96,6 @@ function _participant(state: Object = {}, action) {
         // random ID.
         if (!id && local) {
             id = LOCAL_PARTICIPANT_DEFAULT_ID;
-        }
-
-        // name
-        if (!name) {
-            // TODO Get the display name from config and/or localized.
-            // XXX On Web the default value is handled in conference.js by
-            // getParticipantDisplayName.
-            if (typeof APP === 'undefined') {
-                name
-                    = local ? LOCAL_PARTICIPANT_DEFAULT_NAME : 'Fellow Jitster';
-            }
         }
 
         return {

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -68,7 +68,7 @@ function _participant(state: Object = {}, action) {
         break;
 
     case PARTICIPANT_JOINED: {
-        const participant = action.participant; // eslint-disable-line no-shadow
+        const { participant } = action; // eslint-disable-line no-shadow
         const {
             avatarURL,
             connectionStatus,
@@ -114,9 +114,9 @@ function _participant(state: Object = {}, action) {
     }
 
     case PARTICIPANT_UPDATED: {
-        const participant = action.participant; // eslint-disable-line no-shadow
-        const { local } = participant;
+        const { participant } = action; // eslint-disable-line no-shadow
         let { id } = participant;
+        const { local } = participant;
 
         if (!id && local) {
             id = LOCAL_PARTICIPANT_DEFAULT_ID;


### PR DESCRIPTION
Recently/as part of the work on taking into account the user defined by
JWT, the local participant (on mobile) started telling the remote
participants that he/she had the display name "me". Obviously, that's
incorrect. Do not store the default display name in redux. While it may
be argues that redux is the place for all states, base/participants and
the name property of Participant is not meant to be that display name
because that is being sent to remote participants, the default name
needs to be internationalized, etc. So it's better to not store the
default display name at this time at all because it's not used by mobile
anyway and Web already deals with remote participants who don't share
their display names.