### PR TITLE
feat(UnsupportedMobileBrowser): do not include 'https:'

### DIFF
--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -7,6 +7,18 @@
 export const APP_LINK_SCHEME = 'org.jitsi.meet:';
 
 /**
+ * XXX: The URL class exposed by JavaScript will not include the double dots in
+ * the protocol field. Also in other places (at the time of this writing:
+ * the UnsupportedMobileBrowser.js) the APP_LINK_SCHEME does not include
+ * the double dots, so things are inconsistent.
+ *
+ * The default protocol added to the URI in case it's missing or invalid.
+ *
+ * @type {string}
+ */
+export const DEFAULT_PROTOCOL = 'https:';
+
+/**
  * The {@link RegExp} pattern of the authority of a URI.
  *
  * @private
@@ -95,8 +107,8 @@ function _fixURIStringScheme(uri: string) {
         // sure that it is a well-known one.
         let protocol = match[match.length - 1].toLowerCase();
 
-        if (protocol !== 'http:' && protocol !== 'https:') {
-            protocol = 'https:';
+        if (protocol !== 'http:' && protocol !== DEFAULT_PROTOCOL) {
+            protocol = DEFAULT_PROTOCOL;
         }
 
         /* eslint-disable no-param-reassign */

--- a/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedMobileBrowser.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 
 import { translate, translateToHTML } from '../../base/i18n';
 import { Platform } from '../../base/react';
+import { DEFAULT_PROTOCOL, parseURIString } from '../../base/util';
 import { DialInSummary } from '../../invite';
 import HideNotificationBarStyle from './HideNotificationBarStyle';
 
@@ -82,10 +83,21 @@ class UnsupportedMobileBrowser extends Component<*, *> {
         // appears to be a link with an app-specific scheme, not a Universal
         // Link.
         const appScheme = interfaceConfig.MOBILE_APP_SCHEME || 'org.jitsi.meet';
-        const joinURL = `${appScheme}:${window.location.href}`;
+        const joinURL = parseURIString(window.location.href);
+
+        // Drop the protocol only if it's the https, because that's the app's
+        // default scheme which will be eventually added later on when
+        // the intent URI is being processed. We'd like to preserve the protocol
+        // otherwise to not introduce unexpected side effect of using https when
+        // the site runs on http.
+        if (joinURL.protocol === DEFAULT_PROTOCOL) {
+            joinURL.protocol = `${appScheme}:`;
+        } else {
+            joinURL.protocol = `${appScheme}:${joinURL.protocol}`;
+        }
 
         this.setState({
-            joinURL
+            joinURL: joinURL.toString()
         });
     }
 


### PR DESCRIPTION
Do not include the 'https:' protocol part in the intent URL if the site runs on https, as it's the default and will be eventually added later anyway.