### PR TITLE
ref: remove some direct manipulation of VideoLayout

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1799,12 +1799,9 @@ export default {
 
         room.on(
             JitsiConferenceEvents.PARTICIPANT_CONN_STATUS_CHANGED,
-            (id, connectionStatus) => {
-                APP.store.dispatch(participantConnectionStatusChanged(
-                    id, connectionStatus));
+            (id, connectionStatus) => APP.store.dispatch(
+                participantConnectionStatusChanged(id, connectionStatus)));
 
-                APP.UI.participantConnectionStatusChanged(id);
-            });
         room.on(
             JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED,
             id => APP.store.dispatch(dominantSpeakerChanged(id, room)));

--- a/conference.js
+++ b/conference.js
@@ -1714,7 +1714,11 @@ export default {
             APP.store.dispatch(participantLeft(id, room));
             logger.log('USER %s LEFT', id, user);
             APP.API.notifyUserLeft(id);
-            APP.UI.removeUser(id, user.getDisplayName());
+            APP.UI.messageHandler.participantNotification(
+                user.getDisplayName(),
+                'notify.somebody',
+                'disconnected',
+                'notify.disconnected');
             APP.UI.onSharedVideoStop(id);
         });
 

--- a/modules/FollowMe.js
+++ b/modules/FollowMe.js
@@ -1,3 +1,5 @@
+/* global APP */
+
 /*
  * Copyright @ 2015 Atlassian Pty Ltd
  *
@@ -15,6 +17,10 @@
  */
 const logger = require('jitsi-meet-logger').getLogger(__filename);
 
+import {
+    getPinnedParticipant,
+    pinParticipant
+} from '../react/features/base/participants';
 import UIEvents from '../service/UI/UIEvents';
 import VideoLayout from './UI/videolayout/VideoLayout';
 
@@ -444,11 +450,15 @@ class FollowMe {
         if (smallVideo) {
             this.nextOnStageTimer = 0;
             clearTimeout(this.nextOnStageTimout);
-            /* eslint-disable no-mixed-operators */
-            if (pin && !VideoLayout.isPinned(clickId)
-                || !pin && VideoLayout.isPinned(clickId)) {
-                /* eslint-disable no-mixed-operators */
-                VideoLayout.handleVideoThumbClicked(clickId);
+
+            if (pin) {
+                APP.store.dispatch(pinParticipant(clickId));
+            } else {
+                const { id } = getPinnedParticipant(APP.store.getState()) || {};
+
+                if (id === clickId) {
+                    APP.store.dispatch(pinParticipant(null));
+                }
             }
         } else {
             // If there's no SmallVideo object for the given id, lets wait and

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -822,14 +822,6 @@ UI.notifyInitiallyMuted = function() {
         null);
 };
 
-/**
- * Mark user as dominant speaker.
- * @param {string} id user id
- */
-UI.markDominantSpeaker = function(id) {
-    VideoLayout.onDominantSpeakerChanged(id);
-};
-
 UI.handleLastNEndpoints = function(leavingIds, enteringIds) {
     VideoLayout.onLastNEndpointsChanged(leavingIds, enteringIds);
 };

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -492,9 +492,6 @@ UI.addUser = function(user) {
         APP.store.dispatch(showParticipantJoinedNotification(displayName));
     }
 
-    // Add Peer's container
-    VideoLayout.addParticipantContainer(user);
-
     // Configure avatar
     UI.setUserEmail(id);
 

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -505,18 +505,6 @@ UI.addUser = function(user) {
 };
 
 /**
- * Remove user from UI.
- * @param {string} id   user id
- * @param {string} displayName user nickname
- */
-UI.removeUser = function(id, displayName) {
-    messageHandler.participantNotification(
-        displayName, 'notify.somebody', 'disconnected', 'notify.disconnected');
-
-    VideoLayout.removeParticipantContainer(id);
-};
-
-/**
  * Update videotype for specified user.
  * @param {string} id user id
  * @param {string} newVideoType new videotype

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -960,15 +960,6 @@ UI.getLargeVideo = function() {
 };
 
 /**
- * Returns whether or not the passed in user id is currently pinned to the large
- * video.
- *
- * @param {string} userId - The id of the user to check is pinned or not.
- * @returns {boolean} True if the user is currently pinned to the large video.
- */
-UI.isPinned = userId => VideoLayout.getPinnedId() === userId;
-
-/**
  * Shows "Please go to chrome webstore to install the desktop sharing extension"
  * 2 button dialog with buttons - cancel and go to web store.
  * @param url {string} the url of the extension.

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -827,15 +827,6 @@ UI.handleLastNEndpoints = function(leavingIds, enteringIds) {
 };
 
 /**
- * Will handle notification about participant's connectivity status change.
- *
- * @param {string} id the id of remote participant(MUC jid)
- */
-UI.participantConnectionStatusChanged = function(id) {
-    VideoLayout.onParticipantConnectionStatusChanged(id);
-};
-
-/**
  * Prompt user for nickname.
  */
 UI.promptDisplayName = () => {

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -16,15 +16,14 @@ import {
 } from '../../../react/features/analytics';
 import {
     participantJoined,
-    participantLeft
+    participantLeft,
+    pinParticipant
 } from '../../../react/features/base/participants';
 import {
     dockToolbox,
     getToolboxHeight,
     showToolbox
 } from '../../../react/features/toolbox';
-
-import SharedVideoThumb from './SharedVideoThumb';
 
 export const SHARED_VIDEO_CONTAINER_TYPE = 'sharedvideo';
 
@@ -281,13 +280,6 @@ export default class SharedVideoManager {
 
             player.playVideo();
 
-            const thumb = new SharedVideoThumb(
-                self.url, SHARED_VIDEO_CONTAINER_TYPE, VideoLayout);
-
-            thumb.setDisplayName('YouTube');
-            VideoLayout.addRemoteVideoContainer(self.url, thumb);
-            VideoLayout.resizeThumbnails(true);
-
             const iframe = player.getIframe();
 
             // eslint-disable-next-line no-use-before-define
@@ -317,7 +309,7 @@ export default class SharedVideoManager {
                 name: 'YouTube'
             }));
 
-            thumb.videoClick();
+            APP.store.dispatch(pinParticipant(self.url));
 
             // If we are sending the command and we are starting the player
             // we need to continuously send the player current time position

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -317,7 +317,7 @@ export default class SharedVideoManager {
                 name: 'YouTube'
             }));
 
-            VideoLayout.handleVideoThumbClicked(self.url);
+            thumb.videoClick();
 
             // If we are sending the command and we are starting the player
             // we need to continuously send the player current time position

--- a/modules/UI/shared_video/SharedVideo.js
+++ b/modules/UI/shared_video/SharedVideo.js
@@ -497,7 +497,7 @@ export default class SharedVideoManager {
             this.localAudioMutedListener);
         this.localAudioMutedListener = null;
 
-        VideoLayout.removeParticipantContainer(this.url);
+        APP.store.dispatch(participantLeft(this.url, APP.conference._room));
 
         VideoLayout.showLargeVideoContainer(SHARED_VIDEO_CONTAINER_TYPE, false)
             .then(() => {
@@ -521,8 +521,6 @@ export default class SharedVideoManager {
                 this.emitter.emit(
                     UIEvents.UPDATE_SHARED_VIDEO, null, 'removed');
             });
-
-        APP.store.dispatch(participantLeft(this.url, APP.conference._room));
 
         this.url = null;
         this.isSharedVideoShown = false;

--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -59,7 +59,7 @@ SharedVideoThumb.prototype.createContainer = function(spanId) {
  * The thumb click handler.
  */
 SharedVideoThumb.prototype.videoClick = function() {
-    this.VideoLayout.handleVideoThumbClicked(this.url);
+    this._togglePin();
 };
 
 /**

--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -6,10 +6,10 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 /**
  *
  */
-export default function SharedVideoThumb(url, videoType, VideoLayout) {
-    this.id = url;
+export default function SharedVideoThumb(participant, videoType, VideoLayout) {
+    this.id = participant.id;
 
-    this.url = url;
+    this.url = participant.id;
     this.setVideoType(videoType);
     this.videoSpanId = 'sharedVideoContainer';
     this.container = this.createContainer(this.videoSpanId);
@@ -18,6 +18,7 @@ export default function SharedVideoThumb(url, videoType, VideoLayout) {
     this.bindHoverHandler();
     SmallVideo.call(this, VideoLayout);
     this.isVideoMuted = true;
+    this.setDisplayName(participant.name);
 }
 SharedVideoThumb.prototype = Object.create(SmallVideo.prototype);
 SharedVideoThumb.prototype.constructor = SharedVideoThumb;

--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -68,10 +68,6 @@ SharedVideoThumb.prototype.videoClick = function() {
 SharedVideoThumb.prototype.remove = function() {
     logger.log('Remove shared video thumb', this.id);
 
-    // Make sure that the large video is updated if are removing its
-    // corresponding small video.
-    this.VideoLayout.updateAfterThumbRemoved(this.id);
-
     // Remove whole container
     if (this.container.parentNode) {
         this.container.parentNode.removeChild(this.container);

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -260,7 +260,7 @@ LocalVideo.prototype._onContainerClick = function(event) {
     }
 
     if (!ignoreClick) {
-        this.VideoLayout.handleVideoThumbClicked(this.id);
+        this._togglePin();
     }
 };
 

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -21,9 +21,9 @@ import SmallVideo from './SmallVideo';
 /**
  *
  */
-function LocalVideo(VideoLayout, emitter) {
+function LocalVideo(VideoLayout, emitter, streamEndedCallback) {
     this.videoSpanId = 'localVideoContainer';
-
+    this.streamEndedCallback = streamEndedCallback;
     this.container = this.createContainer();
     this.$container = $(this.container);
     $('#filmstripLocalVideoThumbnail').append(this.container);
@@ -137,15 +137,23 @@ LocalVideo.prototype.changeVideo = function(stream) {
             ReactDOM.unmountComponentAtNode(localVideoContainer);
         }
 
-        // when removing only the video element and we are on stage
-        // update the stage
-        if (this.isCurrentlyOnLargeVideo()) {
-            this.VideoLayout.updateLargeVideo(this.id);
-        }
+        this._notifyOfStreamEnded();
         stream.off(JitsiTrackEvents.LOCAL_TRACK_STOPPED, endedHandler);
     };
 
     stream.on(JitsiTrackEvents.LOCAL_TRACK_STOPPED, endedHandler);
+};
+
+/**
+ * Notify any subscribers of the local video stream ending.
+ *
+ * @private
+ * @returns {void}
+ */
+LocalVideo.prototype._notifyOfStreamEnded = function() {
+    if (this.streamEndedCallback) {
+        this.streamEndedCallback(this.id);
+    }
 };
 
 /**

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -366,14 +366,7 @@ RemoteVideo.prototype.removeRemoteStreamElement = function(stream) {
     logger.info(`${isVideo ? 'Video' : 'Audio'
     } removed ${this.id}`, select);
 
-    // when removing only the video element and we are on stage
-    // update the stage
-    if (isVideo && this.isCurrentlyOnLargeVideo()) {
-        this.VideoLayout.updateLargeVideo(this.id);
-    } else {
-        // Missing video stream will affect display mode
-        this.updateView();
-    }
+    this.updateView();
 };
 
 /**

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -476,10 +476,6 @@ RemoteVideo.prototype.remove = function() {
 
     this.removeRemoteVideoMenu();
 
-    // Make sure that the large video is updated if are removing its
-    // corresponding small video.
-    this.VideoLayout.updateAfterThumbRemoved(this.id);
-
     // Remove whole container
     if (this.container.parentNode) {
         this.container.parentNode.removeChild(this.container);

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -11,7 +11,10 @@ import { i18next } from '../../../react/features/base/i18n';
 import {
     JitsiParticipantConnectionStatus
 } from '../../../react/features/base/lib-jitsi-meet';
-
+import {
+    getPinnedParticipant,
+    pinParticipant
+} from '../../../react/features/base/participants';
 import { PresenceLabel } from '../../../react/features/presence-status';
 import {
     REMOTE_CONTROL_MENU_STATES,
@@ -234,10 +237,12 @@ RemoteVideo.prototype._requestRemoteControlPermissions = function() {
         if (result === true) {
             // the remote control permissions has been granted
             // pin the controlled participant
-            const pinnedId = this.VideoLayout.getPinnedId();
+            const pinnedParticipant
+                = getPinnedParticipant(APP.store.getState()) || {};
+            const pinnedId = pinnedParticipant.id;
 
             if (pinnedId !== this.id) {
-                this.VideoLayout.handleVideoThumbClicked(this.id);
+                APP.store.dispatch(pinParticipant(this.id));
             }
         }
     }, error => {
@@ -648,7 +653,7 @@ RemoteVideo.prototype._onContainerClick = function(event) {
             || classList.contains('popover');
 
     if (!ignoreClick) {
-        this.VideoLayout.handleVideoThumbClicked(this.id);
+        this._togglePin();
     }
 
     // On IE we need to populate this handler on video <object> and it does not

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -679,6 +679,10 @@ SmallVideo.prototype.showDominantSpeakerIndicator = function(show) {
         return;
     }
 
+    if (this._showDominantSpeaker === show) {
+        return;
+    }
+
     this._showDominantSpeaker = show;
 
     this.updateIndicators();

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -12,7 +12,9 @@ import { AudioLevelIndicator }
     from '../../../react/features/audio-level-indicator';
 import {
     Avatar as AvatarDisplay,
-    getAvatarURLByParticipantId
+    getAvatarURLByParticipantId,
+    getPinnedParticipant,
+    pinParticipant
 } from '../../../react/features/base/participants';
 import {
     ConnectionIndicator
@@ -817,6 +819,22 @@ SmallVideo.prototype.updateIndicators = function() {
             </I18nextProvider>,
         indicatorToolbar
     );
+};
+
+/**
+ * Pins the participant displayed by this thumbnail or unpins if already pinned.
+ *
+ * @private
+ * @returns {void}
+ */
+SmallVideo.prototype._togglePin = function() {
+    const pinnedParticipant
+        = getPinnedParticipant(APP.store.getState()) || {};
+    const participantIdToPin
+        = pinnedParticipant && pinnedParticipant.id === this.id
+            ? null : this.id;
+
+    APP.store.dispatch(pinParticipant(participantIdToPin));
 };
 
 /**

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -9,6 +9,9 @@ import {
     pinParticipant
 } from '../../../react/features/base/participants';
 
+import { SHARED_VIDEO_CONTAINER_TYPE } from '../shared_video/SharedVideo';
+import SharedVideoThumb from '../shared_video/SharedVideoThumb';
+
 import Filmstrip from './Filmstrip';
 import UIEvents from '../../../service/UI/UIEvents';
 import UIUtil from '../util/UIUtil';
@@ -16,6 +19,7 @@ import UIUtil from '../util/UIUtil';
 import RemoteVideo from './RemoteVideo';
 import LargeVideoManager from './LargeVideoManager';
 import { VIDEO_CONTAINER_TYPE } from './VideoContainer';
+
 import LocalVideo from './LocalVideo';
 
 const remoteVideos = {};
@@ -434,15 +438,32 @@ const VideoLayout = {
     },
 
     /**
-     * Creates or adds a participant container for the given id and smallVideo.
+     * Creates a participant container for the given id.
      *
-     * @param {JitsiParticipant} user the participant to add
+     * @param {Object} participant - The redux representation of a remote
+     * participant.
+     * @returns {void}
      */
-    addParticipantContainer(user) {
-        const id = user.getId();
-        const remoteVideo = new RemoteVideo(user, VideoLayout, eventEmitter);
+    addRemoteParticipantContainer(participant) {
+        if (!participant || participant.local) {
+            return;
+        } else if (participant.isBot) {
+            const sharedVideoThumb = new SharedVideoThumb(
+                participant,
+                SHARED_VIDEO_CONTAINER_TYPE,
+                VideoLayout);
 
-        this._setRemoteControlProperties(user, remoteVideo);
+            this.addRemoteVideoContainer(participant.id, sharedVideoThumb);
+
+            return;
+        }
+
+        const id = participant.id;
+        const jitsiParticipant = APP.conference.getParticipantById(id);
+        const remoteVideo
+            = new RemoteVideo(jitsiParticipant, VideoLayout, eventEmitter);
+
+        this._setRemoteControlProperties(jitsiParticipant, remoteVideo);
         this.addRemoteVideoContainer(id, remoteVideo);
 
         this.updateMutedForNoTracks(id, 'audio');

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -347,6 +347,11 @@ const VideoLayout = {
         if (remoteVideo) {
             remoteVideo.removeRemoteStreamElement(stream);
         }
+
+        if (stream.isVideoTrack() && this.isCurrentlyOnLarge(id)) {
+            this.updateLargeVideo(id);
+        }
+
         this.updateMutedForNoTracks(id, stream.getType());
     },
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -432,18 +432,11 @@ const VideoLayout = {
      * Creates or adds a participant container for the given id and smallVideo.
      *
      * @param {JitsiParticipant} user the participant to add
-     * @param {SmallVideo} smallVideo optional small video instance to add as a
-     * remote video, if undefined <tt>RemoteVideo</tt> will be created
      */
-    addParticipantContainer(user, smallVideo) {
+    addParticipantContainer(user) {
         const id = user.getId();
-        let remoteVideo;
+        const remoteVideo = new RemoteVideo(user, VideoLayout, eventEmitter);
 
-        if (smallVideo) {
-            remoteVideo = smallVideo;
-        } else {
-            remoteVideo = new RemoteVideo(user, VideoLayout, eventEmitter);
-        }
         this._setRemoteControlProperties(user, remoteVideo);
         this.addRemoteVideoContainer(id, remoteVideo);
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -105,7 +105,10 @@ const VideoLayout = {
     init(emitter) {
         eventEmitter = emitter;
 
-        localVideoThumbnail = new LocalVideo(VideoLayout, emitter);
+        localVideoThumbnail = new LocalVideo(
+            VideoLayout,
+            emitter,
+            this._updateLargeVideoIfDisplayed.bind(this));
 
         // sets default video type of local video
         // FIXME container type is totally different thing from the video type
@@ -175,10 +178,7 @@ const VideoLayout = {
 
         localVideoThumbnail.changeVideo(stream);
 
-        /* Update if we're currently being displayed */
-        if (this.isCurrentlyOnLarge(localId)) {
-            this.updateLargeVideo(localId);
-        }
+        this._updateLargeVideoIfDisplayed(localId);
     },
 
     /**
@@ -348,8 +348,8 @@ const VideoLayout = {
             remoteVideo.removeRemoteStreamElement(stream);
         }
 
-        if (stream.isVideoTrack() && this.isCurrentlyOnLarge(id)) {
-            this.updateLargeVideo(id);
+        if (stream.isVideoTrack()) {
+            this._updateLargeVideoIfDisplayed(id);
         }
 
         this.updateMutedForNoTracks(id, stream.getType());
@@ -1147,6 +1147,20 @@ const VideoLayout = {
         Object.values(remoteVideos).forEach(
             remoteVideo => remoteVideo.updateRemoteVideoMenu()
         );
+    },
+
+    /**
+     * Triggers an update of large video if the passed in participant is
+     * currently displayed on large video.
+     *
+     * @param {string} participantId - The participant ID that should trigger an
+     * update of large video if displayed.
+     * @returns {void}
+     */
+    _updateLargeVideoIfDisplayed(participantId) {
+        if (this.isCurrentlyOnLarge(participantId)) {
+            this.updateLargeVideo(participantId);
+        }
     }
 };
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -253,7 +253,7 @@ const VideoLayout = {
      * Uses focusedID if any or dominantSpeakerID if any,
      * otherwise elects new video, in this order.
      */
-    updateAfterThumbRemoved(id) {
+    _updateAfterThumbRemoved(id) {
         // Always trigger an update if large video is empty.
         if (!largeVideo
             || (this.getLargeVideoID() && !this.isCurrentlyOnLarge(id))) {
@@ -804,6 +804,7 @@ const VideoLayout = {
         }
 
         VideoLayout.resizeThumbnails();
+        VideoLayout._updateAfterThumbRemoved(id);
     },
 
     onVideoTypeChanged(id, newVideoType) {

--- a/react/features/app/components/App.web.js
+++ b/react/features/app/components/App.web.js
@@ -5,6 +5,7 @@ import '../../base/responsive-ui';
 import { getLocationContextRoot } from '../../base/util';
 import '../../chat';
 import '../../room-lock';
+import '../../video-layout';
 
 import { AbstractApp } from './AbstractApp';
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -73,8 +73,6 @@ MiddlewareRegistry.register(store => next => action => {
                 raisedHand: false
             }));
 
-        typeof APP === 'object' && APP.UI.markDominantSpeaker(id);
-
         break;
     }
 

--- a/react/features/video-layout/index.js
+++ b/react/features/video-layout/index.js
@@ -1,0 +1,1 @@
+import './middleware';

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -1,3 +1,6 @@
+import VideoLayout from '../../../modules/UI/videolayout/VideoLayout.js';
+
+import { DOMINANT_SPEAKER_CHANGED } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
 
 /**
@@ -9,4 +12,14 @@ import { MiddlewareRegistry } from '../base/redux';
  * @returns {Function}
  */
 // eslint-disable-next-line no-unused-vars
-MiddlewareRegistry.register(store => next => action => next(action));
+MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case DOMINANT_SPEAKER_CHANGED:
+        VideoLayout.onDominantSpeakerChanged(action.participant.id);
+        break;
+    }
+
+    return result;
+});

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -5,6 +5,7 @@ import UIEvents from '../../../service/UI/UIEvents';
 
 import {
     DOMINANT_SPEAKER_CHANGED,
+    PARTICIPANT_UPDATED,
     PIN_PARTICIPANT
 } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
@@ -26,6 +27,18 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
+
+    case PARTICIPANT_UPDATED: {
+        // Look for actions that triggered a change to connectionStatus. This is
+        // done instead of changing the connection status change action to be
+        // explicit in order to minimize changes to other code.
+        if (typeof action.participant.connectionStatus !== 'undefined') {
+            VideoLayout.onParticipantConnectionStatusChanged(
+                action.participant.id);
+        }
+        break;
+    }
+
     case DOMINANT_SPEAKER_CHANGED:
         VideoLayout.onDominantSpeakerChanged(action.participant.id);
         break;

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -5,9 +5,11 @@ import UIEvents from '../../../service/UI/UIEvents';
 
 import {
     DOMINANT_SPEAKER_CHANGED,
+    PARTICIPANT_JOINED,
     PARTICIPANT_LEFT,
     PARTICIPANT_UPDATED,
-    PIN_PARTICIPANT
+    PIN_PARTICIPANT,
+    getParticipantById
 } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
 
@@ -28,6 +30,13 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
+    case PARTICIPANT_JOINED:
+        if (!action.participant.local) {
+            VideoLayout.addRemoteParticipantContainer(
+                getParticipantById(store.getState(), action.participant.id));
+        }
+        break;
+
     case PARTICIPANT_LEFT:
         VideoLayout.removeParticipantContainer(action.participant.id);
         break;

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -1,0 +1,12 @@
+import { MiddlewareRegistry } from '../base/redux';
+
+/**
+ * Middleware which intercepts actions and updates the legacy component
+ * {@code VideoLayout} as needed. The purpose of this middleware is to redux-ify
+ * {@code VideoLayout} without having to simultaneously react-ifying it.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+// eslint-disable-next-line no-unused-vars
+MiddlewareRegistry.register(store => next => action => next(action));

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -5,6 +5,7 @@ import UIEvents from '../../../service/UI/UIEvents';
 
 import {
     DOMINANT_SPEAKER_CHANGED,
+    PARTICIPANT_LEFT,
     PARTICIPANT_UPDATED,
     PIN_PARTICIPANT
 } from '../base/participants';
@@ -27,6 +28,9 @@ MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
     switch (action.type) {
+    case PARTICIPANT_LEFT:
+        VideoLayout.removeParticipantContainer(action.participant.id);
+        break;
 
     case PARTICIPANT_UPDATED: {
         // Look for actions that triggered a change to connectionStatus. This is

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -1,7 +1,15 @@
-import VideoLayout from '../../../modules/UI/videolayout/VideoLayout.js';
+// @flow
 
-import { DOMINANT_SPEAKER_CHANGED } from '../base/participants';
+import VideoLayout from '../../../modules/UI/videolayout/VideoLayout.js';
+import UIEvents from '../../../service/UI/UIEvents';
+
+import {
+    DOMINANT_SPEAKER_CHANGED,
+    PIN_PARTICIPANT
+} from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
+
+declare var APP: Object;
 
 /**
  * Middleware which intercepts actions and updates the legacy component
@@ -13,11 +21,21 @@ import { MiddlewareRegistry } from '../base/redux';
  */
 // eslint-disable-next-line no-unused-vars
 MiddlewareRegistry.register(store => next => action => {
+    // Purposefully perform additional actions after state update to mimic
+    // being connected to the store for updates.
     const result = next(action);
 
     switch (action.type) {
     case DOMINANT_SPEAKER_CHANGED:
         VideoLayout.onDominantSpeakerChanged(action.participant.id);
+        break;
+
+    case PIN_PARTICIPANT:
+        VideoLayout.onPinChange(action.participant.id);
+        APP.UI.emitEvent(
+            UIEvents.PINNED_ENDPOINT,
+            action.participant.id,
+            Boolean(action.participant.id));
         break;
     }
 


### PR DESCRIPTION
This is in an effort to get VideoLayout subscribing to redux updates so that it can have its state retrieved from redux. This way all calls to VideoLayout#updateLargeVideo can happen after redux state has updated and large-video has been selected in redux.