### PR TITLE
[Android] Add a default signing store

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules-debug.pro'
         }
         release {
+            debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules-release.pro'
             signingConfig signingConfigs.release

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,15 @@ android {
         }
     }
 
+    signingConfigs {
+        release {
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+            storeFile file("${System.properties['user.home']}/.android/debug.keystore")
+            storePassword 'android'
+        }
+    }
+
     buildTypes {
         debug {
             minifyEnabled true
@@ -35,6 +44,7 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules-release.pro'
+            signingConfig signingConfigs.release
         }
     }
 


### PR DESCRIPTION
Use the default debug store which Android Studio installs so it's easy to make a
test release build.