### PR TITLE
feat(1080p): pass new-style constraints to createLocalTracks

### DIFF
--- a/config.js
+++ b/config.js
@@ -92,6 +92,22 @@ var config = {
     // Sets the preferred resolution (height) for local video. Defaults to 720.
     // resolution: 720,
 
+    // w3c spec-compliant video constraints to use for video capture. Currently
+    // used by browsers that return true from lib-jitsi-meet's
+    // RTCBrowserType#usesNewGumFlow. The constraints are independency from
+    // this config's resolution value. Defaults to requesting an ideal aspect
+    // ratio of 16:9 with an ideal resolution of 1080p.
+    // constraints: {
+    //     video: {
+    //         aspectRatio: 16 / 9,
+    //         height: {
+    //             ideal: 1080,
+    //             max: 1080,
+    //             min: 240
+    //         }
+    //     }
+    // },
+
     // Enable / disable simulcast support.
     // disableSimulcast: false,
 

--- a/react/features/base/conference/constants.js
+++ b/react/features/base/conference/constants.js
@@ -42,7 +42,7 @@ export const JITSI_CONFERENCE_URL_KEY = Symbol('url');
  * @type {object}
  */
 export const VIDEO_QUALITY_LEVELS = {
-    HIGH: 720,
+    HIGH: 1080,
     STANDARD: 360,
     LOW: 180
 };

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -45,6 +45,7 @@ export function createLocalTracksF(
     }
 
     const {
+        constraints,
         firefox_fake_device, // eslint-disable-line camelcase
         resolution
     } = store.getState()['features/base/config'];
@@ -53,6 +54,7 @@ export function createLocalTracksF(
         JitsiMeetJS.createLocalTracks(
             {
                 cameraDeviceId,
+                constraints,
                 desktopSharingExtensionExternalInstallation:
                     options.desktopSharingExtensionExternalInstallation,
                 desktopSharingSources: options.desktopSharingSources,


### PR DESCRIPTION
The lib will accept new style constraints and use those
to capture audio/video. By defining the constraints in
config, there is greater flexibility for defining
and changing constraints.

Relies on https://github.com/jitsi/lib-jitsi-meet/pull/617.