### PR TITLE
fix(toolbar): set recording icon size to prevent resizing flash

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -314,7 +314,9 @@
      * Overwrite font-awesome styling to match jitsi-icon styling.
      */
     .fa {
-        font-size: 1.22em;
+        height: 24px;
+        margin-left: 2px;
+        width: 24px;
     }
 
     i {


### PR DESCRIPTION
There is a slight moment when the recording icon is loading that
its container does not have width. Set the width of the container
so it doesn't collapse. Also, push it a little to the right so
it aligns better with other icons.