### PR TITLE
[RN] Ignore mute error if track is disposed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11016,7 +11016,7 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#9b99e6bb33048e1f418465ec33db923f1786ba1f",
+      "version": "github:jitsi/lib-jitsi-meet#21b07deabccd0b28b6d8eacaa6eee613e018b482",
       "requires": {
         "async": "0.9.0",
         "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "js-md5": "0.6.1",
     "jssha": "2.2.0",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#9b99e6bb33048e1f418465ec33db923f1786ba1f",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#21b07deabccd0b28b6d8eacaa6eee613e018b482",
     "lodash": "4.17.4",
     "nuclear-js": "1.4.0",
     "postis": "2.2.0",

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -1,6 +1,7 @@
 /* global APP */
 
-import JitsiMeetJS, { JitsiTrackEvents } from '../lib-jitsi-meet';
+import JitsiMeetJS, { JitsiTrackErrors, JitsiTrackEvents }
+    from '../lib-jitsi-meet';
 import { MEDIA_TYPE } from '../media';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -214,8 +215,10 @@ export function setTrackMuted(track, muted) {
     const f = muted ? 'mute' : 'unmute';
 
     return track[f]().catch(error => {
-
-        // FIXME Emit mute failed, so that the app can show error dialog.
-        console.error(`set track ${f} failed`, error);
+        // Track might be already disposed so ignore such an error.
+        if (error.name !== JitsiTrackErrors.TRACK_IS_DISPOSED) {
+            // FIXME Emit mute failed, so that the app can show error dialog.
+            console.error(`set track ${f} failed`, error);
+        }
     });
 }


### PR DESCRIPTION
Refs: https://github.com/jitsi/lib-jitsi-meet/pull/648

It's possible for a track to be disposed but still on the redux store, before
the reducer removed it.