### PR TITLE
[RN] Allow to override callHandle for CallKit

### DIFF
--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -44,6 +44,21 @@ const WHITELISTED_KEYS = [
     'callDisplayName',
 
     /**
+     * The call handle of the CallKit call representing the conference/meeting
+     * associated with this config.js. The property is meant for use cases in
+     * which Jitsi Meet is to work with a CallKit call created outside of Jitsi
+     * Meet and to be adopted by Jitsi Meet such as, for example, an incoming
+     * and/or outgoing CallKit call created by Jitsi Meet SDK for iOS
+     * clients/consumers prior to giving control to Jitsi Meet. As the value is
+     * associated with a conference/meeting, the value makes sense not as a
+     * deployment-wide configuration, only as a runtime configuration
+     * override/overwrite provided by, for example, Jitsi Meet SDK for iOS.
+     *
+     * @type string
+     */
+    'callHandle',
+
+    /**
      * The UUID of the CallKit call representing the conference/meeting
      * associated with this config.js. The property is meant for use cases in
      * which Jitsi Meet is to work with a CallKit call created outside of Jitsi

--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -44,12 +44,11 @@ const WHITELISTED_KEYS = [
     'callDisplayName',
 
     /**
-     * The call handle of the CallKit call representing the conference/meeting
-     * associated with this config.js. The property is meant for use cases in
-     * which Jitsi Meet is to work with a CallKit call created outside of Jitsi
-     * Meet and to be adopted by Jitsi Meet such as, for example, an incoming
-     * and/or outgoing CallKit call created by Jitsi Meet SDK for iOS
-     * clients/consumers prior to giving control to Jitsi Meet. As the value is
+     * The handle
+     * ({@link https://developer.apple.com/documentation/callkit/cxhandle}) of
+     * the CallKit call representing the conference/meeting associated with this
+     * config.js. The property is meant for use cases in which the room URL is
+     * not desirable as the handle for CallKit purposes. As the value is
      * associated with a conference/meeting, the value makes sense not as a
      * deployment-wide configuration, only as a runtime configuration
      * override/overwrite provided by, for example, Jitsi Meet SDK for iOS.

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -227,7 +227,7 @@ function _conferenceWillJoin({ getState }, next, action) {
 
     const { conference } = action;
     const state = getState();
-    const { callUUID } = state['features/base/config'];
+    const { callUUID, callHandle } = state['features/base/config'];
     const url = getInviteURL(state);
     const hasVideo = !isVideoMutedByAudioOnly(state);
 
@@ -235,7 +235,9 @@ function _conferenceWillJoin({ getState }, next, action) {
     // it upper cased.
     conference.callUUID = (callUUID || uuid.v4()).toUpperCase();
 
-    CallKit.startCall(conference.callUUID, url.toString(), hasVideo)
+    const handleURL = callHandle || url.toString();
+
+    CallKit.startCall(conference.callUUID, handleURL, hasVideo)
         .then(() => {
             const { callee } = state['features/base/jwt'];
             const displayName

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -227,17 +227,16 @@ function _conferenceWillJoin({ getState }, next, action) {
 
     const { conference } = action;
     const state = getState();
-    const { callUUID, callHandle } = state['features/base/config'];
+    const { callHandle, callUUID } = state['features/base/config'];
     const url = getInviteURL(state);
+    const handle = callHandle || url.toString();
     const hasVideo = !isVideoMutedByAudioOnly(state);
 
     // When assigning the call UUID, do so in upper case, since iOS will return
     // it upper cased.
     conference.callUUID = (callUUID || uuid.v4()).toUpperCase();
 
-    const handleURL = callHandle || url.toString();
-
-    CallKit.startCall(conference.callUUID, handleURL, hasVideo)
+    CallKit.startCall(conference.callUUID, handle, hasVideo)
         .then(() => {
             const { callee } = state['features/base/jwt'];
             const displayName


### PR DESCRIPTION
Implement a variable in configOverwrite that a consumer of the SDK can provide when in need to customize the handle for CallKit.