### PR TITLE
Revert "feat(avatars): use initials service for getting images (#2312)"

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -24,12 +24,11 @@ declare var interfaceConfig: Object;
  * @returns {string} The URL of the image for the avatar of the specified
  * participant.
  */
-export function getAvatarURL({ avatarID, avatarURL, email, id, name }: {
+export function getAvatarURL({ avatarID, avatarURL, email, id }: {
         avatarID: string,
         avatarURL: string,
         email: string,
-        id: string,
-        name: string
+        id: string
 }) {
     // If disableThirdPartyRequests disables third-party avatar services, we are
     // restricted to a stock image of ours.
@@ -69,8 +68,9 @@ export function getAvatarURL({ avatarID, avatarURL, email, id, name }: {
         if (urlPrefix) {
             urlSuffix = interfaceConfig.RANDOM_AVATAR_URL_SUFFIX;
         } else {
-            urlPrefix = 'https://avatar-cdn.jitsi.net/';
-            urlSuffix = `/${_getInitials(name) || ' '}/200/avatar.png`;
+            // Otherwise, use a default (meeples, of course).
+            urlPrefix = 'https://abotars.jitsi.net/meeple/';
+            urlSuffix = '';
         }
     }
 
@@ -222,27 +222,4 @@ function _getAllParticipants(stateful) {
         Array.isArray(stateful)
             ? stateful
             : toState(stateful)['features/base/participants'] || []);
-}
-
-/**
- * Gets the initials from a name, assuming a westernized name.
- *
- * @param {string} name - The name from which to parse initials.
- * @private
- * @returns {string}
- */
-function _getInitials(name) {
-    if (!name) {
-        return '';
-    }
-
-    const nameParts = name.toUpperCase().split(' ');
-    const firstName = nameParts[0];
-    let initials = firstName[0];
-
-    if (nameParts.length > 1) {
-        initials += nameParts[nameParts.length - 1];
-    }
-
-    return initials;
 }


### PR DESCRIPTION
There is more avatar work coming down the line for mobile,
which should also affect web, assuming the same getAvatarURL
helper will be used. As such, instead of continuing to
support the initials service and tweaking UI, revert to
make way for the future avatar work.

This reverts commit 2ea5ad68a50095302c8142cdf010f04cd3be63f6.

Heads up, @zbettenbuk. All previous work done for using the avatar initials service was to get web using the same path as mobile, which is to pass the redux participant into getAvatarURL. The last bit was simply swapping out the default abotars url with the initials service, and that swap is being reverted.