### PR TITLE
fix(analytics): use string concatenation for ie11

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -27,8 +27,11 @@
         value = value ? Math.round(parseFloat(value)) : null;
         const label = data.label || '';
 
-        ga('send', 'event', 'jit.si',
-            `${action}.${data.browserName}`, label, value);
+        // Intentionally use string concatenation as analytics needs to work on
+        // IE but this file does not go through babel.
+        // eslint-disable-next-line prefer-template
+        ga('send', 'event', 'jit.si', action + '.' + data.browserName,
+            label, value);
     };
 
     if (typeof ctx.JitsiMeetJS === 'undefined') {


### PR DESCRIPTION
Alternatively the file could be run through webpack but I went with this first because it's less work.