### PR TITLE
Adds in memory log storage, to be used while testing.

### DIFF
--- a/modules/util/JitsiMeetInMemoryLogStorage.js
+++ b/modules/util/JitsiMeetInMemoryLogStorage.js
@@ -15,7 +15,7 @@ export default class JitsiMeetInMemoryLogStorage {
     }
 
     /**
-     * @return {boolean} <tt>true</tt> when this storage is ready or
+     * @returns {boolean} <tt>true</tt> when this storage is ready or
      * <tt>false</tt> otherwise.
      */
     isReady() {
@@ -25,7 +25,7 @@ export default class JitsiMeetInMemoryLogStorage {
     /**
      * Called by the <tt>LogCollector</tt> to store a series of log lines into
      * batch.
-     * @param {string|object[]}logEntries an array containing strings
+     * @param {string|object[]} logEntries an array containing strings
      * representing log lines or aggregated lines objects.
      */
     storeLogs(logEntries) {

--- a/modules/util/JitsiMeetInMemoryLogStorage.js
+++ b/modules/util/JitsiMeetInMemoryLogStorage.js
@@ -1,0 +1,50 @@
+/**
+ * Implements in memory logs storage, used for testing/debugging.
+ */
+export default class JitsiMeetInMemoryLogStorage {
+
+    /**
+     * Creates new <tt>JitsiMeetInMemoryLogStorage</tt>
+     */
+    constructor() {
+        /**
+         * Array of the log entries to keep.
+         * @type {array}
+         */
+        this.logs = [];
+    }
+
+    /**
+     * @return {boolean} <tt>true</tt> when this storage is ready or
+     * <tt>false</tt> otherwise.
+     */
+    isReady() {
+        return true;
+    }
+
+    /**
+     * Called by the <tt>LogCollector</tt> to store a series of log lines into
+     * batch.
+     * @param {string|object[]}logEntries an array containing strings
+     * representing log lines or aggregated lines objects.
+     */
+    storeLogs(logEntries) {
+        for (let i = 0, len = logEntries.length; i < len; i++) {
+            const logEntry = logEntries[i];
+
+            if (typeof logEntry === 'object') {
+                this.logs.push(logEntry.text);
+            } else {
+                // Regular message
+                this.logs.push(logEntry);
+            }
+        }
+    }
+
+    /**
+     * @returns {array} the collected log entries.
+     */
+    getLogs() {
+        return this.logs;
+    }
+}

--- a/react/features/base/logging/middleware.js
+++ b/react/features/base/logging/middleware.js
@@ -10,6 +10,8 @@ import JitsiMeetInMemoryLogStorage
     from '../../../../modules/util/JitsiMeetInMemoryLogStorage';
 import JitsiMeetLogStorage from '../../../../modules/util/JitsiMeetLogStorage';
 
+import { isTestModeEnabled } from '../testing';
+
 import { SET_LOGGING_CONFIG } from './actionTypes';
 
 declare var APP: Object;
@@ -69,11 +71,11 @@ function _appWillMount({ getState }, next, action) {
  *
  * @param {Object} loggingConfig - The configuration with which logging is to be
  * initialized.
- * @param {boolean} isDebugEnabled - Is debug logging enabled.
+ * @param {boolean} isTestingEnabled - Is debug logging enabled.
  * @private
  * @returns {void}
  */
-function _initLogging(loggingConfig, isDebugEnabled) {
+function _initLogging(loggingConfig, isTestingEnabled) {
     // Create the LogCollector and register it as the global log transport. It
     // is done early to capture as much logs as possible. Captured logs will be
     // cached, before the JitsiMeetLogStorage gets ready (statistics module is
@@ -86,7 +88,7 @@ function _initLogging(loggingConfig, isDebugEnabled) {
         JitsiMeetJS.addGlobalLogTransport(APP.logCollector);
     }
 
-    if (isDebugEnabled) {
+    if (isTestingEnabled) {
         APP.debugLogs = new JitsiMeetInMemoryLogStorage();
         const debugLogCollector = new Logger.LogCollector(
             APP.debugLogs, { storeInterval: 1000 });
@@ -134,7 +136,7 @@ function _libWillInit({ getState }, next, action) {
 function _setLoggingConfig({ getState }, next, action) {
     const result = next(action);
     const newValue = getState()['features/base/logging'].config;
-    const isDebugEnabled = getState()['features/base/config'].debug;
+    const isTestingEnabled = isTestModeEnabled(getState());
 
     // TODO Generally, we'll want to _setLogLevels and _initLogging only if the
     // logging config values actually change.
@@ -145,7 +147,7 @@ function _setLoggingConfig({ getState }, next, action) {
     _setLogLevels(Logger, newValue);
     _setLogLevels(JitsiMeetJS, newValue);
 
-    _initLogging(newValue, isDebugEnabled);
+    _initLogging(newValue, isTestingEnabled);
 
     return result;
 }

--- a/react/features/base/logging/middleware.js
+++ b/react/features/base/logging/middleware.js
@@ -86,16 +86,16 @@ function _initLogging(loggingConfig, isTestingEnabled) {
         APP.logCollector = new Logger.LogCollector(new JitsiMeetLogStorage());
         Logger.addGlobalTransport(APP.logCollector);
         JitsiMeetJS.addGlobalLogTransport(APP.logCollector);
-    }
 
-    if (isTestingEnabled) {
-        APP.debugLogs = new JitsiMeetInMemoryLogStorage();
-        const debugLogCollector = new Logger.LogCollector(
-            APP.debugLogs, { storeInterval: 1000 });
+        if (isTestingEnabled) {
+            APP.debugLogs = new JitsiMeetInMemoryLogStorage();
+            const debugLogCollector = new Logger.LogCollector(
+                APP.debugLogs, { storeInterval: 1000 });
 
-        Logger.addGlobalTransport(debugLogCollector);
-        JitsiMeetJS.addGlobalLogTransport(debugLogCollector);
-        debugLogCollector.start();
+            Logger.addGlobalTransport(debugLogCollector);
+            JitsiMeetJS.addGlobalLogTransport(debugLogCollector);
+            debugLogCollector.start();
+        }
     }
 }
 


### PR DESCRIPTION
Enabling it only when config.debug is set, a configuration provided by jitsi-meet-torture.