### PR TITLE
fix(android): do not require java 8 target

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -43,16 +43,6 @@ Add the Maven repository
 `https://github.com/jitsi/jitsi-maven-repository/raw/master/releases` and the
 dependency `org.jitsi.react:jitsi-meet-sdk:1.9.0` into your `build.gradle`.
 
-Add Java 1.8 compatibility support to your project by adding the following lines
-into your `build.gradle` file:
-
-```
-compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
-}
-```
-
 ## API
 
 Jitsi Meet SDK is an Android library which embodies the whole Jitsi Meet

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,10 +31,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9938,7 +9938,7 @@
       }
     },
     "react-native-webrtc": {
-      "version": "github:jitsi/react-native-webrtc#7e54c61679f5a3d1ca5dcdf598f7a7c31f94a0bd",
+      "version": "github:jitsi/react-native-webrtc#626818af40384356617f70366133317b6a475171",
       "requires": {
         "base64-js": "1.2.3",
         "event-target-shim": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-locale-detector": "github:jitsi/react-native-locale-detector#cc76092fc4335488a28a9529c8b50afae2c3ecdc",
     "react-native-prompt": "1.0.0",
     "react-native-vector-icons": "4.4.2",
-    "react-native-webrtc": "github:jitsi/react-native-webrtc#7e54c61679f5a3d1ca5dcdf598f7a7c31f94a0bd",
+    "react-native-webrtc": "github:jitsi/react-native-webrtc#626818af40384356617f70366133317b6a475171",
     "react-redux": "5.0.6",
     "redux": "3.7.2",
     "redux-thunk": "2.2.0",

--- a/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
+++ b/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
@@ -161,7 +161,6 @@ function _makePromiseAware(
         afterCallbacks: number) {
     return function(...args) {
         return new Promise((resolve, reject) => {
-
             if (args.length <= beforeCallbacks + afterCallbacks) {
                 args.splice(beforeCallbacks, 0, resolve, reject);
             }


### PR DESCRIPTION
Updates react-native-webrtc to get rid of Java 8 requirement for the Android app.