### PR TITLE
feat(screenshare): allow using camera as screenshare source

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1536,6 +1536,8 @@ export default {
         const wasVideoMuted = this.isLocalVideoMuted();
 
         return createLocalTracksF({
+            screenSharingSourceDeviceId: config.enableScreenSharingWithCamera
+                && APP.settings.getScreenSharingSourceDeviceId(),
             desktopSharingSources: options.desktopSharingSources,
             devices: [ 'desktop' ],
             desktopSharingExtensionExternalInstallation: {
@@ -1707,6 +1709,9 @@ export default {
         if (error.name === JitsiTrackErrors.PERMISSION_DENIED) {
             descriptionKey = 'dialog.screenSharingPermissionDeniedError';
             titleKey = 'dialog.screenSharingFailedToInstallTitle';
+        } else if (error.name === JitsiTrackErrors.CONSTRAINT_FAILED) {
+            descriptionKey = 'dialog.cameraConstraintFailedError';
+            titleKey = 'deviceError.cameraError';
         } else {
             descriptionKey = 'dialog.screenSharingFailedToInstall';
             titleKey = 'dialog.screenSharingFailedToInstallTitle';

--- a/config.js
+++ b/config.js
@@ -338,6 +338,7 @@ var config = {
      disableRemoteControl
      displayJids
      enableLocalVideoFlip
+     enableScreenSharingWithCamera
      etherpad_base
      externalConnectUrl
      firefox_fake_device

--- a/modules/settings/Settings.js
+++ b/modules/settings/Settings.js
@@ -21,6 +21,8 @@ let displayName = UIUtil.unescapeHtml(
     jitsiLocalStorage.getItem('displayname') || '');
 let cameraDeviceId = jitsiLocalStorage.getItem('cameraDeviceId') || '';
 let micDeviceId = jitsiLocalStorage.getItem('micDeviceId') || '';
+let screenSharingSourceDeviceId
+    = jitsiLocalStorage.getItem('screenSharingSourceDeviceId') || '';
 let welcomePageDisabled = JSON.parse(
     jitsiLocalStorage.getItem('welcomePageDisabled') || false);
 
@@ -135,6 +137,10 @@ export default {
         return cameraDeviceId;
     },
 
+    getScreenSharingSourceDeviceId() {
+        return screenSharingSourceDeviceId;
+    },
+
     /**
      * Set device id of the camera which is currently in use.
      * Empty string stands for default device.
@@ -145,6 +151,13 @@ export default {
         cameraDeviceId = newId;
         if (store) {
             jitsiLocalStorage.setItem('cameraDeviceId', newId);
+        }
+    },
+
+    setScreenSharingSourceDeviceId(newId, store) {
+        screenSharingSourceDeviceId = newId;
+        if (store) {
+            jitsiLocalStorage.setItem('screenSharingSourceDeviceId', newId);
         }
     },
 

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -59,6 +59,8 @@ export function createLocalTracksF(
                 desktopSharingExtensionExternalInstallation:
                     options.desktopSharingExtensionExternalInstallation,
                 desktopSharingSources: options.desktopSharingSources,
+                screenSharingSourceDeviceId:
+                    options.screenSharingSourceDeviceId,
 
                 // Copy array to avoid mutations inside library.
                 devices: options.devices.slice(0),


### PR DESCRIPTION
For spot, a usb dongle will be useable for screensharing. The
doggle is detected as a camera source. When screensharing is
clicked, that camera source should be used. For now put
in a bare minumum to get the feature working, which is
passing the camera device id into createLocalTracks for
desktop.