### PR TITLE
fix(recording): fetch events also for available broadcasts

### DIFF
--- a/react/features/recording/components/LiveStream/StartLiveStreamDialog.web.js
+++ b/react/features/recording/components/LiveStream/StartLiveStreamDialog.web.js
@@ -341,37 +341,30 @@ class StartLiveStreamDialog extends Component {
     /**
      * Takes in a list of broadcasts from the YouTube API, removes dupes,
      * removes broadcasts that cannot get a stream key, and parses the
-     * broacasts into flat objects.
+     * broadcasts into flat objects.
      *
-     * @param {Array} broadcasts - Broadcast descriptions as obtains from
+     * @param {Array} broadcasts - Broadcast descriptions as obtained from
      * calling the YouTube API.
      * @private
-     * @returns {Array} An array of objects that are flat and contain only data
-     * that is needed. The objects have the shape: {{
-     *     boundStreamID: string
-     *     status: string,
-     *     title: string
-     * }}
+     * @returns {Array} An array of objects describing each unique broadcast.
      */
     _parseBroadcasts(broadcasts) {
-        const parsedIds = new Set();
-        const parsedBroadcasts = [];
+        const parsedBroadcasts = {};
 
         for (let i = 0; i < broadcasts.length; i++) {
             const broadcast = broadcasts[i];
             const boundStreamID = broadcast.contentDetails.boundStreamId;
 
-            if (boundStreamID && !parsedIds.has(boundStreamID)) {
-                parsedBroadcasts.push({
+            if (boundStreamID && !parsedBroadcasts[boundStreamID]) {
+                parsedBroadcasts[boundStreamID] = {
                     boundStreamID,
                     status: broadcast.status.lifeCycleStatus,
                     title: broadcast.snippet.title
-                });
-                parsedIds.add(boundStreamID);
+                };
             }
         }
 
-        return parsedBroadcasts;
+        return Object.values(parsedBroadcasts);
     }
 
     /**

--- a/react/features/recording/googleApi.js
+++ b/react/features/recording/googleApi.js
@@ -205,7 +205,7 @@ const googleApi = {
     _getURLForLiveBroadcasts() {
         return [
             'https://content.googleapis.com/youtube/v3/liveBroadcasts',
-            '?broadcastType=persistent',
+            '?broadcastType=all',
             '&mine=true&part=id%2Csnippet%2CcontentDetails%2Cstatus'
         ].join('');
     },


### PR DESCRIPTION
Only "persistent" broadcasts were being fetched using the
YouTube API. Fetching "all" will get persistent broadcasts
and events. If events use a custom encoder then the stream
key can be obtained. If google hangouts is used for the event
then a stream key will not be obtainable; in those cases
input empty string as the stream key.