### PR TITLE
Separate local thumbnail in filmstrip

### DIFF
--- a/react/features/filmstrip/components/Filmstrip.native.js
+++ b/react/features/filmstrip/components/Filmstrip.native.js
@@ -70,8 +70,7 @@ class Filmstrip extends Component<Props> {
                 style = { filmstripStyle }
                 visible = { this.props._visible }>
                 {
-                    !isNarrowAspectRatio_
-                    && <LocalThumbnail />
+                    !isNarrowAspectRatio_ && <LocalThumbnail />
                 }
                 <ScrollView
                     horizontal = { isNarrowAspectRatio_ }
@@ -93,8 +92,7 @@ class Filmstrip extends Component<Props> {
                     }
                 </ScrollView>
                 {
-                    isNarrowAspectRatio_
-                    && <LocalThumbnail />
+                    isNarrowAspectRatio_ && <LocalThumbnail />
                 }
             </Container>
         );

--- a/react/features/filmstrip/components/Filmstrip.native.js
+++ b/react/features/filmstrip/components/Filmstrip.native.js
@@ -10,6 +10,7 @@ import {
     makeAspectRatioAware
 } from '../../base/responsive-ui';
 
+import LocalThumbnail from './LocalThumbnail';
 import styles from './styles';
 import Thumbnail from './Thumbnail';
 
@@ -68,10 +69,15 @@ class Filmstrip extends Component<Props> {
             <Container
                 style = { filmstripStyle }
                 visible = { this.props._visible }>
+                {
+                    !isNarrowAspectRatio_
+                    && <LocalThumbnail />
+                }
                 <ScrollView
                     horizontal = { isNarrowAspectRatio_ }
                     showsHorizontalScrollIndicator = { false }
-                    showsVerticalScrollIndicator = { false }>
+                    showsVerticalScrollIndicator = { false }
+                    style = { styles.scrollView } >
                     {
                         /* eslint-disable react/jsx-wrap-multilines */
 
@@ -86,6 +92,10 @@ class Filmstrip extends Component<Props> {
                         /* eslint-enable react/jsx-wrap-multilines */
                     }
                 </ScrollView>
+                {
+                    isNarrowAspectRatio_
+                    && <LocalThumbnail />
+                }
             </Container>
         );
     }
@@ -106,12 +116,7 @@ class Filmstrip extends Component<Props> {
         // in place and (2) it is not necessarily stable.
 
         const sortedParticipants = [
-
-            // First put the local participant.
-            ...participants.filter(p => p.local),
-
-            // Then the remote participants, which are sorted by join order.
-            ...participants.filter(p => !p.local)
+            ...participants
         ];
 
         if (isNarrowAspectRatio_) {
@@ -149,12 +154,12 @@ function _mapStateToProps(state) {
         _enabled: enabled,
 
         /**
-         * The participants in the conference.
+         * The remote participants in the conference.
          *
          * @private
          * @type {Participant[]}
          */
-        _participants: participants,
+        _participants: participants.filter(p => !p.local),
 
         /**
          * The indicator which determines whether the filmstrip is visible. The

--- a/react/features/filmstrip/components/LocalThumbnail.js
+++ b/react/features/filmstrip/components/LocalThumbnail.js
@@ -1,0 +1,63 @@
+// @flow
+
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { connect } from 'react-redux';
+
+import { getLocalParticipant } from '../../base/participants';
+
+import styles from './styles';
+import Thumbnail from './Thumbnail';
+
+type Props = {
+
+    /**
+     * The local participant.
+     */
+    _localParticipant: Object
+};
+
+/**
+ * Component to render a local thumbnail that can be separated from the
+ * remote thumbnails later.
+ */
+class LocalThumbnail extends Component<Props> {
+    /**
+     * Implements React Component's render.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const { _localParticipant } = this.props;
+
+        return (
+            <View style = { styles.localThumbnail }>
+                <Thumbnail participant = { _localParticipant } />
+            </View>
+        );
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated {@code LocalThumbnail}'s
+ * props.
+ *
+ * @param {Object} state - The redux state.
+ * @private
+ * @returns {{
+ *     _localParticipant: Participant
+ * }}
+ */
+function _mapStateToProps(state) {
+    return {
+        /**
+         * The local participant.
+         *
+         * @private
+         * @type {Participant}
+         */
+        _localParticipant: getLocalParticipant(state)
+    };
+}
+
+export default connect(_mapStateToProps)(LocalThumbnail);

--- a/react/features/filmstrip/components/styles.js
+++ b/react/features/filmstrip/components/styles.js
@@ -9,7 +9,6 @@ export const AVATAR_SIZE = 50;
  * The base style of {@link Filmstrip} shared between narrow and wide versions.
  */
 const filmstrip = {
-    flexDirection: 'column',
     flexGrow: 0
 };
 
@@ -43,7 +42,8 @@ export default {
      */
     filmstripNarrow: {
         ...filmstrip,
-        alignItems: 'flex-end',
+        flexDirection: 'row',
+        justifyContent: 'flex-end',
         height: 90
     },
 
@@ -54,9 +54,21 @@ export default {
     filmstripWide: {
         ...filmstrip,
         bottom: 0,
+        flexDirection: 'column',
         left: 0,
         position: 'absolute',
         top: 0
+    },
+
+    /**
+     * Container of the {@link LocalThumbnail}.
+     */
+    localThumbnail: {
+        alignContent: 'stretch',
+        alignSelf: 'stretch',
+        aspectRatio: 1,
+        flexShrink: 0,
+        flexDirection: 'row'
     },
 
     /**
@@ -68,6 +80,13 @@ export default {
         color: ColorPalette.white,
         position: 'absolute',
         right: 4
+    },
+
+    /**
+     * The style of the scrollview containing the remote thumbnails.
+     */
+    scrollView: {
+        flexGrow: 0
     },
 
     /**


### PR DESCRIPTION
This is a separation of the local thumbnail and the remote thumbnails. The local thumbnail is still rendered inside the filmstrip, but not in the scrollable area, so it can be physically separated in a later stage.