### PR TITLE
fix(info): do not truncate url

### DIFF
--- a/css/modals/invite/_info.scss
+++ b/css/modals/invite/_info.scss
@@ -56,11 +56,14 @@
     }
 
     .info-dialog-conference-url {
-        max-width: 250px;
-        overflow: hidden;
-        text-overflow: ellipsis;
         user-select: text;
-        white-space: nowrap;
+        -moz-user-select: text;
+        -webkit-user-select: text;
+        max-width: 400px;
+        width: max-content;
+        width: -moz-max-content;
+        width: -webkit-max-content;
+        word-break: break-all;
     }
 
     .info-dialog-dial-in {


### PR DESCRIPTION
Maybe truncation was okay when the invite dialog existed but now it
doesn't. Remove CSS for truncation and add CSS to make the URL
expand and wrap.