### PR TITLE
[iOS] Don't bundle the React resources in Debug mode

### DIFF
--- a/ios/sdk/sdk.xcodeproj/project.pbxproj
+++ b/ios/sdk/sdk.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\nif [[ \"$CONFIGURATION\" == *Debug* ]]; then\n    export SKIP_BUNDLING=1\nfi\n../../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		26796D8589142D80C8AFDA51 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
It significantly speeds up debug builds, putting them on par with Android, where
we also don't bundle the React resources.