### PR TITLE
fix(filmstrip): do not show video for large video speaker in audio only

### DIFF
--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -550,7 +550,7 @@ SmallVideo.prototype.isVideoPlayable = function() {
 SmallVideo.prototype.selectDisplayMode = function() {
     // Display name is always and only displayed when user is on the stage
     if (this.isCurrentlyOnLargeVideo()) {
-        return this.isVideoPlayable()
+        return this.isVideoPlayable() && !APP.conference.isAudioOnly()
             ? DISPLAY_BLACKNESS_WITH_NAME : DISPLAY_AVATAR_WITH_NAME;
     } else if (this.isVideoPlayable()
         && this.selectVideoElement().length


### PR DESCRIPTION
When in audio only, the video should not be shown and instead the
avatar should display.