### PR TITLE
fix(filmstrip): set SmallVideo styles instead of using animate

### DIFF
--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -286,7 +286,7 @@ export default class SharedVideoManager {
 
             thumb.setDisplayName('YouTube');
             VideoLayout.addRemoteVideoContainer(self.url, thumb);
-            VideoLayout.resizeThumbnails(false, true);
+            VideoLayout.resizeThumbnails(true);
 
             const iframe = player.getIframe();
 

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -438,12 +438,11 @@ const Filmstrip = {
      * Resizes thumbnails
      * @param local
      * @param remote
-     * @param animate
      * @param forceUpdate
      * @returns {Promise}
      */
-    // eslint-disable-next-line max-params, no-unused-vars
-    resizeThumbnails(local, remote, animate = false, forceUpdate = false) {
+    // eslint-disable-next-line max-params
+    resizeThumbnails(local, remote, forceUpdate = false) {
         const thumbs = this.getThumbs(!forceUpdate);
 
         if (thumbs.localThumb) {

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -450,25 +450,23 @@ const Filmstrip = {
 
             if (thumbs.localThumb) {
                 // eslint-disable-next-line no-shadow
-                promises.push(new Promise(resolve => {
-                    thumbs.localThumb.animate({
-                        height: local.thumbHeight,
-                        'min-height': local.thumbHeight,
-                        'min-width': local.thumbWidth,
-                        width: local.thumbWidth
-                    }, this._getAnimateOptions(animate, resolve));
-                }));
+                thumbs.localThumb.css({
+                    display: 'inline-block',
+                    height: `${local.thumbHeight}px`,
+                    'min-height': `${local.thumbHeight}px`,
+                    'min-width': `${local.thumbWidth}px`,
+                    width: `${local.thumbWidth}px`
+                });
             }
+
             if (thumbs.remoteThumbs) {
-                // eslint-disable-next-line no-shadow
-                promises.push(new Promise(resolve => {
-                    thumbs.remoteThumbs.animate({
-                        height: remote.thumbHeight,
-                        'min-height': remote.thumbHeight,
-                        'min-width': remote.thumbWidth,
-                        width: remote.thumbWidth
-                    }, this._getAnimateOptions(animate, resolve));
-                }));
+                thumbs.remoteThumbs.css({
+                    display: 'inline-block',
+                    height: `${remote.thumbHeight}px`,
+                    'min-height': `${remote.thumbHeight}px`,
+                    'min-width': `${remote.thumbWidth}px`,
+                    width: `${remote.thumbWidth}px`
+                });
             }
             // eslint-disable-next-line no-shadow
             promises.push(new Promise(resolve => {

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -442,79 +442,51 @@ const Filmstrip = {
      * @param forceUpdate
      * @returns {Promise}
      */
-    // eslint-disable-next-line max-params
+    // eslint-disable-next-line max-params, no-unused-vars
     resizeThumbnails(local, remote, animate = false, forceUpdate = false) {
-        return new Promise(resolve => {
-            const thumbs = this.getThumbs(!forceUpdate);
-            const promises = [];
+        const thumbs = this.getThumbs(!forceUpdate);
 
-            if (thumbs.localThumb) {
-                // eslint-disable-next-line no-shadow
-                thumbs.localThumb.css({
-                    display: 'inline-block',
-                    height: `${local.thumbHeight}px`,
-                    'min-height': `${local.thumbHeight}px`,
-                    'min-width': `${local.thumbWidth}px`,
-                    width: `${local.thumbWidth}px`
-                });
-            }
-
-            if (thumbs.remoteThumbs) {
-                thumbs.remoteThumbs.css({
-                    display: 'inline-block',
-                    height: `${remote.thumbHeight}px`,
-                    'min-height': `${remote.thumbHeight}px`,
-                    'min-width': `${remote.thumbWidth}px`,
-                    width: `${remote.thumbWidth}px`
-                });
-            }
+        if (thumbs.localThumb) {
             // eslint-disable-next-line no-shadow
-            promises.push(new Promise(resolve => {
-                // Let CSS take care of height in vertical filmstrip mode.
-                if (interfaceConfig.VERTICAL_FILMSTRIP) {
-                    $('#filmstripLocalVideo').animate({
-                        // adds 4 px because of small video 2px border
-                        width: local.thumbWidth + 4
-                    }, this._getAnimateOptions(animate, resolve));
-                } else {
-                    this.filmstrip.animate({
-                        // adds 4 px because of small video 2px border
-                        height: remote.thumbHeight + 4
-                    }, this._getAnimateOptions(animate, resolve));
-                }
-            }));
+            thumbs.localThumb.css({
+                display: 'inline-block',
+                height: `${local.thumbHeight}px`,
+                'min-height': `${local.thumbHeight}px`,
+                'min-width': `${local.thumbWidth}px`,
+                width: `${local.thumbWidth}px`
+            });
+        }
 
-            promises.push(new Promise(() => {
-                const { localThumb } = this.getThumbs();
-                const height = localThumb ? localThumb.height() : 0;
-                const fontSize = UIUtil.getIndicatorFontSize(height);
+        if (thumbs.remoteThumbs) {
+            thumbs.remoteThumbs.css({
+                display: 'inline-block',
+                height: `${remote.thumbHeight}px`,
+                'min-height': `${remote.thumbHeight}px`,
+                'min-width': `${remote.thumbWidth}px`,
+                width: `${remote.thumbWidth}px`
+            });
+        }
 
-                this.filmstrip.find('.indicator').animate({
-                    fontSize
-                }, this._getAnimateOptions(animate, resolve));
-            }));
+        // Let CSS take care of height in vertical filmstrip mode.
+        if (interfaceConfig.VERTICAL_FILMSTRIP) {
+            $('#filmstripLocalVideo').css({
+                // adds 4 px because of small video 2px border
+                width: `${local.thumbWidth + 4}px`
+            });
+        } else {
+            this.filmstrip.css({
+                // adds 4 px because of small video 2px border
+                height: `${remote.thumbHeight + 4}px`
+            });
+        }
 
-            if (!animate) {
-                resolve();
-            }
+        const { localThumb } = this.getThumbs();
+        const height = localThumb ? localThumb.height() : 0;
+        const fontSize = UIUtil.getIndicatorFontSize(height);
 
-            Promise.all(promises).then(resolve);
+        this.filmstrip.find('.indicator').css({
+            'font-size': `${fontSize}px`
         });
-    },
-
-    /**
-     * Helper method. Returns options for jQuery animation
-     * @param animate {Boolean} - animation flag
-     * @param cb {Function} - complete callback
-     * @returns {Object} - animation options object
-     * @private
-     */
-    _getAnimateOptions(animate, cb = $.noop) {
-        return {
-            queue: false,
-            duration: animate ? 500 : 0,
-            complete: cb
-        };
     },
 
     /**

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -95,7 +95,7 @@ RemoteVideo.prototype.addRemoteVideoContainer = function() {
 
     this.updateRemoteVideoMenu();
 
-    this.VideoLayout.resizeThumbnails(false, true);
+    this.VideoLayout.resizeThumbnails(true);
 
     this.addAudioLevelIndicator();
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -582,12 +582,11 @@ const VideoLayout = {
             = Filmstrip.calculateThumbnailSize();
 
         Filmstrip.resizeThumbnails(localVideo, remoteVideo,
-            animate, forceUpdate)
-            .then(() => {
-                if (onComplete && typeof onComplete === 'function') {
-                    onComplete();
-                }
-            });
+            animate, forceUpdate);
+
+        if (onComplete && typeof onComplete === 'function') {
+            onComplete();
+        }
 
         return { localVideo,
             remoteVideo };

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -74,7 +74,7 @@ const VideoLayout = {
 
         // if we do not resize the thumbs here, if there is no video device
         // the local video thumb maybe one pixel
-        this.resizeThumbnails(false, true);
+        this.resizeThumbnails(true);
 
         this.handleVideoThumbClicked = this.handleVideoThumbClicked.bind(this);
 
@@ -468,7 +468,7 @@ const VideoLayout = {
             remoteVideo.setVideoType(VIDEO_CONTAINER_TYPE);
         }
 
-        VideoLayout.resizeThumbnails(false, true);
+        VideoLayout.resizeThumbnails(true);
 
         // Initialize the view
         remoteVideo.updateView();
@@ -480,7 +480,7 @@ const VideoLayout = {
         logger.info(`${resourceJid} video is now active`, videoElement);
 
         VideoLayout.resizeThumbnails(
-            false, false, () => {
+            false, () => {
                 if (videoElement) {
                     $(videoElement).show();
                 }
@@ -575,14 +575,12 @@ const VideoLayout = {
      * Resizes thumbnails.
      */
     resizeThumbnails(
-            animate = false,
             forceUpdate = false,
             onComplete = null) {
         const { localVideo, remoteVideo }
             = Filmstrip.calculateThumbnailSize();
 
-        Filmstrip.resizeThumbnails(localVideo, remoteVideo,
-            animate, forceUpdate);
+        Filmstrip.resizeThumbnails(localVideo, remoteVideo, forceUpdate);
 
         if (onComplete && typeof onComplete === 'function') {
             onComplete();
@@ -878,7 +876,7 @@ const VideoLayout = {
         }
 
         // Resize the thumbnails first.
-        this.resizeThumbnails(false, forceUpdate);
+        this.resizeThumbnails(forceUpdate);
 
         // Resize the video area element.
         $('#videospace').animate({


### PR DESCRIPTION
jquery animate during animations sets an element's overflow to
hidden and then back to the overflow declared before the start
of the animation. If multiple animations are fired, then the
overflow could be set to hidden permanently. No calls
to Filmstrip#resizeThumbnails have animate set to true, so the
animate call is not even needed.