### PR TITLE
[iOS] Fix JitsiMeet SDK  to be able to compile with iOS 9.3

### DIFF
--- a/ios/sdk/src/callkit/JMCallKitEmitter.swift
+++ b/ios/sdk/src/callkit/JMCallKitEmitter.swift
@@ -18,6 +18,7 @@ import AVKit
 import CallKit
 import Foundation
 
+@available(iOS 10.0, *)
 internal final class JMCallKitEmitter: NSObject, CXProviderDelegate {
 
     private var listeners = Set<JMCallKitEventListenerWrapper>()
@@ -130,6 +131,7 @@ internal final class JMCallKitEmitter: NSObject, CXProviderDelegate {
     }
 }
 
+@available(iOS 10.0, *)
 fileprivate struct JMCallKitEventListenerWrapper: Hashable {
 
     public var hashValue: Int

--- a/ios/sdk/src/callkit/JMCallKitListener.swift
+++ b/ios/sdk/src/callkit/JMCallKitListener.swift
@@ -18,6 +18,7 @@ import AVKit
 import CallKit
 import Foundation
 
+@available(iOS 10.0, *)
 @objc public protocol JMCallKitListener: NSObjectProtocol {
 
     @available(iOS 10.0, *)


### PR DESCRIPTION
Adding missing framework version checks for CallKit proxy components in the iOS Jitsi Meet SDK. This will enable the SDK to be able to compile with iOS 9.3 as deployment target again.