### PR TITLE
fix(large-video): for web, use explicit state for who is on large video

### DIFF
--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -18,6 +18,7 @@ import {
     getAvatarURLByParticipantId
 } from '../../../react/features/base/participants';
 import {
+    setParticipantDisplayedOnLargeVideo,
     updateKnownLargeVideoResolution
 } from '../../../react/features/large-video';
 import { createDeferred } from '../../util/helpers';
@@ -307,6 +308,7 @@ export default class LargeVideoManager {
             // new streams.
             this.updateInProcess = false;
             this.eventEmitter.emit(UIEvents.LARGE_VIDEO_ID_CHANGED, this.id);
+            APP.store.dispatch(setParticipantDisplayedOnLargeVideo(this.id));
             this.scheduleLargeVideoUpdate();
         });
     }

--- a/react/features/large-video/actionTypes.js
+++ b/react/features/large-video/actionTypes.js
@@ -10,6 +10,18 @@ export const SELECT_LARGE_VIDEO_PARTICIPANT
     = Symbol('SELECT_LARGE_VIDEO_PARTICIPANT');
 
 /**
+ * Action to update the redux store with the participant that is displayed on
+ * large video.
+ *
+ * @returns {{
+ *     type: SET_PARTICIPANT_ON_LARGE_VIDEO,
+ *     participantId: string
+ * }}
+ */
+export const SET_PARTICIPANT_ON_LARGE_VIDEO
+    = Symbol('SET_PARTICIPANT_ON_LARGE_VIDEO');
+
+/**
  * Action to update the redux store with the current resolution of large video.
  *
  * @returns {{

--- a/react/features/large-video/actions.js
+++ b/react/features/large-video/actions.js
@@ -6,6 +6,7 @@ import { getTrackByMediaTypeAndParticipant } from '../base/tracks';
 
 import {
     SELECT_LARGE_VIDEO_PARTICIPANT,
+    SET_PARTICIPANT_ON_LARGE_VIDEO,
     UPDATE_KNOWN_LARGE_VIDEO_RESOLUTION
 } from './actionTypes';
 
@@ -63,6 +64,26 @@ export function selectParticipantInLargeVideo() {
 
             dispatch(selectParticipant());
         }
+    };
+}
+
+/**
+ * Action to update the redux store with the participant that is displayed on
+ * large video. Note: this action is only used by web to reconcile large-video
+ * not being fully integrated into redux and to account for timing delays
+ * introduced the web logic's promise chaining for video switching.
+ *
+ * @param {string} participantId - The participant currently displayed on large
+ * video.
+ * @returns {{
+ *     type: SET_PARTICIPANT_ON_LARGE_VIDEO,
+ *     participantId: string
+ * }}
+ */
+export function setParticipantDisplayedOnLargeVideo(participantId: string) {
+    return {
+        type: SET_PARTICIPANT_ON_LARGE_VIDEO,
+        participantId
     };
 }
 

--- a/react/features/large-video/reducer.js
+++ b/react/features/large-video/reducer.js
@@ -5,6 +5,7 @@ import { ReducerRegistry } from '../base/redux';
 
 import {
     SELECT_LARGE_VIDEO_PARTICIPANT,
+    SET_PARTICIPANT_ON_LARGE_VIDEO,
     UPDATE_KNOWN_LARGE_VIDEO_RESOLUTION
 } from './actionTypes';
 
@@ -29,6 +30,12 @@ ReducerRegistry.register('features/large-video', (state = {}, action) => {
         return {
             ...state,
             participantId: action.participantId
+        };
+
+    case SET_PARTICIPANT_ON_LARGE_VIDEO:
+        return {
+            ...state,
+            displayedParticipantId: action.participantId
         };
 
     case UPDATE_KNOWN_LARGE_VIDEO_RESOLUTION:

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -157,11 +157,14 @@ function _mapResolutionToTranslationsKeys(resolution) {
  */
 function _mapStateToProps(state) {
     const { audioOnly } = state['features/base/conference'];
-    const { resolution, participantId } = state['features/large-video'];
+    const {
+        displayedParticipantId,
+        resolution
+    } = state['features/large-video'];
     const videoTrackOnLargeVideo = getTrackByMediaTypeAndParticipant(
         state['features/base/tracks'],
         MEDIA_TYPE.VIDEO,
-        participantId
+        displayedParticipantId
     );
 
     const translationKeys


### PR DESCRIPTION
Web large-video is not completely hooked into redux. Web also has
timing delays due to its promise based update logic. These two
details can make the video quality label, which is hooked into
redux, temporarily show the status for a participant not on
large-video. As such, introduce an action that essentially is
a confirmation for large-video update, and that updates state
which the video quality label can hook onto.
