### PR TITLE
Callkit use displayName from config

### DIFF
--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -28,7 +28,37 @@ const WHITELISTED_KEYS = [
     'callStatsConfIDNamespace',
     'callStatsID',
     'callStatsSecret',
+
+    /**
+     * The display name of the CallKit call representing the conference/meeting
+     * associated with this config.js including while the call is ongoing in the
+     * UI presented by CallKit and in the system-wide call history. The property
+     * is meant for use cases in which the room name is not desirable as a
+     * display name for CallKit purposes and the desired display name is not
+     * provided in the form of a JWT callee. As the value is associated with a
+     * conference/meeting, the value makes sense not as a deployment-wide
+     * configuration, only as a runtime configuration override/overwrite
+     * provided by, for example, Jitsi Meet SDK for iOS.
+     *
+     * @type string
+     */
+    'callDisplayName',
+
+    /**
+     * The UUID of the CallKit call representing the conference/meeting
+     * associated with this config.js. The property is meant for use cases in
+     * which Jitsi Meet is to work with a CallKit call created outside of Jitsi
+     * Meet and to be adopted by Jitsi Meet such as, for example, an incoming
+     * and/or outgoing CallKit call created by Jitsi Meet SDK for iOS
+     * clients/consumers prior to giving control to Jitsi Meet. As the value is
+     * associated with a conference/meeting, the value makes sense not as a
+     * deployment-wide configuration, only as a runtime configuration
+     * override/overwrite provided by, for example, Jitsi Meet SDK for iOS.
+     *
+     * @type string
+     */
     'callUUID',
+
     'channelLastN',
     'constraints',
     'debug',

--- a/react/features/base/media/components/native/VideoTransform.js
+++ b/react/features/base/media/components/native/VideoTransform.js
@@ -704,7 +704,6 @@ function _mapDispatchToProps(dispatch) {
  * Maps (parts of) the redux state to the component's props.
  *
  * @param {Object} state - The redux state.
- * @param {Object} ownProps - The component's own props.
  * @private
  * @returns {{
  *     _transforms: Object

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -237,15 +237,18 @@ function _conferenceWillJoin({ getState }, next, action) {
 
     CallKit.startCall(conference.callUUID, url.toString(), hasVideo)
         .then(() => {
-            const { room } = state['features/base/conference'];
             const { callee } = state['features/base/jwt'];
-            const tracks = state['features/base/tracks'];
-            const muted = isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO);
+            const displayName
+                 = state['features/base/config'].callDisplayName
+                     || (callee && callee.name)
+                     || state['features/base/conference'].room;
 
-            CallKit.updateCall(
-                conference.callUUID,
-                { displayName: (callee && callee.name) || room });
+            const muted
+                = isLocalTrackMuted(
+                    state['features/base/tracks'],
+                    MEDIA_TYPE.AUDIO);
 
+            CallKit.updateCall(conference.callUUID, { displayName });
             CallKit.setMuted(conference.callUUID, muted);
         });
 


### PR DESCRIPTION
Add ability to provide a display name in the configOverwrite object, that when available, it will be used to customize the name of the meeting in callkit screen and recent call list.