### PR TITLE
[RN] Turn off filmstrip videos that get scrolled out

### DIFF
--- a/react/features/base/participants/components/ParticipantView.native.js
+++ b/react/features/base/participants/components/ParticipantView.native.js
@@ -217,13 +217,15 @@ class ParticipantView extends Component<Props> {
                     === JitsiParticipantConnectionStatus.ACTIVE)
                 && shouldRenderVideoTrack(videoTrack, waitForVideoStarted);
 
-        // Is the avatar to be rendered?
-        let renderAvatar = Boolean(!renderVideo && avatar);
-
         // The consumer of this ParticipantView is allowed to forbid showing the
         // video if the private logic of this ParticipantView determines that
         // the video could be rendered.
         renderVideo = renderVideo && _toBoolean(this.props.showVideo, true);
+
+        // Is the avatar to be rendered?
+        // NOTE: This check was before the previous assignment in the past, but
+        // now we need to take the final renderVideo value into account.
+        let renderAvatar = Boolean(!renderVideo && avatar);
 
         // The consumer of this ParticipantView is allowed to forbid showing the
         // avatar if the private logic of this ParticipantView determines that

--- a/react/features/base/react/components/native/Container.js
+++ b/react/features/base/react/components/native/Container.js
@@ -33,6 +33,7 @@ export default class Container extends AbstractContainer {
             accessibilityLabel,
             accessible,
             onClick,
+            onLayout,
             touchFeedback = onClick,
             visible = true,
             ...props
@@ -44,12 +45,14 @@ export default class Container extends AbstractContainer {
         }
 
         const onClickOrTouchFeedback = onClick || touchFeedback;
+
         let element
             = super._render(
                 View,
                 {
                     pointerEvents: onClickOrTouchFeedback ? 'auto' : 'box-none',
-                    ...props
+                    ...props,
+                    onLayout: onClickOrTouchFeedback ? undefined : onLayout
                 });
 
         // onClick & touchFeedback
@@ -62,6 +65,7 @@ export default class Container extends AbstractContainer {
                     {
                         accessibilityLabel,
                         accessible,
+                        onLayout,
                         onPress: onClick
                     },
                     element);

--- a/react/features/filmstrip/components/native/Filmstrip.js
+++ b/react/features/filmstrip/components/native/Filmstrip.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { ScrollView } from 'react-native';
 import { connect } from 'react-redux';
 
-import { Container, Platform } from '../../../base/react';
+import { Container } from '../../../base/react';
 import {
     isNarrowAspectRatio,
     makeAspectRatioAware
@@ -13,6 +13,13 @@ import {
 import LocalThumbnail from './LocalThumbnail';
 import styles from './styles';
 import Thumbnail from './Thumbnail';
+
+/**
+ * A threshold that tells the app how much the video may go out of the
+ * ScrollView before it gets hidden. This should be increased if the Filmstrip
+ * disables videos too agressively.
+ */
+const VIDEO_DISABLE_FLEXIBILITY = 2;
 
 /**
  * Filmstrip component's property types.
@@ -41,18 +48,48 @@ type Props = {
     _visible: boolean
 };
 
+type State = {
+
+    /**
+     * An Object that stores the visibility of every thumbnails. True if hidden
+     * (not fully visible inside the ScrollView) and false or undefined
+     * otherwise. We default to false (hence the name) to avoid an initializer
+     * call on mount/render.
+     */
+    hiddenThumbnails: Object
+};
+
 /**
  * Implements a React {@link Component} which represents the filmstrip on
  * mobile/React Native.
  *
+ * NOTE: This new implementation automagically hides those Thumbnails that get
+ * out of the area of the {@code ScrollView}. This has two purposes:
+ *   - Performance improvement
+ *   - Avoids a limitation of Android's EGL implementation aroung GL layers.
+ *
  * @extends Component
  */
-class Filmstrip extends Component<Props> {
+class Filmstrip extends Component<Props, State> {
     /**
-     * Whether the local participant should be rendered separately from the
-     * remote participants i.e. outside of their {@link ScrollView}.
+     * The current scroll (offset) value of the {@code ScrollView}.
      */
-    _separateLocalThumbnail: boolean;
+    currentScroll: number;
+
+    /**
+     * The layout of the {@code ScrollView}.
+     */
+    scrollViewLayout: {
+        height: number,
+        width: number,
+        x: number,
+        y: number
+    };
+
+    /**
+     * Layouts of each rendered remote {@code Thumbnail}s.
+     */
+    thumbnailLayouts: Object;
 
     /**
      * Constructor of the component.
@@ -62,24 +99,16 @@ class Filmstrip extends Component<Props> {
     constructor(props) {
         super(props);
 
-        // XXX Our current design is to have the local participant separate from
-        // the remote participants. Unfortunately, Android's Video
-        // implementation cannot accommodate that because remote participants'
-        // videos appear on top of the local participant's video at times.
-        // That's because Android's Video utilizes EGL and EGL gives us only two
-        // practical layers in which we can place our participants' videos:
-        // layer #0 sits behind the window, creates a hole in the window, and
-        // there we render the LargeVideo; layer #1 is known as media overlay in
-        // EGL terms, renders on top of layer #0, and, consequently, is for the
-        // Filmstrip. With the separate LocalThumnail, we should have left the
-        // remote participants' Thumbnails in layer #1 and utilized layer #2 for
-        // LocalThumbnail. Unfortunately, layer #2 is not practical (that's why
-        // I said we had two practical layers only) because it renders on top of
-        // everything which in our case means on top of participant-related
-        // indicators such as moderator, audio and video muted, etc. For now we
-        // do not have much of a choice but to continue rendering LocalThumbnail
-        // as any other remote Thumbnail on Android.
-        this._separateLocalThumbnail = Platform.OS !== 'android';
+        this.currentScroll = 0;
+        this.thumbnailLayouts = {};
+
+        this.state = {
+            hiddenThumbnails: {}
+        };
+
+        this._onScroll = this._onScroll.bind(this);
+        this._onScrollViewLayout = this._onScrollViewLayout.bind(this);
+        this._onThumbnailLayout = this._onThumbnailLayout.bind(this);
     }
 
     /**
@@ -98,26 +127,23 @@ class Filmstrip extends Component<Props> {
             = isNarrowAspectRatio_
                 ? styles.filmstripNarrow
                 : styles.filmstripWide;
+        const { hiddenThumbnails } = this.state;
 
         return (
             <Container
                 style = { filmstripStyle }
                 visible = { this.props._visible }>
                 {
-                    this._separateLocalThumbnail
-                        && !isNarrowAspectRatio_
-                        && <LocalThumbnail />
+                    !isNarrowAspectRatio_ && <LocalThumbnail />
                 }
                 <ScrollView
                     horizontal = { isNarrowAspectRatio_ }
+                    onLayout = { this._onScrollViewLayout }
+                    onScroll = { this._onScroll }
+                    scrollEventThrottle = { 200 }
                     showsHorizontalScrollIndicator = { false }
                     showsVerticalScrollIndicator = { false }
                     style = { styles.scrollView } >
-                    {
-                        !this._separateLocalThumbnail
-                            && !isNarrowAspectRatio_
-                            && <LocalThumbnail />
-                    }
                     {
                         /* eslint-disable react/jsx-wrap-multilines */
 
@@ -126,24 +152,160 @@ class Filmstrip extends Component<Props> {
                                 isNarrowAspectRatio_)
                             .map(p =>
                                 <Thumbnail
+                                    hideVideo = {
+                                        Boolean(hiddenThumbnails[p.id])
+                                    }
                                     key = { p.id }
+                                    onLayout = { this._onThumbnailLayout(p.id) }
                                     participant = { p } />)
 
                         /* eslint-enable react/jsx-wrap-multilines */
                     }
-                    {
-                        !this._separateLocalThumbnail
-                            && isNarrowAspectRatio_
-                            && <LocalThumbnail />
-                    }
                 </ScrollView>
                 {
-                    this._separateLocalThumbnail
-                        && isNarrowAspectRatio_
-                        && <LocalThumbnail />
+                    isNarrowAspectRatio_ && <LocalThumbnail />
                 }
             </Container>
         );
+    }
+
+    _onScroll: ?Object => void
+
+    /**
+     * Callback for the {@code ScrollView}'s onScroll event.
+     *
+     * NOTE:
+     * - This function calculates the position of the thumbnails and
+     * updates their hideVideo prop to disable rendering a thumbnail if it goes
+     * out of the ScrollView, even partially. Partially: because otherwise we
+     * don't get around the EGL bug.
+     * - When boundaries are calculated, {@code begin} always means the position
+     * of the side of the {@code Thumbnail} that is closer to the scroll origin
+     * of the {@code ScrollView}, and {@code end} is the opposite. E.g. if the
+     * {@code ScrollView} is horizontal, then {@code begin} is the leftmost
+     * edge, {@code end} is the rightmost. When the {@code ScrollView} is
+     * vertical, {@code begin} is the topmost edge, {@code end} is the bottom of
+     * the component.
+     *
+     * @private
+     * @param {Object} nativeEvent - The native event.
+     * @returns {void}
+     */
+    _onScroll({ nativeEvent } = {}) {
+        if (!this.scrollViewLayout) {
+            // ScrollView is not laid out yet, we'll come back here later.
+            return;
+        }
+
+        // Retreives the current scroll value of the ScrollView.
+        // If no parameter provided to the function, we use the last used value.
+        // This can happen when we request a re-render in the onLayout callback
+        // of either the ScrollView or the Thumbnail.
+        if (nativeEvent) {
+            this.currentScroll = isNarrowAspectRatio(this)
+                ? nativeEvent.contentOffset.x
+                : nativeEvent.contentOffset.y;
+        }
+        const { hiddenThumbnails } = this.state;
+        const newHiddenThumbnails = {
+            ...hiddenThumbnails
+        };
+        const _isNarrowAspectRatio = isNarrowAspectRatio(this);
+        const participants
+            = this._sort(this.props._participants, _isNarrowAspectRatio);
+
+        // This is the boundary we use to decide if the video of a thumbnail is
+        // to be rendered or not.
+        const scrollViewBoundaries = {
+            begin: 0 - VIDEO_DISABLE_FLEXIBILITY,
+            end:
+                (_isNarrowAspectRatio
+                    ? this.scrollViewLayout.width
+                    : this.scrollViewLayout.height)
+                + VIDEO_DISABLE_FLEXIBILITY
+        };
+        let needsUpdate = false;
+
+        for (const participant of participants) {
+            const layout = this.thumbnailLayouts[participant.id];
+
+            if (!layout) {
+                // There is at least one Thumbnail that is not rendered yet,
+                // so no need to update as we'll re-run this method when all is
+                // done.
+                return;
+            }
+
+            // Boundaries of a thumbnail, corrected with the scroll value of the
+            // ScrollView.
+            const participantBoundaries = {
+                begin:
+                    (_isNarrowAspectRatio
+                        ? layout.x
+                        : layout.y)
+                    - this.currentScroll,
+                end:
+                    (_isNarrowAspectRatio
+                        ? layout.x + layout.width
+                        : layout.y + layout.height)
+                    - this.currentScroll
+            };
+
+            const oldParticipantHidden = hiddenThumbnails[participant.id];
+            const participantHidden
+                = participantBoundaries.begin < scrollViewBoundaries.begin
+                || participantBoundaries.end > scrollViewBoundaries.end;
+
+            // NOTE: oldParticipantHidden may be undefined, that is considered
+            // false here
+            if ((participantHidden && !oldParticipantHidden)
+                || (!participantHidden && oldParticipantHidden)) {
+                newHiddenThumbnails[participant.id] = participantHidden;
+                needsUpdate = true;
+            }
+        }
+
+        // Check if there were any changes, so then we need to update the state.
+        // Otherwise we don't to avoid unnecessary re-renders.
+        if (needsUpdate) {
+            this.setState({
+                hiddenThumbnails: newHiddenThumbnails
+            });
+        }
+    }
+
+    _onScrollViewLayout: Object => void
+
+    /**
+     * Callback to handle the onLayout event of the {@code ScrollView}.
+     *
+     * @private
+     * @param {Object} layout - The layout data.
+     * @returns {void}
+     */
+    _onScrollViewLayout({ nativeEvent: { layout } }) {
+        this.scrollViewLayout = layout;
+
+        // ScrollView goes back to 0 scroll on re-layout
+        // (e.g. orientation change)
+        this.currentScroll = 0;
+        this._onScroll();
+    }
+
+    _onThumbnailLayout: string => Function
+
+    /**
+     * Callback to handle the onLayout event of the {@code Thumbnail}s.
+     *
+     * @private
+     * @param {string} participantId - The ID of the rendered participant.
+     * @returns {Function}
+     */
+    _onThumbnailLayout(participantId) {
+        return ({ nativeEvent: { layout } }) => {
+            this.thumbnailLayouts[participantId] = layout;
+            this._onScroll();
+        };
     }
 
     /**

--- a/react/features/filmstrip/components/native/LocalThumbnail.js
+++ b/react/features/filmstrip/components/native/LocalThumbnail.js
@@ -32,7 +32,9 @@ class LocalThumbnail extends Component<Props> {
 
         return (
             <View style = { styles.localThumbnail }>
-                <Thumbnail participant = { _localParticipant } />
+                <Thumbnail
+                    participant = { _localParticipant }
+                    showVideo = { true } />
             </View>
         );
     }

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -34,6 +34,17 @@ class Thumbnail extends Component {
         _largeVideo: PropTypes.object,
         _videoTrack: PropTypes.object,
         dispatch: PropTypes.func,
+
+        /**
+         * If true, we need to render the avatar instead of the video,
+         * overriding other considerations.
+         */
+        hideVideo: PropTypes.boolean,
+
+        /**
+         * Callback for the onLayout event of the {@code Container}
+         */
+        onLayout: PropTypes.func,
         participant: PropTypes.object
     };
 
@@ -56,10 +67,14 @@ class Thumbnail extends Component {
      * @returns {ReactElement}
      */
     render() {
-        const audioTrack = this.props._audioTrack;
-        const largeVideo = this.props._largeVideo;
-        const participant = this.props.participant;
-        const videoTrack = this.props._videoTrack;
+        const {
+            _audioTrack,
+            _largeVideo,
+            _videoTrack,
+            hideVideo,
+            onLayout,
+            participant
+        } = this.props;
 
         let style = styles.thumbnail;
 
@@ -76,28 +91,30 @@ class Thumbnail extends Component {
         //    silence (& not even comfort noise).
         // 2. The audio is local. If we were to render local audio, the local
         //    participants would be hearing themselves.
-        const audioMuted = !audioTrack || audioTrack.muted;
-        const renderAudio = !audioMuted && !audioTrack.local;
+        const audioMuted = !_audioTrack || _audioTrack.muted;
+        const renderAudio = !audioMuted && !_audioTrack.local;
         const participantId = participant.id;
         const participantNotInLargeVideo
-            = participantId !== largeVideo.participantId;
-        const videoMuted = !videoTrack || videoTrack.muted;
+            = participantId !== _largeVideo.participantId;
+        const videoMuted = !_videoTrack || _videoTrack.muted;
 
         return (
             <Container
                 onClick = { this._onClick }
+                onLayout = { onLayout }
                 style = { style }>
 
                 { renderAudio
                     && <Audio
-                        stream
-                            = { audioTrack.jitsiTrack.getOriginalStream() } /> }
+                        stream = {
+                            _audioTrack.jitsiTrack.getOriginalStream()
+                        } /> }
 
                 <ParticipantView
                     avatarSize = { AVATAR_SIZE }
                     participantId = { participantId }
-                    showAvatar = { participantNotInLargeVideo }
-                    showVideo = { participantNotInLargeVideo }
+                    showAvatar = { hideVideo || participantNotInLargeVideo }
+                    showVideo = { !hideVideo && participantNotInLargeVideo }
                     zOrder = { 1 } />
 
                 { participant.role === PARTICIPANT_ROLE.MODERATOR


### PR DESCRIPTION
With this PR we stop rendering videos that are scrolled out of the filmstrip.

This is supposed to achieve improvement in two ways:
- Fixes the issue when the thumbnails scroll over the separated local participant
- Intended to bring a slight performance improvement by avoiding rendering unnecessary thumbnails.

Note: This is a bit strict (can be adjusted though) as it stops rendering a video even if it slightly goes out of the scroll view, but this is necessary if we want to fix the separated local video issue this way. 

Other than this we may only do some EGL magic.