### PR TITLE
Update uninstall documentation.

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -84,7 +84,7 @@ Enjoy!
 ## Uninstall
 
 ```sh
-apt-get purge jigasi jitsi-meet jitsi-meet-web-config jitsi-meet-web jicofo jitsi-videobridge
+apt-get purge jigasi jitsi-meet jitsi-meet-web-config jitsi-meet-prosody jitsi-meet-web jicofo jitsi-videobridge
 ```
 
 Sometimes the following packages will fail to uninstall properly:


### PR DESCRIPTION
The package jitsi-meet-prosody was missing from the list of packages.