### PR TITLE
feat(analytics): shield sending analytics events

### DIFF
--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -16,7 +16,11 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  * @returns {void}
  */
 export function sendAnalytics(event: Object) {
-    analytics.sendEvent(event);
+    try {
+        analytics.sendEvent(event);
+    } catch (e) {
+        logger.warn(`Error sending analytics event: ${e}`);
+    }
 }
 
 /**


### PR DESCRIPTION
Any failure in analytics should not prevent the natural flow of the code. Shield
the function by catching and logging any exception.