### PR TITLE
ref(base/conference): clear the 'conference' field on WILL_LEAVE

### DIFF
--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -271,6 +271,7 @@ function _conferenceWillLeave(state, { conference }) {
 
     return assign(state, {
         authRequired: undefined,
+        conference: undefined,
         joining: undefined,
 
         /**


### PR DESCRIPTION
The conference state field is referring to the current conference in progress, so it feels like this field should be cleared as soon as we declare that the conference is being left and the asynchronous process of leaving the conference starts (which happens on CONFERENCE_WILL_LEAVE).

The issues targeted by this PR are duplicated thumbnails caused participants not being cleared when rejoining the same conference, before the old one is gracefully left. It's supposed to be fixed by this middleware [1] (I guess), but it is not because there's no conference state change until the 'conference' field is cleared or changed.

1: https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/participants/middleware.js#L145