### PR TITLE
[RN] Set the local user ID on CONFERENCE_WILL_JOIN

### DIFF
--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -4,7 +4,7 @@ import UIEvents from '../../../../service/UI/UIEvents';
 
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../../app';
 import {
-    CONFERENCE_JOINED,
+    CONFERENCE_WILL_JOIN,
     CONFERENCE_LEFT
 } from '../conference';
 import { MiddlewareRegistry } from '../redux';
@@ -59,10 +59,12 @@ MiddlewareRegistry.register(store => next => action => {
         _registerSounds(store);
 
         return _localParticipantJoined(store, next, action);
+
     case APP_WILL_UNMOUNT:
         _unregisterSounds(store);
         break;
-    case CONFERENCE_JOINED:
+
+    case CONFERENCE_WILL_JOIN:
         store.dispatch(localParticipantIdChanged(action.conference.myUserId()));
         break;
 


### PR DESCRIPTION
Doing so in CONFERENCE_JOINED is too late because if we are moderators that
event will come first and we won't know what ID to match it with.

This is safe because our local ID is created early.