### PR TITLE
fix(invite): use cancel to dismiss modal on outside click

### DIFF
--- a/react/features/invite/components/InviteDialog.web.js
+++ b/react/features/invite/components/InviteDialog.web.js
@@ -67,8 +67,8 @@ class InviteDialog extends Component {
 
         return (
             <Dialog
-                cancelDisabled = { true }
-                okTitleKey = 'dialog.done'
+                cancelTitleKey = 'dialog.done'
+                submitDisabled = { true }
                 titleString = { titleString }>
                 <div className = 'invite-dialog'>
                     <ShareLinkForm toCopy = { _inviteURL } />


### PR DESCRIPTION
Disabling cancel for a modal prevents outside clicks of the
modal from hiding the modal. So instead, disable submit
and use the cancel button to dismiss the modal. That would
allow for outside clicking to cancel and hide the modal.

Depends on https://github.com/jitsi/jitsi-meet-torture/pull/108.