### PR TITLE
[RN] Fix internationalization on mobile

### DIFF
--- a/react/features/base/i18n/BuiltinLanguages.native.js
+++ b/react/features/base/i18n/BuiltinLanguages.native.js
@@ -1,0 +1,144 @@
+import i18next from 'i18next';
+
+/**
+ * Collection of builtin languages.
+ */
+const languages = [
+
+    // Bulgarian
+    {
+        name: 'bg',
+        mainResource: require('../../../../lang/main-bg'),
+        langResource: require('../../../../lang/languages-bg')
+    },
+
+    // German
+    {
+        name: 'de',
+        mainResource: require('../../../../lang/main-de'),
+        langResource: require('../../../../lang/languages-de')
+    },
+
+    // Esperanto
+    {
+        name: 'eo',
+        mainResource: require('../../../../lang/main-eo'),
+        langResource: require('../../../../lang/languages-eo')
+    },
+
+    // Spanish
+    {
+        name: 'es',
+        mainResource: require('../../../../lang/main-es'),
+        langResource: require('../../../../lang/languages-es')
+    },
+
+    // French
+    {
+        name: 'fr',
+        mainResource: require('../../../../lang/main-fr'),
+        langResource: require('../../../../lang/languages-fr')
+    },
+
+    // Armenian
+    {
+        name: 'hy',
+        mainResource: require('../../../../lang/main-hy'),
+        langResource: require('../../../../lang/languages-hy')
+    },
+
+    // Italian
+    {
+        name: 'it',
+        mainResource: require('../../../../lang/main-it'),
+        langResource: require('../../../../lang/languages-it')
+    },
+
+    // Norwegian Bokmal
+    {
+        name: 'nb',
+        mainResource: require('../../../../lang/main-nb'),
+        langResource: require('../../../../lang/languages-nb')
+    },
+
+    // Occitan
+    {
+        name: 'oc',
+        mainResource: require('../../../../lang/main-oc'),
+        langResource: require('../../../../lang/languages-oc')
+    },
+
+    // Polish
+    {
+        name: 'pl',
+        mainResource: require('../../../../lang/main-pl'),
+        langResource: require('../../../../lang/languages-pl')
+    },
+
+    // Portuguese (Brazil)
+    {
+        name: 'ptBR',
+        mainResource: require('../../../../lang/main-ptBR'),
+        langResource: require('../../../../lang/languages-ptBR')
+    },
+
+    // Russian
+    {
+        name: 'ru',
+        mainResource: require('../../../../lang/main-ru'),
+        langResource: require('../../../../lang/languages-ru')
+    },
+
+    // Slovak
+    {
+        name: 'sk',
+        mainResource: require('../../../../lang/main-sk'),
+        langResource: require('../../../../lang/languages-sk')
+    },
+
+    // Slovenian
+    {
+        name: 'sl',
+        mainResource: require('../../../../lang/main-sl'),
+        langResource: require('../../../../lang/languages-sl')
+    },
+
+    // Swedish
+    {
+        name: 'sv',
+        mainResource: require('../../../../lang/main-sv'),
+        langResource: require('../../../../lang/languages-sv')
+    },
+
+    // Turkish
+    {
+        name: 'tr',
+        mainResource: require('../../../../lang/main-tr'),
+        langResource: require('../../../../lang/languages-tr')
+    },
+
+    // Chinese (China)
+    {
+        name: 'zhCN',
+        mainResource: require('../../../../lang/main-zhCN'),
+        langResource: require('../../../../lang/languages-zhCN')
+    }
+];
+
+/**
+ * Registers all builtin languages with the i18n library.
+ */
+for (const language of languages) {
+    i18next.addResourceBundle(
+        language.name,
+        'main',
+        language.mainResource,
+        /* deep */ true,
+        /* overwrite */ true);
+    i18next.addResourceBundle(
+        language.name,
+        'languages',
+        language.langResource,
+        /* deep */ true,
+        /* overwrite */ true);
+}

--- a/react/features/base/i18n/i18next.js
+++ b/react/features/base/i18n/i18next.js
@@ -81,4 +81,10 @@ i18next.addResourceBundle(
     /* deep */ true,
     /* overwrite */ true);
 
+// Add builtin languages.
+// XXX: Note we are using require here, because we want the side-effects of
+// the import, but imports can only be placed at the top, and it would be
+// too early, since i18next is not yet initialized at that point.
+require('./BuiltinLanguages');
+
 export default i18next;


### PR DESCRIPTION
Only the first commit is necessary to fix the Android crash, but I thought I'd try to add actual internationalization support, hence commit number 2.

I'd like to hear thoughts on the implementation :-)

Here is how it looks like in Spanish screenshot is on Android, but I also tested iOS):

![screenshot_20171222-112543](https://user-images.githubusercontent.com/317464/34295058-989ae876-e70b-11e7-95ab-e2a6441a54df.png)

As you can see, dates are not translated, maybe @zbettenbuk can take a look at that.