### PR TITLE
fix: discard outdated loadConfig requests

### DIFF
--- a/react/features/base/connection/actionTypes.js
+++ b/react/features/base/connection/actionTypes.js
@@ -51,3 +51,19 @@ export const CONNECTION_WILL_CONNECT = Symbol('CONNECTION_WILL_CONNECT');
  * }
  */
 export const SET_LOCATION_URL = Symbol('SET_LOCATION_URL');
+
+/**
+ * The type of (redux) action which sets the pending location URL of
+ * the application, connection, conference, etc. It indicates that the process
+ * of resolving a location has been started (loading config). Because that's an
+ * asynchronous operation it's not know how long it may take. It may turn out
+ * that a request for new location may come in before the previous one
+ * has finished. The information about pending URL stored in the store is used
+ * to discard any previous requests which are no longer relevant.
+ *
+ * {
+ *     type: SET_PENDING_LOCATION_URL,
+ *     pendingLocationURL: ?URL
+ * }
+ */
+export const SET_PENDING_LOCATION_URL = Symbol('SET_PENDING_LOCATION_URL');

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -12,7 +12,8 @@ import {
     CONNECTION_ESTABLISHED,
     CONNECTION_FAILED,
     CONNECTION_WILL_CONNECT,
-    SET_LOCATION_URL
+    SET_LOCATION_URL,
+    SET_PENDING_LOCATION_URL
 } from './actionTypes';
 
 /**
@@ -362,5 +363,19 @@ export function setLocationURL(locationURL: ?URL) {
     return {
         type: SET_LOCATION_URL,
         locationURL
+    };
+}
+
+/**
+ * Sets a pending location URL for which the config is being resolved - that's
+ * an async operation which may take unknown amount of time.
+ *
+ * @param {URL} pendingLocationURL - The candidate location URL.
+ * @returns {{type, pendingLocationURL: URL}}
+ */
+export function setPendingLocationURL(pendingLocationURL: ?URL) {
+    return {
+        type: SET_PENDING_LOCATION_URL,
+        pendingLocationURL
     };
 }

--- a/react/features/base/connection/reducer.js
+++ b/react/features/base/connection/reducer.js
@@ -2,7 +2,7 @@
 
 import { SET_ROOM } from '../conference';
 import { JitsiConnectionErrors } from '../lib-jitsi-meet';
-import { assign, ReducerRegistry } from '../redux';
+import { assign, ReducerRegistry, set } from '../redux';
 import { parseURIString } from '../util';
 
 import {
@@ -10,7 +10,8 @@ import {
     CONNECTION_ESTABLISHED,
     CONNECTION_FAILED,
     CONNECTION_WILL_CONNECT,
-    SET_LOCATION_URL
+    SET_LOCATION_URL,
+    SET_PENDING_LOCATION_URL
 } from './actionTypes';
 
 import type { ConnectionFailedError } from './actions.native';
@@ -36,6 +37,9 @@ ReducerRegistry.register(
 
         case SET_LOCATION_URL:
             return _setLocationURL(state, action);
+
+        case SET_PENDING_LOCATION_URL:
+            return _setPendingLocationURL(state, action);
 
         case SET_ROOM:
             return _setRoom(state);
@@ -203,8 +207,25 @@ function _setLocationURL(
         { locationURL }: { locationURL: ?URL }) {
     return assign(state, {
         locationURL,
-        options: locationURL ? _constructOptions(locationURL) : undefined
+        options: locationURL ? _constructOptions(locationURL) : undefined,
+        pendingLocationURL: undefined
     });
+}
+
+/**
+ * Updates the latest pending URL. Check {@link SET_PENDING_LOCATION_URL}
+ * description for more details.
+ *
+ * @param {Object} state - The redux state of the feature base/connection.
+ * @param {Action} action - The redux action {@code SET_PENDING_LOCATION_URL} to
+ * reduce.
+ * @returns {Object}
+ * @private
+ */
+function _setPendingLocationURL(
+        state: Object,
+        { pendingLocationURL }: { pendingLocationURL: ?URL }) {
+    return set(state, 'pendingLocationURL', pendingLocationURL);
 }
 
 /**


### PR DESCRIPTION
Uses new SET_PENDING_LOCATION_URL action to store the most recent pending URL and discard outdated loadConfig requests which may have not been resolved before new one was scheduled.