### PR TITLE
fix(display-name): listen for display name changes

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -11,6 +11,7 @@ import { getName } from '../../app';
 import { JitsiConferenceEvents } from '../lib-jitsi-meet';
 import { setAudioMuted, setVideoMuted } from '../media';
 import {
+    MAX_DISPLAY_NAME_LENGTH,
     dominantSpeakerChanged,
     participantConnectionStatusChanged,
     participantJoined,
@@ -119,6 +120,12 @@ function _addConferenceListeners(conference, dispatch) {
         t => t && !t.isLocal() && dispatch(trackRemoved(t)));
 
     // Dispatches into features/base/participants follow:
+    conference.on(
+        JitsiConferenceEvents.DISPLAY_NAME_CHANGED,
+        (id, displayName) => dispatch(participantUpdated({
+            id,
+            name: displayName.substr(0, MAX_DISPLAY_NAME_LENGTH)
+        })));
 
     conference.on(
         JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED,


### PR DESCRIPTION
Make sure participants in the redux store have updated names.
This will be needed for showing avatars with user initials.