### PR TITLE
cleanup: Does not add the userAgent string as

### DIFF
--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -50,8 +50,7 @@ export function initAnalytics({ getState }: { getState: Function }) {
         .then(handlers => {
             const state = getState();
             const permanentProperties: Object = {
-                roomName: state['features/base/conference'].room,
-                userAgent: navigator.userAgent
+                roomName: state['features/base/conference'].room
             };
             const { group, server } = state['features/base/jwt'];
 


### PR DESCRIPTION
a permanent property for statistics, as lib-jitsi-meet now does that.

DO NOT MERGE before lib-jitsi-meet#643 (and an update to jitsi-meet's dependencies)