### PR TITLE
fix(toolbar): move chat counter and stop its pointer events

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -420,12 +420,13 @@
         position: relative;
 
         .badge-round {
-            bottom: 9px;
+            bottom: -5px;
             font-size: 12px;
             line-height: 20px;
             min-width: 20px;
+            pointer-events: none;
             position: absolute;
-            right: 9px;
+            right: -5px;
         }
     }
 


### PR DESCRIPTION
The chat counter needs to be moved out of the way of the chat
button. The counter started covering the button when all the
toolbar buttons were made smaller. Also, turning off the
counters pointer events should at least make the button
clickable if this ever happens again.