### PR TITLE
fix error "Can't find variable: DOMParser" in _connect_cb_wrapper

### DIFF
--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -99,6 +99,10 @@ function _visitNode(node, callback) {
 (global => {
     const { DOMParser } = require('xmldom');
 
+    // DOMParser
+    //
+    // Required by:
+    // - lib-jitsi-meet if using WebSockets
     global.DOMParser = DOMParser;
 
     // addEventListener

--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -99,6 +99,8 @@ function _visitNode(node, callback) {
 (global => {
     const { DOMParser } = require('xmldom');
 
+    global.DOMParser = DOMParser;
+
     // addEventListener
     //
     // Required by:

--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -102,7 +102,7 @@ function _visitNode(node, callback) {
     // DOMParser
     //
     // Required by:
-    // - lib-jitsi-meet if using WebSockets
+    // - lib-jitsi-meet requires this if using WebSockets
     global.DOMParser = DOMParser;
 
     // addEventListener


### PR DESCRIPTION
Native app shows "Can't find variable: DOMParser" in _connect_cb_wrapper in lib-jitsi-meet.min.js when connected to an Openfire server that we established.

Make DOMParser globally to resolve this problem