### PR TITLE
ref(css): add height/width reset for html tag

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -14,6 +14,11 @@ textarea {
     user-select: text;
 }
 
+html {
+    height: 100%;
+    width: 100%;
+}
+
 body {
     margin: 0px;
     width: 100%;


### PR DESCRIPTION
This is needed for newer versions of electron that might
use the iframe integration of jitsi-meet. Newer versions
seem to have some kind of regression with setting height
and width to 100%.