### PR TITLE
[RN] Make video track fade-in effect cross-platform

### DIFF
--- a/react/features/base/media/components/native/styles.js
+++ b/react/features/base/media/components/native/styles.js
@@ -1,15 +1,27 @@
 import { StyleSheet } from 'react-native';
-
-/**
- * Make {@code Video} fill its container.
- */
-const video = {
-    flex: 1
-};
+import { ColorPalette } from '../../../styles';
 
 /**
  * The styles of the feature base/media.
  */
 export default StyleSheet.create({
-    video
+    /**
+     * Make {@code Video} fill its container.
+     */
+    video: {
+        flex: 1
+    },
+
+    /**
+     * Black cover for the video, which will be animated by reducing its opacity
+     * and create a fade-in effect.
+     */
+    videoCover: {
+        backgroundColor: ColorPalette.black,
+        height: '100%',
+        left: 0,
+        position: 'absolute',
+        top: 0,
+        width: '100%'
+    }
 });


### PR DESCRIPTION
Android uses a SurfaceView to render video, which is not quite a View, so the
fade-in animation (which varies the opacity) doesn't work.

Instead, add an opaque black view covering the video, which transitions to
transparent. This creates much smoother transitions on Android, while behaving
the same.

In addition, I removed the flip animation for local tracks, which is no longer
used, since the camera is switched without changing tracks.