### PR TITLE
fix(large-video): make dominant speaker avatar smaller

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -497,8 +497,7 @@
     visibility: hidden;
     width: 300px;
     height: 300px;
-    margin: auto;
-    position: relative;
+    @include absoluteAligning();
 }
 
 #mixedstream {
@@ -507,25 +506,18 @@
 
 #dominantSpeakerAvatar,
 .dynamic-shadow {
-    width: 200px;
-    height: 200px;
+    border-radius: 50%;
+    height: 120px;
+    width: 120px;
+    @include absoluteAligning();
 }
 
 #dominantSpeakerAvatar {
-    top: 50px;
-    margin: auto;
-    position: relative;
-    border-radius: 100px;
     visibility: inherit;
     background-color: #000000;
 }
 
 .dynamic-shadow {
-    border-radius: 50%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    margin: -100px 0 0 -100px;
     transition: box-shadow 0.3s ease;
 }
 

--- a/modules/UI/audio_levels/AudioLevels.js
+++ b/modules/UI/audio_levels/AudioLevels.js
@@ -78,10 +78,11 @@ const AudioLevels = {
      */
     _updateLargeVideoShadow(level) {
         const scale = 2;
+        const intShadowSpread = 10;
 
         // Internal circle audio level.
         const int = {
-            level: level > 0.15 ? 20 : 0,
+            level: level > 0.15 ? intShadowSpread : 0,
             color: interfaceConfig.AUDIO_LEVEL_PRIMARY_COLOR
         };
 

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -457,11 +457,6 @@ export class VideoContainer extends LargeContainer {
             = this.getVideoPosition(width, height,
             containerWidth, containerHeight);
 
-        // update avatar position
-        const top = (containerHeight / 2) - (this.avatarHeight / 4 * 3);
-
-        this.$avatar.css('top', top);
-
         this.positionRemoteStatusMessages();
 
         this.$wrapper.animate({


### PR DESCRIPTION
The dominant speaker avatar has been shrunk. To facilitate
its positioning in the center of the screen, javascript
used to position the avatar container in the center has
been swapped with CSS. Also, the speaker level shadow
has been made smaller to better match the avatar size.