### PR TITLE
Cleaning up call flow presence stanzas and cancel triggers.

### DIFF
--- a/resources/prosody-plugins/mod_muc_call.lua
+++ b/resources/prosody-plugins/mod_muc_call.lua
@@ -17,7 +17,6 @@ end
 
 -- Status strings that trigger call events.
 local calling_status   = "calling"
-local ringing_status   = "ringing"
 local busy_status      = "busy"
 local rejected_status  = "rejected"
 local connected_status = "connected"
@@ -53,7 +52,6 @@ end
 --    Status      | Event Type
 --    _________________________
 --    "calling"   | INVITE
---    "ringing"   | CANCEL
 --    "busy"      | CANCEL
 --    "rejected"  | CANCEL
 --    "connected" | CANCEL
@@ -93,7 +91,6 @@ module:hook("muc-broadcast-presence", function (event)
 	local switch = function(status)
 	   case = {
 		  [calling_status]   = function() invite() end,
-		  [ringing_status]   = function() cancel() end,
 		  [busy_status]      = function() cancel() end,
 		  [rejected_status]  = function() cancel() end,
 		  [connected_status] = function() cancel() end

--- a/resources/prosody-plugins/mod_muc_poltergeist.lua
+++ b/resources/prosody-plugins/mod_muc_poltergeist.lua
@@ -241,8 +241,14 @@ function create_poltergeist_occupant(room, nick, name, avatar, status, context)
         join:tag("password", { xmlns = MUC_NS }):text(room_password);
     end
 
+    -- Update the nil call id to the initial call id for call flows.
 	local call_id = get_username(room, context.user.id);
-	join_presence:tag("call_id"):text(get_username(room, context.user.id)):up();
+    join_presence:maptags(function (tag)
+        if tag.name == "call_id" then
+           return st.stanza("call_id"):text(call_id);
+        end
+        return tag;
+    end);
 
     update_presence_identity(
         join_presence,
@@ -356,6 +362,7 @@ function update_presence_tags(presence_stanza, status, call_details)
                 return st.stanza("call_cancel"):text("false");
             end
         end
+        return tag;
     end);
 
     return presence_stanza


### PR DESCRIPTION
We do not want to send a cancel when we are notified of a ringing device. Also, all tags should propagate in a presence stanza when it is updated.