### PR TITLE
Fix overflow on meet.jit.si home page

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -14,11 +14,13 @@ body {
     height: 100%;
     font-size: 12px;
     font-weight: 400;
-    overflow: hidden;
     color: $defaultColor;
     background: $defaultBackground;
     &.filmstrip-only {
         background: transparent;
+    }
+    &.vertical-filmstrip {
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
The home page now can scroll normally, and the scroll is blocked on the conference page.