### PR TITLE
fix(device-selection): add proptypes shim for popup

### DIFF
--- a/react/features/device-selection/popup.js
+++ b/react/features/device-selection/popup.js
@@ -3,6 +3,9 @@
 import 'aui-css';
 import 'aui-experimental-css';
 
+// FIXME: remove once atlaskit work with React 16.
+import '../base/react/prop-types-polyfill.js';
+
 import DeviceSelectionPopup from './DeviceSelectionPopup';
 
 let deviceSelectionPopup;


### PR DESCRIPTION
AtlasKit is not fully compatible with React 16. One problem
is PropTypes will not be defined on the React object. So,
add the prop-types shim to the popup bundle.