### PR TITLE
fix(hangup): destroy local tracks on conference leave

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2645,6 +2645,7 @@ export default {
      */
     hangup(requestFeedback = false) {
         eventEmitter.emit(JitsiMeetConferenceEvents.BEFORE_HANGUP);
+        APP.UI.removeLocalMedia();
 
         let requestFeedbackPromise;
 

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -28,6 +28,7 @@ import {
     participantPresenceChanged,
     showParticipantJoinedNotification
 } from '../../react/features/base/participants';
+import { destroyLocalTracks } from '../../react/features/base/tracks';
 import { openDisplayNamePrompt } from '../../react/features/display-name';
 import {
     setNotificationsEnabled,
@@ -374,15 +375,6 @@ UI.start = function() {
     }
 
     document.title = interfaceConfig.APP_NAME;
-};
-
-/**
- * Invokes cleanup of any deferred execution within relevant UI modules.
- *
- * @returns {void}
- */
-UI.stopDaemons = () => {
-    VideoLayout.resetLargeVideo();
 };
 
 /**
@@ -1289,6 +1281,18 @@ UI.setRemoteControlActiveStatus = function(participantID, isActive) {
  */
 UI.setLocalRemoteControlActiveChanged = function() {
     VideoLayout.setLocalRemoteControlActiveChanged();
+};
+
+/**
+ * Remove media tracks and UI elements so the user no longer sees media in the
+ * UI. The intent is to provide a feeling that the meeting has ended.
+ *
+ * @returns {void}
+ */
+UI.removeLocalMedia = function() {
+    APP.store.dispatch(destroyLocalTracks());
+    VideoLayout.resetLargeVideo();
+    $('#videospace').hide();
 };
 
 // TODO: Export every function separately. For now there is no point of doing

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -87,7 +87,6 @@ class Conference extends Component<Props> {
      * @inheritdoc
      */
     componentWillUnmount() {
-        APP.UI.stopDaemons();
         APP.UI.unregisterListeners();
         APP.UI.unbindEvents();
 


### PR DESCRIPTION
The difference from this change and 88325ae is there is no
attempt to do this in redux. This is the safer change in that
the cleanup logic is known only to trigger on hangup.