### PR TITLE
 fix(welcome-page): fix alignment issues

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -193,7 +193,8 @@
     /*font-weight: bold;*/
     text-align: center;
     display: table-cell;
-    padding: 50px 26px 0px 20px;
+    padding: 0px 26px 0px 20px;
+    vertical-align: middle;
 }
 
 .feature_description

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -175,10 +175,11 @@
 
 .feature_holder
 {
-    float:left;
+    display: inline-block;
     width: 169px;
     padding-left: 75px;
     padding-bottom: 30px;
+    vertical-align: top;
 }
 
 .feature_icon


### PR DESCRIPTION
With current Spanish translations, some alignments on the welcome page are off. The alignment with the feature holders was off and I'll be honest I didn't bother figuring out the cause because float doesn't need to be used anyway when inline block puts the feature holders in a row. Removing the float fixed it so I moved on. The longer description titles were also misaligned as the top alignment was being set with padding, but the titles are already in a table-cell which supports vertical-alignment setting.