### PR TITLE
fix(gum): add electron string for requesting gum permissions

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -23,6 +23,7 @@
       "react-nativeGrantPermissions": "Select <b><i>Allow</i></b> when your browser asks for permissions.",
       "chromeGrantPermissions": "Select <b><i>Allow</i></b> when your browser asks for permissions.",
       "androidGrantPermissions": "Select <b><i>Allow</i></b> when your browser asks for permissions.",
+      "electronGrantPermissions": "Please grant permissions to use your camera and microphone",
       "firefoxGrantPermissions": "Select <b><i>Share Selected Device</i></b> when your browser asks for permissions.",
       "operaGrantPermissions": "Select <b><i>Allow</i></b> when your browser asks for permissions.",
       "iexplorerGrantPermissions": "Select <b><i>OK</i></b> when your browser asks for permissions.",


### PR DESCRIPTION
Electron generally can bypass having to get permission for
audio and video. In the case it doesn't have it, and the
permission screen is displayed, a string should still display
prompting the user to click allow. Right now the string id
displays.