### PR TITLE
[PREVIEW|RN]: Handle getUserMedia in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,3 @@ fastlane/screenshots
 
 # CocoaPods
 Pods/
-Podfile.lock

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,91 @@
+PODS:
+  - React (0.49.5):
+    - React/Core (= 0.49.5)
+  - react-native-background-timer (1.3.0):
+    - React
+  - react-native-fetch-blob (0.10.6):
+    - React/Core
+  - react-native-keep-awake (2.0.5):
+    - React
+  - react-native-webrtc (1.58.2)
+  - React/BatchedBridge (0.49.5):
+    - React/Core
+    - React/cxxreact_legacy
+  - React/Core (0.49.5):
+    - yoga (= 0.49.5.React)
+  - React/cxxreact_legacy (0.49.5):
+    - React/jschelpers_legacy
+  - React/DevSupport (0.49.5):
+    - React/Core
+    - React/RCTWebSocket
+  - React/fishhook (0.49.5)
+  - React/jschelpers_legacy (0.49.5)
+  - React/RCTActionSheet (0.49.5):
+    - React/Core
+  - React/RCTAnimation (0.49.5):
+    - React/Core
+  - React/RCTBlob (0.49.5):
+    - React/Core
+  - React/RCTImage (0.49.5):
+    - React/Core
+    - React/RCTNetwork
+  - React/RCTLinkingIOS (0.49.5):
+    - React/Core
+  - React/RCTNetwork (0.49.5):
+    - React/Core
+  - React/RCTText (0.49.5):
+    - React/Core
+  - React/RCTWebSocket (0.49.5):
+    - React/Core
+    - React/fishhook
+    - React/RCTBlob
+  - RNVectorIcons (4.4.0):
+    - React
+  - yoga (0.49.5.React)
+
+DEPENDENCIES:
+  - react-native-background-timer (from `../node_modules/react-native-background-timer`)
+  - react-native-fetch-blob (from `../node_modules/react-native-fetch-blob`)
+  - react-native-keep-awake (from `../node_modules/react-native-keep-awake`)
+  - react-native-webrtc (from `../node_modules/react-native-webrtc`)
+  - React/BatchedBridge (from `../node_modules/react-native`)
+  - React/Core (from `../node_modules/react-native`)
+  - React/DevSupport (from `../node_modules/react-native`)
+  - React/RCTActionSheet (from `../node_modules/react-native`)
+  - React/RCTAnimation (from `../node_modules/react-native`)
+  - React/RCTImage (from `../node_modules/react-native`)
+  - React/RCTLinkingIOS (from `../node_modules/react-native`)
+  - React/RCTNetwork (from `../node_modules/react-native`)
+  - React/RCTText (from `../node_modules/react-native`)
+  - React/RCTWebSocket (from `../node_modules/react-native`)
+  - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
+  - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
+
+EXTERNAL SOURCES:
+  React:
+    :path: ../node_modules/react-native
+  react-native-background-timer:
+    :path: ../node_modules/react-native-background-timer
+  react-native-fetch-blob:
+    :path: ../node_modules/react-native-fetch-blob
+  react-native-keep-awake:
+    :path: ../node_modules/react-native-keep-awake
+  react-native-webrtc:
+    :path: ../node_modules/react-native-webrtc
+  RNVectorIcons:
+    :path: ../node_modules/react-native-vector-icons
+  yoga:
+    :path: ../node_modules/react-native/ReactCommon/yoga
+
+SPEC CHECKSUMS:
+  React: 9d5a23842dcc75ffef540ee2d2ef0eee1904ee58
+  react-native-background-timer: ca2afbbdda52ed2caa0c51762938a1e4296d097c
+  react-native-fetch-blob: 2bef9be702de8726f4d7bf58d2345579aaaee60d
+  react-native-keep-awake: 8fda9ff5acfdde27bc9b3a5cfde381b415297f71
+  react-native-webrtc: 6fd0b3aa890d7a9b9b4d01d30f958d17ae88a785
+  RNVectorIcons: 208e7e1507e3bc800619caf1c2748ad6b6b68188
+  yoga: 596e987aa8aac0165abb235d2977982f090476a0
+
+PODFILE CHECKSUM: a7cb8c7365f8cf9a01ee4eb78325139933776faf
+
+COCOAPODS: 1.3.1

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -211,12 +211,12 @@ export function conferenceLeft(conference: Object) {
 }
 
 /**
- * Attaches any pre-existing local media to the conference, before
- * the conference will be joined. Then signals the intention of the application
- * to have the local participant join a specific conference.
+ * Adds any existing local tracks to a specific conference before the conference
+ * is joined. Then signals the intention of the application to have the local
+ * participant join the specified conference.
  *
- * @param {JitsiConference} conference - The JitsiConference instance the
- * local participant will (try to) join.
+ * @param {JitsiConference} conference - The {@code JitsiConference} instance
+ * the local participant will (try to) join.
  * @returns {Function}
  */
 function _conferenceWillJoin(conference: Object) {

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -12,7 +12,7 @@ import {
     participantRoleChanged,
     participantUpdated
 } from '../participants';
-import { trackAdded, trackRemoved } from '../tracks';
+import { getLocalTracks, trackAdded, trackRemoved } from '../tracks';
 
 import {
     CONFERENCE_FAILED,
@@ -222,8 +222,7 @@ export function conferenceLeft(conference: Object) {
 function _conferenceWillJoin(conference: Object) {
     return (dispatch: Dispatch<*>, getState: Function) => {
         const localTracks
-            = getState()['features/base/tracks']
-                .filter(t => t.local)
+            = getLocalTracks(getState()['features/base/tracks'])
                 .map(t => t.jitsiTrack);
 
         if (localTracks.length) {

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -10,15 +10,45 @@
 export const TRACK_ADDED = Symbol('TRACK_ADDED');
 
 /**
- * Action for when a track cannot be created because permissions have not been
- * granted.
+ * Action triggered when a local track starts being created through the WebRTC
+ * getUserMedia call. It will include extra 'gumProcess' field which is
+ * a Promise with extra 'cancel' method which can be used to cancel the process.
+ * Canceling will result in disposing any JitsiLocalTrack returned by the GUM
+ * callback. There will be TRACK_CREATE_CANCELED event instead of track
+ * added/gum failed events.
  *
  * {
- *     type: TRACK_PERMISSION_ERROR,
- *     trackType: string
+ *     type: TRACK_BEING_CREATED
+ *     track: {
+ *         local: true,
+ *         gumProcess: Promise with cancel() method to abort,
+ *         mediaType: MEDIA_TYPE
+ *     }
  * }
  */
-export const TRACK_PERMISSION_ERROR = Symbol('TRACK_PERMISSION_ERROR');
+export const TRACK_BEING_CREATED = Symbol('TRACK_BEING_CREATED');
+
+/**
+ * Action sent when canceled GUM process completes either successfully or with
+ * an error (error is ignored and track is immediately disposed if created).
+ *
+ * {
+ *     type: TRACK_CREATE_CANCELED,
+ *     trackType: MEDIA_TYPE
+ * }
+ */
+export const TRACK_CREATE_CANCELED = Symbol('TRACK_CREATE_CANCELED');
+
+/**
+ * Action sent when GUM fails with an error other than permission denied.
+ *
+ * {
+ *     type: TRACK_CREATE_ERROR,
+ *     permissionDenied: Boolean,
+ *     trackType: MEDIA_TYPE
+ * }
+ */
+export const TRACK_CREATE_ERROR = Symbol('TRACK_CREATE_ERROR');
 
 /**
  * Action for when a track has been removed from the conference,

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -1,6 +1,6 @@
 /**
- * Action for when a track has been added to the conference,
- * local or remote.
+ * The type of redux action dispatched when a track has been (locally or
+ * remotely) added to the conference.
  *
  * {
  *     type: TRACK_ADDED,
@@ -10,18 +10,19 @@
 export const TRACK_ADDED = Symbol('TRACK_ADDED');
 
 /**
- * Action triggered when a local track starts being created through the WebRTC
- * getUserMedia call. It will include extra 'gumProcess' field which is
- * a Promise with extra 'cancel' method which can be used to cancel the process.
- * Canceling will result in disposing any JitsiLocalTrack returned by the GUM
- * callback. There will be TRACK_CREATE_CANCELED event instead of track
- * added/gum failed events.
+ * The type of redux action dispatched when a local track starts being created
+ * via a WebRTC {@code getUserMedia} call. The action's payload includes an
+ * extra {@code gumProcess} property which is a {@code Promise} with an extra
+ * {@code cancel} method which can be used to cancel the process. Canceling will
+ * result in disposing any {@code JitsiLocalTrack} returned by the
+ * {@code getUserMedia} callback. There will be a {@code TRACK_CREATE_CANCELED}
+ * action instead of a {@code TRACK_ADDED} or {@code TRACK_CREATE_ERROR} action.
  *
  * {
  *     type: TRACK_BEING_CREATED
  *     track: {
+ *         gumProcess: Promise with a `cancel` method to cancel the process,
  *         local: true,
- *         gumProcess: Promise with cancel() method to abort,
  *         mediaType: MEDIA_TYPE
  *     }
  * }
@@ -29,8 +30,9 @@ export const TRACK_ADDED = Symbol('TRACK_ADDED');
 export const TRACK_BEING_CREATED = Symbol('TRACK_BEING_CREATED');
 
 /**
- * Action sent when canceled GUM process completes either successfully or with
- * an error (error is ignored and track is immediately disposed if created).
+ * The type of redux action dispatched when a canceled {@code getUserMedia}
+ * process completes either successfully or with an error (the error is ignored
+ * and the track is immediately disposed if it has been created).
  *
  * {
  *     type: TRACK_CREATE_CANCELED,
@@ -40,7 +42,8 @@ export const TRACK_BEING_CREATED = Symbol('TRACK_BEING_CREATED');
 export const TRACK_CREATE_CANCELED = Symbol('TRACK_CREATE_CANCELED');
 
 /**
- * Action sent when GUM fails with an error other than permission denied.
+ * The type of redux action dispatched when {@code getUserMedia} fails with an
+ * error (such as permission denied).
  *
  * {
  *     type: TRACK_CREATE_ERROR,
@@ -51,8 +54,8 @@ export const TRACK_CREATE_CANCELED = Symbol('TRACK_CREATE_CANCELED');
 export const TRACK_CREATE_ERROR = Symbol('TRACK_CREATE_ERROR');
 
 /**
- * Action for when a track has been removed from the conference,
- * local or remote.
+ * The type of redux action dispatched when a track has been (locally or
+ * remotely) removed from the conference.
  *
  * {
  *     type: TRACK_REMOVED,
@@ -62,7 +65,7 @@ export const TRACK_CREATE_ERROR = Symbol('TRACK_CREATE_ERROR');
 export const TRACK_REMOVED = Symbol('TRACK_REMOVED');
 
 /**
- * Action for when a track properties were updated.
+ * The type of redux action dispatched when a track's properties were updated.
  *
  * {
  *     type: TRACK_UPDATED,

--- a/react/features/base/tracks/actionTypes.js
+++ b/react/features/base/tracks/actionTypes.js
@@ -10,26 +10,6 @@
 export const TRACK_ADDED = Symbol('TRACK_ADDED');
 
 /**
- * The type of redux action dispatched when a local track starts being created
- * via a WebRTC {@code getUserMedia} call. The action's payload includes an
- * extra {@code gumProcess} property which is a {@code Promise} with an extra
- * {@code cancel} method which can be used to cancel the process. Canceling will
- * result in disposing any {@code JitsiLocalTrack} returned by the
- * {@code getUserMedia} callback. There will be a {@code TRACK_CREATE_CANCELED}
- * action instead of a {@code TRACK_ADDED} or {@code TRACK_CREATE_ERROR} action.
- *
- * {
- *     type: TRACK_BEING_CREATED
- *     track: {
- *         gumProcess: Promise with a `cancel` method to cancel the process,
- *         local: true,
- *         mediaType: MEDIA_TYPE
- *     }
- * }
- */
-export const TRACK_BEING_CREATED = Symbol('TRACK_BEING_CREATED');
-
-/**
  * The type of redux action dispatched when a canceled {@code getUserMedia}
  * process completes either successfully or with an error (the error is ignored
  * and the track is immediately disposed if it has been created).
@@ -73,3 +53,23 @@ export const TRACK_REMOVED = Symbol('TRACK_REMOVED');
  * }
  */
 export const TRACK_UPDATED = Symbol('TRACK_UPDATED');
+
+/**
+ * The type of redux action dispatched when a local track starts being created
+ * via a WebRTC {@code getUserMedia} call. The action's payload includes an
+ * extra {@code gumProcess} property which is a {@code Promise} with an extra
+ * {@code cancel} method which can be used to cancel the process. Canceling will
+ * result in disposing any {@code JitsiLocalTrack} returned by the
+ * {@code getUserMedia} callback. There will be a {@code TRACK_CREATE_CANCELED}
+ * action instead of a {@code TRACK_ADDED} or {@code TRACK_CREATE_ERROR} action.
+ *
+ * {
+ *     type: TRACK_WILL_CREATE
+ *     track: {
+ *         gumProcess: Promise with a `cancel` method to cancel the process,
+ *         local: true,
+ *         mediaType: MEDIA_TYPE
+ *     }
+ * }
+ */
+export const TRACK_WILL_CREATE = Symbol('TRACK_WILL_CREATE');

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -10,11 +10,11 @@ import { getLocalParticipant } from '../participants';
 
 import {
     TRACK_ADDED,
-    TRACK_BEING_CREATED,
     TRACK_CREATE_CANCELED,
     TRACK_CREATE_ERROR,
     TRACK_REMOVED,
-    TRACK_UPDATED
+    TRACK_UPDATED,
+    TRACK_WILL_CREATE
 } from './actionTypes';
 import { createLocalTracksF } from './functions';
 
@@ -138,7 +138,7 @@ export function createLocalTracksA(options = {}) {
             };
 
             dispatch({
-                type: TRACK_BEING_CREATED,
+                type: TRACK_WILL_CREATE,
                 track: {
                     gumProcess,
                     local: true,

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -110,21 +110,21 @@ export function getLocalTrack(tracks, mediaType) {
 }
 
 /**
- * Returns an array containing local tracks. Local tracks without valid
- * JitsiTrack will not be included in the list.
+ * Returns an array containing the local tracks with a (valid)
+ * {@code JitsiTrack}.
  *
- * @param {Track[]} tracks - An array of all local tracks.
+ * @param {Track[]} tracks - An array containing all local tracks.
  * @returns {Track[]}
  */
 export function getLocalTracks(tracks) {
 
-    // XXX A local track is considered ready only once it has 'jitsiTrack' field
-    // set by the TRACK_ADDED action. Until then there is a stub added just
-    // before get user media call with a cancellable 'gumInProgress' field which
-    // then can be used to destroy the track that has not yet been added to
-    // the Redux store. Once GUM is cancelled it will never make it to the store
-    // nor there will be any TRACK_ADDED/TRACK_REMOVED related events fired for
-    // it.
+    // XXX A local track is considered ready only once it has its `jitsiTrack`
+    // property set by the `TRACK_ADDED` action. Until then there is a stub
+    // added just before the `getUserMedia` call with a cancellable
+    // `gumInProgress` property which then can be used to destroy the track that
+    // has not yet been added to the redux store. Once GUM is cancelled, it will
+    // never make it to the store nor there will be any
+    // `TRACK_ADDED`/`TRACK_REMOVED` actions dispatched for it.
     return tracks.filter(t => t.local && t.jitsiTrack);
 }
 
@@ -215,7 +215,7 @@ export function setTrackMuted(track, muted) {
 
     return track[f]().catch(error => {
 
-        // FIXME emit mute failed, so that the app can show error dialog
+        // FIXME Emit mute failed, so that the app can show error dialog.
         console.error(`set track ${f} failed`, error);
     });
 }

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -106,7 +106,26 @@ export function getLocalAudioTrack(tracks) {
  * @returns {(Track|undefined)}
  */
 export function getLocalTrack(tracks, mediaType) {
-    return tracks.find(t => t.local && t.mediaType === mediaType);
+    return getLocalTracks(tracks).find(t => t.mediaType === mediaType);
+}
+
+/**
+ * Returns an array containing local tracks. Local tracks without valid
+ * JitsiTrack will not be included in the list.
+ *
+ * @param {Track[]} tracks - An array of all local tracks.
+ * @returns {Track[]}
+ */
+export function getLocalTracks(tracks) {
+
+    // XXX A local track is considered ready only once it has 'jitsiTrack' field
+    // set by the TRACK_ADDED action. Until then there is a stub added just
+    // before get user media call with a cancellable 'gumInProgress' field which
+    // then can be used to destroy the track that has not yet been added to
+    // the Redux store. Once GUM is cancelled it will never make it to the store
+    // nor there will be any TRACK_ADDED/TRACK_REMOVED related events fired for
+    // it.
+    return tracks.filter(t => t.local && t.jitsiTrack);
 }
 
 /**

--- a/react/features/base/tracks/reducer.js
+++ b/react/features/base/tracks/reducer.js
@@ -12,23 +12,24 @@ import {
 
 /**
  * @typedef {Object} Track
- * @property {(JitsiLocalTrack|JitsiRemoteTrack)} [jitsiTrack] - JitsiTrack
- * instance. Optional for local tracks if those are being created (GUM in
- * progress).
- * @property {boolean} local=false - If track is local.
- * @property {Promise} [gumProcess] - if local track is being created it
- * will have no JitsiTrack, but a 'gumProcess' set to a Promise with and extra
- * cancel().
- * @property {MEDIA_TYPE} mediaType=false - Media type of track.
+ * @property {(JitsiLocalTrack|JitsiRemoteTrack)} [jitsiTrack] - The associated
+ * {@code JitsiTrack} instance. Optional for local tracks if those are still
+ * being created (i.e. {@code getUserMedia} is still in progress).
+ * @property {Promise} [gumProcess] - If a local track is still being created,
+ * it will have no {@code JitsiTrack}, but a {@code gumProcess} set to a
+ * {@code Promise} with and extra {@code cancel()}.
+ * @property {boolean} local=false - If the track is local.
+ * @property {MEDIA_TYPE} mediaType=false - The media type of the track.
  * @property {boolean} mirror=false - The indicator which determines whether the
  * display/rendering of the track should be mirrored. It only makes sense in the
  * context of video (at least at the time of this writing).
- * @property {boolean} muted=false - If track is muted.
- * @property {(string|undefined)} participantId - ID of participant whom this
- * track belongs to.
- * @property {boolean} videoStarted=false - If video track has already started
- * to play.
- * @property {(VIDEO_TYPE|undefined)} videoType - Type of video track if any.
+ * @property {boolean} muted=false - If the track is muted.
+ * @property {(string|undefined)} participantId - The ID of the participant whom
+ * the track belongs to.
+ * @property {boolean} videoStarted=false - If the video track has already
+ * started to play.
+ * @property {(VIDEO_TYPE|undefined)} videoType - The type of video track if
+ * any.
  */
 
 /**

--- a/react/features/base/tracks/reducer.js
+++ b/react/features/base/tracks/reducer.js
@@ -3,11 +3,11 @@ import { ReducerRegistry } from '../redux';
 
 import {
     TRACK_ADDED,
-    TRACK_BEING_CREATED,
     TRACK_CREATE_CANCELED,
     TRACK_CREATE_ERROR,
     TRACK_REMOVED,
-    TRACK_UPDATED
+    TRACK_UPDATED,
+    TRACK_WILL_CREATE
 } from './actionTypes';
 
 /**
@@ -101,9 +101,6 @@ ReducerRegistry.register('features/base/tracks', (state = [], action) => {
         return [ ...withoutTrackStub, action.track ];
     }
 
-    case TRACK_BEING_CREATED:
-        return [ ...state, action.track ];
-
     case TRACK_CREATE_CANCELED:
     case TRACK_CREATE_ERROR: {
         return state.filter(t => !t.local || t.mediaType !== action.trackType);
@@ -111,6 +108,9 @@ ReducerRegistry.register('features/base/tracks', (state = [], action) => {
 
     case TRACK_REMOVED:
         return state.filter(t => t.jitsiTrack !== action.track.jitsiTrack);
+
+    case TRACK_WILL_CREATE:
+        return [ ...state, action.track ];
 
     default:
         return state;

--- a/react/features/mobile/permissions/middleware.js
+++ b/react/features/mobile/permissions/middleware.js
@@ -5,7 +5,7 @@ import { Alert, Linking, NativeModules } from 'react-native';
 import { isRoomValid } from '../../base/conference';
 import { Platform } from '../../base/react';
 import { MiddlewareRegistry } from '../../base/redux';
-import { TRACK_PERMISSION_ERROR } from '../../base/tracks';
+import { TRACK_CREATE_ERROR } from '../../base/tracks';
 
 /**
  * Middleware that captures track permission errors and alerts the user so they
@@ -18,14 +18,16 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
-    case TRACK_PERMISSION_ERROR:
+    case TRACK_CREATE_ERROR:
         // XXX We do not currently have user interface outside of a conference
         // which the user may tap and cause a permission-related error. If we
         // alert whenever we (intend to) ask for a permission, the scenario of
         // entering the WelcomePage, being asked for the camera permission, me
         // denying it, and being alerted that there is an error is overwhelming
         // me.
-        if (isRoomValid(store.getState()['features/base/conference'].room)) {
+        if (action.permissionDenied
+                && isRoomValid(
+                        store.getState()['features/base/conference'].room)) {
             _alertPermissionErrorWithSettings(action.trackType);
         }
         break;

--- a/react/features/remote-video-menu/components/MuteRemoteParticipantDialog.web.js
+++ b/react/features/remote-video-menu/components/MuteRemoteParticipantDialog.web.js
@@ -95,9 +95,9 @@ class MuteRemoteParticipantDialog extends Component {
     /**
      * Renders the content of the dialog.
      *
-     * @returns {Component} the react component, which is the view of the dialog
-     * content
      * @private
+     * @returns {Component} The React {@code Component} which is the view of the
+     * dialog content.
      */
     _renderContent() {
         const { t } = this.props;


### PR DESCRIPTION
Still to be rebased and may need more testing.

'createDesiredLocalTracks' in 'base/tracks/actions' contains the logic which checks whether or not tracks for audio/video media type exist and then decides to create tracks for those media for which there is no track yet. The problem is that if you call this method twice and trackAdded is not emitted, before the second call it will make an attempt to create track for given media twice. That's because track is not added to redux until GUM callback succeeds and trackAdded action is sent.

We're hitting similar scenario if JitsiMeet app does not exist in the background and you try to join conference by clicking on Jitsi Meet compatible URL. First it will create video track from 'audio only turned to off' and 'ensureTrack' flag and then from the conference native 'onConnect' which calls 'createDesiredLocalTracks'.