### PR TITLE
fix(info): do not open dial in page with blank target on electron

### DIFF
--- a/react/features/invite/components/info-dialog/InfoDialog.web.js
+++ b/react/features/invite/components/info-dialog/InfoDialog.web.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { setPassword } from '../../../base/conference';
 import { getInviteURL } from '../../../base/connection';
 import { translate } from '../../../base/i18n';
+import { browser } from '../../../base/lib-jitsi-meet';
 import {
     PARTICIPANT_ROLE,
     getLocalParticipant
@@ -404,7 +405,7 @@ class InfoDialog extends Component {
                     className = 'more-numbers'
                     href = { this._getDialInfoPageURL() }
                     rel = 'noopener noreferrer'
-                    target = '_blank'>
+                    target = { browser.isElectron() ? undefined : '_blank' }>
                     { this.props.t('info.moreNumbers') }
                 </a>
             </div>


### PR DESCRIPTION
To force electron to open the page in the browser, do not
apply target _blank.