### PR TITLE
ref(base/conference): simplify code

### DIFF
--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -341,6 +341,20 @@ function _setPassword(state, { conference, method, password }) {
     case conference.join:
         if (state.passwordRequired === conference) {
             return assign(state, {
+                // XXX 1. The JitsiConference which transitions away from
+                // passwordRequired MUST remain in the redux state
+                // features/base/conference until it transitions into
+                // conference; otherwise, there is a span of time during which
+                // the redux state does not even know that there is a
+                // JitsiConference whatsoever.
+                //
+                // 2. The redux action setPassword will attempt to join the
+                // JitsiConference so joining is an appropriate transitional
+                // redux state.
+                //
+                // 3. The redux action setPassword will perform the same check
+                // before it proceeds with the re-join.
+                joining: state.conference ? state.joining : conference,
                 locked: LOCKED_REMOTELY,
 
                 /**


### PR DESCRIPTION
Simplify parts of the logic introduced in
11b7144ad004118a3fa8904458733b3c6c317448.

Specificaly, using all the state change avoiding functions doesn't give us much
since we need to copy the state for sure.