### PR TITLE
Fixes around duplicated thumbnails

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1702,6 +1702,7 @@ export default {
             const displayName = user.getDisplayName();
 
             APP.store.dispatch(participantJoined({
+                conference: room,
                 id,
                 name: displayName,
                 role: user.getRole()
@@ -1723,7 +1724,7 @@ export default {
             if (user.isHidden()) {
                 return;
             }
-            APP.store.dispatch(participantLeft(id, user));
+            APP.store.dispatch(participantLeft(room, id));
             logger.log('USER %s LEFT', id, user);
             APP.API.notifyUserLeft(id);
             APP.UI.removeUser(id, user.getDisplayName());

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -306,6 +306,7 @@ export default class SharedVideoManager {
                 SHARED_VIDEO_CONTAINER_TYPE, self.sharedVideo);
 
             APP.store.dispatch(participantJoined({
+                conference: null,
                 id: self.url,
                 isBot: true,
                 name: 'YouTube'
@@ -516,7 +517,7 @@ export default class SharedVideoManager {
                     UIEvents.UPDATE_SHARED_VIDEO, null, 'removed');
             });
 
-        APP.store.dispatch(participantLeft(this.url));
+        APP.store.dispatch(participantLeft(/* conference */ null, this.url));
 
         this.url = null;
         this.isSharedVideoShown = false;

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -140,13 +140,14 @@ function _addConferenceListeners(conference, dispatch) {
     conference.on(
         JitsiConferenceEvents.USER_JOINED,
         (id, user) => dispatch(participantJoined({
+            conference,
             id,
             name: user.getDisplayName(),
             role: user.getRole()
         })));
     conference.on(
         JitsiConferenceEvents.USER_LEFT,
-        (...args) => dispatch(participantLeft(...args)));
+        (...args) => dispatch(participantLeft(conference, ...args)));
     conference.on(
         JitsiConferenceEvents.USER_ROLE_CHANGED,
         (...args) => dispatch(participantRoleChanged(...args)));

--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -126,6 +126,7 @@ function _conferenceFailed(state, { conference, error }) {
         authRequired,
         conference: undefined,
         error,
+        failed: conference,
         joining: undefined,
         leaving: undefined,
 
@@ -175,6 +176,7 @@ function _conferenceJoined(state, { conference }) {
          * @type {JitsiConference}
          */
         conference,
+        failed: undefined,
         joining: undefined,
         leaving: undefined,
 
@@ -250,6 +252,7 @@ function _conferenceLeft(state, { conference }) {
 function _conferenceWillJoin(state, { conference }) {
     return assign(state, {
         error: undefined,
+        failed: undefined,
         joining: conference
     });
 }
@@ -265,12 +268,14 @@ function _conferenceWillJoin(state, { conference }) {
  * reduction of the specified action.
  */
 function _conferenceWillLeave(state, { conference }) {
-    if (state.conference !== conference) {
+    // Either the current or a failed conference can be "left".
+    if (state.conference !== conference && state.failed !== conference) {
         return state;
     }
 
     return assign(state, {
         authRequired: undefined,
+        failed: undefined,
         joining: undefined,
 
         /**

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -303,10 +303,15 @@ function _constructOptions(state) {
 export function disconnect() {
     return (dispatch: Dispatch<*>, getState: Function): Promise<void> => {
         const state = getState();
-        const { conference, joining } = state['features/base/conference'];
+        const { conference, failed, joining }
+            = state['features/base/conference'];
 
-        // The conference we have already joined or are joining.
-        const conference_ = conference || joining;
+        // The conference we have already joined or are joining. A failed
+        // conference also needs to be "left" in order to release any resources
+        // allocated so far. That's because a conference can fail not only
+        // before it's established, but also in the middle of the call
+        // (ICE_FAILED, FOCUS_LEFT etc.)
+        const conference_ = conference || failed || joining;
 
         // Promise which completes when the conference has been left and the
         // connection has been disconnected.

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -71,6 +71,7 @@ function _participant(state: Object = {}, action) {
         const { participant } = action; // eslint-disable-line no-shadow
         const {
             avatarURL,
+            conference,
             connectionStatus,
             dominantSpeaker,
             email,
@@ -101,6 +102,7 @@ function _participant(state: Object = {}, action) {
         return {
             avatarID,
             avatarURL,
+            conference,
             connectionStatus,
             dominantSpeaker: dominantSpeaker || false,
             email,
@@ -169,7 +171,9 @@ ReducerRegistry.register('features/base/participants', (state = [], action) => {
         return [ ...state, _participant(undefined, action) ];
 
     case PARTICIPANT_LEFT:
-        return state.filter(p => p.id !== action.participant.id);
+        return state.filter(
+            p => p.id !== action.participant.id
+                || p.conference !== action.participant.conference);
 
     default:
         return state;


### PR DESCRIPTION
Work in progress... I'm still looking into the cases where multiple connections can be triggered in case the "load config" gets stuck and it takes more time for it to resolve.

Also I'm not 100% sure if the remaining cases I observe are caused only by the stuck load config promise, so this commits are only food for thoughts.