### PR TITLE
On adding participant show the initial status text if any.

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -482,7 +482,9 @@ UI.addUser = function(user) {
         // if user has initial status dispatch it
         // and skip 'connected' notifications
         APP.store.dispatch(participantPresenceChanged(id, status));
-        APP.UI.updateUserStatus(user, status);
+
+        // FIXME: move updateUserStatus in participantPresenceChanged action
+        UI.updateUserStatus(user, status);
     } else {
         APP.store.dispatch(showParticipantJoinedNotification(displayName));
     }

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -27,6 +27,7 @@ import { updateDeviceList } from '../../react/features/base/devices';
 import { JitsiTrackErrors } from '../../react/features/base/lib-jitsi-meet';
 import {
     getLocalParticipant,
+    participantPresenceChanged,
     showParticipantJoinedNotification
 } from '../../react/features/base/participants';
 import { openDisplayNamePrompt } from '../../react/features/display-name';
@@ -475,8 +476,16 @@ UI.getSharedDocumentManager = () => etherpadManager;
 UI.addUser = function(user) {
     const id = user.getId();
     const displayName = user.getDisplayName();
+    const status = user.getStatus();
 
-    APP.store.dispatch(showParticipantJoinedNotification(displayName));
+    if (status) {
+        // if user has initial status dispatch it
+        // and skip 'connected' notifications
+        APP.store.dispatch(participantPresenceChanged(id, status));
+        APP.UI.updateUserStatus(user, status);
+    } else {
+        APP.store.dispatch(showParticipantJoinedNotification(displayName));
+    }
 
     if (!config.startAudioMuted
         || config.startAudioMuted > APP.conference.membersCount) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10991,7 +10991,7 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#1c743d65eeccbbd63c765dc84d832112c907422a",
+      "version": "github:jitsi/lib-jitsi-meet#365bd886ee9de81f5d9bd731a57e3b75ab0e766f",
       "requires": {
         "async": "0.9.0",
         "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "js-md5": "0.6.1",
     "jssha": "2.2.0",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#1c743d65eeccbbd63c765dc84d832112c907422a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#365bd886ee9de81f5d9bd731a57e3b75ab0e766f",
     "lodash": "4.17.4",
     "nuclear-js": "1.4.0",
     "postis": "2.2.0",


### PR DESCRIPTION
When participant joins and there is an initial status we show it, instead of the connected notification. If initial status is missing proceed with the default user connected notification.