### PR TITLE
[iOS] Fix issue with Invite RNModule being nil after first time joining call

### DIFF
--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -411,10 +411,9 @@ static NSMapTable<NSString *, JitsiMeetView *> *views;
     externalAPIScope = [NSUUID UUID].UUIDString;
     [views setObject:self forKey:externalAPIScope];
 
-    Invite *inviteModule = [bridgeWrapper.bridge moduleForName:@"Invite"];
     _inviteController
         = [[JMInviteController alloc] initWithExternalAPIScope:externalAPIScope
-                                               andInviteModule:inviteModule];
+                                                 bridgeWrapper:bridgeWrapper];
 
     // Set a background color which is in accord with the JavaScript and Android
     // parts of the application and causes less perceived visual flicker than

--- a/ios/sdk/src/invite/InviteController+Private.h
+++ b/ios/sdk/src/invite/InviteController+Private.h
@@ -18,6 +18,7 @@
 
 #import "AddPeopleController.h"
 #import "Invite+Private.h"
+#import "RCTBridgeWrapper.h"
 
 @interface JMInviteController ()
 
@@ -25,10 +26,12 @@
 
 @property (nonatomic) NSString * _Nonnull externalAPIScope;
 
-@property (nonatomic, nullable, weak) Invite *inviteModule;
+@property (nonatomic, nullable, weak) RCTBridgeWrapper *bridgeWrapper;
+
+@property (nonatomic, readonly) Invite * _Nullable inviteModule;
 
 - (instancetype _Nonnull)initWithExternalAPIScope:(NSString * _Nonnull)externalAPIScope
-                         andInviteModule:(Invite * _Nonnull)inviteModule;
+                                    bridgeWrapper:(RCTBridgeWrapper * _Nullable)bridgeWrapper;
 
 - (void)beginAddPeople;
 

--- a/ios/sdk/src/invite/InviteController.m
+++ b/ios/sdk/src/invite/InviteController.m
@@ -28,17 +28,21 @@
 #pragma mark Constructor
 
 -(instancetype)initWithExternalAPIScope:(NSString * _Nonnull)externalAPIScope
-                        andInviteModule:(Invite * _Nonnull)inviteModule {
+                          bridgeWrapper:(RCTBridgeWrapper * _Nullable)bridgeWrapper {
     self = [super init];
     if (self) {
         self.externalAPIScope = externalAPIScope;
-        self.inviteModule = inviteModule;
+        self.bridgeWrapper = bridgeWrapper;
     }
 
     return self;
 }
 
 #pragma mark Public API
+
+-(Invite * _Nullable)inviteModule {
+    return [self.bridgeWrapper.bridge moduleForName:@"Invite"];
+}
 
 -(void)beginAddPeople {
     if (_delegate == nil) {


### PR DESCRIPTION
The `inviteModule` property is a weak reference and was being cleared after the first time an user joined a call in a JitsiMeetView. This PR fixes this by injecting the RNBridgeWrapper to the `InviteController` and query for the module any time we want access to it instead of passing the module on initialization.