### PR TITLE
fix(notifications): reduce duration of initially muted notification

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -851,8 +851,7 @@ UI.notifyInitiallyMuted = function() {
         'notify.mutedTitle',
         'connected',
         'notify.muted',
-        null,
-        120000);
+        null);
 };
 
 /**


### PR DESCRIPTION
The current notification for starting muted is 2 minutes, which
may seem like "forever" so reduce it to dismiss faster.

For now I've reduced it to 2.5 seconds, which is the default for participant notifications.