### PR TITLE
Changing the status strings for call flows to be lowercased where pos…

### DIFF
--- a/resources/prosody-plugins/mod_muc_call.lua
+++ b/resources/prosody-plugins/mod_muc_call.lua
@@ -16,11 +16,11 @@ if not muc_domain_base then
 end
 
 -- Status strings that trigger call events.
-local invited_status  = "Invited"
-local calling_status  = "Calling"
-local ringing_status  = "Ringing"
-local busy_status     = "Busy"
-local rejected_status = "Rejected"
+local invited_status   = "Invited"
+local calling_status   = "calling"
+local ringing_status   = "ringing"
+local busy_status      = "busy"
+local rejected_status  = "rejected"
 local connected_status = "connected"
 
 
@@ -53,11 +53,11 @@ end
 --    -------------------------
 --    Status      | Event Type
 --    _________________________
---    "Calling"   | INVITE
+--    "calling"   | INVITE
 --    "Invited"   | INVITE
---    "Ringing"   | CANCEL
---    "Busy"      | CANCEL
---    "Rejected"  | CANCEL
+--    "ringing"   | CANCEL
+--    "busy"      | CANCEL
+--    "rejected"  | CANCEL
 --    "connected" | CANCEL
 module:hook("muc-broadcast-presence", function (event)
     -- Detect if the presence is for a poltergeist or not.


### PR DESCRIPTION
…sible.

This should allow us to have a consistent convention and assist
with client translation of status strings.