### PR TITLE
fix(toolbars): do not let primary toolbar wrap

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -145,6 +145,7 @@
         height: $defaultToolbarSize;
         border-radius: 3px;
         opacity: 0;
+        white-space: nowrap;
 
         &.always-on-top {
             height: $alwaysOnTopToolbarSize;


### PR DESCRIPTION
Elements that are inline block will try to wrap if they
cannot fit in a row. Having the parent prevent wrapping
is one quick workaround for this.