### PR TITLE
fix(keyboard-shortcuts): process Unidentified keys

### DIFF
--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -144,7 +144,7 @@ const KeyboardShortcut = {
      * @returns {string} e.key or something close if not supported
      */
     _getKeyboardKey(e) {
-        if (typeof e.key === 'string') {
+        if (typeof e.key === 'string' && e.key !== 'Unidentified') {
             return e.key;
         }
         if (e.type === 'keypress'

--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -144,6 +144,11 @@ const KeyboardShortcut = {
      * @returns {string} e.key or something close if not supported
      */
     _getKeyboardKey(e) {
+        // If e.key is a string, then it is assumed it already plainly states
+        // the key pressed. This may not be true in all cases, such as with Edge
+        // and "?", when the browser cannot properly map a key press event to a
+        // keyboard key. To be safe, when a key is "Unidentified" it must be
+        // further analyzed by jitsi to a key using e.which.
         if (typeof e.key === 'string' && e.key !== 'Unidentified') {
             return e.key;
         }


### PR DESCRIPTION
When processing keyboard events for keyboard shortcuts,
if the value of an event's "key" attribute is "Unidentified",
the event should be further processed instead of the "key"
being returned to be mapped to a registered keyboard shortcut.
This occurs on edge, where question mark has the key
"Unidentified" but has the proper keyCode of 191.