### PR TITLE
fix(invite): allow arbitrary strings if no dialOutAuthUrl

### DIFF
--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -11,7 +11,6 @@ import {
 import {
     getDialInConferenceID,
     getDialInNumbers,
-    getDigitsOnly,
     invitePeopleAndChatRooms
 } from './functions';
 
@@ -65,7 +64,7 @@ export function invite(invitees: Array<Object>) {
             // For each number, dial out. On success, remove the number from
             // {@link invitesLeftToSend}.
             const phoneInvitePromises = phoneNumbers.map(item => {
-                const numberToInvite = getDigitsOnly(item.number);
+                const numberToInvite = item.number;
 
                 return conference.dial(numberToInvite)
                     .then(() => {


### PR DESCRIPTION
Bless me Father for I have sinned. It’s been...14 hours...since my last confession...

Probably all of invite should be cleaned up to better or at least clearly handle the appending "+" case. For now, allow arbitrary strings in the AddPeople dialog if dial out is enabled but without any number validation url.