### PR TITLE
fix(info): hide anchor hover colors for the call url

### DIFF
--- a/css/modals/invite/_info.scss
+++ b/css/modals/invite/_info.scss
@@ -81,7 +81,8 @@
         font-size: 16px;
     }
 
-    .info-dialog-invite-link {
+    .info-dialog-invite-link,
+    .info-dialog-invite-link:hover {
         color: inherit;
         cursor: inherit;
     }


### PR DESCRIPTION
The call url is an anchor element so that right clicking it
can bring up the copy link option in the context menu.
Clicking on it does a no-op so the anchor was colored to
look like plain text. Hovering over it right now makes it
look like an anchor due to some atlaskit color, so supress
the coloring.