### PR TITLE
add a prosody module to insert identity information (when available) …

### DIFF
--- a/resources/prosody-plugins/mod_presence_identity.lua
+++ b/resources/prosody-plugins/mod_presence_identity.lua
@@ -6,7 +6,6 @@ local core_post_stanza = prosody.core_post_stanza;
 -- for that session.
 function on_message(event)
     if event["stanza"] then
-      local presence = event["stanza"]
       if event.origin["jitsi_meet_context_user"] then
           local new_stanza = stanza.clone(event.stanza)
           -- First remove any 'identity' element if it already

--- a/resources/prosody-plugins/mod_presence_identity.lua
+++ b/resources/prosody-plugins/mod_presence_identity.lua
@@ -5,7 +5,7 @@ local stanza = require "util.stanza";
 -- for that session.
 function on_message(event)
     if event and event["stanza"] then
-      if event.origin and event.origin.jitsi_meet_context_user and event.origin.jitsi_meet_context_group then
+      if event.origin and event.origin.jitsi_meet_context_user then
           -- First remove any 'identity' element if it already
           -- exists
           event.stanza:maptags(
@@ -25,7 +25,11 @@ function on_message(event)
               event.stanza:tag(k):text(v):up()
           end
           event.stanza:up()
-          event.stanza:tag("group"):text(event.origin.jitsi_meet_context_group)
+            
+          -- Add the group information if it is present
+          if event.origin.jitsi_meet_context_group then
+              event.stanza:tag("group"):text(event.origin.jitsi_meet_context_group)
+          end
 
           module:log("debug", "Sending presence with identity inserted %s", tostring(event.stanza))
       end

--- a/resources/prosody-plugins/mod_presence_identity.lua
+++ b/resources/prosody-plugins/mod_presence_identity.lua
@@ -1,0 +1,40 @@
+local stanza = require "util.stanza";
+local core_post_stanza = prosody.core_post_stanza;
+
+-- For all received presence messages, if the jitsi_meet_context_(user|group)
+-- values are set in the session, then insert them into the presence messages
+-- for that session.
+function on_message(event)
+    if event["stanza"] then
+      local presence = event["stanza"]
+      if event.origin["jitsi_meet_context_user"] then
+          local new_stanza = stanza.clone(event.stanza)
+          -- First remove any 'identity' element if it already
+          -- exists
+          new_stanza:maptags(
+              function(tag)
+                  for k, v in pairs(tag) do
+                      if k == "name" and v == "identity" then
+                          module:log("debug", "filtering out 'identity' field")
+                          return nil
+                      end
+                  end
+                  return tag
+              end
+          )
+          new_stanza:tag("identity"):tag("user")
+          for k, v in pairs(event.origin["jitsi_meet_context_user"]) do
+              new_stanza:tag(k):text(v):up()
+          end
+          new_stanza:up()
+          new_stanza:tag("group"):text(event.origin["jitsi_meet_context_group"])
+
+          module:log("debug", "Sending presence with identity inserted %s", tostring(new_stanza))
+          core_post_stanza(event.origin, new_stanza)
+      end
+    end
+    return true
+end
+
+module:hook("pre-presence/bare", on_message);
+module:hook("pre-presence/full", on_message);

--- a/resources/prosody-plugins/mod_presence_identity.lua
+++ b/resources/prosody-plugins/mod_presence_identity.lua
@@ -21,11 +21,11 @@ function on_message(event)
           module:log("debug", "Presence after previous identity stripped: %s", tostring(event.stanza))
 
           event.stanza:tag("identity"):tag("user")
-          for k, v in pairs(event.origin["jitsi_meet_context_user"]) do
+          for k, v in pairs(event.origin.jitsi_meet_context_user) do
               event.stanza:tag(k):text(v):up()
           end
           event.stanza:up()
-          event.stanza:tag("group"):text(event.origin["jitsi_meet_context_group"])
+          event.stanza:tag("group"):text(event.origin.jitsi_meet_context_group)
 
           module:log("debug", "Sending presence with identity inserted %s", tostring(event.stanza))
       end

--- a/resources/prosody-plugins/mod_presence_identity.lua
+++ b/resources/prosody-plugins/mod_presence_identity.lua
@@ -1,38 +1,35 @@
 local stanza = require "util.stanza";
-local core_post_stanza = prosody.core_post_stanza;
 
 -- For all received presence messages, if the jitsi_meet_context_(user|group)
 -- values are set in the session, then insert them into the presence messages
 -- for that session.
 function on_message(event)
-    if event["stanza"] then
-      if event.origin["jitsi_meet_context_user"] then
-          local new_stanza = stanza.clone(event.stanza)
+    if event and event["stanza"] then
+      if event.origin and event.origin.jitsi_meet_context_user and event.origin.jitsi_meet_context_group then
           -- First remove any 'identity' element if it already
           -- exists
-          new_stanza:maptags(
+          event.stanza:maptags(
               function(tag)
                   for k, v in pairs(tag) do
                       if k == "name" and v == "identity" then
-                          module:log("debug", "filtering out 'identity' field")
                           return nil
                       end
                   end
                   return tag
               end
           )
-          new_stanza:tag("identity"):tag("user")
-          for k, v in pairs(event.origin["jitsi_meet_context_user"]) do
-              new_stanza:tag(k):text(v):up()
-          end
-          new_stanza:up()
-          new_stanza:tag("group"):text(event.origin["jitsi_meet_context_group"])
+          module:log("debug", "Presence after previous identity stripped: %s", tostring(event.stanza))
 
-          module:log("debug", "Sending presence with identity inserted %s", tostring(new_stanza))
-          core_post_stanza(event.origin, new_stanza)
+          event.stanza:tag("identity"):tag("user")
+          for k, v in pairs(event.origin["jitsi_meet_context_user"]) do
+              event.stanza:tag(k):text(v):up()
+          end
+          event.stanza:up()
+          event.stanza:tag("group"):text(event.origin["jitsi_meet_context_group"])
+
+          module:log("debug", "Sending presence with identity inserted %s", tostring(event.stanza))
       end
     end
-    return true
 end
 
 module:hook("pre-presence/bare", on_message);


### PR DESCRIPTION
…into presence

prosody will check for jitsi_meet_context_user and
jitsi_meet_context_group in the session and, if they are present, insert
them into presence (we do this in prosody so they cannot be spoofed).