### PR TITLE
ref(deps): remove jquery-ui

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,6 @@ import './react/features/base/react/prop-types-polyfill.js';
 
 import 'jquery';
 import 'jquery-contextmenu';
-import 'jquery-ui';
 import 'jQuery-Impromptu';
 import 'autosize';
 

--- a/modules/UI/side_pannels/chat/Chat.js
+++ b/modules/UI/side_pannels/chat/Chat.js
@@ -116,13 +116,8 @@ function getCurrentTime(stamp) {
 function toggleSmileys() {
     const smileys = $('#smileysContainer'); // eslint-disable-line no-shadow
 
-    if (smileys.is(':visible')) {
-        smileys.hide('slide', { direction: 'down',
-            duration: 300 });
-    } else {
-        smileys.show('slide', { direction: 'down',
-            duration: 300 });
-    }
+    smileys.slideToggle();
+
     $('#usermsg').focus();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10175,11 +10175,6 @@
       "resolved": "https://registry.npmjs.org/jquery-i18next/-/jquery-i18next-1.2.0.tgz",
       "integrity": "sha1-jQMDa7ip1v090MX7H+jK0jO94qM="
     },
-    "jquery-ui": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.10.5.tgz",
-      "integrity": "sha1-gmrtPdH4jTKudddN9IZD3EMaWBU="
-    },
     "js-base64": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
@@ -12862,6 +12857,7 @@
         "mkdirp": "0.5.1",
         "normalize-package-data": "2.4.0",
         "npm-package-arg": "4.2.1",
+        "npmlog": "4.1.2",
         "once": "1.4.0",
         "request": "2.83.0",
         "retry": "0.6.1",
@@ -12876,6 +12872,17 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "requires": {
             "natives": "1.1.0"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "jquery": "2.1.4",
     "jquery-contextmenu": "2.4.5",
     "jquery-i18next": "1.2.0",
-    "jquery-ui": "1.10.5",
     "js-md5": "0.6.1",
     "jssha": "2.2.0",
     "jwt-decode": "2.2.0",


### PR DESCRIPTION
After looking at the jquery-ui documentation, I believe it
is being used only in one place, when toggling the smiley
menu. That toggling has been quickly replaced with a normal
jquery call.

Note: @atlassian/aui also uses jquery-ui but killing that
off will be more difficult due to its CSS being used.