### PR TITLE
fix(invite): prefix a + when faking the validation response

### DIFF
--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -100,7 +100,7 @@ export function checkDialNumber(
         // no auth url, let's say it is valid
         const response = {
             allow: true,
-            phone: dialNumber
+            phone: `+${dialNumber}`
         };
 
         return Promise.resolve(response);


### PR DESCRIPTION
Pre-existing logic made it so numbers were assumed as valid
if no validation url was specified. To be consistent with
the validation server, the faked number should include a
+ at the beginning.