### PR TITLE
fix(welcome-page): allow scrolling

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -1,3 +1,9 @@
+#welcome_page {
+    height: 100%;
+    overflow: auto;
+    position: relative;
+}
+
 #disable_welcome {
     display:none;
 }


### PR DESCRIPTION
Overflow on body was set to hidden, likely because of
various tricks used to hide elements off screen in the
SPA. Overflow hidden also has the benefit of hiding
scroll bounce when using a MacBook touchpad. The
welcome page is the exception that needs scrolling,
so style welcome page to scroll.

A couple others had made pull requests to addrses this issue
but there hasn't been follow up.