### PR TITLE
feat(mobile): handle kicked out of the conference

### DIFF
--- a/react/features/base/conference/actionTypes.js
+++ b/react/features/base/conference/actionTypes.js
@@ -63,6 +63,17 @@ export const CONFERENCE_WILL_LEAVE = Symbol('CONFERENCE_WILL_LEAVE');
 export const DATA_CHANNEL_OPENED = Symbol('DATA_CHANNEL_OPENED');
 
 /**
+ * The type of action which signals that the user has been kicked out from
+ * the conference.
+ *
+ * {
+ *     type: KICKED_OUT,
+ *     conference: JitsiConference
+ * }
+ */
+export const KICKED_OUT = Symbol('KICKED_OUT');
+
+/**
  * The type of (redux) action which signals that the lock state of a specific
  * {@code JitsiConference} changed.
  *

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -28,6 +28,7 @@ import {
     CONFERENCE_WILL_JOIN,
     CONFERENCE_WILL_LEAVE,
     DATA_CHANNEL_OPENED,
+    KICKED_OUT,
     LOCK_STATE_CHANGED,
     P2P_STATUS_CHANGED,
     SET_AUDIO_ONLY,
@@ -77,6 +78,10 @@ function _addConferenceListeners(conference, dispatch) {
     conference.on(
         JitsiConferenceEvents.CONFERENCE_LEFT,
         (...args) => dispatch(conferenceLeft(conference, ...args)));
+
+    conference.on(
+        JitsiConferenceEvents.KICKED,
+        () => dispatch(kickedOut(conference)));
 
     conference.on(
         JitsiConferenceEvents.LOCK_STATE_CHANGED,
@@ -355,6 +360,23 @@ export function checkIfCanJoin() {
 export function dataChannelOpened() {
     return {
         type: DATA_CHANNEL_OPENED
+    };
+}
+
+/**
+ * Signals that we've been kicked out of the conference.
+ *
+ * @param {JitsiConference} conference - The {@link JitsiConference} instance
+ * for which the event is being signaled.
+ * @returns {{
+ *     type: KICKED_OUT,
+ *     conference: JitsiConference
+ * }}
+ */
+export function kickedOut(conference: Object) {
+    return {
+        type: KICKED_OUT,
+        conference
     };
 }
 

--- a/react/features/conference/middleware.js
+++ b/react/features/conference/middleware.js
@@ -1,10 +1,14 @@
 // @flow
 
+import { appNavigate } from '../app';
 import {
     CONFERENCE_JOINED,
+    KICKED_OUT,
     VIDEO_QUALITY_LEVELS,
+    conferenceFailed,
     setReceiveVideoQuality
 } from '../base/conference';
+import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
 import { SET_REDUCED_UI } from '../base/responsive-ui';
 import { MiddlewareRegistry } from '../base/redux';
 import { setFilmstripEnabled } from '../filmstrip';
@@ -33,6 +37,15 @@ MiddlewareRegistry.register(store => next => action => {
                         ? VIDEO_QUALITY_LEVELS.LOW
                         : VIDEO_QUALITY_LEVELS.HIGH));
 
+        break;
+    }
+
+    case KICKED_OUT: {
+        const { dispatch } = store;
+
+        dispatch(
+            conferenceFailed(action.conference, JitsiConferenceEvents.KICKED));
+        dispatch(appNavigate(undefined));
         break;
     }
     }


### PR DESCRIPTION
Being kicked out of the conference will result with a conference failed event with 'conference.kicked' reason and take the user back to the welcome page by navigating to 'undefined'.