### PR TITLE
feat: Whitelists the gatherStats option.

### DIFF
--- a/config.js
+++ b/config.js
@@ -245,8 +245,11 @@ var config = {
     // Stats
     //
 
-    // Whether to enable stats collection or not.
-    // disableStats: false,
+    // Whether to enable stats collection or not in the TraceablePeerConnection.
+    // This can be useful for debugging purposes (post-processing/analysis of
+    // the webrtc stats) as it is done in the jitsi-meet-torture bandwidth
+    // estimation tests.
+    // gatherStats: false,
 
     // To enable sending statistics to callstats.io you must provide the
     // Application ID and Secret.

--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -64,6 +64,7 @@ const WHITELISTED_KEYS = [
     'failICE',
     'firefox_fake_device',
     'forceJVB121Ratio',
+    'gatherStats',
     'hiddenDomain',
     'hosts',
     'iAmRecorder',


### PR DESCRIPTION
This allows the new bandwidth estimation jitsi-meet-torture tests to enable stats gathering (and analysis).