### PR TITLE
[RN] Fix assigning Dialog state

### DIFF
--- a/react/features/base/dialog/components/Dialog.native.js
+++ b/react/features/base/dialog/components/Dialog.native.js
@@ -76,7 +76,9 @@ class Dialog extends AbstractDialog<Props, State> {
     constructor(props: Object) {
         super(props);
 
-        this.state.text = '';
+        this.state = {
+            text: ''
+        };
 
         // Bind event handlers so they are only bound once per instance.
         this._onChangeText = this._onChangeText.bind(this);


### PR DESCRIPTION
75bf7638b353cf09c4fc35bb071b6ecb69fc2b14 introduced this regression, state must
be assigned as an object, even though one would think it's automagically
initialized to an object. Oh well!