### PR TITLE
WIP - [RN] Wrap the conference in a SafeAreaView

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -2,8 +2,14 @@
 
 import React, { Component } from 'react';
 
-// eslint-disable-next-line react-native/split-platform-components
-import { BackAndroid, BackHandler, StatusBar, View } from 'react-native';
+import {
+    // eslint-disable-next-line react-native/split-platform-components
+    BackAndroid,
+    BackHandler,
+    SafeAreaView,
+    StatusBar,
+    View
+} from 'react-native';
 import { connect as reactReduxConnect } from 'react-redux';
 
 import { appNavigate } from '../../app';
@@ -181,12 +187,12 @@ class Conference extends Component<Props> {
     }
 
     /**
-     * Implements React's {@link Component#render()}.
+     * Helper for rendering the conference itself.
      *
-     * @inheritdoc
+     * @private
      * @returns {ReactElement}
      */
-    render() {
+    _renderConference() {
         return (
             <Container style = { styles.conference }>
                 <StatusBar
@@ -244,6 +250,22 @@ class Conference extends Component<Props> {
                     this.props._reducedUI || <DialogContainer />
                 }
             </Container>
+        );
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        // Wrap the conference in a SafeAreaView so the notch doesn't obstruct
+        // the filmstrip, amongst other things.
+        return (
+            <SafeAreaView style = { styles.conferenceWrapper }>
+                { this._renderConference() }
+            </SafeAreaView>
         );
     }
 

--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -12,7 +12,14 @@ export default createStyleSheet({
     /**
      * {@code Conference} style.
      */
-    conference: fixAndroidViewClipping({
+    conference: {
+        flex: 1
+    },
+
+    /**
+     * Style for {@code Conference} wrapper.
+     */
+    conferenceWrapper: fixAndroidViewClipping({
         alignSelf: 'stretch',
         backgroundColor: ColorPalette.appBackground,
         flex: 1
@@ -24,16 +31,14 @@ export default createStyleSheet({
      * the {@link Toolbox}.
      */
     toolboxAndFilmstripContainer: {
-        bottom: BoxModel.margin,
+        bottom: 0,
         flexDirection: 'column',
         justifyContent: 'flex-end',
-        left: BoxModel.margin,
+        left: 0,
+        marginHorizontal: BoxModel.margin,
+        marginVertical: BoxModel.margin / 2,
         position: 'absolute',
-        right: BoxModel.margin,
-
-        // Both on Android and iOS there is the status bar which may be visible.
-        // On iPhone X there is the notch. In the two cases BoxModel.margin is
-        // not enough.
-        top: BoxModel.margin * 3
+        right: 0,
+        top: 0
     }
 });


### PR DESCRIPTION
Avoids thumbnail clipping on devices with a notch. Also, as a result, the
styling for the filmstrip and toolbar is simplified.

<hr />

Why the WIP, Saúl? Glad you asked. I created this PR to get my head off something else... and deep down the rabbit hole we go.

Currently we use SafeAreaView, which only works properly on iOS 11. On iOS 10 it doesn't account for the status bar height. In addition, on Android it's just an alias of `View`, so it doesn't account for the status bar height either.

While running the app I also noticed we now hide the status bar at all times while in a conference. @zbettenbuk was this intentional? If so, our lives will be simpler, because we can assume its height is 0, but if not, we have to fix this. If this is what we want, however, this needs to go: https://github.com/jitsi/jitsi-meet/blob/master/react/features/mobile/full-screen/middleware.js#L113

My personal opinion is that hiding the status bar at all times while in a conference is a bug. There is no reason why we cannot spare 20-30px while in audio only. This is what we used to do, which IMHO it's The Right Thing (R).