### PR TITLE
fix(large-video): do not reselect video on self dominant speaker

### DIFF
--- a/react/features/large-video/middleware.js
+++ b/react/features/large-video/middleware.js
@@ -4,7 +4,8 @@ import {
     DOMINANT_SPEAKER_CHANGED,
     PARTICIPANT_JOINED,
     PARTICIPANT_LEFT,
-    PIN_PARTICIPANT
+    PIN_PARTICIPANT,
+    getLocalParticipant
 } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
 import {
@@ -27,7 +28,16 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
-    case DOMINANT_SPEAKER_CHANGED:
+    case DOMINANT_SPEAKER_CHANGED: {
+        const localParticipant = getLocalParticipant(store.getState());
+
+        if (localParticipant && localParticipant.id !== action.participant.id) {
+            store.dispatch(selectParticipantInLargeVideo());
+        }
+
+        break;
+    }
+
     case PARTICIPANT_JOINED:
     case PARTICIPANT_LEFT:
     case PIN_PARTICIPANT:


### PR DESCRIPTION
In the current middleware logic, when the local participant becomes
dominant speaker, a new participant can be selected to receive
high quality video from. This means large-video could potentially
do a switch to another participant when the local participant
becomes dominant speaker. Prevent such behavior.