### PR TITLE
[iOS] use display: 'none' to hide elements

### DIFF
--- a/react/features/base/react/components/native/Container.js
+++ b/react/features/base/react/components/native/Container.js
@@ -40,17 +40,15 @@ export default class Container extends AbstractContainer {
         // visible
         if (!visible) {
             // FIXME: Whatever I try ends up failing somehow on Android, give up
-            // for now, hoping display: 'none' solves this.
+            // for now.
             if (Platform.OS === 'android') {
                 return null;
             }
 
             // Intentionally hide this Container without destroying it.
-            // TODO Replace with display: 'none' supported in RN >= 0.43.
             props.style = {
                 ...props.style,
-                height: 0,
-                width: 0
+                display: 'none'
             };
         }
 

--- a/react/features/base/react/components/native/Container.js
+++ b/react/features/base/react/components/native/Container.js
@@ -39,8 +39,8 @@ export default class Container extends AbstractContainer {
 
         // visible
         if (!visible) {
-            // FIXME: Whatever I try ends up failing somehow on Android, give up
-            // for now.
+            // FIXME: It turns out that display: none will fail on some Android
+            // devices, but work on the others (currently fails on Google Pixel)
             if (Platform.OS === 'android') {
                 return null;
             }


### PR DESCRIPTION
No, it still doesn't work properly on Android, sigh.