### PR TITLE
fix(shared-video): hardcode shared video name

### DIFF
--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -270,7 +270,7 @@ export default class SharedVideoManager {
             const thumb = new SharedVideoThumb(
                 self.url, SHARED_VIDEO_CONTAINER_TYPE, VideoLayout);
 
-            thumb.setDisplayName(player.getVideoData().title);
+            thumb.setDisplayName('YouTube');
             VideoLayout.addRemoteVideoContainer(self.url, thumb);
 
             const iframe = player.getIframe();
@@ -293,7 +293,7 @@ export default class SharedVideoManager {
             APP.store.dispatch(participantJoined({
                 id: self.url,
                 isBot: true,
-                name: player.getVideoData().title
+                name: 'YouTube'
             }));
 
             VideoLayout.handleVideoThumbClicked(self.url);


### PR DESCRIPTION
The YouTube api removed player#getVideoData years ago.
I am completely baffled as to how the feature kept working.
The title of the video is no longer obtainable through
the player itself, so instead call the bot participant
"YouTube."