### PR TITLE
fix(filmstrip): create a specific target for local video appending

### DIFF
--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -22,7 +22,7 @@ function LocalVideo(VideoLayout, emitter) {
 
     this.container = this.createContainer();
     this.$container = $(this.container);
-    $('#filmstripLocalVideo').append(this.container);
+    $('#filmstripLocalVideoThumbnail').append(this.container);
 
     this.localVideoId = null;
     this.bindHoverHandler();

--- a/react/features/filmstrip/components/Filmstrip.web.js
+++ b/react/features/filmstrip/components/Filmstrip.web.js
@@ -111,6 +111,7 @@ class Filmstrip extends Component<*> {
                         onMouseOut = { this._onMouseOut }
                         onMouseOver = { this._onMouseOver }>
                         { this.props.filmstripOnly ? null : <InviteButton /> }
+                        <div id = 'filmstripLocalVideoThumbnail' />
                     </div>
                     <div
                         className = 'filmstrip__videos'


### PR DESCRIPTION
Instead of targetting a div that contains multiple elements
and risking the elements appearing out of order, create a
specific div for local video to append to.