### PR TITLE
ref(layout): use css to make video layout containers fit window

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -4,6 +4,8 @@
 
 #videospace {
     display: block;
+    height: 100%;
+    width: 100%;
     min-height: 100%;
     position: absolute;
     top: 0px;
@@ -222,6 +224,11 @@
 #largeVideoContainer {
     overflow: hidden;
     text-align: center;
+}
+
+#largeVideoContainer {
+    height: 100%;
+    width: 100%;
 }
 
 #largeVideoWrapper {

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -397,14 +397,6 @@ export default class LargeVideoManager {
         // resize all containers
         Object.keys(this.containers)
             .forEach(type => this.resizeContainer(type, animate));
-
-        this.$container.animate({
-            width: this.width,
-            height: this.height
-        }, {
-            queue: false,
-            duration: animate ? 500 : 0
-        });
     }
 
     /**

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -855,13 +855,10 @@ const VideoLayout = {
      * Resizes the video area.
      *
      * @param forceUpdate indicates that hidden thumbnails will be shown
-     * @param completeFunction a function to be called when the video area is
-     * resized.
      */
     resizeVideoArea(
             forceUpdate = false,
-            animate = false,
-            completeFunction = null) {
+            animate = false) {
         if (largeVideo) {
             largeVideo.updateContainerSize();
             largeVideo.resize(animate);
@@ -877,17 +874,6 @@ const VideoLayout = {
 
         // Resize the thumbnails first.
         this.resizeThumbnails(forceUpdate);
-
-        // Resize the video area element.
-        $('#videospace').animate({
-            right: window.innerWidth - availableWidth,
-            width: availableWidth,
-            height: availableHeight
-        }, {
-            queue: false,
-            duration: animate ? 500 : 1,
-            complete: completeFunction
-        });
     },
 
     getSmallVideo(id) {


### PR DESCRIPTION
Instead of using JS, just use CSS 100% width and height. This
also resolves a jitter that occurs on edge when a modal's
container appends to the body.