### PR TITLE
fix(base/participants): ensure default local id outside of conference

### DIFF
--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -7,7 +7,8 @@ import { toState } from '../redux';
 import {
     AVATAR_ID_COMMAND,
     AVATAR_URL_COMMAND,
-    EMAIL_COMMAND
+    EMAIL_COMMAND,
+    JITSI_CONFERENCE_URL_KEY
 } from './constants';
 
 /**
@@ -38,6 +39,45 @@ export function _addLocalTracksToConference(
     }
 
     return Promise.all(promises);
+}
+
+/**
+ * Evaluates a specific predicate for each {@link JitsiConference} known to the
+ * redux state features/base/conference while it returns {@code true}.
+ *
+ * @param {Function | Object} stateful - The redux store, state, or
+ * {@code getState} function.
+ * @param {Function} predicate - The predicate to evaluate for each
+ * {@code JitsiConference} know to the redux state features/base/conference
+ * while it returns {@code true}.
+ * @returns {boolean} If the specified {@code predicate} returned {@code true}
+ * for all {@code JitsiConference} instances known to the redux state
+ * features/base/conference.
+ */
+export function forEachConference(
+        stateful: Function | Object,
+        predicate: (Object, URL) => boolean) {
+    const state = toState(stateful)['features/base/conference'];
+
+    for (const v of Object.values(state)) {
+        // Does the value of the base/conference's property look like a
+        // JitsiConference?
+        if (v && typeof v === 'object') {
+            // $FlowFixMe
+            const url: URL = v[JITSI_CONFERENCE_URL_KEY];
+
+            // XXX The Web version of Jitsi Meet does not utilize
+            // JITSI_CONFERENCE_URL_KEY at the time of this writing. An
+            // alternative is necessary then to recognize JitsiConference
+            // instances and myUserId is as good as any other property.
+            if ((url || typeof v.myUserId === 'function')
+                    && !predicate(v, url)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/react/features/mobile/external-api/middleware.js
+++ b/react/features/mobile/external-api/middleware.js
@@ -11,6 +11,7 @@ import {
     CONFERENCE_WILL_LEAVE,
     JITSI_CONFERENCE_URL_KEY,
     SET_ROOM,
+    forEachConference,
     isRoomValid
 } from '../../base/conference';
 import { LOAD_CONFIG_ERROR } from '../../base/config';
@@ -249,28 +250,18 @@ function _swallowConferenceLeft({ getState }, action, { url }) {
     // the same URL string multiple times) to try to send CONFERENCE_LEFT
     // externally for a URL string which identifies a JitsiConference that the
     // app is internally legitimately working with.
+    let swallowConferenceLeft = false;
 
-    if (url) {
-        const stateFeaturesBaseConference
-            = getState()['features/base/conference'];
-
-        // eslint-disable-next-line guard-for-in
-        for (const p in stateFeaturesBaseConference) {
-            const v = stateFeaturesBaseConference[p];
-
-            // Does the value of the base/conference's property look like a
-            // JitsiConference?
-            if (v && typeof v === 'object') {
-                const vURL = v[JITSI_CONFERENCE_URL_KEY];
-
-                if (vURL && vURL.toString() === url) {
-                    return true;
-                }
+    url
+        && forEachConference(getState, (conference, conferenceURL) => {
+            if (conferenceURL && conferenceURL.toString() === url) {
+                swallowConferenceLeft = true;
             }
-        }
-    }
 
-    return false;
+            return !swallowConferenceLeft;
+        });
+
+    return swallowConferenceLeft;
 }
 
 /**


### PR DESCRIPTION
Makes sure that whenever a conference is left or switched, the local
participant's id will be equal to the default value.

The problem fixed by this commit is a situation where the local
participant may end up sharing the same ID with it's "ghost" when
rejoining a disconnected conference. The most important and easiest to
hit case is when the conference is left after the CONFERENCE_FAILED
event.

Another rare and harder to encounter in the real world issue is
where CONFERENCE_LEFT may come with the delay due to it's asynchronous
nature. The step by step scenario is as follows: trying to leave a
conference, but the network is not doing well, so it takes time,
requests are timing out. After getting back to the welcome page the
the CONFERENCE_LEFT has not arrived yet. The same conference is joined
again and the load config may timeout, but it will be read from the
cache. Now the network gets better and conference is joining which
results in our ghost participant added to the redux state. At this point
there's the root issue: two participants with the same id, because the
local one was neither cleared nor set to the new one yet
(PARTICIPANT_JOINED come, before CONFERENCE_JOINED where we adjust the
id). Then comes CONFERENCE_JOINED and we try to update our local id.
We're updating the ID of both ghost and local participant. It could be
also that the delayed CONFERENCE_LEFT comes for the old conference, but
it's too late and it would update the id for both participants.

As an alternative we could just make sure to update the id only for the
participant with the 'local' flag, but here we're getting an extra of
always having the LOCAL_PARTICIPANT_DEFAULT_ID when outside of
the conference (not sure if we care).