### PR TITLE
[iOS] Fix syncing muted state with CallKit

### DIFF
--- a/ios/sdk/src/callkit/CallKit.m
+++ b/ios/sdk/src/callkit/CallKit.m
@@ -72,6 +72,11 @@ RCT_EXTERN void RCTRegisterModule(Class);
     [JMCallKitProxy removeListener:self];
 }
 
+- (dispatch_queue_t)methodQueue {
+    // Make sure all our methods run in the main thread.
+    return dispatch_get_main_queue();
+}
+
 // End call
 RCT_EXPORT_METHOD(endCall:(NSString *)callUUID
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/ios/sdk/src/callkit/JMCallKitProxy.swift
+++ b/ios/sdk/src/callkit/JMCallKitProxy.swift
@@ -18,6 +18,8 @@ import CallKit
 import Foundation
 
 /// JitsiMeet CallKit proxy
+// NOTE: The methods this class exposes are meant to be called in the UI thread.
+// All delegate methods called by JMCallKitEmitter will be called in the UI thread.
 @available(iOS 10.0, *)
 @objc public final class JMCallKitProxy: NSObject {
 
@@ -150,6 +152,14 @@ import Foundation
             _ transaction: CXTransaction,
             completion: @escaping (Error?) -> Swift.Void) {
         guard enabled else { return }
+
+        // XXX keep track of muted actions to avoid "ping-pong"ing. See
+        // JMCallKitEmitter for details on the CXSetMutedCallAction handling.
+        for action in transaction.actions {
+            if (action as? CXSetMutedCallAction) != nil {
+                emitter.addMuteAction(action.uuid)
+            }
+        }
 
         callController.request(transaction, completion: completion)
     }

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -385,13 +385,22 @@ function _syncTrackState({ getState }, next, action) {
     const conference = getCurrentConference(state);
 
     if (jitsiTrack.isLocal() && conference && conference.callUUID) {
-        const tracks = state['features/base/tracks'];
-        const muted = isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO);
+        switch (jitsiTrack.getType()) {
+        case 'audio': {
+            const tracks = state['features/base/tracks'];
+            const muted = isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO);
 
-        CallKit.setMuted(conference.callUUID, muted);
-        CallKit.updateCall(
-            conference.callUUID,
-            { hasVideo: !isVideoMutedByAudioOnly(state) });
+            CallKit.setMuted(conference.callUUID, muted);
+            break;
+        }
+        case 'video': {
+            CallKit.updateCall(
+                conference.callUUID,
+                { hasVideo: !isVideoMutedByAudioOnly(state) });
+            break;
+        }
+
+        }
     }
 
     return result;

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -380,11 +380,11 @@ function _setCallKitSubscriptions({ getState }, next, action) {
  */
 function _syncTrackState({ getState }, next, action) {
     const result = next(action);
-    const { track } = action;
+    const { jitsiTrack } = action.track;
     const state = getState();
     const conference = getCurrentConference(state);
 
-    if (track.local && conference && conference.callUUID) {
+    if (jitsiTrack.isLocal() && conference && conference.callUUID) {
         const tracks = state['features/base/tracks'];
         const muted = isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO);
 

--- a/react/features/mobile/callkit/middleware.js
+++ b/react/features/mobile/callkit/middleware.js
@@ -286,23 +286,14 @@ function _onPerformEndCallAction({ callUUID }) {
  * {@code performSetMutedCallAction}.
  * @returns {void}
  */
-function _onPerformSetMutedCallAction({ callUUID, muted: newValue }) {
+function _onPerformSetMutedCallAction({ callUUID, muted }) {
     const { dispatch, getState } = this; // eslint-disable-line no-invalid-this
     const conference = getCurrentConference(getState);
 
     if (conference && conference.callUUID === callUUID) {
-        // Break the loop. Audio can be muted from both CallKit and Jitsi Meet.
-        // We must keep them in sync, but at some point the loop needs to be
-        // broken. We are doing it here, on the CallKit handler.
-        const tracks = getState()['features/base/tracks'];
-        const oldValue = isLocalTrackMuted(tracks, MEDIA_TYPE.AUDIO);
-
-        newValue = Boolean(newValue); // eslint-disable-line no-param-reassign
-
-        if (oldValue !== newValue) {
-            sendAnalytics(createTrackMutedEvent('audio', 'callkit', newValue));
-            dispatch(setAudioMuted(newValue, /* ensureTrack */ true));
-        }
+        muted = Boolean(muted); // eslint-disable-line no-param-reassign
+        sendAnalytics(createTrackMutedEvent('audio', 'callkit', muted));
+        dispatch(setAudioMuted(muted, /* ensureTrack */ true));
     }
 }
 


### PR DESCRIPTION
Fix the "mute ping pong" for once and for all. This patch takes a new approach
to the problem: it keeps track of the user generated CallKit transaction ations
and avoids calling the delegate method in those cases.

This results in a much cleaner and easier to understand handling of the flow: if
the delegate method is called it means the user tapped on the mute button. When
we sync the muted state in JS with CallKit the delegate method won't be called
at all, thus avoiding the ping-pong altogether.