### PR TITLE
[RN] Status indicators

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -27,7 +27,6 @@ import {
     redirectWithStoredParams,
     reloadWithStoredParams
 } from './react/features/app';
-import { updateRecordingSessionData } from './react/features/recording';
 
 import EventEmitter from 'events';
 
@@ -1942,13 +1941,6 @@ export default {
                     logger.error(
                         'Received invalid recorder status update',
                         recorderSession);
-
-                    return;
-                }
-
-                if (recorderSession.getID()) {
-                    APP.store.dispatch(
-                        updateRecordingSessionData(recorderSession));
 
                     return;
                 }

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -140,7 +140,7 @@ function _addConferenceListeners(conference, dispatch) {
 
     conference.on(
         JitsiConferenceEvents.USER_JOINED,
-        (id, user) => dispatch(participantJoined({
+        (id, user) => !user.isHidden() && dispatch(participantJoined({
             conference,
             id,
             name: user.getDisplayName(),
@@ -148,7 +148,8 @@ function _addConferenceListeners(conference, dispatch) {
         })));
     conference.on(
         JitsiConferenceEvents.USER_LEFT,
-        id => dispatch(participantLeft(id, conference)));
+        (id, user) => !user.isHidden()
+            && dispatch(participantLeft(id, conference)));
     conference.on(
         JitsiConferenceEvents.USER_ROLE_CHANGED,
         (...args) => dispatch(participantRoleChanged(...args)));

--- a/react/features/base/label/components/AbstractCircularLabel.js
+++ b/react/features/base/label/components/AbstractCircularLabel.js
@@ -1,0 +1,17 @@
+// @flow
+import { Component } from 'react';
+
+export type Props = {
+
+    /**
+     * String that will be rendered as the label itself.
+     */
+    label: string
+};
+
+/**
+ * Abstract class for the {@code CircularLabel} component.
+ */
+export default class AbstractCircularLabel<P: Props> extends Component<P> {
+
+}

--- a/react/features/base/label/components/CircularLabel.native.js
+++ b/react/features/base/label/components/CircularLabel.native.js
@@ -1,0 +1,44 @@
+// @flow
+import React from 'react';
+import { Text, View } from 'react-native';
+
+import { combineStyles, type StyleType } from '../../styles';
+
+import AbstractCircularLabel, {
+    type Props as AbstractProps
+} from './AbstractCircularLabel';
+import styles from './styles';
+
+type Props = AbstractProps & {
+
+    /**
+     * Style of the label.
+     */
+    style?: ?StyleType
+};
+
+/**
+ * Renders a circular indicator to be used for status icons, such as recording
+ * on, audio-only conference, video quality and similar.
+ */
+export default class CircularLabel extends AbstractCircularLabel<Props> {
+    /**
+     * Implements React {@link Component}'s render.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const { label, style } = this.props;
+
+        return (
+            <View
+                style = {
+                    combineStyles(styles.indicatorContainer, style)
+                }>
+                <Text style = { styles.indicatorText }>
+                    { label }
+                </Text>
+            </View>
+        );
+    }
+}

--- a/react/features/base/label/components/CircularLabel.web.js
+++ b/react/features/base/label/components/CircularLabel.web.js
@@ -1,13 +1,12 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
 
-type Props = {
+import AbstractCircularLabel, {
+    type Props as AbstractProps
+} from './AbstractCircularLabel';
 
-    /**
-     * The children to be displayed within {@code CircularLabel}.
-     */
-    children: React$Node,
+type Props = AbstractProps & {
 
     /**
      * Additional CSS class names to add to the root of {@code CircularLabel}.
@@ -26,7 +25,7 @@ type Props = {
  *
  * @extends Component
  */
-export default class CircularLabel extends Component<Props> {
+export default class CircularLabel extends AbstractCircularLabel<Props> {
     /**
      * Default values for {@code CircularLabel} component's properties.
      *
@@ -44,16 +43,16 @@ export default class CircularLabel extends Component<Props> {
      */
     render() {
         const {
-            children,
             className,
-            id
+            id,
+            label
         } = this.props;
 
         return (
             <div
                 className = { `circular-label ${className}` }
                 id = { id }>
-                { children }
+                { label }
             </div>
         );
     }

--- a/react/features/base/label/components/styles.js
+++ b/react/features/base/label/components/styles.js
@@ -1,0 +1,30 @@
+// @flow
+
+import { ColorPalette, createStyleSheet } from '../../styles';
+
+/**
+ * The styles of the native base/label feature.
+ */
+export default createStyleSheet({
+
+    /**
+     * The outermost view.
+     */
+    indicatorContainer: {
+        alignItems: 'center',
+        backgroundColor: '#808080',
+        borderRadius: 18,
+        borderWidth: 0,
+        flex: 0,
+        height: 36,
+        justifyContent: 'center',
+        margin: 5,
+        opacity: 0.6,
+        width: 36
+    },
+
+    indicatorText: {
+        color: ColorPalette.white,
+        fontSize: 12
+    }
+});

--- a/react/features/base/styles/components/styles/ColorPalette.js
+++ b/react/features/base/styles/components/styles/ColorPalette.js
@@ -22,6 +22,7 @@ export const ColorPalette = {
     blueHighlight: '#1081b2',
     buttonUnderlay: '#495258',
     darkGrey: '#555555',
+    green: '#40b183',
     red: '#D00000',
     white: 'white'
 };

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -10,6 +10,7 @@ import { appNavigate } from '../../app';
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
 import { CalleeInfoContainer } from '../../base/jwt';
+import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
 import { getParticipantCount } from '../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../base/react';
 import { TestConnectionInfo } from '../../base/testing';
@@ -17,6 +18,7 @@ import { createDesiredLocalTracks } from '../../base/tracks';
 import { ConferenceNotification } from '../../calendar-sync';
 import { Filmstrip } from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
+import { RecordingLabel } from '../../recording';
 import { setToolboxVisible, Toolbox } from '../../toolbox';
 import { VideoQualityLabel } from '../../video-quality';
 
@@ -246,7 +248,14 @@ class Conference extends Component<Props> {
                       * participants.
                       */}
                     <Filmstrip />
-                    <VideoQualityLabel style = { styles.videoQualityLabel } />
+
+                    <View style = { styles.indicatorContainer }>
+                        <RecordingLabel
+                            mode = { JitsiRecordingConstants.mode.FILE } />
+                        <RecordingLabel
+                            mode = { JitsiRecordingConstants.mode.STREAM } />
+                        <VideoQualityLabel />
+                    </View>
                 </View>
                 <TestConnectionInfo />
 

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -10,7 +10,6 @@ import { appNavigate } from '../../app';
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
 import { CalleeInfoContainer } from '../../base/jwt';
-import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
 import { getParticipantCount } from '../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../base/react';
 import { TestConnectionInfo } from '../../base/testing';
@@ -18,10 +17,9 @@ import { createDesiredLocalTracks } from '../../base/tracks';
 import { ConferenceNotification } from '../../calendar-sync';
 import { Filmstrip } from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
-import { RecordingLabel } from '../../recording';
 import { setToolboxVisible, Toolbox } from '../../toolbox';
-import { VideoQualityLabel } from '../../video-quality';
 
+import ConferenceIndicators from './ConferenceIndicators';
 import styles from './styles';
 
 /**
@@ -249,13 +247,11 @@ class Conference extends Component<Props> {
                       */}
                     <Filmstrip />
 
-                    <View style = { styles.indicatorContainer }>
-                        <RecordingLabel
-                            mode = { JitsiRecordingConstants.mode.FILE } />
-                        <RecordingLabel
-                            mode = { JitsiRecordingConstants.mode.STREAM } />
-                        <VideoQualityLabel />
-                    </View>
+                    {/*
+                      * A container that automatically renders indicators such
+                      * as VideoQualityLabel or RecordingLabel if need be.
+                      */}
+                    <ConferenceIndicators />
                 </View>
                 <TestConnectionInfo />
 

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -18,6 +18,7 @@ import { ConferenceNotification } from '../../calendar-sync';
 import { Filmstrip } from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
 import { setToolboxVisible, Toolbox } from '../../toolbox';
+import { VideoQualityLabel } from '../../video-quality';
 
 import styles from './styles';
 
@@ -245,6 +246,7 @@ class Conference extends Component<Props> {
                       * participants.
                       */}
                     <Filmstrip />
+                    <VideoQualityLabel style = { styles.videoQualityLabel } />
                 </View>
                 <TestConnectionInfo />
 

--- a/react/features/conference/components/ConferenceIndicators.native.js
+++ b/react/features/conference/components/ConferenceIndicators.native.js
@@ -1,0 +1,81 @@
+// @flow
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import { connect } from 'react-redux';
+
+import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
+import {
+    isNarrowAspectRatio,
+    makeAspectRatioAware
+} from '../../base/responsive-ui';
+import { RecordingLabel } from '../../recording';
+import { VideoQualityLabel } from '../../video-quality';
+
+import styles from './styles';
+
+type Props = {
+
+    /**
+     * The indicator which determines whether the filmstrip is visible.
+     */
+    _filmstripVisible: boolean
+};
+
+/**
+ * A container that renders the conference indicators, if any.
+ */
+class ConferenceIndicators extends Component<Props> {
+    /**
+     * Implements React {@code Component}'s render.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const _wide = !isNarrowAspectRatio(this);
+        const { _filmstripVisible } = this.props;
+
+        return (
+            <View
+                style = { [
+                    styles.indicatorContainer,
+                    _wide && _filmstripVisible && styles.indicatorContainerWide
+                ] }>
+                <RecordingLabel
+                    mode = { JitsiRecordingConstants.mode.FILE } />
+                <RecordingLabel
+                    mode = { JitsiRecordingConstants.mode.STREAM } />
+                <VideoQualityLabel />
+            </View>
+        );
+    }
+
+}
+
+/**
+ * Maps (parts of) the redux state to the associated
+ * {@code ConferenceIndicators}'s props.
+ *
+ * @param {Object} state - The redux state.
+ * @private
+ * @returns {{
+ *     _filmstripVisible: boolean
+ * }}
+ */
+function _mapStateToProps(state) {
+    const { length: participantCount } = state['features/base/participants'];
+    const { visible } = state['features/filmstrip'];
+
+    return {
+        /**
+         * The indicator which determines whether the filmstrip is visible.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _filmstripVisible: visible && participantCount > 1
+    };
+}
+
+export default connect(_mapStateToProps)(
+    makeAspectRatioAware(ConferenceIndicators)
+);

--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -19,6 +19,18 @@ export default createStyleSheet({
     }),
 
     /**
+     * View that contains the indicators.
+     */
+    indicatorContainer: {
+        flex: 1,
+        flexDirection: 'row',
+        margin: BoxModel.margin,
+        position: 'absolute',
+        right: 0,
+        top: 0
+    },
+
+    /**
      * The style of the {@link View} which expands over the whole
      * {@link Conference} area and splits it between the {@link Filmstrip} and
      * the {@link Toolbox}.
@@ -35,11 +47,5 @@ export default createStyleSheet({
         // On iPhone X there is the notch. In the two cases BoxModel.margin is
         // not enough.
         top: BoxModel.margin * 3
-    },
-
-    videoQualityLabel: {
-        right: 0,
-        top: 0,
-        position: 'absolute'
     }
 });

--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -31,6 +31,13 @@ export default createStyleSheet({
     },
 
     /**
+     * Indicator container for wide aspect ratio.
+     */
+    indicatorContainerWide: {
+        right: 80
+    },
+
+    /**
      * The style of the {@link View} which expands over the whole
      * {@link Conference} area and splits it between the {@link Filmstrip} and
      * the {@link Toolbox}.

--- a/react/features/conference/components/styles.js
+++ b/react/features/conference/components/styles.js
@@ -35,5 +35,11 @@ export default createStyleSheet({
         // On iPhone X there is the notch. In the two cases BoxModel.margin is
         // not enough.
         top: BoxModel.margin * 3
+    },
+
+    videoQualityLabel: {
+        right: 0,
+        top: 0,
+        position: 'absolute'
     }
 });

--- a/react/features/recording/components/AbstractRecordingLabel.js
+++ b/react/features/recording/components/AbstractRecordingLabel.js
@@ -1,0 +1,66 @@
+// @flow
+
+import { Component } from 'react';
+
+import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
+
+/**
+ * NOTE: Web currently renders multiple indicators if multiple recording
+ * sessions are running. This is however may not be a good UX as it's not
+ * obvious why there are multiple similar 'REC' indicators rendered. Mobile
+ * only renders one indicator if there is at least one recording session
+ * running. These boolean are shared across the two components to make it
+ * easier to align web's behaviour to mobile's later if necessary.
+ */
+export type Props = {
+
+    /**
+     * True if there is an active recording with the provided mode therefore the
+     * component must be rendered.
+     */
+    _visible: boolean,
+
+    /**
+     * The recording mode this indicator should display.
+     */
+    mode: string,
+
+    /**
+     * Invoked to obtain translated strings.
+     */
+    t: Function
+};
+
+/**
+ * Abstract class for the {@code RecordingLabel} component.
+ */
+export default class AbstractRecordingLabel<P: Props, S: *>
+    extends Component<P, S> {
+
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code AbstractRecordingLabel}'s props.
+ *
+ * @param {Object} state - The Redux state.
+ * @param {Props} ownProps - The component's own props.
+ * @private
+ * @returns {{
+ *     _visible: boolean
+ * }}
+ */
+export function _abstractMapStateToProps(state: Object, ownProps: Props) {
+    const { mode } = ownProps;
+    const _recordingSessions = state['features/recording'].sessionDatas;
+    const _visible
+        = Array.isArray(_recordingSessions)
+        && _recordingSessions.some(
+            session => session.status === JitsiRecordingConstants.status.ON
+            && session.mode === mode
+        );
+
+    return {
+        _visible
+    };
+}

--- a/react/features/recording/components/RecordingLabel.native.js
+++ b/react/features/recording/components/RecordingLabel.native.js
@@ -1,0 +1,91 @@
+// @flow
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../base/i18n';
+import { CircularLabel } from '../../base/label';
+import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
+import { combineStyles } from '../../base/styles';
+
+import AbstractRecordingLabel, {
+    type Props as AbstractProps,
+    _abstractMapStateToProps
+} from './AbstractRecordingLabel';
+import styles from './styles';
+
+type Props = AbstractProps & {
+
+    /**
+     * Style of the component passed as props.
+     */
+    style: ?Object
+};
+
+/**
+ * Implements a React {@link Component} which displays the current state of
+ * conference recording.
+ *
+ * @extends {Component}
+ */
+class RecordingLabel extends AbstractRecordingLabel<Props, *> {
+
+    /**
+     * Implements React {@code Component}'s render.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const { _visible, mode, style, t } = this.props;
+
+        if (!_visible) {
+            return null;
+        }
+
+        let labelKey;
+        let indicatorStyle;
+
+        switch (mode) {
+        case JitsiRecordingConstants.mode.STREAM:
+            labelKey = 'recording.live';
+            indicatorStyle = styles.indicatorLive;
+            break;
+        case JitsiRecordingConstants.mode.FILE:
+            labelKey = 'recording.rec';
+            indicatorStyle = styles.indicatorRecording;
+            break;
+        default:
+            // Invalid mode is passed to the component.
+            return null;
+        }
+
+        return (
+            <CircularLabel
+                label = { t(labelKey) }
+                style = {
+                    combineStyles(indicatorStyle, style)
+                } />
+        );
+    }
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code RecordingLabel}'s props.
+ *
+ * NOTE: This component has no props other than the abstract ones but keeping
+ * the coding style the same for consistency reasons.
+ *
+ * @param {Object} state - The Redux state.
+ * @param {Object} ownProps - The component's own props.
+ * @private
+ * @returns {{
+ * }}
+ */
+function _mapStateToProps(state: Object, ownProps: Object) {
+    return {
+        ..._abstractMapStateToProps(state, ownProps)
+    };
+}
+
+export default translate(connect(_mapStateToProps)(RecordingLabel));

--- a/react/features/recording/components/RecordingLabel.web.js
+++ b/react/features/recording/components/RecordingLabel.web.js
@@ -189,9 +189,9 @@ class RecordingLabel extends Component<Props, State> {
                     ? <div>
                         { this.props.t(messageKey) }
                     </div>
-                    : <CircularLabel className = { circularLabelClass }>
-                        { this.props.t(circularLabelKey) }
-                    </CircularLabel> }
+                    : <CircularLabel
+                        className = { circularLabelClass }
+                        label = { this.props.t(circularLabelKey) } /> }
             </div>
         );
     }

--- a/react/features/recording/components/RecordingLabel.web.js
+++ b/react/features/recording/components/RecordingLabel.web.js
@@ -1,10 +1,16 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
 
 import { CircularLabel } from '../../base/label';
 import { translate } from '../../base/i18n';
 import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
+
+import AbstractRecordingLabel, {
+    type Props as AbstractProps,
+    _abstractMapStateToProps
+} from './AbstractRecordingLabel';
 
 /**
  * The translation keys to use when displaying messages. The values are set
@@ -61,7 +67,7 @@ function _getTranslationKeysByMode() {
 /**
  * The type of the React {@code Component} props of {@link RecordingLabel}.
  */
-type Props = {
+type Props = AbstractProps & {
 
     /**
      * The redux representation of a recording session.
@@ -91,7 +97,7 @@ type State = {
  *
  * @extends {Component}
  */
-class RecordingLabel extends Component<Props, State> {
+class RecordingLabel extends AbstractRecordingLabel<Props, State> {
     _autohideTimeout: number;
 
     state = {
@@ -219,4 +225,23 @@ class RecordingLabel extends Component<Props, State> {
     }
 }
 
-export default translate(RecordingLabel);
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code RecordingLabel}'s props.
+ *
+ * NOTE: This component has no props other than the abstract ones but keeping
+ * the coding style the same for consistency reasons.
+ *
+ * @param {Object} state - The Redux state.
+ * @param {Object} ownProps - The component's own props.
+ * @private
+ * @returns {{
+ * }}
+ */
+function _mapStateToProps(state: Object, ownProps: Object) {
+    return {
+        ..._abstractMapStateToProps(state, ownProps)
+    };
+}
+
+export default translate(connect(_mapStateToProps)(RecordingLabel));

--- a/react/features/recording/components/styles.js
+++ b/react/features/recording/components/styles.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { ColorPalette, createStyleSheet } from '../../base/styles';
+
+/**
+ * The styles of the React {@code Components} of the feature recording.
+ */
+export default createStyleSheet({
+
+    /**
+     * Style for the recording indicator.
+     */
+    indicatorLive: {
+        backgroundColor: ColorPalette.blue
+    },
+
+    /**
+     * Style for the recording indicator.
+     */
+    indicatorRecording: {
+        backgroundColor: ColorPalette.red
+    }
+});

--- a/react/features/recording/index.js
+++ b/react/features/recording/index.js
@@ -3,4 +3,5 @@ export * from './components';
 export * from './constants';
 export * from './functions';
 
+import './middleware';
 import './reducer';

--- a/react/features/recording/middleware.js
+++ b/react/features/recording/middleware.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import { CONFERENCE_WILL_JOIN } from '../base/conference';
+import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
+import { MiddlewareRegistry } from '../base/redux';
+
+import { updateRecordingSessionData } from './actions';
+
+/**
+ * The redux middleware to handle the recorder updates in a React way.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(({ dispatch }) => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case CONFERENCE_WILL_JOIN: {
+        const { conference } = action;
+
+        conference.on(
+            JitsiConferenceEvents.RECORDER_STATE_CHANGED,
+            recorderSession => {
+
+                if (recorderSession && recorderSession.getID()) {
+                    dispatch(
+                        updateRecordingSessionData(recorderSession));
+
+                    return;
+                }
+            });
+
+        break;
+    }
+    }
+
+    return result;
+});

--- a/react/features/video-quality/components/AbstractVideoQualityLabel.js
+++ b/react/features/video-quality/components/AbstractVideoQualityLabel.js
@@ -1,0 +1,41 @@
+// @flow
+
+import { Component } from 'react';
+
+export type Props = {
+
+    /**
+     * Whether or not the conference is in audio only mode.
+     */
+    _audioOnly: boolean,
+
+    /**
+     * Invoked to obtain translated strings.
+     */
+    t: Function
+};
+
+/**
+ * Abstract class for the {@code VideoQualityLabel} component.
+ */
+export default class AbstractVideoQualityLabel<P: Props> extends Component<P> {
+
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code AbstractVideoQualityLabel}'s props.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {{
+ *     _audioOnly: boolean
+ * }}
+ */
+export function _abstractMapStateToProps(state: Object) {
+    const { audioOnly } = state['features/base/conference'];
+
+    return {
+        _audioOnly: audioOnly
+    };
+}

--- a/react/features/video-quality/components/VideoQualityLabel.native.js
+++ b/react/features/video-quality/components/VideoQualityLabel.native.js
@@ -1,0 +1,76 @@
+// @flow
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../base/i18n';
+import { CircularLabel } from '../../base/label';
+import { combineStyles, type StyleType } from '../../base/styles';
+
+import AbstractVideoQualityLabel, {
+    _abstractMapStateToProps,
+    type Props as AbstractProps
+} from './AbstractVideoQualityLabel';
+import styles from './styles';
+
+type Props = AbstractProps & {
+
+    /**
+     * Style of the component passed as props.
+     */
+    style: ?StyleType
+};
+
+/**
+ * React {@code Component} responsible for displaying a label that indicates
+ * the displayed video state of the current conference.
+ *
+ * NOTE: Due to the lack of actual video quality information on mobile side,
+ * this component currently only displays audio only indicator, but the naming
+ * is kept consistent with web and in the future we may introduce the required
+ * api and extend this component with actual quality indication.
+ */
+class VideoQualityLabel extends AbstractVideoQualityLabel<Props> {
+
+    /**
+     * Implements React {@link Component}'s render.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const { _audioOnly, style, t } = this.props;
+
+        if (!_audioOnly) {
+            // We don't have info about the quality so no need for the indicator
+            return null;
+        }
+
+        return (
+            <CircularLabel
+                label = { t('videoStatus.audioOnly') }
+                style = {
+                    combineStyles(styles.indicatorAudioOnly, style)
+                } />
+        );
+    }
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code VideoQualityLabel}'s props.
+ *
+ * NOTE: This component has no props other than the abstract ones but keeping
+ * the coding style the same for consistency reasons.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {{
+ * }}
+ */
+function _mapStateToProps(state: Object) {
+    return {
+        ..._abstractMapStateToProps(state)
+    };
+}
+
+export default translate(connect(_mapStateToProps)(VideoQualityLabel));

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -1,6 +1,7 @@
+// @flow
+
 import Tooltip from '@atlaskit/tooltip';
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
@@ -8,15 +9,38 @@ import { CircularLabel } from '../../base/label';
 import { MEDIA_TYPE } from '../../base/media';
 import { getTrackByMediaTypeAndParticipant } from '../../base/tracks';
 
+import AbstractVideoQualityLabel, {
+    _abstractMapStateToProps,
+    type Props as AbstractProps
+} from './AbstractVideoQualityLabel';
+
+type Props = AbstractProps & {
+
+    /**
+     * The message to show within the label.
+     */
+    _labelKey: string,
+
+    /**
+     * The message to show within the label's tooltip.
+     */
+    _tooltipKey: string,
+
+    /**
+     * The redux representation of the JitsiTrack displayed on large video.
+     */
+    _videoTrack: Object
+};
+
 /**
  * A map of video resolution (number) to translation key.
  *
  * @type {Object}
  */
 const RESOLUTION_TO_TRANSLATION_KEY = {
-    720: 'videoStatus.hd',
-    360: 'videoStatus.sd',
-    180: 'videoStatus.ld'
+    '720': 'videoStatus.hd',
+    '360': 'videoStatus.sd',
+    '180': 'videoStatus.ld'
 };
 
 /**
@@ -37,38 +61,7 @@ const RESOLUTIONS
  * will display if not in audio only mode and a high-definition large video is
  * being displayed.
  */
-export class VideoQualityLabel extends Component {
-    /**
-     * {@code VideoQualityLabel}'s property types.
-     *
-     * @static
-     */
-    static propTypes = {
-        /**
-         * Whether or not the conference is in audio only mode.
-         */
-        _audioOnly: PropTypes.bool,
-
-        /**
-         * The message to show within the label.
-         */
-        _labelKey: PropTypes.string,
-
-        /**
-         * The message to show within the label's tooltip.
-         */
-        _tooltipKey: PropTypes.string,
-
-        /**
-         * The redux representation of the JitsiTrack displayed on large video.
-         */
-        _videoTrack: PropTypes.object,
-
-        /**
-         * Invoked to obtain translated strings.
-         */
-        t: PropTypes.func
-    };
+export class VideoQualityLabel extends AbstractVideoQualityLabel<Props> {
 
     /**
      * Implements React's {@link Component#render()}.
@@ -157,7 +150,6 @@ function _mapResolutionToTranslationsKeys(resolution) {
  * @param {Object} state - The Redux state.
  * @private
  * @returns {{
- *     _audioOnly: boolean,
  *     _labelKey: string,
  *     _tooltipKey: string,
  *     _videoTrack: Object
@@ -176,7 +168,7 @@ function _mapStateToProps(state) {
         = audioOnly ? {} : _mapResolutionToTranslationsKeys(resolution);
 
     return {
-        _audioOnly: audioOnly,
+        ..._abstractMapStateToProps(state),
         _labelKey: translationKeys.labelKey,
         _tooltipKey: translationKeys.tooltipKey,
         _videoTrack: videoTrackOnLargeVideo

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -109,9 +109,8 @@ export class VideoQualityLabel extends Component {
                 position = { 'left' }>
                 <CircularLabel
                     className = { className }
-                    id = 'videoResolutionLabel'>
-                    { labelContent }
-                </CircularLabel>
+                    id = 'videoResolutionLabel'
+                    label = { labelContent } />
             </Tooltip>
         );
     }

--- a/react/features/video-quality/components/styles.js
+++ b/react/features/video-quality/components/styles.js
@@ -1,0 +1,16 @@
+// @flow
+
+import { ColorPalette, createStyleSheet } from '../../base/styles';
+
+/**
+ * The styles of the React {@code Components} of the feature video-quality.
+ */
+export default createStyleSheet({
+
+    /**
+     * Style for the audio-only indicator.
+     */
+    indicatorAudioOnly: {
+        backgroundColor: ColorPalette.green
+    }
+});


### PR DESCRIPTION
Initial commit covering:
- Generic implementation of CircularLabel that web uses, reusing as much code as possible
- Audio only indicator following web's way of indicators

Please note, further status indicators to come in this PR, hence the general title