### PR TITLE
fix(recording): do not spell check stream key input

### DIFF
--- a/react/features/recording/components/LiveStream/StreamKeyForm.web.js
+++ b/react/features/recording/components/LiveStream/StreamKeyForm.web.js
@@ -66,6 +66,7 @@ class StreamKeyForm extends Component {
                 <FieldTextStateless
                     autoFocus = { true }
                     compact = { true }
+                    isSpellCheckEnabled = { false }
                     label = { t('dialog.streamKey') }
                     name = 'streamId'
                     okDisabled = { !this.props.value }


### PR DESCRIPTION
I didn't bother turning off autocomplete. I think it might be useful.