### PR TITLE
[RN] Support landscape and portrait orientations in BottomSheet

### DIFF
--- a/react/features/base/dialog/components/BottomSheet.native.js
+++ b/react/features/base/dialog/components/BottomSheet.native.js
@@ -53,6 +53,10 @@ export default class BottomSheet extends Component<Props> {
                 animationType = { 'slide' }
                 key = 'modal'
                 onRequestClose = { this._onCancel }
+                supportedOrientations = { [
+                    'landscape',
+                    'portrait'
+                ] }
                 transparent = { true }
                 visible = { true }>
                 <View style = { styles.container }>


### PR DESCRIPTION
One has to be explicit on iOS, otherwise it seems to be locked to portrait only.