### PR TITLE
fix(video-layout): handle undefined video type for large video update

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -4,11 +4,11 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
 import {
     JitsiParticipantConnectionStatus
 } from '../../../react/features/base/lib-jitsi-meet';
+import { VIDEO_TYPE } from '../../../react/features/base/media';
 import {
     getPinnedParticipant,
     pinParticipant
 } from '../../../react/features/base/participants';
-
 import { SHARED_VIDEO_CONTAINER_TYPE } from '../shared_video/SharedVideo';
 import SharedVideoThumb from '../shared_video/SharedVideoThumb';
 
@@ -977,7 +977,7 @@ const VideoLayout = {
             largeVideo.updateLargeVideo(
                 id,
                 smallVideo.videoStream,
-                videoType
+                videoType || VIDEO_TYPE.CAMERA
             ).then(() => {
                 // update current small video and the old one
                 smallVideo.updateView();


### PR DESCRIPTION
When replace track is called in JitsiConference, there is no
guarantee a videoType update will come in presence before
the track added event. This can lead to the situation in
LargeVideoManager where an update is called with a track
with an undefined videoType.