### PR TITLE
[iOS] Fix running in Debug mode on a device

### DIFF
--- a/ios/sdk/sdk.xcodeproj/project.pbxproj
+++ b/ios/sdk/sdk.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\nif [[ \"$CONFIGURATION\" == *Debug* ]]; then\n    export SKIP_BUNDLING=1\nfi\n../../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "if [[ \"$CONFIGURATION\" == *Debug* && ! \"$PLATFORM_NAME\" == *simulator ]]; then\n    IP=$(ipconfig getifaddr en0)\n    if [ -z \"$IP\" ]; then\n        IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\\   -f2  | awk 'NR==1{print $1}')\n    fi\n    DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\n    echo \"$IP\" > \"$DEST/ip.txt\"\n    exit 0\nfi\nexport NODE_BINARY=node\n../../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		26796D8589142D80C8AFDA51 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Thsi fixed a regression in https://github.com/jitsi/jitsi-meet/commit/8f75c2e279911f2859eba394cfd84a5068eb8323

The bundler script doesn't do anything (it literally exits right at the top)
when skipping the bundle. This is arguably wrong, because it doesn't generate
"ip.txt", the file with the bundler IP address either!

So, generate that ourselves. While ding this, also drop the need for xip.io,
which has also been removed from RN, since it gives more trouble than it solves.