### PR TITLE
fix(filmstrip): prevent error on updating indicators for shared video

### DIFF
--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -775,6 +775,10 @@ SmallVideo.prototype.updateIndicators = function() {
     const indicatorToolbar
         = this.container.querySelector('.videocontainer__toptoolbar');
 
+    if (!indicatorToolbar) {
+        return;
+    }
+
     const iconSize = UIUtil.getIndicatorFontSize();
     const showConnectionIndicator = this.videoIsHovered
         || !interfaceConfig.CONNECTION_INDICATOR_AUTO_HIDE_ENABLED;


### PR DESCRIPTION
Shared video (youtube videos) do not have indicator icons about
dominant speaker and raised hand. Add a check to see if the
indicator icon container exists before trying to attach react
icons to it. The error thrown didn't seem to be causing any
UI issues though.

While this truthy check before doing ReactDOM.render seems
like it should be a general practice, I'm hesistatnt to make
the change broadly because it hasn't been a problem so far.