### PR TITLE
fix(hangup): truthy check for deviceChangeListener before removing it

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2479,9 +2479,11 @@ export default {
         APP.UI.removeLocalMedia();
 
         // Remove unnecessary event listeners from firing callbacks.
-        JitsiMeetJS.mediaDevices.removeEventListener(
-            JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED,
-            this.deviceChangeListener);
+        if (this.deviceChangeListener) {
+            JitsiMeetJS.mediaDevices.removeEventListener(
+                JitsiMediaDevicesEvents.DEVICE_LIST_CHANGED,
+                this.deviceChangeListener);
+        }
 
         let requestFeedbackPromise;
 


### PR DESCRIPTION
It can be that deviceChangeListener is never defined because
the isDeviceList call never completes. On hangup, that would
cause an error to be thrown within lib-jitsi-meet because of
an attempt to remove an undefined event handler. That is
what happens on Safari right now.