### PR TITLE
fix(hangup): destroy local tracks on conference leave

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -377,11 +377,12 @@ UI.start = function() {
 };
 
 /**
- * Invokes cleanup of any deferred execution within relevant UI modules.
+ * Invokes cleanup of large video so it stops running polling tasks and stops
+ * displaying.
  *
  * @returns {void}
  */
-UI.stopDaemons = () => {
+UI.resetLargeVideo = () => {
     VideoLayout.resetLargeVideo();
 };
 

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -129,6 +129,8 @@ export default class LargeVideoManager {
             this._onVideoResolutionUpdate);
 
         this.removePresenceLabel();
+
+        this.$container.remove();
     }
 
     /**

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -17,7 +17,7 @@ import {
 } from '../participants';
 import { MiddlewareRegistry } from '../redux';
 import UIEvents from '../../../../service/UI/UIEvents';
-import { TRACK_ADDED, TRACK_REMOVED } from '../tracks';
+import { TRACK_ADDED, TRACK_REMOVED, destroyLocalTracks } from '../tracks';
 
 import {
     createConference,
@@ -130,6 +130,11 @@ function _conferenceFailedOrLeft({ dispatch, getState }, next, action) {
         sendAnalytics(createAudioOnlyDisableEvent());
         logger.log('Audio only disabled');
         dispatch(setAudioOnly(false));
+    }
+
+    if (typeof APP === 'object') {
+        dispatch(destroyLocalTracks());
+        APP.UI.resetLargeVideo();
     }
 
     return result;

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -87,7 +87,6 @@ class Conference extends Component<Props> {
      * @inheritdoc
      */
     componentWillUnmount() {
-        APP.UI.stopDaemons();
         APP.UI.unregisterListeners();
         APP.UI.unbindEvents();
 


### PR DESCRIPTION
Destroy local tracks and also destroy large video so the
user does not wonder why camera (and mic) are still enabled
even though hangup has been pressed.

There has to be a better way to do this but it's just not coming to mel