### PR TITLE
feat(overlay): reload without countdown on split-brain

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -132,7 +132,7 @@ function connect(id, password, roomName) {
          *
          */
         function handleConnectionEstablished() {
-            APP.store.dispatch(connectionEstablished(connection));
+            APP.store.dispatch(connectionEstablished(connection, Date.now()));
             unsubscribe();
             resolve(connection);
         }

--- a/lang/main.json
+++ b/lang/main.json
@@ -259,6 +259,7 @@
         "detectext": "Error when trying to detect desktopsharing extension.",
         "failedpermissions": "Failed to obtain permissions to use the local microphone and/or camera.",
         "conferenceReloadTitle": "Unfortunately, something went wrong.",
+        "conferenceReloadImmediatelyMsg": "We're reloading the application now to address the issue.",
         "conferenceReloadMsg": "We're trying to fix this. Reconnecting in __seconds__ sec...",
         "conferenceDisconnectTitle": "You have been disconnected.",
         "conferenceDisconnectMsg": "You may want to check your network connection. Reconnecting in __seconds__ sec...",

--- a/react/features/base/connection/actionTypes.js
+++ b/react/features/base/connection/actionTypes.js
@@ -15,7 +15,8 @@ export const CONNECTION_DISCONNECTED = Symbol('CONNECTION_DISCONNECTED');
  *
  * {
  *     type: CONNECTION_ESTABLISHED,
- *     connection: JitsiConnection
+ *     connection: JitsiConnection,
+ *     timeEstablished: number
  * }
  */
 export const CONNECTION_ESTABLISHED = Symbol('CONNECTION_ESTABLISHED');

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -126,7 +126,7 @@ export function connect(id: ?string, password: ?string) {
             connection.removeEventListener(
                 JitsiConnectionEvents.CONNECTION_ESTABLISHED,
                 _onConnectionEstablished);
-            dispatch(connectionEstablished(connection));
+            dispatch(connectionEstablished(connection, Date.now()));
         }
 
         /**
@@ -197,16 +197,20 @@ function _connectionDisconnected(connection: Object, message: string) {
  *
  * @param {JitsiConnection} connection - The {@code JitsiConnection} which was
  * established.
+ * @param {number} timeEstablished - The time when connection was established.
  * @public
  * @returns {{
  *     type: CONNECTION_ESTABLISHED,
- *     connection: JitsiConnection
+ *     connection: JitsiConnection,
+ *     timeEstablished: number
  * }}
  */
-export function connectionEstablished(connection: Object) {
+export function connectionEstablished(
+        connection: Object, timeEstablished: number) {
     return {
         type: CONNECTION_ESTABLISHED,
-        connection
+        connection,
+        timeEstablished
     };
 }
 

--- a/react/features/base/connection/reducer.js
+++ b/react/features/base/connection/reducer.js
@@ -63,7 +63,8 @@ function _connectionDisconnected(
 
     return assign(state, {
         connecting: undefined,
-        connection: undefined
+        connection: undefined,
+        timeEstablished: undefined
     });
 }
 
@@ -79,12 +80,16 @@ function _connectionDisconnected(
  */
 function _connectionEstablished(
         state: Object,
-        { connection }: { connection: Object }) {
+        { connection, timeEstablished }: {
+            connection: Object,
+            timeEstablished: number
+        }) {
     return assign(state, {
         connecting: undefined,
         connection,
         error: undefined,
-        passwordRequired: undefined
+        passwordRequired: undefined,
+        timeEstablished
     });
 }
 
@@ -140,7 +145,8 @@ function _connectionWillConnect(
     return assign(state, {
         connecting: connection,
         error: undefined,
-        passwordRequired: undefined
+        passwordRequired: undefined,
+        timeEstablished: undefined
     });
 }
 

--- a/react/features/overlay/components/PageReloadOverlay.native.js
+++ b/react/features/overlay/components/PageReloadOverlay.native.js
@@ -65,7 +65,7 @@ class PageReloadOverlay extends AbstractPageReloadOverlay {
      * @returns {ReactElement}
      */
     render() {
-        const { t } = this.props;
+        const { reloadImmediately, t } = this.props;
         const { message, timeLeft, title } = this.state;
 
         return (
@@ -80,20 +80,34 @@ class PageReloadOverlay extends AbstractPageReloadOverlay {
                     <Text style = { styles.message }>
                         { t(message, { seconds: timeLeft }) }
                     </Text>
-                    <View style = { styles.buttonBox }>
-                        <Text
-                            onPress = { this._onReloadNow }
-                            style = { styles.button } >
-                            { t('dialog.rejoinNow') }
-                        </Text>
-                        <Text
-                            onPress = { this._onCancel }
-                            style = { styles.button } >
-                            { t('dialog.Cancel') }
-                        </Text>
-                    </View>
+                    { reloadImmediately ? null : this._renderButtons() }
                 </View>
             </OverlayFrame>
+        );
+    }
+
+    /**
+     * Renders buttons used for interacting with the {@code PageReloadOverlay}.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+    _renderButtons() {
+        const { t } = this.props;
+
+        return (
+            <View style = { styles.buttonBox }>
+                <Text
+                    onPress = { this._onReloadNow }
+                    style = { styles.button } >
+                    { t('dialog.rejoinNow') }
+                </Text>
+                <Text
+                    onPress = { this._onCancel }
+                    style = { styles.button } >
+                    { t('dialog.Cancel') }
+                </Text>
+            </View>
         );
     }
 }


### PR DESCRIPTION
A split-brain scenaior occurs when two users are in the same
conference but on different bridges. In this case, haproxy
will try to resolve this automatically but this causes one
participant to have a failed connection. To get updated
bridge information a reload is needed, or at least strongly
preferred. However, it is undesired for the user to have to
wait for a countdown timer for the reload to complete. As
such, the page reload overlay has been changed to support
reloading without a timer. The initial 1 second delay before
starting the actual countdown/reload has been left in to
make the experience a little less jarring.

Edit: There isn't an explicit way to detect a split-brain
scenario so instead it is assumed an error that happens
early on and is the "item-not-found" error are indicators
of split-brain.