### PR TITLE
[RN] Avoid Toolbox changing size on first render

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -129,7 +129,8 @@ class Conference extends Component<Props> {
                 this._onHardwareBackPress);
         }
 
-        // Show the toolbox if we are the only participant.
+        // Show the toolbox if we are the only participant; otherwise, the whole
+        // UI looks too unpopulated the LargeVideo visible.
         const { _participantCount, _setToolboxVisible } = this.props;
 
         _participantCount === 1 && _setToolboxVisible(true);

--- a/react/features/toolbox/components/native/Toolbox.js
+++ b/react/features/toolbox/components/native/Toolbox.js
@@ -85,6 +85,62 @@ class Toolbox extends Component<Props, State> {
     }
 
     /**
+     * Renders the toolbar. It will only be rendered if the {@code Toolbox} is
+     * visible and we have already calculated the available width. This avoids
+     * a weird effect in which the toolbar is displayed and then changes size.
+     *
+     * @returns {ReactElement}
+     */
+    _renderToolbar() {
+        const { _visible } = this.props;
+        const { width } = this.state;
+
+        if (!_visible || !width) {
+            return null;
+        }
+
+        let buttonStyles = toolbarButtonStyles;
+        let toggledButtonStyles = toolbarToggledButtonStyles;
+
+        const buttonSize = this._calculateButtonSize();
+
+        if (buttonSize > 0) {
+            const extraButtonStyle = {
+                borderRadius: buttonSize / 2,
+                height: buttonSize,
+                width: buttonSize
+            };
+
+            buttonStyles = {
+                ...buttonStyles,
+                style: [ buttonStyles.style, extraButtonStyle ]
+            };
+            toggledButtonStyles = {
+                ...toggledButtonStyles,
+                style: [ toggledButtonStyles.style, extraButtonStyle ]
+            };
+        }
+
+        return (
+            <View
+                pointerEvents = 'box-none'
+                style = { styles.toolbar }>
+                <InviteButton styles = { buttonStyles } />
+                <AudioMuteButton
+                    styles = { buttonStyles }
+                    toggledStyles = { toggledButtonStyles } />
+                <HangupButton styles = { hangupButtonStyles } />
+                <VideoMuteButton
+                    styles = { buttonStyles }
+                    toggledStyles = { toggledButtonStyles } />
+                <OverflowMenuButton
+                    styles = { buttonStyles }
+                    toggledStyles = { toggledButtonStyles } />
+            </View>
+        );
+    }
+
+    /**
      * Implements React's {@link Component#render()}.
      *
      * @inheritdoc
@@ -96,50 +152,13 @@ class Toolbox extends Component<Props, State> {
                 ? styles.toolboxNarrow
                 : styles.toolboxWide;
         const { _visible } = this.props;
-        let buttonStyles = toolbarButtonStyles;
-        let toggledButtonStyles = toolbarToggledButtonStyles;
-
-        if (_visible) {
-            const buttonSize = this._calculateButtonSize();
-
-            if (buttonSize > 0) {
-                const extraButtonStyle = {
-                    borderRadius: buttonSize / 2,
-                    height: buttonSize,
-                    width: buttonSize
-                };
-
-                buttonStyles = {
-                    ...buttonStyles,
-                    style: [ buttonStyles.style, extraButtonStyle ]
-                };
-                toggledButtonStyles = {
-                    ...toggledButtonStyles,
-                    style: [ toggledButtonStyles.style, extraButtonStyle ]
-                };
-            }
-        }
 
         return (
             <Container
                 onLayout = { this._onLayout }
                 style = { toolboxStyle }
                 visible = { _visible }>
-                <View
-                    pointerEvents = 'box-none'
-                    style = { styles.toolbar }>
-                    <InviteButton styles = { buttonStyles } />
-                    <AudioMuteButton
-                        styles = { buttonStyles }
-                        toggledStyles = { toggledButtonStyles } />
-                    <HangupButton styles = { hangupButtonStyles } />
-                    <VideoMuteButton
-                        styles = { buttonStyles }
-                        toggledStyles = { toggledButtonStyles } />
-                    <OverflowMenuButton
-                        styles = { buttonStyles }
-                        toggledStyles = { toggledButtonStyles } />
-                </View>
+                { this._renderToolbar() }
             </Container>
         );
     }

--- a/react/features/toolbox/components/native/styles.js
+++ b/react/features/toolbox/components/native/styles.js
@@ -15,6 +15,9 @@ const toolbarButton = {
     flexDirection: 'row',
     height: 40,
     justifyContent: 'center',
+
+    // XXX We probably tested BoxModel.margin and discovered it to be too small
+    // for our taste.
     marginHorizontal: 7,
     opacity: 0.7,
     width: 40
@@ -181,7 +184,7 @@ const overflowMenuStyles = createStyleSheet({
         flex: 1,
         fontSize: 16,
         marginLeft: 32,
-        opacity: 0.87
+        opacity: 0.90
     }
 });
 


### PR DESCRIPTION
Wait until the right button size has been calculated before rendering it.