### PR TITLE
fix(external-api): build with polyfill for IE11

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -172,7 +172,12 @@ module.exports = [
     // JitsiMeetExternalAPI).
     Object.assign({}, config, {
         entry: {
-            'external_api': './modules/API/external/index.js'
+            'external_api': [
+
+                // XXX Required by at least IE11 at the time of this writing.
+                'babel-polyfill',
+                './modules/API/external/index.js'
+            ]
         },
         output: Object.assign({}, config.output, {
             library: 'JitsiMeetExternalAPI',


### PR DESCRIPTION
I'm not sure if there is a better way to apply the polyfill in the webpack config, as currently with this change the adding of the polyfill is duplicated for both app.js and external_api.js. The polyfill itself is needed right now so external_api can get String.prototype.startsWith and to protect against future changes that could introduce es6 that is not supported by IE11.