### PR TITLE
feat(avatars): use initials service for getting images

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -236,14 +236,12 @@ function _getInitials(name) {
         return '';
     }
 
-    const nameParts = name.split(' ');
+    const nameParts = name.toUpperCase().split(' ');
     const firstName = nameParts[0];
     let initials = firstName[0];
 
     if (nameParts.length > 1) {
-        const lastName = nameParts[nameParts.length - 1];
-
-        initials = `${initials}${lastName[0]}`;
+        initials += nameParts[nameParts.length - 1];
     }
 
     return initials;

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -24,11 +24,12 @@ declare var interfaceConfig: Object;
  * @returns {string} The URL of the image for the avatar of the specified
  * participant.
  */
-export function getAvatarURL({ avatarID, avatarURL, email, id }: {
+export function getAvatarURL({ avatarID, avatarURL, email, id, name }: {
         avatarID: string,
         avatarURL: string,
         email: string,
-        id: string
+        id: string,
+        name: string
 }) {
     // If disableThirdPartyRequests disables third-party avatar services, we are
     // restricted to a stock image of ours.
@@ -68,9 +69,8 @@ export function getAvatarURL({ avatarID, avatarURL, email, id }: {
         if (urlPrefix) {
             urlSuffix = interfaceConfig.RANDOM_AVATAR_URL_SUFFIX;
         } else {
-            // Otherwise, use a default (meeples, of course).
-            urlPrefix = 'https://abotars.jitsi.net/meeple/';
-            urlSuffix = '';
+            urlPrefix = 'https://avatar-cdn.jitsi.net/';
+            urlSuffix = `/${_getInitials(name) || ' '}/200/avatar.png`;
         }
     }
 
@@ -222,4 +222,29 @@ function _getAllParticipants(stateful) {
         Array.isArray(stateful)
             ? stateful
             : toState(stateful)['features/base/participants'] || []);
+}
+
+/**
+ * Gets the initials from a name, assuming a westernized name.
+ *
+ * @param {string} name - The name from which to parse initials.
+ * @private
+ * @returns {string}
+ */
+function _getInitials(name) {
+    if (!name) {
+        return '';
+    }
+
+    const nameParts = name.split(' ');
+    const firstName = nameParts[0];
+    let initials = firstName[0];
+
+    if (nameParts.length > 1) {
+        const lastName = nameParts[nameParts.length - 1];
+
+        initials = `${initials}${lastName[0]}`;
+    }
+
+    return initials;
 }


### PR DESCRIPTION
Relies on https://github.com/jitsi/jitsi-meet/pull/2289 to have web passing in names to get initials. Relies on https://github.com/jitsi/jitsi-meet/pull/2309 to have mobile updating redux when display names change.

The URL for the initials service is such: https://{base}/{hash for color}/{initials}/{size}/{filename}

The hash looks like it can be arbitrary although docs say to use a hashed email. The size specified in the pull request is the one currently used for gravatars. The filename can be whatever but the service returns a png.

A couple decisions to agree on:
- What to do when there is no name. Currently a space is used so that the api at least does not error and returns an image with color and no initials.
- How complex to the make parsing the initials. Currently it is done simple with a string.prototype.split.