### PR TITLE
misc: ignore jshint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+
+# precommit-hook
+.jshintignore
+.jshintrc
+


### PR DESCRIPTION
They are automatically created by precommit-hook:
https://github.com/nlf/precommit-hook/blob/362a2024982af1986ccb4c332b9642b3a58f9672/bin/install#L5-L6