### PR TITLE
Fix "nil object from objects[0]" errors

### DIFF
--- a/ios/sdk/src/AppInfo.m
+++ b/ios/sdk/src/AppInfo.m
@@ -31,7 +31,13 @@ RCT_EXPORT_MODULE();
         = [[NSBundle mainBundle] infoDictionary];
     NSString *name = infoDictionary[@"CFBundleDisplayName"];
     NSString *version = infoDictionary[@"CFBundleShortVersionString"];
-
+    
+    if (name == nil) {
+        name = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey];
+        if (name == nil) {
+            name = @"";
+        }
+    }
     if (version == nil) {
         version = infoDictionary[@"CFBundleVersion"];
         if (version == nil) {

--- a/ios/sdk/src/AppInfo.m
+++ b/ios/sdk/src/AppInfo.m
@@ -33,7 +33,7 @@ RCT_EXPORT_MODULE();
     NSString *version = infoDictionary[@"CFBundleShortVersionString"];
     
     if (name == nil) {
-        name = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey];
+        name = [infoDictionary[@"kCFBundleNameKey"]];
         if (name == nil) {
             name = @"";
         }


### PR DESCRIPTION
Somehow, `name` might be undefined when building the SDK. This adds a check so that the SDK doesn't blow up. 
fixes #2377 #2267 #2158