### PR TITLE
[RN] Only ask for calendar permission on user interaction

### DIFF
--- a/react/features/base/react/components/native/AbstractPagedList.js
+++ b/react/features/base/react/components/native/AbstractPagedList.js
@@ -82,7 +82,7 @@ export default class AbstractPagedList extends Component<Props, State> {
      * @inheritdoc
      */
     componentDidMount() {
-        this._maybeRefreshSelectedPage();
+        this._maybeRefreshSelectedPage(false);
     }
 
     /**
@@ -118,7 +118,7 @@ export default class AbstractPagedList extends Component<Props, State> {
         );
     }
 
-    _maybeRefreshSelectedPage: () => void;
+    _maybeRefreshSelectedPage: ?boolean => void;
 
     /**
      * Components that this PagedList displays may have a refresh function to
@@ -126,9 +126,11 @@ export default class AbstractPagedList extends Component<Props, State> {
      * function invokes this logic if it's present.
      *
      * @private
+     * @param {boolean} isInteractive - If true this refresh was caused by
+     * direct user interaction, false otherwise.
      * @returns {void}
      */
-    _maybeRefreshSelectedPage() {
+    _maybeRefreshSelectedPage(isInteractive: boolean = true) {
         const selectedPage = this.props.pages[this.state.pageIndex];
         let component;
 
@@ -136,7 +138,7 @@ export default class AbstractPagedList extends Component<Props, State> {
             const { refresh } = component;
 
             typeof refresh === 'function'
-                && refresh.call(component, this.props.dispatch);
+                && refresh.call(component, this.props.dispatch, isInteractive);
         }
     }
 

--- a/react/features/calendar-sync/actionTypes.js
+++ b/react/features/calendar-sync/actionTypes.js
@@ -5,7 +5,8 @@
  *
  * {
  *     type: REFRESH_CALENDAR,
- *     forcePermission: boolean
+ *     forcePermission: boolean,
+ *     isInteractive: boolean
  * }
  */
 export const REFRESH_CALENDAR = Symbol('REFRESH_CALENDAR');

--- a/react/features/calendar-sync/actions.js
+++ b/react/features/calendar-sync/actions.js
@@ -9,17 +9,22 @@ import {
 /**
  * Sends an action to refresh the entry list (fetches new data).
  *
- * @param {boolean|undefined} forcePermission - Whether to force to re-ask for
+ * @param {boolean} forcePermission - Whether to force to re-ask for
  * the permission or not.
+ * @param {boolean} isInteractive - If true this refresh was caused by
+ * direct user interaction, false otherwise.
  * @returns {{
  *     type: REFRESH_CALENDAR,
- *     forcePermission: boolean
+ *     forcePermission: boolean,
+ *     isInteractive: boolean
  * }}
  */
-export function refreshCalendar(forcePermission: boolean = false) {
+export function refreshCalendar(
+        forcePermission: boolean = false, isInteractive: boolean = true) {
     return {
         type: REFRESH_CALENDAR,
-        forcePermission
+        forcePermission,
+        isInteractive
     };
 }
 

--- a/react/features/calendar-sync/components/MeetingList.native.js
+++ b/react/features/calendar-sync/components/MeetingList.native.js
@@ -65,11 +65,13 @@ class MeetingList extends Component<Props> {
      * change).
      *
      * @param {Function} dispatch - The Redux dispatch function.
+     * @param {boolean} isInteractive - If true this refresh was caused by
+     * direct user interaction, false otherwise.
      * @public
      * @returns {void}
      */
-    static refresh(dispatch) {
-        dispatch(refreshCalendar());
+    static refresh(dispatch, isInteractive) {
+        dispatch(refreshCalendar(false, isInteractive));
     }
 
     /**

--- a/react/features/calendar-sync/middleware.js
+++ b/react/features/calendar-sync/middleware.js
@@ -75,7 +75,8 @@ CALENDAR_ENABLED
         case REFRESH_CALENDAR: {
             const result = next(action);
 
-            _fetchCalendarEntries(store, true, action.forcePermission);
+            _fetchCalendarEntries(
+                store, action.isInteractive, action.forcePermission);
 
             return result;
         }


### PR DESCRIPTION
This PR changes the way the calendar permission is asked. It now only asks if the calendar refresh is the result of a direct user interaction (e.g. change welcome screen tabs, or refresh calendar list), but will no ask for permission if the calendar tab is rendered default on application startup