### PR TITLE
fix(button-group): use ButtonGroup from the Button package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@atlaskit/avatar": "8.0.5",
     "@atlaskit/button": "5.4.2",
-    "@atlaskit/button-group": "1.5.3",
     "@atlaskit/dropdown-menu": "3.10.2",
     "@atlaskit/droplist": "4.11.1",
     "@atlaskit/field-text": "4.0.1",

--- a/react/features/base/dialog/components/StatelessDialog.web.js
+++ b/react/features/base/dialog/components/StatelessDialog.web.js
@@ -1,5 +1,4 @@
-import AKButton from '@atlaskit/button';
-import AKButtonGroup from '@atlaskit/button-group';
+import Button, { ButtonGroup } from '@atlaskit/button';
 import ModalDialog from '@atlaskit/modal-dialog';
 import { AtlasKitThemeProvider } from '@atlaskit/theme';
 import PropTypes from 'prop-types';
@@ -189,12 +188,14 @@ class StatelessDialog extends Component {
         }
 
         return (
-            <AKButton
+            <Button
                 appearance = 'subtle'
                 id = { CANCEL_BUTTON_ID }
-                onClick = { this._onCancel }>
+                key = 'cancel'
+                onClick = { this._onCancel }
+                type = 'button'>
                 { this.props.t(this.props.cancelTitleKey || 'dialog.Cancel') }
-            </AKButton>
+            </Button>
         );
     }
 
@@ -205,12 +206,18 @@ class StatelessDialog extends Component {
      * @returns {ReactElement}
      */
     _renderFooter() {
+        // Filter out falsy (null) values because {@code ButtonGroup} will error
+        // if passed in anything but buttons with valid type props.
+        const buttons = [
+            this._renderCancelButton(),
+            this._renderOKButton()
+        ].filter(Boolean);
+
         return (
             <footer className = 'modal-dialog-footer'>
-                <AKButtonGroup>
-                    { this._renderCancelButton() }
-                    { this._renderOKButton() }
-                </AKButtonGroup>
+                <ButtonGroup>
+                    { buttons }
+                </ButtonGroup>
             </footer>
         );
     }
@@ -245,14 +252,16 @@ class StatelessDialog extends Component {
         }
 
         return (
-            <AKButton
+            <Button
                 appearance = 'primary'
                 form = 'modal-dialog-form'
                 id = { OK_BUTTON_ID }
                 isDisabled = { this.props.okDisabled }
-                onClick = { this._onSubmit }>
+                key = 'submit'
+                onClick = { this._onSubmit }
+                type = 'button'>
                 { this.props.t(this.props.okTitleKey || 'dialog.Ok') }
-            </AKButton>
+            </Button>
         );
     }
 

--- a/react/features/base/react/components/web/InlineDialogFailure.js
+++ b/react/features/base/react/components/web/InlineDialogFailure.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import AKButton from '@atlaskit/button';
+import Button from '@atlaskit/button';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -64,11 +64,11 @@ class InlineDialogFailure extends Component<*> {
                     { t('inlineDialogFailure.msg') }
                 </div>
                 { supportLinkElem }
-                <AKButton
+                <Button
                     className = 'inline-dialog-error-button'
                     onClick = { this.props.onRetry } >
                     { t('inlineDialogFailure.retry') }
-                </AKButton>
+                </Button>
             </div>
         );
     }


### PR DESCRIPTION
That standalone ButtonGroup package has been deprecated.
The deprecation warning says to use the ButtonGroup component
from the Button package.