### PR TITLE
[RN] Hide conference indicators on reduced UI

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -258,7 +258,9 @@ class Conference extends Component<Props> {
                       * A container that automatically renders indicators such
                       * as VideoQualityLabel or RecordingLabel if need be.
                       */}
-                    <ConferenceIndicators />
+                    {
+                        !this.props._reducedUI && <ConferenceIndicators />
+                    }
                 </View>
                 <TestConnectionInfo />
 

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -255,11 +255,10 @@ class Conference extends Component<Props> {
                     <Filmstrip />
 
                     {/*
-                      * A container that automatically renders indicators such
-                      * as VideoQualityLabel or RecordingLabel if need be.
-                      */}
-                    {
-                        !this.props._reducedUI && <ConferenceIndicators />
+                      * Examples of conference indicators are VideoQualityLabel
+                      * and RecordingLabel.
+                      */
+                        this.props._reducedUI || <ConferenceIndicators />
                     }
                 </View>
                 <TestConnectionInfo />


### PR DESCRIPTION
This commit hides the conference indicators from the reduced UI. I think the indicators don't belong to the reduced UI, that is only to see a video (or maybe the active speaker).

For later: Extending the thumbnail indicators and render them in PiP may be a good idea, but we don't have thumbnail indicators in PiP mode at all right now.