### PR TITLE
fix(AudioMuteButton): ensure track on unmute

### DIFF
--- a/react/features/toolbox/components/AudioMuteButton.js
+++ b/react/features/toolbox/components/AudioMuteButton.js
@@ -121,7 +121,7 @@ class AudioMuteButton extends AbstractAudioMuteButton<Props, *> {
      */
     _setAudioMuted(audioMuted: boolean) {
         sendAnalytics(createToolbarEvent(AUDIO_MUTE, { enable: audioMuted }));
-        this.props.dispatch(setAudioMuted(audioMuted));
+        this.props.dispatch(setAudioMuted(audioMuted, /* ensureTrack */ true));
 
         // FIXME: The old conference logic as well as the shared video feature
         // still rely on this event being emitted.


### PR DESCRIPTION
If "startWithAudioMuted" option is used we need to make sure that new local audio track will be created on unmute.