### PR TITLE
Calendar feature disabled state getter

### DIFF
--- a/react/features/calendar-sync/constants.js
+++ b/react/features/calendar-sync/constants.js
@@ -11,6 +11,17 @@ import { NativeModules } from 'react-native';
 export const CALENDAR_ENABLED = _isCalendarEnabled();
 
 /**
+ * The default state of the calendar.
+ *
+ * NOTE: This is defined here, to be reusable by functions.js as well (see file
+ * for details).
+ */
+export const DEFAULT_STATE = {
+    authorization: undefined,
+    events: []
+};
+
+/**
  * Determines whether the calendar feature is enabled by the app. For
  * example, Apple through its App Store requires
  * {@code NSCalendarsUsageDescription} in the app's Info.plist or App Store

--- a/react/features/calendar-sync/functions.js
+++ b/react/features/calendar-sync/functions.js
@@ -1,0 +1,18 @@
+// @flow
+import { toState } from '../base/redux';
+
+import { CALENDAR_ENABLED, DEFAULT_STATE } from './constants';
+
+/**
+ * Returns the calendar state, considering the enabled/disabled state of the
+ * feature. Since that is the normal Redux behaviour, this function will always
+ * return an object (the default state if the feature is disabled).
+ *
+ * @param {Object | Function} stateful - An object or a function that can be
+ * resolved to a Redux state by {@code toState}.
+ * @returns {Object}
+ */
+export function getCalendarState(stateful: Object | Function) {
+    return CALENDAR_ENABLED
+        ? toState(stateful)['features/calendar-sync'] : DEFAULT_STATE;
+}

--- a/react/features/calendar-sync/index.js
+++ b/react/features/calendar-sync/index.js
@@ -1,4 +1,5 @@
 export * from './components';
+export * from './functions';
 
 import './middleware';
 import './reducer';

--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -8,22 +8,29 @@ import {
     SET_CALENDAR_AUTHORIZATION,
     SET_CALENDAR_EVENTS
 } from './actionTypes';
-import { CALENDAR_ENABLED } from './constants';
+import { CALENDAR_ENABLED, DEFAULT_STATE } from './constants';
 
-const DEFAULT_STATE = {
-    /**
-     * Note: If features/calendar-sync ever gets persisted, do not persist the
-     * authorization value as it's needed to remain a runtime value to see if we
-     * need to re-request the calendar permission from the user.
-     */
-    authorization: undefined,
-    events: []
-};
-
+/**
+ * Constant for the Redux subtree of the calendar feature.
+ *
+ * NOTE: Please do not access this subtree directly outside of this feature.
+ * This feature can be disabled (see {@code constants.js} for details), and in
+ * that case, accessing this subtree directly will return undefined and will
+ * need a bunch of repetitive type checks in other features. Use the
+ * {@code getCalendarState} function instead, or make sure you take care of
+ * those checks, or consider using the {@code CALENDAR_ENABLED} const to gate
+ * features if needed.
+ */
 const STORE_NAME = 'features/calendar-sync';
 
-// XXX For legacy purposes, read any {@code knownDomains} persisted by the
-// feature calendar-sync.
+/**
+ * NOTE 1: For legacy purposes, read any {@code knownDomains} persisted by the
+ * feature calendar-sync.
+ *
+ * NOTE 2: Never persist the authorization value as it's needed to remain a
+ * runtime value to see if we need to re-request the calendar permission from
+ * the user.
+ */
 CALENDAR_ENABLED
     && PersistenceRegistry.register(STORE_NAME, {
         knownDomains: true


### PR DESCRIPTION
This commit adds a state getter that considers checking the enabled/disabled state of the calendar feature, so then other features don’t have to do it manually.