### PR TITLE
fix(hangup): remove device change listener

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2525,6 +2525,11 @@ export default {
         eventEmitter.emit(JitsiMeetConferenceEvents.BEFORE_HANGUP);
         APP.UI.removeLocalMedia();
 
+        // Remove unnecessary event listeners from firing callbacks.
+        JitsiMeetJS.mediaDevices.removeEventListener(
+            JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED,
+            this.deviceChangeListener);
+
         let requestFeedbackPromise;
 
         if (requestFeedback) {


### PR DESCRIPTION
When closing and reopening a notebook, the browser will fire
a devicechange event. This event should not be listened to
after hangup because the current listener will call gum if
there is no current audio/video, which is the case after
hangup.

Initially this change was going to be remove all conference
listeners but then I noticed that the listener for devicechange
is set differently. It might be worthwhile future work, although
potentially unnecessary right now, to ensure all listeners
registered in conference.js are properly cleaned up on hangup.