### PR TITLE
fix(invite): check Toolbox render method error

### DIFF
--- a/react/features/invite/components/index.js
+++ b/react/features/invite/components/index.js
@@ -1,3 +1,4 @@
 export { default as AddPeopleDialog } from './AddPeopleDialog';
 export { default as InfoDialogButton } from './InfoDialogButton';
+export { default as InviteButton } from './InviteButton';
 export { DialInSummary } from './dial-in-summary';


### PR DESCRIPTION
The app will crash with react complaining about not a component being passed to render method.