### PR TITLE
fix(audio-only): remove extra audio-only toggle with config.startAudi…

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -29,8 +29,7 @@ import {
     EMAIL_COMMAND,
     lockStateChanged,
     p2pStatusChanged,
-    sendLocalParticipant,
-    toggleAudioOnly
+    sendLocalParticipant
 } from './react/features/base/conference';
 import { updateDeviceList } from './react/features/base/devices';
 import {
@@ -550,11 +549,6 @@ export default {
         );
 
         let tryCreateLocalTracks;
-
-        // Enable audio only mode
-        if (config.startAudioOnly) {
-            APP.store.dispatch(toggleAudioOnly());
-        }
 
         // FIXME is there any simpler way to rewrite this spaghetti below ?
         if (options.startScreenSharing) {


### PR DESCRIPTION
…oOnly

There is middleware in base/media that, if the conference room is defined, looks
at url parameters and the config to dispatch setAudioOnly. The call inside
conference would call toggleAudioOnly, which would then set audio only to false.