### PR TITLE
fix(base/conference): leave a failed conference

### DIFF
--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -62,7 +62,7 @@ export type ConnectionFailedError = {
      * Indicates whether this event is recoverable or not.
      */
     recoverable?: boolean
-}
+};
 
 /**
  * Opens new connection.
@@ -100,7 +100,7 @@ export function connect(id: ?string, password: ?string) {
         });
 
         /**
-         * Dispatches CONNECTION_DISCONNECTED action when connection is
+         * Dispatches {@code CONNECTION_DISCONNECTED} action when connection is
          * disconnected.
          *
          * @param {string} message - Disconnect reason.
@@ -153,8 +153,8 @@ export function connect(id: ?string, password: ?string) {
         }
 
         /**
-         * Unsubscribes connection instance from CONNECTION_ESTABLISHED
-         * and CONNECTION_FAILED events.
+         * Unsubscribes connection instance from {@code CONNECTION_ESTABLISHED}
+         * and {@code CONNECTION_FAILED} events.
          *
          * @returns {void}
          */
@@ -172,7 +172,8 @@ export function connect(id: ?string, password: ?string) {
 /**
  * Create an action for when the signaling connection has been lost.
  *
- * @param {JitsiConnection} connection - The JitsiConnection which disconnected.
+ * @param {JitsiConnection} connection - The {@code JitsiConnection} which
+ * disconnected.
  * @param {string} message - Error message.
  * @private
  * @returns {{
@@ -190,26 +191,9 @@ function _connectionDisconnected(connection: Object, message: string) {
 }
 
 /**
- * Create an action for when a connection will connect.
- *
- * @param {JitsiConnection} connection - The JitsiConnection which will connect.
- * @private
- * @returns {{
- *     type: CONNECTION_WILL_CONNECT,
- *     connection: JitsiConnection
- * }}
- */
-function _connectionWillConnect(connection) {
-    return {
-        type: CONNECTION_WILL_CONNECT,
-        connection
-    };
-}
-
-/**
  * Create an action for when the signaling connection has been established.
  *
- * @param {JitsiConnection} connection - The JitsiConnection which was
+ * @param {JitsiConnection} connection - The {@code JitsiConnection} which was
  * established.
  * @public
  * @returns {{
@@ -227,7 +211,8 @@ export function connectionEstablished(connection: Object) {
 /**
  * Create an action for when the signaling connection could not be created.
  *
- * @param {JitsiConnection} connection - The JitsiConnection which failed.
+ * @param {JitsiConnection} connection - The {@code JitsiConnection} which
+ * failed.
  * @param {ConnectionFailedError} error - Error.
  * @public
  * @returns {{
@@ -249,6 +234,24 @@ export function connectionFailed(
         type: CONNECTION_FAILED,
         connection,
         error
+    };
+}
+
+/**
+ * Create an action for when a connection will connect.
+ *
+ * @param {JitsiConnection} connection - The {@code JitsiConnection} which will
+ * connect.
+ * @private
+ * @returns {{
+ *     type: CONNECTION_WILL_CONNECT,
+ *     connection: JitsiConnection
+ * }}
+ */
+function _connectionWillConnect(connection) {
+    return {
+        type: CONNECTION_WILL_CONNECT,
+        connection
     };
 }
 
@@ -326,7 +329,7 @@ export function disconnect() {
                 = conference_.leave()
                     .catch(error => {
                         logger.warn(
-                            'JitsiConference.leave() rejected with: ',
+                            'JitsiConference.leave() rejected with:',
                             error);
 
                         // The library lib-jitsi-meet failed to make the


### PR DESCRIPTION
Because a conference can fail before or after it's joined it must be "left" in order to release any allocated resources like peerconnections, tracks and all the other things.