### PR TITLE
Separate handling config and profile with precedence

### DIFF
--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -124,10 +124,8 @@ function _appNavigateToMandatoryLocation(
             });
         }
 
-        const profile = getState()['features/base/profile'];
-
         return promise.then(() =>
-            dispatch(setConfig(_mergeConfigWithProfile(config, profile))));
+            dispatch(setConfig(config)));
     }
 }
 
@@ -289,24 +287,4 @@ function _loadConfig({ contextRoot, host, protocol, room }) {
 
             throw error;
         });
-}
-
-/**
- * Merges the downloaded config with the current profile values. The profile
- * values are named the same way as the config values in the config.js so
- * a clean merge is possible.
- *
- * @param {Object|undefined} config - The downloaded config.
- * @param {Object} profile - The persisted profile.
- * @returns {Object}
- */
-function _mergeConfigWithProfile(config, profile) {
-    if (!config) {
-        return;
-    }
-
-    return {
-        ...config,
-        ...profile
-    };
 }

--- a/react/features/base/profile/functions.js
+++ b/react/features/base/profile/functions.js
@@ -1,0 +1,68 @@
+// @flow
+
+import { parseURLParams } from '../config';
+import { toState } from '../redux';
+
+/**
+ * Returns the effective value of a property by applying a precedence
+ * between values in URL, config and profile.
+ *
+ * @param {Object|Function} stateful - The redux state object or function
+ * to retreive the state.
+ * @param {string} propertyName - The name of the property we need.
+ * @param {{
+ *     ignoreJWT: boolean,
+ *     ignoreUrlParams: boolean,
+ *     ignoreProfile: boolean,
+ *     ignoreConfig: boolean
+ * }} precedence - A structure of booleans to set which property sources
+ * should be ignored.
+ * @returns {any}
+ */
+export function getPropertyValue(
+        stateful: Object | Function,
+        propertyName: string,
+        precedence: Object = {
+            ignoreJWT: false,
+            ignoreUrlParams: false,
+            ignoreProfile: false,
+            ignoreConfig: false
+        }
+) {
+    const state = toState(stateful);
+    const jwt = state['features/base/jwt'];
+    const urlParams
+        = parseURLParams(state['features/base/connection'].locationURL);
+    const profile = state['features/base/profile'];
+    const config = state['features/base/config'];
+    const urlParamName = `config.${propertyName}`;
+
+    // Precedence: jwt -> urlParams -> profile -> config
+
+    if (
+        !precedence.ignoreJWT
+        && typeof jwt[propertyName] !== 'undefined'
+    ) {
+        return jwt[propertyName];
+    }
+
+    if (
+        !precedence.ignoreUrlParams
+        && typeof urlParams[urlParamName] !== 'undefined'
+    ) {
+        return urlParams[urlParamName];
+    }
+
+    if (
+        !precedence.ignoreProfile
+        && typeof profile[propertyName] !== 'undefined'
+    ) {
+        return profile[propertyName];
+    }
+
+    if (!precedence.ignoreConfig) {
+        return config[propertyName];
+    }
+
+    return undefined;
+}

--- a/react/features/base/profile/index.js
+++ b/react/features/base/profile/index.js
@@ -1,4 +1,5 @@
 export * from './actions';
+export * from './functions';
 
 import './middleware';
 import './reducer';


### PR DESCRIPTION
This change separates handling of config and profile and avoids merging it on app navigate. There is a new generic function to retrieve URL/profile/config values with (overridable) precedence.

Question: Where should this function be? Currently it's in base/profile, but I have the feeling it doesn't belong there.