### PR TITLE
[RN] Update Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ buck-out/
 .jshintignore
 .jshintrc
 
+# Ignore asset files that are generated upon build
+android/sdk/src/main/assets
+android/sdk/src/main/res/drawable*

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files.
@@ -144,7 +144,7 @@ allprojects {
 }
 
 ext {
-    buildToolsVersion = "26.0.2"
+    buildToolsVersion = "27.0.3"
     compileSdkVersion = 26
     minSdkVersion    = 16
     targetSdkVersion = 26

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -48,58 +48,48 @@ void runBefore(String dependentTaskName, Task task) {
 }
 
 gradle.projectsEvaluated {
-    android.buildTypes.all { buildType ->
-        def buildNameCapitalized = "${buildType.name.capitalize()}"
-        def bundlePath = "${buildDir}/intermediates/bundles/${buildType.name}"
 
-        // Bundle fonts in react-native-vector-icons.
-        //
+    // Copy fonts from react-native-vector-icons and /fonts to assets folder.
+    def currentFontTask = tasks.create(
+            name: "copyFonts",
+            type: Copy) {
+        from("${projectDir}/../../fonts/jitsi.ttf")
+        from("${projectDir}/../../node_modules/react-native-vector-icons/Fonts/")
+        into("${projectDir}/src/main/assets/fonts")
+    }
 
-        def currentFontTask = tasks.create(
-                name: "copy${buildNameCapitalized}Fonts",
-                type: Copy) {
-            from("${projectDir}/../../fonts/jitsi.ttf")
-            from("${projectDir}/../../node_modules/react-native-vector-icons/Fonts/")
-            into("${bundlePath}/assets/fonts")
-        }
+    // Hook the task to run right before the build, once.
+    runBefore("preBuild", currentFontTask)
 
-        currentFontTask.dependsOn("merge${buildNameCapitalized}Resources")
-        currentFontTask.dependsOn("merge${buildNameCapitalized}Assets")
+    // Copy sounds into the assets folder.
+    def currentSoundsTask = tasks.create(
+            name: "copySounds",
+            type: Copy) {
+         from("${projectDir}/../../sounds/joined.wav")
+         from("${projectDir}/../../sounds/left.wav")
+         from("${projectDir}/../../sounds/outgoingRinging.wav")
+         from("${projectDir}/../../sounds/outgoingStart.wav")
+         from("${projectDir}/../../sounds/recordingOn.mp3")
+         from("${projectDir}/../../sounds/recordingOff.mp3")
+         from("${projectDir}/../../sounds/rejected.wav")
+         into("${projectDir}/src/main/assets/sounds")
+    }
 
-        runBefore("processArmeabi-v7a${buildNameCapitalized}Resources", currentFontTask)
-        runBefore("processX86${buildNameCapitalized}Resources", currentFontTask)
-        runBefore("processUniversal${buildNameCapitalized}Resources", currentFontTask)
-        runBefore("process${buildNameCapitalized}Resources", currentFontTask)
+    // Hook the task to run right before the build, once.
+    runBefore("preBuild", currentSoundsTask)
 
-        def currentSoundsTask = tasks.create(
-                name: "copy${buildNameCapitalized}Sounds",
-                type: Copy) {
-             from("${projectDir}/../../sounds/joined.wav")
-             from("${projectDir}/../../sounds/left.wav")
-             from("${projectDir}/../../sounds/outgoingRinging.wav")
-             from("${projectDir}/../../sounds/outgoingStart.wav")
-             from("${projectDir}/../../sounds/recordingOn.mp3")
-             from("${projectDir}/../../sounds/recordingOff.mp3")
-             from("${projectDir}/../../sounds/rejected.wav")
-             into("${bundlePath}/assets/sounds")
-        }
 
-        currentSoundsTask.dependsOn("merge${buildNameCapitalized}Resources")
-        currentSoundsTask.dependsOn("merge${buildNameCapitalized}Assets")
 
-        runBefore("processArmeabi-v7a${buildNameCapitalized}Resources", currentSoundsTask)
-        runBefore("processX86${buildNameCapitalized}Resources", currentSoundsTask)
-        runBefore("processUniversal${buildNameCapitalized}Resources", currentSoundsTask)
-        runBefore("process${buildNameCapitalized}Resources", currentSoundsTask)
+    android.libraryVariants.all { variant ->
+        def buildNameCapitalized = "${variant.buildType.name.capitalize()}"
 
         // Bundle JavaScript and React resources.
         // (adapted from react-native/react.gradle)
-        //
 
         // React JS bundle directories
-        def jsBundleDir = file("${bundlePath}/assets")
-        def resourcesDir = file("${bundlePath}/res/merged")
-        def jsBundleFile = file("${jsBundleDir}/index.android.bundle")
+        def outputDir = file("${projectDir}/src/main/assets");
+        def assetsDestination = file("${projectDir}/src/main/res")
+        def bundleOutput = file("${projectDir}/src/main/assets/index.android.bundle")
 
         // Bundle task name for variant.
         def bundleJsAndAssetsTaskName = "bundle${buildNameCapitalized}JsAndAssets"
@@ -110,20 +100,20 @@ gradle.projectsEvaluated {
             // Set up inputs and outputs so gradle can cache the result.
             def reactRoot = file("${projectDir}/../../")
             inputs.files fileTree(dir: reactRoot, excludes: ['android/**', 'ios/**'])
-            outputs.dir jsBundleDir
-            outputs.dir resourcesDir
+            outputs.dir outputDir
 
             // Set up the call to the react-native cli.
             workingDir reactRoot
 
             // Create JS bundle
             def devEnabled = !buildNameCapitalized.toLowerCase().contains('release')
+
             commandLine(
                 'node',
                 'node_modules/react-native/local-cli/cli.js',
                 'bundle',
-                '--assets-dest', resourcesDir,
-                '--bundle-output', jsBundleFile,
+                '--assets-dest', assetsDestination,
+                '--bundle-output', bundleOutput,
                 '--dev', "${devEnabled}",
                 '--entry-file', 'index.android.js',
                 '--platform', 'android',
@@ -133,14 +123,12 @@ gradle.projectsEvaluated {
             enabled !devEnabled
         }
 
-        // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process
-        currentBundleTask.dependsOn("merge${buildNameCapitalized}Resources")
-        currentBundleTask.dependsOn("merge${buildNameCapitalized}Assets")
+        // Hook $bundleJsAndAssetsTaskName into the beginning
+        // of the android build process, so then the native build process can pick
+        // it up during build, regardless of the build workflow changes (e.g.
+        // build tool version changes).
 
-        runBefore("processArmeabi-v7a${buildNameCapitalized}Resources", currentBundleTask)
-        runBefore("processX86${buildNameCapitalized}Resources", currentBundleTask)
-        runBefore("processUniversal${buildNameCapitalized}Resources", currentBundleTask)
-        runBefore("process${buildNameCapitalized}Resources", currentBundleTask)
+        runBefore("preBuild", currentBundleTask)
     }
 }
 


### PR DESCRIPTION
This PR updates gradle to the latest versions (4.4, plugin version 3.1.2). This is required for the Google sign-in lib we want to use for streaming.

Some notes:
- The new plugin version doesn't seem to have the tasks process${buildTypeHere}Resources (any anything similar) task, so font icons and sounds were missing from the build with the new versions. To come around this I got gradle to copy over the assets into the assets folder in src so then they get included with the standard build process.
- With that said, since the assets folder is generated I added that to gitignore
- Everything seems to be working this way, but I'm not sure how to test the ```bundleJsAndAssetsTaskName``` and ```currentBundleTask``` tasks, where I applied a similar logic, but got one phase (task) later. Any input on this is welcome!

If anyone has a better task to execute the font and sound copy tasks on in mind, don't keep the info!