### PR TITLE
[RN] Fix processing outdated loadConfig requests

### DIFF
--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type { Dispatch } from 'redux';
+
 import { setRoom } from '../base/conference';
 import {
     configWillLoad,
@@ -71,9 +73,17 @@ function _appNavigateToMandatoryLocation(
      * @returns {void}
      */
     function loadConfigSettled(error, config) {
-        // FIXME Due to the asynchronous nature of the loading, the specified
+        // Due to the asynchronous nature of the loading, the specified
         // config may or may not be required by the time the notification
-        // arrives.
+        // arrives. If we receive the config for a location we are no longer
+        // interested in, just dump it.
+
+        const { locationURL: currentLocationURL }
+            = getState()['features/base/config'];
+
+        if (currentLocationURL !== newLocation) {
+            throw new Error('Config no longer needed');
+        }
 
         const promise
             = dispatch(setLocationURL(new URL(newLocation.toString())));

--- a/react/features/base/config/actionTypes.js
+++ b/react/features/base/config/actionTypes.js
@@ -1,22 +1,22 @@
 /**
- * The redux action which signals that a configuration will be loaded for a
- * specific locationURL.
+ * The redux action which signals that a configuration (commonly known in Jitsi
+ * Meet as config.js) will be loaded for a specific locationURL.
  *
  * {
  *     type: CONFIG_WILL_LOAD,
- *     locationURL: string | URL
+ *     locationURL: URL
  * }
  */
 export const CONFIG_WILL_LOAD = Symbol('CONFIG_WILL_LOAD');
 
 /**
- * The redux action which signals that a configuration could not be loaded due
- * to a specific error.
+ * The redux action which signals that a configuration (commonly known in Jitsi
+ * Meet as config.js) could not be loaded due to a specific error.
  *
  * {
  *     type: LOAD_CONFIG_ERROR,
  *     error: Error,
- *     locationURL: string | URL
+ *     locationURL: URL
  * }
  */
 export const LOAD_CONFIG_ERROR = Symbol('LOAD_CONFIG_ERROR');

--- a/react/features/base/config/actions.js
+++ b/react/features/base/config/actions.js
@@ -5,25 +5,22 @@ import type { Dispatch } from 'redux';
 import { addKnownDomains } from '../known-domains';
 import { parseURIString } from '../util';
 
-import {
-    CONFIG_WILL_LOAD,
-    LOAD_CONFIG_ERROR,
-    SET_CONFIG
-} from './actionTypes';
+import { CONFIG_WILL_LOAD, LOAD_CONFIG_ERROR, SET_CONFIG } from './actionTypes';
 import { _CONFIG_STORE_PREFIX } from './constants';
 import { setConfigFromURLParams } from './functions';
 
 /**
- * Signals that the configuration for a specific locationURL will be loaded now.
+ * Signals that the configuration (commonly known in Jitsi Meet as config.js)
+ * for a specific locationURL will be loaded now.
  *
- * @param {string|URL} locationURL - The URL of the location which necessitated
- * the loading of a configuration.
+ * @param {URL} locationURL - The URL of the location which necessitated the
+ * loading of a configuration.
  * @returns {{
  *     type: CONFIG_WILL_LOAD,
- *     locationURL
+ *     locationURL: URL
  * }}
  */
-export function configWillLoad(locationURL: string | URL) {
+export function configWillLoad(locationURL: URL) {
     return {
         type: CONFIG_WILL_LOAD,
         locationURL
@@ -31,19 +28,20 @@ export function configWillLoad(locationURL: string | URL) {
 }
 
 /**
- * Signals that a configuration could not be loaded due to a specific error.
+ * Signals that a configuration (commonly known in Jitsi Meet as config.js)
+ * could not be loaded due to a specific error.
  *
  * @param {Error} error - The {@code Error} which prevented the successful
  * loading of a configuration.
- * @param {string|URL} locationURL - The URL of the location which necessitated
- * the loading of a configuration.
+ * @param {URL} locationURL - The URL of the location which necessitated the
+ * loading of a configuration.
  * @returns {{
  *     type: LOAD_CONFIG_ERROR,
  *     error: Error,
- *     locationURL
+ *     locationURL: URL
  * }}
  */
-export function loadConfigError(error: Error, locationURL: string | URL) {
+export function loadConfigError(error: Error, locationURL: URL) {
     return {
         type: LOAD_CONFIG_ERROR,
         error,

--- a/react/features/base/config/reducer.js
+++ b/react/features/base/config/reducer.js
@@ -1,14 +1,10 @@
-/* @flow */
+// @flow
 
 import _ from 'lodash';
 
 import { equals, ReducerRegistry, set } from '../redux';
 
-import {
-    CONFIG_WILL_LOAD,
-    LOAD_CONFIG_ERROR,
-    SET_CONFIG
-} from './actionTypes';
+import { CONFIG_WILL_LOAD, LOAD_CONFIG_ERROR, SET_CONFIG } from './actionTypes';
 
 /**
  * The initial state of the feature base/config when executing in a
@@ -54,20 +50,41 @@ ReducerRegistry.register(
         case CONFIG_WILL_LOAD:
             return {
                 error: undefined,
+
+                /**
+                 * The URL of the location associated with/configured by this
+                 * configuration.
+                 *
+                 * @type URL
+                 */
                 locationURL: action.locationURL
             };
 
         case LOAD_CONFIG_ERROR:
-            return {
-                error: action.error
-            };
+            // XXX LOAD_CONFIG_ERROR is one of the settlement execution paths of
+            // the asynchronous "loadConfig procedure/process" started with
+            // CONFIG_WILL_LOAD. Due to the asynchronous nature of it, whoever
+            // is settling the process needs to provide proof that they have
+            // started it and that the iteration of the process being completed
+            // now is still of interest to the app.
+            if (state.locationURL === action.locationURL) {
+                return {
+                    /**
+                     * The {@link Error} which prevented the loading of the
+                     * configuration of the associated {@code locationURL}.
+                     *
+                     * @type Error
+                     */
+                    error: action.error
+                };
+            }
+            break;
 
         case SET_CONFIG:
             return _setConfig(state, action);
-
-        default:
-            return state;
         }
+
+        return state;
     });
 
 /**

--- a/react/features/base/config/reducer.js
+++ b/react/features/base/config/reducer.js
@@ -53,7 +53,8 @@ ReducerRegistry.register(
         switch (action.type) {
         case CONFIG_WILL_LOAD:
             return {
-                error: undefined
+                error: undefined,
+                locationURL: action.locationURL
             };
 
         case LOAD_CONFIG_ERROR:

--- a/react/features/mobile/external-api/middleware.js
+++ b/react/features/mobile/external-api/middleware.js
@@ -28,8 +28,9 @@ import { ENTER_PICTURE_IN_PICTURE } from '../picture-in-picture';
  */
 MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
+    const { type } = action;
 
-    switch (action.type) {
+    switch (type) {
     case CONFERENCE_FAILED: {
         const { error, ...data } = action;
 
@@ -64,16 +65,19 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case ENTER_PICTURE_IN_PICTURE:
-        _sendEvent(store, _getSymbolDescription(action.type), /* data */ {});
+        _sendEvent(store, _getSymbolDescription(type), /* data */ {});
         break;
 
     case LOAD_CONFIG_ERROR: {
-        const { error, locationURL, type } = action;
+        const { error, locationURL } = action;
 
-        _sendEvent(store, _getSymbolDescription(type), /* data */ {
-            error: _toErrorString(error),
-            url: toURLString(locationURL)
-        });
+        _sendEvent(
+            store,
+            _getSymbolDescription(type),
+            /* data */ {
+                error: _toErrorString(error),
+                url: toURLString(locationURL)
+            });
         break;
     }
 


### PR DESCRIPTION
This fix is based on storing the location URL object we are loading the
configuration for in the redux store. Once the config has been loaded (or it has
failed, for that matter!) we'll check if the current "config URL" is the same we
set, and discard the old one if they don't match.