### PR TITLE
[iOS] Fix uncaught NSInvalidArgumentException in RTCPeerConnection's createAnswer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9938,7 +9938,7 @@
       }
     },
     "react-native-webrtc": {
-      "version": "github:jitsi/react-native-webrtc#806435b41fa152a8239ebeb7d002d1c6e979be86",
+      "version": "github:jitsi/react-native-webrtc#7e54c61679f5a3d1ca5dcdf598f7a7c31f94a0bd",
       "requires": {
         "base64-js": "1.2.3",
         "event-target-shim": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-locale-detector": "github:jitsi/react-native-locale-detector#cc76092fc4335488a28a9529c8b50afae2c3ecdc",
     "react-native-prompt": "1.0.0",
     "react-native-vector-icons": "4.4.2",
-    "react-native-webrtc": "github:jitsi/react-native-webrtc#806435b41fa152a8239ebeb7d002d1c6e979be86",
+    "react-native-webrtc": "github:jitsi/react-native-webrtc#7e54c61679f5a3d1ca5dcdf598f7a7c31f94a0bd",
     "react-redux": "5.0.6",
     "redux": "3.7.2",
     "redux-thunk": "2.2.0",


### PR DESCRIPTION
Brings the following fix from jitsi/react-native-webrtc into jitsi/jitsi-meet:

WebRTC used to report createAnswer (and createOffer) NSError with key
"error". But now the key's called "NSLocalizedDescription".

Additionally, NSMutableDictionary doesn't accept nil.