### PR TITLE
WIP - Invite people API for mobile

### DIFF
--- a/ios/sdk/sdk.xcodeproj/project.pbxproj
+++ b/ios/sdk/sdk.xcodeproj/project.pbxproj
@@ -27,10 +27,10 @@
 		0BCA496C1EC4BBF900B793EE /* jitsi.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0BCA496B1EC4BBF900B793EE /* jitsi.ttf */; };
 		0BD906EA1EC0C00300C8C18E /* JitsiMeet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BD906E81EC0C00300C8C18E /* JitsiMeet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F65EECE1D95DA94561BB47E /* libPods-JitsiMeet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 03F2ADC957FF109849B7FCA1 /* libPods-JitsiMeet.a */; };
-		75635B0A20751D6D00F29C9F /* joined.wav in Resources */ = {isa = PBXBuildFile; fileRef = 75635B0820751D6D00F29C9F /* joined.wav */; };
-		75635B0B20751D6D00F29C9F /* left.wav in Resources */ = {isa = PBXBuildFile; fileRef = 75635B0920751D6D00F29C9F /* left.wav */; };
 		412BF89D206AA66F0053B9E5 /* InviteSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = 412BF89C206AA66F0053B9E5 /* InviteSearch.m */; };
 		412BF89F206ABAE40053B9E5 /* InviteSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = 412BF89E206AA82F0053B9E5 /* InviteSearch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		75635B0A20751D6D00F29C9F /* joined.wav in Resources */ = {isa = PBXBuildFile; fileRef = 75635B0820751D6D00F29C9F /* joined.wav */; };
+		75635B0B20751D6D00F29C9F /* left.wav in Resources */ = {isa = PBXBuildFile; fileRef = 75635B0920751D6D00F29C9F /* left.wav */; };
 		C6245F5D2053091D0040BE68 /* image-resize@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C6245F5B2053091D0040BE68 /* image-resize@2x.png */; };
 		C6245F5E2053091D0040BE68 /* image-resize@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = C6245F5C2053091D0040BE68 /* image-resize@3x.png */; };
 		C6A34261204EF76800E062DD /* DragGestureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A3425E204EF76800E062DD /* DragGestureController.swift */; };
@@ -44,6 +44,7 @@
 		0B412F171EDEC65D00B1A0A6 /* JitsiMeetView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JitsiMeetView.m; sourceTree = "<group>"; };
 		0B412F1B1EDEC80100B1A0A6 /* JitsiMeetViewDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JitsiMeetViewDelegate.h; sourceTree = "<group>"; };
 		0B44A0181F902126009D1D64 /* MPVolumeViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MPVolumeViewManager.m; sourceTree = "<group>"; };
+		0B6F414E2091F25500FF6789 /* InviteSearch+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "InviteSearch+Private.h"; sourceTree = "<group>"; };
 		0B7C2CFC200F51D60060D076 /* LaunchOptions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LaunchOptions.m; sourceTree = "<group>"; };
 		0B93EF7A1EC608550030D24D /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		0B93EF7C1EC9DDCD0030D24D /* RCTBridgeWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTBridgeWrapper.h; sourceTree = "<group>"; };
@@ -62,10 +63,10 @@
 		0BD906E51EC0C00300C8C18E /* JitsiMeet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JitsiMeet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BD906E81EC0C00300C8C18E /* JitsiMeet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JitsiMeet.h; sourceTree = "<group>"; };
 		0BD906E91EC0C00300C8C18E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		75635B0820751D6D00F29C9F /* joined.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = joined.wav; path = ../../sounds/joined.wav; sourceTree = "<group>"; };
-		75635B0920751D6D00F29C9F /* left.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = left.wav; path = ../../sounds/left.wav; sourceTree = "<group>"; };
 		412BF89C206AA66F0053B9E5 /* InviteSearch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InviteSearch.m; sourceTree = "<group>"; };
 		412BF89E206AA82F0053B9E5 /* InviteSearch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InviteSearch.h; sourceTree = "<group>"; };
+		75635B0820751D6D00F29C9F /* joined.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = joined.wav; path = ../../sounds/joined.wav; sourceTree = "<group>"; };
+		75635B0920751D6D00F29C9F /* left.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = left.wav; path = ../../sounds/left.wav; sourceTree = "<group>"; };
 		98E09B5C73D9036B4ED252FC /* Pods-JitsiMeet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JitsiMeet.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-JitsiMeet/Pods-JitsiMeet.debug.xcconfig"; sourceTree = "<group>"; };
 		9C77CA3CC919B081F1A52982 /* Pods-JitsiMeet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JitsiMeet.release.xcconfig"; path = "../Pods/Target Support Files/Pods-JitsiMeet/Pods-JitsiMeet.release.xcconfig"; sourceTree = "<group>"; };
 		C6245F5B2053091D0040BE68 /* image-resize@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "image-resize@2x.png"; path = "src/picture-in-picture/image-resize@2x.png"; sourceTree = "<group>"; };
@@ -130,6 +131,7 @@
 				0BB9AD7C1F60356D001C08DB /* AppInfo.m */,
 				0BB9AD7A1F5EC8F4001C08DB /* CallKit.m */,
 				412BF89E206AA82F0053B9E5 /* InviteSearch.h */,
+				0B6F414E2091F25500FF6789 /* InviteSearch+Private.h */,
 				412BF89C206AA66F0053B9E5 /* InviteSearch.m */,
 				0BA13D301EE83FF8007BEF7F /* ExternalAPI.m */,
 				0BD906E91EC0C00300C8C18E /* Info.plist */,

--- a/ios/sdk/src/InviteSearch+Private.h
+++ b/ios/sdk/src/InviteSearch+Private.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright @ 2018-present Atlassian Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <React/RCTBridge.h>
+#import <React/RCTEventEmitter.h>
+
+@interface InviteSearch : RCTEventEmitter <RCTBridgeModule>
+
+- (void)invitePeople:(NSArray<NSDictionary *> * _Nonnull)items
+           withScope:(NSString * _Nonnull)scope;
+
+@end

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -23,6 +23,7 @@
 #import <React/RCTLinkingManager.h>
 #import <React/RCTRootView.h>
 
+#import "InviteSearch+Private.h"
 #import "JitsiMeetView+Private.h"
 #import "RCTBridgeWrapper.h"
 
@@ -239,6 +240,17 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
 }
 
 #pragma mark API
+
+/**
+ * Invites the given participants to the conference.
+ *
+ * @param items An array of participants, described as a dictionary, which will
+ *        be used as the JSON payload for the invitation service.
+ */
+- (void)inviteParticipants:(NSArray<NSDictionary *> * _Nonnull)items {
+    InviteSearch *module = [bridgeWrapper.bridge moduleForName:@"InviteSearch"];
+    [module invitePeople:items withScope:externalAPIScope];
+}
 
 /**
  * Loads a specific `NSURL` which may identify a conference to join. If the

--- a/react/features/mobile/invite-search/actionTypes.js
+++ b/react/features/mobile/invite-search/actionTypes.js
@@ -21,26 +21,3 @@ export const _SET_INVITE_SEARCH_SUBSCRIPTIONS
  * }
  */
 export const LAUNCH_NATIVE_INVITE = Symbol('LAUNCH_NATIVE_INVITE');
-
-/**
- * The type of the action which signals that native invites were sent
- * successfully.
- *
- * {
- *     type: SEND_INVITE_SUCCESS,
- *     inviteScope: string
- * }
- */
-export const SEND_INVITE_SUCCESS = Symbol('SEND_INVITE_SUCCESS');
-
-/**
- * The type of the action which signals that native invites failed to send
- * successfully.
- *
- * {
- *     type: SEND_INVITE_FAILURE,
- *     items: Array<*>,
- *     inviteScope: string
- * }
- */
-export const SEND_INVITE_FAILURE = Symbol('SEND_INVITE_FAILURE');

--- a/react/features/mobile/invite-search/actions.js
+++ b/react/features/mobile/invite-search/actions.js
@@ -1,10 +1,6 @@
 // @flow
 
-import {
-    LAUNCH_NATIVE_INVITE,
-    SEND_INVITE_SUCCESS,
-    SEND_INVITE_FAILURE
-} from './actionTypes';
+import { LAUNCH_NATIVE_INVITE } from './actionTypes';
 
 /**
  * Launches the native invite dialog.
@@ -16,35 +12,5 @@ import {
 export function launchNativeInvite() {
     return {
         type: LAUNCH_NATIVE_INVITE
-    };
-}
-
-/**
- * Indicates that all native invites were sent successfully.
- *
- * @param  {string} inviteScope - Scope identifier for the invite success. This
- * is used to look up relevant information on the native side.
- * @returns {void}
- */
-export function sendInviteSuccess(inviteScope: string) {
-    return {
-        type: SEND_INVITE_SUCCESS,
-        inviteScope
-    };
-}
-
-/**
- * Indicates that some native invites failed to send successfully.
- *
- * @param  {Array<*>} items - Invite items that failed to send.
- * @param  {string} inviteScope - Scope identifier for the invite failure. This
- * is used to look up relevant information on the native side.
- * @returns {void}
- */
-export function sendInviteFailure(items: Array<*>, inviteScope: string) {
-    return {
-        type: SEND_INVITE_FAILURE,
-        items,
-        inviteScope
     };
 }


### PR DESCRIPTION
This PR is a WIP which introduces a `view.invitePeople(payload)` function. It's currently only done for iOS.

Things that got changed:

- use externalAPIScope for keeping track of the search controllers
- the actual invitePeople function is implemented in the module, because that's The React Way (TM) of emitting events, that is, from a module, instead of a global emitter. I circumvented exporting anything we don't want by using a private header.
- removed 2 actions which we don't really need: they just call a function on the native side, which is how the consumer of this API expects to be notified
- added checks in case multiple views are used and events re dispatched to them, filter by externalAPIScope