### PR TITLE
New auth params for room password/ xmpp auth auto

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -298,7 +298,7 @@ class ConferenceConnector {
         // not enough rights to create conference
         case JitsiConferenceErrors.AUTHENTICATION_REQUIRED: {
             // Schedule reconnect to check if someone else created the room.
-            this.reconnectTimeout = setTimeout(() => room.join(), 5000);
+            this.reconnectTimeout = setTimeout(() => room.join(config.roomPassword), 5000);
 
             const { password }
                 = APP.store.getState()['features/base/conference'];
@@ -411,7 +411,7 @@ class ConferenceConnector {
      *
      */
     connect() {
-        room.join();
+        room.join(config.roomPassword);
     }
 }
 

--- a/conference.js
+++ b/conference.js
@@ -123,6 +123,8 @@ const commands = {
  */
 function connect(roomName) {
     return openConnection({
+	id: config.userJid,
+	password: config.userPassword,
         retry: true,
         roomName
     })

--- a/config.js
+++ b/config.js
@@ -51,6 +51,12 @@ var config = {
     // to enter password itself if needed.
     roomPassword: undefined,
 
+    // The default username and password of XMPP user, can
+    // be overriden here, default as undefined, user use default auth
+    // when not provided (anonymous or login UI)
+    userJid: undefined,
+    userPassword: undefined,
+
     // Testing / experimental features.
     //
 

--- a/config.js
+++ b/config.js
@@ -46,6 +46,10 @@ var config = {
     // The real JID of focus participant - can be overridden here
     // focusUserJid: 'focus@auth.jitsi-meet.example.com',
 
+    // The default password for rooms. can be overriden here,
+    // default as undefined, no password specified, user has
+    // to enter password itself if needed.
+    roomPassword: undefined,
 
     // Testing / experimental features.
     //


### PR DESCRIPTION
In some case, it might be useful to force xmpp auth or room password directly from config file (example : you want to use a true xmpp auth  but need to be directly connected when you arrived in jitsi meet  external APi).

This patch allow user to directly set xmpp auth params and/or room password in config file.
This patch fix most of https://github.com/jitsi/jitsi-meet/issues/2075 issue (Don't know yet how to handle sid,rid).