### PR TITLE
Mobile looping sounds

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -15,6 +15,7 @@ import {
     participantConnectionStatusChanged,
     participantJoined,
     participantLeft,
+    participantPresenceChanged,
     participantRoleChanged,
     participantUpdated
 } from '../participants';
@@ -146,6 +147,7 @@ function _addConferenceListeners(conference, dispatch) {
             conference,
             id,
             name: user.getDisplayName(),
+            presence: user.getStatus(),
             role: user.getRole()
         })));
     conference.on(
@@ -155,6 +157,9 @@ function _addConferenceListeners(conference, dispatch) {
     conference.on(
         JitsiConferenceEvents.USER_ROLE_CHANGED,
         (...args) => dispatch(participantRoleChanged(...args)));
+    conference.on(
+        JitsiConferenceEvents.USER_STATUS_CHANGED,
+        (...args) => dispatch(participantPresenceChanged(...args)));
 
     conference.addCommandListener(
         AVATAR_ID_COMMAND,

--- a/react/features/base/media/components/AbstractAudio.js
+++ b/react/features/base/media/components/AbstractAudio.js
@@ -10,7 +10,8 @@ export type AudioElement = {
     currentTime?: number,
     pause: () => void,
     play: () => void,
-    setSinkId?: string => void
+    setSinkId?: string => void,
+    stop: () => void
 };
 
 /**
@@ -61,8 +62,6 @@ export default class AbstractAudio extends Component<Props> {
         this.setAudioElementImpl = this.setAudioElementImpl.bind(this);
     }
 
-    pause: () => void;
-
     /**
      * Attempts to pause the playback of the media.
      *
@@ -73,10 +72,8 @@ export default class AbstractAudio extends Component<Props> {
         this._audioElementImpl && this._audioElementImpl.pause();
     }
 
-    play: () => void;
-
     /**
-     * Attempts to being the playback of the media.
+     * Attempts to begin the playback of the media.
      *
      * @public
      * @returns {void}
@@ -106,8 +103,6 @@ export default class AbstractAudio extends Component<Props> {
         typeof setRef === 'function' && setRef(element ? this : null);
     }
 
-    setSinkId: string => void;
-
     /**
      * Sets the sink ID (output device ID) on the underlying audio element.
      * NOTE: Currently, implemented only on Web.
@@ -119,5 +114,15 @@ export default class AbstractAudio extends Component<Props> {
         this._audioElementImpl
             && typeof this._audioElementImpl.setSinkId === 'function'
             && this._audioElementImpl.setSinkId(sinkId);
+    }
+
+    /**
+     * Attempts to stop the playback of the media.
+     *
+     * @public
+     * @returns {void}
+     */
+    stop(): void {
+        this._audioElementImpl && this._audioElementImpl.stop();
     }
 }

--- a/react/features/base/media/components/native/Audio.js
+++ b/react/features/base/media/components/native/Audio.js
@@ -12,11 +12,10 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  * {@link RTCView}.
  */
 export default class Audio extends AbstractAudio {
-
     /**
      * Reference to 'react-native-sound} {@link Sound} instance.
      */
-    _sound: Sound
+    _sound: ?Sound;
 
     /**
      * A callback passed to the 'react-native-sound''s {@link Sound} instance,
@@ -56,9 +55,22 @@ export default class Audio extends AbstractAudio {
      */
     componentWillUnmount() {
         if (this._sound) {
-            this.setAudioElementImpl(null);
             this._sound.release();
             this._sound = null;
+            this.setAudioElementImpl(null);
+        }
+    }
+
+    /**
+     * Attempts to begin the playback of the media.
+     *
+     * @inheritdoc
+     * @override
+     */
+    play() {
+        if (this._sound) {
+            this._sound.setNumberOfLoops(this.props.loop ? -1 : 0);
+            super.play();
         }
     }
 
@@ -81,10 +93,8 @@ export default class Audio extends AbstractAudio {
      * @returns {void}
      */
     stop() {
-        // Currently not implemented for mobile. If needed, a possible
-        // implementation is:
-        // if (this._sound) {
-        //     this._sound.stop();
-        // }
+        if (this._sound) {
+            this._sound.stop();
+        }
     }
 }


### PR DESCRIPTION
This is required for "call flows". I added presence state handling, since that is also required and was not being handled.

How to test this:

- join a meeting on Stride
- join that meeting on Jitsi Meet using the URL
- invite someone else using Stride
- hear the looping ringtone

Tested:

- [x] Android
- [x] iOS