### PR TITLE
[RN] Join room when pressing "go" on the keyboard

### DIFF
--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -77,8 +77,10 @@ class WelcomePage extends AbstractWelcomePage {
                         autoCorrect = { false }
                         autoFocus = { false }
                         onChangeText = { this._onRoomChange }
+                        onSubmitEditing = { this._onJoin }
                         placeholder = { t('welcomepage.roomname') }
                         placeholderTextColor = { PLACEHOLDER_TEXT_COLOR }
+                        returnKeyType = { 'go' }
                         style = { styles.textInput }
                         underlineColorAndroid = 'transparent'
                         value = { this.state.room } />


### PR DESCRIPTION
Improve the experience when joining a room by removing the need to tap the join
button. The keyboard type has also been set to "go", which translated on the
builtin keyboard button label to be "go" (it's builtin, the operating system
translates it). This works on both Android and iOS.