### PR TITLE
Revert "fix(hangup): destroy local tracks on conference leave (#2502)"

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -377,12 +377,11 @@ UI.start = function() {
 };
 
 /**
- * Invokes cleanup of large video so it stops running polling tasks and stops
- * displaying.
+ * Invokes cleanup of any deferred execution within relevant UI modules.
  *
  * @returns {void}
  */
-UI.resetLargeVideo = () => {
+UI.stopDaemons = () => {
     VideoLayout.resetLargeVideo();
 };
 

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -129,8 +129,6 @@ export default class LargeVideoManager {
             this._onVideoResolutionUpdate);
 
         this.removePresenceLabel();
-
-        this.$container.remove();
     }
 
     /**

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -17,7 +17,7 @@ import {
 } from '../participants';
 import { MiddlewareRegistry } from '../redux';
 import UIEvents from '../../../../service/UI/UIEvents';
-import { TRACK_ADDED, TRACK_REMOVED, destroyLocalTracks } from '../tracks';
+import { TRACK_ADDED, TRACK_REMOVED } from '../tracks';
 
 import {
     createConference,
@@ -142,11 +142,6 @@ function _conferenceFailedOrLeft({ dispatch, getState }, next, action) {
         sendAnalytics(createAudioOnlyChangedEvent(true));
         logger.log('Audio only enabled');
         dispatch(setAudioOnly(true));
-    }
-
-    if (typeof APP === 'object') {
-        dispatch(destroyLocalTracks());
-        APP.UI.resetLargeVideo();
     }
 
     return result;

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -87,6 +87,7 @@ class Conference extends Component<Props> {
      * @inheritdoc
      */
     componentWillUnmount() {
+        APP.UI.stopDaemons();
         APP.UI.unregisterListeners();
         APP.UI.unbindEvents();
 


### PR DESCRIPTION
This reverts commit 88325aeef26b11f9d6dfe91aaeb550df10b53ad4.
Turns out a conference with a password triggers a failed conference
join. It's going to be tricky to decipher when to do actual
cleanup, and where to shove that code, so reverting is easier for
now.