### PR TITLE
fix(ie11): fix script error from string templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ deploy-appbundle:
 		$(BUILD_DIR)/device_selection_popup_bundle.min.map \
 		$(BUILD_DIR)/alwaysontop.min.js \
 		$(BUILD_DIR)/alwaysontop.min.map \
+		$(BUILD_DIR)/close.min.js \
+		$(BUILD_DIR)/close.min.map \
 		$(OUTPUT_DIR)/analytics-ga.js \
 		$(DEPLOY_DIR)
 

--- a/static/close.html
+++ b/static/close.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../css/all.css"/>
     <!--#include virtual="/title.html" -->
     <script><!--#include virtual="/interface_config.js" --></script>
-    <script src="close.js"></script>
+    <script src="../libs/close.min.js"></script>
 </head>
 <body>
 <div class="redirectPageMessage">

--- a/static/close2.html
+++ b/static/close2.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../css/all.css"/>
     <!--#include virtual="/title.html" -->
     <script><!--#include virtual="/interface_config.js" --></script>
-    <script src="close.js"></script>
+    <script src="../libs/close.min.js"></script>
 </head>
 <body>
     <div class="redirectPageMessage">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,7 +151,10 @@ module.exports = [
                 './react/features/always-on-top/index.js',
 
             'do_external_connect':
-                './connection_optimization/do_external_connect.js'
+                './connection_optimization/do_external_connect.js',
+
+            'close':
+                './static/close.js'
         }
     }),
 


### PR DESCRIPTION
~The close page has a file of loose javascript that does
not go through babel. Its use of template strings will
cause a script error in IE11.~

~An alternative fix would be to run the file through webpack and change close.html and close2.html to use the built javascript.~
  
I've changed the build to also run close.js through babelification and minification.