### PR TITLE
fix(feedback): remove textarea overflow hiding to allow scrolling

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -66,7 +66,6 @@ input[type="reset"], input[type="submit"] {
 }
 
 textarea {
-    overflow: hidden;
     word-wrap: break-word;
     resize: none;
     line-height: 1.5em;


### PR DESCRIPTION
I'm unsure why all textareas need overflow hidden. Doing so
essentially overrides what I would expect to be standard textarea
behavior. I would rather remove the reset and fix any areas that
have issues.