### PR TITLE
[RN] Improve video switch style and remove react warning

### DIFF
--- a/react/features/welcome/components/VideoSwitch.js
+++ b/react/features/welcome/components/VideoSwitch.js
@@ -62,9 +62,11 @@ class VideoSwitch extends Component<Props> {
             <View style = { styles.audioVideoSwitchContainer }>
                 <TouchableWithoutFeedback
                     onPress = { this._onStartAudioOnlyFalse }>
-                    <Text style = { textStyle }>
-                        { t('welcomepage.audioVideoSwitch.video') }
-                    </Text>
+                    <View style = { styles.switchLabel }>
+                        <Text style = { textStyle }>
+                            { t('welcomepage.audioVideoSwitch.video') }
+                        </Text>
+                    </View>
                 </TouchableWithoutFeedback>
                 <Switch
                     onTintColor = { SWITCH_UNDER_COLOR }
@@ -74,9 +76,11 @@ class VideoSwitch extends Component<Props> {
                     value = { _settings.startAudioOnly } />
                 <TouchableWithoutFeedback
                     onPress = { this._onStartAudioOnlyTrue }>
-                    <Text style = { textStyle }>
-                        { t('welcomepage.audioVideoSwitch.audio') }
-                    </Text>
+                    <View style = { styles.switchLabel }>
+                        <Text style = { textStyle }>
+                            { t('welcomepage.audioVideoSwitch.audio') }
+                        </Text>
+                    </View>
                 </TouchableWithoutFeedback>
             </View>
         );

--- a/react/features/welcome/components/styles.js
+++ b/react/features/welcome/components/styles.js
@@ -34,6 +34,7 @@ export default createStyleSheet({
      * View that contains the audio-video switch and the labels.
      */
     audioVideoSwitchContainer: {
+        alignItems: 'center',
         flexDirection: 'row'
     },
 
@@ -220,6 +221,13 @@ export default createStyleSheet({
     sideBarItemText: {
         color: ColorPalette.black,
         fontWeight: 'bold'
+    },
+
+    /**
+     * The container of the label of the audio-video switch.
+     */
+    switchLabel: {
+        paddingHorizontal: 3
     },
 
     /**


### PR DESCRIPTION
This commit removes a warning from the console by wrapping the text labels in a View inside the Touchable component. Also aligns the labels nicely with this new component tree.