### PR TITLE
fix(base/conference): do not execute leave conference on web

### DIFF
--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -104,6 +104,13 @@ MiddlewareRegistry.register(store => next => action => {
 function _conferenceFailed(store, next, action) {
     const result = next(action);
 
+    // FIXME: Workaround for the web version. Currently, the creation of the
+    // conference is handled by /conference.js and appropriate failure handlers
+    // are set there.
+    if (typeof APP !== 'undefined') {
+        return result;
+    }
+
     // XXX After next(action), it is clear whether the error is recoverable.
     const { conference, error } = action;
 


### PR DESCRIPTION
On web CONFERENCE_FAILED handlers are not setting the 'recoverable' flag thus any middleware which rely on those should not execute on web.