### PR TITLE
fix(feedback): modify user-select none declaration for edge

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -3,9 +3,15 @@
  * none is applied. Other browsers already support selecting within inputs while
  * user-select is none. As such, disallow user-select except on inputs.
  */
-*:not(input) {
+* {
     -webkit-user-select: none;
     user-select: none;
+}
+
+input,
+textarea {
+    -webkit-user-select: text;
+    user-select: text;
 }
 
 body {


### PR DESCRIPTION
Explicitly allow selecting (cursor highlighting) on inputs as well as textareas. On edge, the explicit declaration of textarea is needed whereas other browsers seem okay with automatically allowing input on editable fields.