### PR TITLE
chore(npm): update lib-jitsi-meet to fa58b9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10969,7 +10969,7 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#9eaf57f1571f369c7b1432b97f58f5c77bf59aa1",
+      "version": "github:jitsi/lib-jitsi-meet#fa58b973f09aab1d6e21f4d7f7023f678c7fe7ef",
       "requires": {
         "async": "0.9.0",
         "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "js-md5": "0.6.1",
     "jssha": "2.2.0",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#9eaf57f1571f369c7b1432b97f58f5c77bf59aa1",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#fa58b973f09aab1d6e21f4d7f7023f678c7fe7ef",
     "lodash": "4.17.4",
     "nuclear-js": "1.4.0",
     "postis": "2.2.0",


### PR DESCRIPTION
This brings in fixes for Safari Temasys and IE11 not loading,
as well as Safari 11 and up using adapter.