### PR TITLE
fix(conference): initialize UI features on CONFERENCE_JOINED

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1700,11 +1700,7 @@ export default {
     _setupListeners() {
         // add local streams when joined to the conference
         room.on(JitsiConferenceEvents.CONFERENCE_JOINED, () => {
-            APP.store.dispatch(conferenceJoined(room));
-
-            APP.UI.mucJoined();
-            APP.API.notifyConferenceJoined(APP.conference.roomName);
-            APP.UI.markVideoInterrupted(false);
+            this._onConferenceJoined();
         });
 
         room.on(
@@ -2330,6 +2326,62 @@ export default {
                     APP.UI.onSharedVideoUpdate(id, value, attributes);
                 }
             });
+    },
+
+    /**
+     * Callback invoked when the conference has been successfully joined.
+     * Initializes the UI and various other features.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onConferenceJoined() {
+        if (APP.logCollector) {
+            // Start the LogCollector's periodic "store logs" task
+            APP.logCollector.start();
+            APP.logCollectorStarted = true;
+
+            // Make an attempt to flush in case a lot of logs have been
+            // cached, before the collector was started.
+            APP.logCollector.flush();
+
+            // This event listener will flush the logs, before
+            // the statistics module (CallStats) is stopped.
+            //
+            // NOTE The LogCollector is not stopped, because this event can
+            // be triggered multiple times during single conference
+            // (whenever statistics module is stopped). That includes
+            // the case when Jicofo terminates the single person left in the
+            // room. It will then restart the media session when someone
+            // eventually join the room which will start the stats again.
+            APP.conference.addConferenceListener(
+                JitsiConferenceEvents.BEFORE_STATISTICS_DISPOSED,
+                () => {
+                    if (APP.logCollector) {
+                        APP.logCollector.flush();
+                    }
+                }
+            );
+        }
+
+        APP.UI.initConference();
+
+        APP.UI.addListener(
+            UIEvents.LANG_CHANGED,
+            language => APP.translation.setLanguage(language));
+
+        APP.keyboardshortcut.init();
+
+        if (config.requireDisplayName
+                && !APP.conference.getLocalDisplayName()) {
+            APP.UI.promptDisplayName();
+        }
+
+        APP.store.dispatch(conferenceJoined(room));
+
+        APP.UI.mucJoined();
+        APP.API.notifyConferenceJoined(APP.conference.roomName);
+        APP.UI.markVideoInterrupted(false);
     },
 
     /**

--- a/react/features/base/connection/actions.web.js
+++ b/react/features/base/connection/actions.web.js
@@ -3,12 +3,10 @@
 import type { Dispatch } from 'redux';
 
 import {
-    JitsiConferenceEvents,
     libInitError,
     WEBRTC_NOT_READY,
     WEBRTC_NOT_SUPPORTED
 } from '../lib-jitsi-meet';
-import UIEvents from '../../../../service/UI/UIEvents';
 
 declare var APP: Object;
 declare var config: Object;
@@ -35,48 +33,7 @@ export function connect() {
 
         // XXX For web based version we use conference initialization logic
         // from the old app (at the moment of writing).
-        return APP.conference.init({ roomName: room }).then(() => {
-            if (APP.logCollector) {
-                // Start the LogCollector's periodic "store logs" task
-                APP.logCollector.start();
-                APP.logCollectorStarted = true;
-
-                // Make an attempt to flush in case a lot of logs have been
-                // cached, before the collector was started.
-                APP.logCollector.flush();
-
-                // This event listener will flush the logs, before
-                // the statistics module (CallStats) is stopped.
-                //
-                // NOTE The LogCollector is not stopped, because this event can
-                // be triggered multiple times during single conference
-                // (whenever statistics module is stopped). That includes
-                // the case when Jicofo terminates the single person left in the
-                // room. It will then restart the media session when someone
-                // eventually join the room which will start the stats again.
-                APP.conference.addConferenceListener(
-                    JitsiConferenceEvents.BEFORE_STATISTICS_DISPOSED,
-                    () => {
-                        if (APP.logCollector) {
-                            APP.logCollector.flush();
-                        }
-                    }
-                );
-            }
-
-            APP.UI.initConference();
-
-            APP.UI.addListener(
-                UIEvents.LANG_CHANGED,
-                language => APP.translation.setLanguage(language));
-
-            APP.keyboardshortcut.init();
-
-            if (config.requireDisplayName
-                    && !APP.conference.getLocalDisplayName()) {
-                APP.UI.promptDisplayName();
-            }
-        })
+        return APP.conference.init({ roomName: room })
             .catch(error => {
                 APP.API.notifyConferenceLeft(APP.conference.roomName);
                 logger.error(error);


### PR DESCRIPTION
Initializing UI features, like keyboard shortcuts, by chaining
onto APP.conference.init is not safe because init can fail,
skipping the initializing of UI features. This can happen when
the room is locked and then a failure event is dispatched into
middleware. I couldn't find a place to properly chain onto
in the APP.conference.init promise chain, primarily due
to the flow continued within middleware, so instead I
leveraged an existing listener for CONFERENCE_JOINED.