### PR TITLE
[RN] Don't request camera permission on first launch

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -23,6 +23,7 @@
 ; seen to cause errors and we have chosen not to fix.
 .*/node_modules/@atlaskit/.*/*.js.flow
 .*/node_modules/react-native-keep-awake/.*
+.*/node_modules/react-native-permissions/.*
 .*/node_modules/styled-components/.*
 
 .*/\.git/.*

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -35,6 +35,8 @@ target 'JitsiMeet' do
   pod 'react-native-locale-detector',
     :path => '../node_modules/react-native-locale-detector'
   pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
+  pod 'ReactNativePermissions',
+    :path => '../node_modules/react-native-permissions'
   pod 'RNSound', :path => '../node_modules/react-native-sound'
   pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'
   pod 'react-native-calendar-events',

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -59,6 +59,8 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
+  - ReactNativePermissions (1.1.1):
+    - React
   - RNSound (0.10.9):
     - React/Core
     - RNSound/Core (= 0.10.9)
@@ -88,6 +90,7 @@ DEPENDENCIES:
   - React/RCTNetwork (from `../node_modules/react-native`)
   - React/RCTText (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
+  - ReactNativePermissions (from `../node_modules/react-native-permissions`)
   - RNSound (from `../node_modules/react-native-sound`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -117,6 +120,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-locale-detector"
   react-native-webrtc:
     :path: "../node_modules/react-native-webrtc"
+  ReactNativePermissions:
+    :path: "../node_modules/react-native-permissions"
   RNSound:
     :path: "../node_modules/react-native-sound"
   RNVectorIcons:
@@ -136,10 +141,11 @@ SPEC CHECKSUMS:
   react-native-keep-awake: 0de4bd66de0c23178107dce0c2fcc3354b2a8e94
   react-native-locale-detector: d1b2c6fe5abb56e3a1efb6c2d6f308c05c4251f1
   react-native-webrtc: 31b6d3f1e3e2ce373aa43fd682b04367250f807d
+  ReactNativePermissions: 9f2d9c45c98800795e6c2ed330e25d11a66a8169
   RNSound: b360b3862d3118ed1c74bb9825696b5957686ac4
   RNVectorIcons: c0dbfbf6068fefa240c37b0f71bd03b45dddac44
   yoga: a23273df0088bf7f2bb7e5d7b00044ea57a2a54a
 
-PODFILE CHECKSUM: fb12a5ae406b901e95aeb1ab5ebbb02773c46ede
+PODFILE CHECKSUM: e24d0131e937934fbe4d1f0b7ad5947ee0192f58
 
 COCOAPODS: 1.5.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -12755,6 +12755,11 @@
       "version": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9",
       "from": "react-native-locale-detector@github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9"
     },
+    "react-native-permissions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-1.1.1.tgz",
+      "integrity": "sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ=="
+    },
     "react-native-prompt": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-native-prompt/-/react-native-prompt-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native-immersive": "1.1.0",
     "react-native-keep-awake": "2.0.6",
     "react-native-locale-detector": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9",
+    "react-native-permissions": "1.1.1",
     "react-native-prompt": "1.0.0",
     "react-native-sound": "0.10.9",
     "react-native-vector-icons": "4.4.2",

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -8,6 +8,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import Permissions from 'react-native-permissions';
 import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
@@ -59,7 +60,7 @@ class WelcomePage extends AbstractWelcomePage {
     /**
      * Implements React's {@link Component#componentWillMount()}. Invoked
      * immediately before mounting occurs. Creates a local video track if none
-     * is available.
+     * is available and the camera permission was already granted.
      *
      * @inheritdoc
      * @returns {void}
@@ -72,7 +73,13 @@ class WelcomePage extends AbstractWelcomePage {
         if (this.props._settings.startAudioOnly) {
             dispatch(destroyLocalTracks());
         } else {
-            dispatch(createDesiredLocalTracks(MEDIA_TYPE.VIDEO));
+            // Make sure we don't request the permission for the camera from
+            // the start. We will, however, create a video track iff the user
+            // already granted the permission.
+            Permissions.check('camera').then(response => {
+                response === 'authorized'
+                    && dispatch(createDesiredLocalTracks(MEDIA_TYPE.VIDEO));
+            });
         }
     }
 


### PR DESCRIPTION
It will only be requested if a user joins a meeting or flips the switch from
video to audio and back, but never as the first thing when the welcome page is
mounted.