### PR TITLE
chore(deps): update lib-jitsi-meet to 6282e7a8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7468,7 +7468,7 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#ef0e14babea88305ede161943b5b6de5e50acb37",
+      "version": "github:jitsi/lib-jitsi-meet#6282e7a82e768dd6a5970de89602757a8f882ffb",
       "requires": {
         "async": "0.9.0",
         "current-executing-script": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "jquery-i18next": "1.2.0",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ef0e14babea88305ede161943b5b6de5e50acb37",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6282e7a82e768dd6a5970de89602757a8f882ffb",
     "lodash": "4.17.4",
     "moment": "2.19.4",
     "postis": "2.2.0",


### PR DESCRIPTION
This update is explicitly for FF screenshare and
gum retry fixes.