### PR TITLE
fix(toolbar): ensure centered toolbar

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -39,8 +39,12 @@
     box-sizing: border-box;
     display: flex;
     justify-content: space-between;
+    left: 0;
+    margin-left: auto;
+    margin-right: auto;
     padding: 12px 8px;
     position: absolute;
+    right: 0;
     transition: bottom .3s ease-in;
     width: 100%;
     z-index: $toolbarZ;


### PR DESCRIPTION
Maybe there is a case that can be triggered somehow where
the toolbar becomes off center.