### PR TITLE
[RN] Fix handling new props to the root component

### DIFF
--- a/react/features/base/lib-jitsi-meet/native/Storage.js
+++ b/react/features/base/lib-jitsi-meet/native/Storage.js
@@ -34,16 +34,7 @@ export default class Storage {
             // Load all previously persisted data items from React Native's
             // AsyncStorage.
 
-            /**
-             * A flag to indicate that the async {@code AsyncStorage} is not
-             * initialized yet. This is native specific but it will work
-             * fine on web as well, as it will have no value (== false) there.
-             * This is required to be available as we need a sync way to check
-             * if the storage is inited or not.
-             */
-            this._initializing = true;
-
-            this._inited = new Promise(resolve => {
+            this._initialized = new Promise(resolve => {
                 AsyncStorage.getAllKeys().then((...getAllKeysCallbackArgs) => {
                     // XXX The keys argument of getAllKeys' callback may
                     // or may not be preceded by an error argument.
@@ -77,7 +68,6 @@ export default class Storage {
                             }
                         }
 
-                        this._initializing = false;
                         resolve();
                     });
                 });


### PR DESCRIPTION
Since we now need to wait for the storage to be initialized, by the time we get
to check this.props, they will already be nextProp. In order to avoid this,
shallow-clone this.props before the async operation.

This is to be considered a stopgap.

In addition, remove an unneeded flag in the Storeage class and use a better name
for the promise indicating if it was initialized or not.