### PR TITLE
Toolbar icon size adjustments

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -100,6 +100,10 @@
 
     .icon-hangup {
         color: $hangupColor;
+        font-size: 32px;
+        /*
+          Video icon is too small relative to other icons in Stride Meetings.
+        */
     }
 
     .overflow-menu {
@@ -137,7 +141,7 @@
 
             i {
                 display: inline;
-                font-size: 24px;
+                font-size: 20px;
             }
 
             i:hover {
@@ -145,8 +149,8 @@
             }
 
             img {
-                max-width: 24px;
-                max-height: 24px;
+                max-width: 20px;
+                max-height: 20px;
             }
         }
 

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -39,8 +39,8 @@ $newToolbarBackgroundColor: rgba(22, 38, 55, 0.8);
 $newToolbarButtonHoverColor: rgba(14, 20, 35, 0.6);
 $newToolbarButtonToggleColor: rgba(14, 20, 35, 1);
 $newToolbarFontSize: 1.9em;
-$newToolbarSize: 32px;
-$newToolbarSizeWithPadding: calc(32px + 32px);
+$newToolbarSize: 40px;
+$newToolbarSizeWithPadding: calc(40px + 40px);
 $toolbarTitleFontSize: 19px;
 
 /**


### PR DESCRIPTION
Adjust size of:
- overflow icons (smaller)
- hang up icon (larger)
- toolbar icon hover states. (larger)