### PR TITLE
[RN] Change default WelcomeScreen tab and persist user choice

### DIFF
--- a/ios/app/src/Info.plist
+++ b/ios/app/src/Info.plist
@@ -56,13 +56,13 @@
 		</dict>
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
-	<string>See your scheduled conferences in the app.</string>
+	<string>See your scheduled meetings in the app.</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Participate in conferences with video.</string>
+	<string>Participate in meetings with video.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Participate in conferences with voice.</string>
+	<string>Participate in meetings with voice.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/lang/main.json
+++ b/lang/main.json
@@ -608,7 +608,7 @@
         "now": "Now",
         "ongoingMeeting": "ongoing meeting",
         "permissionButton": "Open settings",
-        "permissionMessage": "Calendar permission is required to list your meetings in the app."
+        "permissionMessage": "The Calendar permission is required to see your meetings in the app."
     },
     "recentList": {
         "today": "Today",

--- a/react/features/base/react/components/native/PagedList.android.js
+++ b/react/features/base/react/components/native/PagedList.android.js
@@ -87,18 +87,6 @@ class PagedList extends AbstractPagedList {
     }
 
     /**
-     * Platform specific actions to run on page select.
-     *
-     * @private
-     * @param {number} pageIndex - The selected page index.
-     * @returns {void}
-     */
-    _platformSpecificPageSelect(pageIndex) {
-        this._viewPager.setPage(pageIndex);
-        this._selectPage(pageIndex);
-    }
-
-    /**
      * Renders a single page of the page list.
      *
      * @private

--- a/react/features/calendar-sync/actions.js
+++ b/react/features/calendar-sync/actions.js
@@ -1,9 +1,9 @@
 // @flow
 
 import {
+    REFRESH_CALENDAR,
     SET_CALENDAR_AUTHORIZATION,
-    SET_CALENDAR_EVENTS,
-    REFRESH_CALENDAR
+    SET_CALENDAR_EVENTS
 } from './actionTypes';
 
 /**

--- a/react/features/calendar-sync/components/MeetingList.native.js
+++ b/react/features/calendar-sync/components/MeetingList.native.js
@@ -96,14 +96,21 @@ class MeetingList extends Component<Props> {
      * @inheritdoc
      */
     render() {
-        const { disabled } = this.props;
+        const { _authorization, disabled } = this.props;
 
         return (
             <NavigateSectionList
                 disabled = { disabled }
                 onPress = { this._onPress }
                 onRefresh = { this._onRefresh }
-                renderListEmptyComponent = { this._getRenderListEmptyComponent }
+
+                // If we don't provide a list specific renderListEmptyComponent,
+                // then the default empty component of the NavigateSectionList
+                // will be rendered, which (atm) is a simple "Pull to refresh"
+                // message.
+                renderListEmptyComponent
+                    = { _authorization === 'denied'
+                        ? this._getRenderListEmptyComponent() : undefined }
                 sections = { this._toDisplayableList() } />
         );
     }
@@ -115,29 +122,25 @@ class MeetingList extends Component<Props> {
      * of the default one in the {@link NavigateSectionList}.
      *
      * @private
-     * @returns {Component}
+     * @returns {Function}
      */
     _getRenderListEmptyComponent() {
-        const { _authorization, t } = this.props;
+        const { t } = this.props;
 
-        if (_authorization === 'denied') {
-            return (
-                <View style = { styles.noPermissionMessageView }>
-                    <Text style = { styles.noPermissionMessageText }>
-                        { t('calendarSync.permissionMessage') }
+        return (
+            <View style = { styles.noPermissionMessageView }>
+                <Text style = { styles.noPermissionMessageText }>
+                    { t('calendarSync.permissionMessage') }
+                </Text>
+                <TouchableOpacity
+                    onPress = { openSettings }
+                    style = { styles.noPermissionMessageButton } >
+                    <Text style = { styles.noPermissionMessageButtonText }>
+                        { t('calendarSync.permissionButton') }
                     </Text>
-                    <TouchableOpacity
-                        onPress = { openSettings }
-                        style = { styles.noPermissionMessageButton } >
-                        <Text style = { styles.noPermissionMessageButtonText }>
-                            { t('calendarSync.permissionButton') }
-                        </Text>
-                    </TouchableOpacity>
-                </View>
-            );
-        }
-
-        return null;
+                </TouchableOpacity>
+            </View>
+        );
     }
 
     _onPress: string => Function;

--- a/react/features/calendar-sync/components/styles.js
+++ b/react/features/calendar-sync/components/styles.js
@@ -34,7 +34,8 @@ export default createStyleSheet({
      */
     noPermissionMessageText: {
         backgroundColor: 'transparent',
-        color: 'rgba(255, 255, 255, 0.6)'
+        color: 'rgba(255, 255, 255, 0.6)',
+        textAlign: 'center'
     },
 
     /**

--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -43,16 +43,10 @@ CALENDAR_ENABLED
             break;
 
         case SET_CALENDAR_AUTHORIZATION:
-            return {
-                ...state,
-                authorization: action.authorization
-            };
+            return set(state, 'authorization', action.authorization);
 
         case SET_CALENDAR_EVENTS:
-            return {
-                ...state,
-                events: action.events
-            };
+            return set(state, 'events', action.events);
         }
 
         return state;

--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -45,7 +45,7 @@ CALENDAR_ENABLED
         case SET_CALENDAR_AUTHORIZATION:
             return {
                 ...state,
-                authorization: action.status
+                authorization: action.authorization
             };
 
         case SET_CALENDAR_EVENTS:

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -21,7 +21,6 @@ import {
     MEDIA_TYPE,
     SET_AUDIO_MUTED,
     SET_VIDEO_MUTED,
-    VIDEO_MUTISM_AUTHORITY,
     isVideoMutedByAudioOnly,
     setAudioMuted
 } from '../../base/media';
@@ -297,8 +296,7 @@ function _onPerformSetMutedCallAction({ callUUID, muted: newValue }) {
             const value = Boolean(newValue);
 
             sendAnalytics(createTrackMutedEvent('audio', 'callkit', value));
-            dispatch(setAudioMuted(
-                value, VIDEO_MUTISM_AUTHORITY.USER, /* ensureTrack */ true));
+            dispatch(setAudioMuted(value, /* ensureTrack */ true));
         }
     }
 }

--- a/react/features/welcome/actionTypes.js
+++ b/react/features/welcome/actionTypes.js
@@ -12,13 +12,13 @@
 export const SET_SIDEBAR_VISIBLE = Symbol('SET_SIDEBAR_VISIBLE');
 
 /**
- * Action to update the default page index of the {@code WelcomePageLists}
- * component.
+ * The type of (redux) action to set the default page index of
+ * {@link WelcomePageLists}.
  *
  * {
- *     type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
+ *     type: SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE,
  *     pageIndex: number
  * }
  */
-export const SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+export const SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE
     = Symbol('SET_WELCOME_PAGE_LIST_DEFAULT_PAGE');

--- a/react/features/welcome/actionTypes.js
+++ b/react/features/welcome/actionTypes.js
@@ -1,3 +1,5 @@
+// @flow
+
 /**
  * The type of the (redux) action which sets the visibility of
  * {@link WelcomePageSideBar}.
@@ -8,3 +10,15 @@
  * }
  */
 export const SET_SIDEBAR_VISIBLE = Symbol('SET_SIDEBAR_VISIBLE');
+
+/**
+ * Action to update the default page index of the {@code WelcomePageLists}
+ * component.
+ *
+ * {
+ *     type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
+ *     pageIndex: number
+ * }
+ */
+export const SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+    = Symbol('SET_WELCOME_PAGE_LIST_DEFAULT_PAGE');

--- a/react/features/welcome/actions.js
+++ b/react/features/welcome/actions.js
@@ -1,6 +1,26 @@
 // @flow
 
-import { SET_SIDEBAR_VISIBLE } from './actionTypes';
+import {
+    SET_SIDEBAR_VISIBLE,
+    SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+} from './actionTypes';
+
+/**
+ * Action to update the default page index of the {@code WelcomePageLists}
+ * component.
+ *
+ * @param {number} pageIndex - The index of the selected page.
+ * @returns {{
+ *     type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
+ *     pageIndex: number
+ * }}
+ */
+export function setWelcomePageListDefaultPage(pageIndex: number) {
+    return {
+        type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
+        pageIndex
+    };
+}
 
 /**
  * Sets the visibility of {@link WelcomePageSideBar}.

--- a/react/features/welcome/actions.js
+++ b/react/features/welcome/actions.js
@@ -2,25 +2,8 @@
 
 import {
     SET_SIDEBAR_VISIBLE,
-    SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+    SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE
 } from './actionTypes';
-
-/**
- * Action to update the default page index of the {@code WelcomePageLists}
- * component.
- *
- * @param {number} pageIndex - The index of the selected page.
- * @returns {{
- *     type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
- *     pageIndex: number
- * }}
- */
-export function setWelcomePageListDefaultPage(pageIndex: number) {
-    return {
-        type: SET_WELCOME_PAGE_LIST_DEFAULT_PAGE,
-        pageIndex
-    };
-}
 
 /**
  * Sets the visibility of {@link WelcomePageSideBar}.
@@ -36,5 +19,21 @@ export function setSideBarVisible(visible: boolean) {
     return {
         type: SET_SIDEBAR_VISIBLE,
         visible
+    };
+}
+
+/**
+ * Sets the default page index of {@link WelcomePageLists}.
+ *
+ * @param {number} pageIndex - The index of the default page.
+ * @returns {{
+ *     type: SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE,
+ *     pageIndex: number
+ * }}
+ */
+export function setWelcomePageListsDefaultPage(pageIndex: number) {
+    return {
+        type: SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE,
+        pageIndex
     };
 }

--- a/react/features/welcome/components/WelcomePageLists.js
+++ b/react/features/welcome/components/WelcomePageLists.js
@@ -9,8 +9,11 @@ import { PagedList } from '../../base/react';
 import { MeetingList } from '../../calendar-sync';
 import { RecentList } from '../../recent-list';
 
-import { setWelcomePageListDefaultPage } from '../actions';
+import { setWelcomePageListsDefaultPage } from '../actions';
 
+/**
+ * The type of the React {@code Component} props of {@link WelcomePageLists}.
+ */
 type Props = {
 
     /**
@@ -50,17 +53,19 @@ const IOS_RECENT_LIST_ICON = require('../../../../images/history.png');
 class WelcomePageLists extends Component<Props> {
     /**
      * The pages to be rendered.
-     * Note: The component field may be undefined if a feature (such as
-     * Calendar) is disabled, and that means that the page must not be rendered.
+     *
+     * Note: An element's  {@code component} may be {@code undefined} if a
+     * feature (such as Calendar) is disabled, and that means that the page must
+     * not be rendered.
      */
     pages: Array<{
-        component: Object,
+        component: ?Object,
         icon: string | number,
         title: string
-    }>
+    }>;
 
     /**
-     * Component contructor.
+     * Initializes a new {@code WelcomePageLists} instance.
      *
      * @inheritdoc
      */
@@ -68,28 +73,32 @@ class WelcomePageLists extends Component<Props> {
         super(props);
 
         const { t } = props;
-        const isAndroid = Platform.OS === 'android';
+        const android = Platform.OS === 'android';
 
-        this.pages = [ {
-            component: RecentList,
-            icon: isAndroid ? 'restore' : IOS_RECENT_LIST_ICON,
-            title: t('welcomepage.recentList')
-        }, {
-            component: MeetingList,
-            icon: isAndroid ? 'event_note' : IOS_CALENDAR_ICON,
-            title: t('welcomepage.calendar')
-        } ];
+        this.pages = [
+            {
+                component: RecentList,
+                icon: android ? 'restore' : IOS_RECENT_LIST_ICON,
+                title: t('welcomepage.recentList')
+            },
+            {
+                component: MeetingList,
+                icon: android ? 'event_note' : IOS_CALENDAR_ICON,
+                title: t('welcomepage.calendar')
+            }
+        ];
 
+        // Bind event handlers so they are only bound once per instance.
         this._onSelectPage = this._onSelectPage.bind(this);
     }
 
     /**
-     * Implements React Component's render.
+     * Implements React's {@link Component#render}.
      *
      * @inheritdoc
      */
     render() {
-        const { disabled, _defaultPage } = this.props;
+        const { _defaultPage } = this.props;
 
         if (typeof _defaultPage === 'undefined') {
             return null;
@@ -98,13 +107,13 @@ class WelcomePageLists extends Component<Props> {
         return (
             <PagedList
                 defaultPage = { _defaultPage }
-                disabled = { disabled }
+                disabled = { this.props.disabled }
                 onSelectPage = { this._onSelectPage }
                 pages = { this.pages } />
         );
     }
 
-    _onSelectPage: number => void
+    _onSelectPage: number => void;
 
     /**
      * Callback for the {@code PagedList} page select action.
@@ -114,9 +123,7 @@ class WelcomePageLists extends Component<Props> {
      * @returns {void}
      */
     _onSelectPage(pageIndex) {
-        const { dispatch } = this.props;
-
-        dispatch(setWelcomePageListDefaultPage(pageIndex));
+        this.props.dispatch(setWelcomePageListsDefaultPage(pageIndex));
     }
 }
 
@@ -127,18 +134,20 @@ class WelcomePageLists extends Component<Props> {
  * @param {Object} state - The redux state.
  * @protected
  * @returns {{
- *     _hasRecentListEntries: boolean
+ *     _defaultPage: number
  * }}
  */
 function _mapStateToProps(state: Object) {
-    const { defaultPage } = state['features/welcome'];
-    const recentList = state['features/recent-list'];
-    const _hasRecentListEntries = Boolean(recentList && recentList.length);
+    let { defaultPage } = state['features/welcome'];
+
+    if (typeof defaultPage === 'undefined') {
+        const recentList = state['features/recent-list'];
+
+        defaultPage = recentList && recentList.length ? 0 : 1;
+    }
 
     return {
-        _defaultPage: defaultPage === 'undefined'
-            ? _hasRecentListEntries ? 0 : 1
-            : defaultPage
+        _defaultPage: defaultPage
     };
 }
 

--- a/react/features/welcome/reducer.js
+++ b/react/features/welcome/reducer.js
@@ -1,17 +1,39 @@
 // @flow
 
 import { ReducerRegistry } from '../base/redux';
-import { SET_SIDEBAR_VISIBLE } from './actionTypes';
+import { PersistenceRegistry } from '../base/storage';
+import {
+    SET_SIDEBAR_VISIBLE,
+    SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+} from './actionTypes';
+
+/**
+ * The Redux store name this feature uses.
+ */
+const STORE_NAME = 'features/welcome';
+
+/**
+ * Sets up the persistence of the feature {@code features/welcome}.
+ */
+PersistenceRegistry.register(STORE_NAME, {
+    defaultPage: true
+});
 
 /**
  * Reduces redux actions for the purposes of {@code features/welcome}.
  */
-ReducerRegistry.register('features/welcome', (state = {}, action) => {
+ReducerRegistry.register(STORE_NAME, (state = {}, action) => {
     switch (action.type) {
     case SET_SIDEBAR_VISIBLE:
         return {
             ...state,
             sideBarVisible: action.visible
+        };
+
+    case SET_WELCOME_PAGE_LIST_DEFAULT_PAGE:
+        return {
+            ...state,
+            defaultPage: action.pageIndex
         };
 
     default:

--- a/react/features/welcome/reducer.js
+++ b/react/features/welcome/reducer.js
@@ -1,42 +1,37 @@
 // @flow
 
-import { ReducerRegistry } from '../base/redux';
+import { ReducerRegistry, set } from '../base/redux';
 import { PersistenceRegistry } from '../base/storage';
+
 import {
     SET_SIDEBAR_VISIBLE,
-    SET_WELCOME_PAGE_LIST_DEFAULT_PAGE
+    SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE
 } from './actionTypes';
 
 /**
- * The Redux store name this feature uses.
+ * The name of the redux store/state property which is the root of the redux
+ * state of the feature {@code welcome}.
  */
 const STORE_NAME = 'features/welcome';
 
 /**
- * Sets up the persistence of the feature {@code features/welcome}.
+ * Sets up the persistence of the feature {@code welcome}.
  */
 PersistenceRegistry.register(STORE_NAME, {
     defaultPage: true
 });
 
 /**
- * Reduces redux actions for the purposes of {@code features/welcome}.
+ * Reduces redux actions for the purposes of the feature {@code welcome}.
  */
 ReducerRegistry.register(STORE_NAME, (state = {}, action) => {
     switch (action.type) {
     case SET_SIDEBAR_VISIBLE:
-        return {
-            ...state,
-            sideBarVisible: action.visible
-        };
+        return set(state, 'sideBarVisible', action.visible);
 
-    case SET_WELCOME_PAGE_LIST_DEFAULT_PAGE:
-        return {
-            ...state,
-            defaultPage: action.pageIndex
-        };
-
-    default:
-        return state;
+    case SET_WELCOME_PAGE_LISTS_DEFAULT_PAGE:
+        return set(state, 'defaultPage', action.pageIndex);
     }
+
+    return state;
 });


### PR DESCRIPTION
Changes:

- The defaul tab logic is not the other way 'round: if the recent list is empty, the calendar tab is default
- The app persists the user's last tab and will use that as default for later

Requires https://github.com/jitsi/jitsi-meet-torture/pull/192 which deals with the Calendar permission prompt which appears on startup after this PR defaults to the Calendar tab.