### PR TITLE
Update node-sass to version 4.8.3 -- Adding support for Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "file-loader": "1.1.5",
     "flow-bin": "0.57.3",
     "imports-loader": "0.7.1",
-    "node-sass": "3.13.1",
+    "node-sass": "4.8.3",
     "precommit-hook": "3.0.0",
     "string-replace-loader": "1.3.0",
     "style-loader": "0.19.0",


### PR DESCRIPTION
This adds support for **Node 8** by upgrading the version of dependency `node-sass` in the `package.json` file.