### PR TITLE
fix(android): webrtc proguard rule

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -402,6 +402,7 @@ rules file:
 # WebRTC
 
 -keep class org.webrtc.** { *; }
+-dontwarn org.chromium.build.BuildHooksAndroid
 
 # Jisti Meet SDK
 


### PR DESCRIPTION
The new libwebrtc.jar contains an extra unused class file, when proguard is enabled result in the following warning:

org.chromium.build.BuildHooksAndroidImpl: can't find superclass or interface org.chromium.build.BuildHooksAndroid