### PR TITLE
[iOS] Fix crash on startup when fetching calendar entries

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - React/Core (= 0.55.4)
   - react-native-background-timer (2.0.0):
     - React
-  - react-native-calendar-events (1.5.0):
+  - react-native-calendar-events (1.6.0):
     - React
   - react-native-fetch-blob (0.10.6):
     - React/Core

--- a/package-lock.json
+++ b/package-lock.json
@@ -12624,7 +12624,7 @@
       "integrity": "sha512-vLNJIedXQZN4p3ChFsAgVHacnJqQMnLl+wBsnZuliRkmsjEHo8kQOA9fnLih/OoiDi1O3eHQvXC5L8f+RYiKgw=="
     },
     "react-native-calendar-events": {
-      "version": "github:jitsi/react-native-calendar-events#dabfabc4bacc1424a8b93ebdda6f3820dee198cb"
+      "version": "github:jitsi/react-native-calendar-events#cad37355f36d17587d84af72b0095e8cc5fd3df9"
     },
     "react-native-callstats": {
       "version": "3.50.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-i18next": "4.8.0",
     "react-native": "0.55.4",
     "react-native-background-timer": "2.0.0",
-    "react-native-calendar-events": "github:jitsi/react-native-calendar-events#dabfabc4bacc1424a8b93ebdda6f3820dee198cb",
+    "react-native-calendar-events": "github:jitsi/react-native-calendar-events#cad37355f36d17587d84af72b0095e8cc5fd3df9",
     "react-native-callstats": "3.50.4",
     "react-native-fetch-blob": "github:joltup/react-native-fetch-blob#1f9a1761aea4e37bd672bd0d233f3adf0e113a11",
     "react-native-img-cache": "1.5.2",


### PR DESCRIPTION
Turns out sometimes a calendar is missing the tile and it crashes because nil is
inserted into a NSDictionary. Fix it by applying this pending PR:
https://github.com/wmcmahan/react-native-calendar-events/pull/164