### PR TITLE
Update RNFetchBlob to fixes issues with calling UI API in background thread

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10158,9 +10158,7 @@
       }
     },
     "react-native-fetch-blob": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/react-native-fetch-blob/-/react-native-fetch-blob-0.10.8.tgz",
-      "integrity": "sha1-T8JWq64MtfEOfEHyjBGz/zMNcqk=",
+      "version": "github:flatfox-ag/react-native-fetch-blob#01f38a4537baecd3ea0cb93c27e84553f3fc5231",
       "requires": {
         "base-64": "0.1.0",
         "glob": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-native-background-timer": "2.0.0",
     "react-native-calendar-events": "1.4.3",
     "react-native-callstats": "3.27.0",
-    "react-native-fetch-blob": "0.10.8",
+    "react-native-fetch-blob": "github:flatfox-ag/react-native-fetch-blob#exception_fixes",
     "react-native-img-cache": "1.5.2",
     "react-native-immersive": "1.1.0",
     "react-native-keep-awake": "2.0.6",


### PR DESCRIPTION
Note: The commit used is from a forked repo that is not yet merged on the new source for this RN component,  eventually we should be consuming from this repo instead https://github.com/joltup/react-native-fetch-blob