### PR TITLE
ref(large-video): combine selectParticipant logic from web

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -7,8 +7,6 @@ import Recorder from './modules/recorder/Recorder';
 
 import mediaDeviceHelper from './modules/devices/mediaDeviceHelper';
 
-import { reportError } from './modules/util/helpers';
-
 import * as RemoteControlEvents
     from './service/remotecontrol/RemoteControlEvents';
 import UIEvents from './service/UI/UIEvents';
@@ -18,7 +16,6 @@ import * as JitsiMeetConferenceEvents from './ConferenceEvents';
 import {
     createDeviceChangedEvent,
     createScreenSharingEvent,
-    createSelectParticipantFailedEvent,
     createStreamSwitchDelayEvent,
     createTrackMutedEvent,
     sendAnalytics
@@ -1812,24 +1809,6 @@ export default {
                     room.sendTextMessage(message);
                 });
             }
-
-            APP.UI.addListener(UIEvents.SELECTED_ENDPOINT, id => {
-                APP.API.notifyOnStageParticipantChanged(id);
-                try {
-                    // do not try to select participant if there is none (we
-                    // are alone in the room), otherwise an error will be
-                    // thrown cause reporting mechanism is not available
-                    // (datachannels currently)
-                    if (room.getParticipants().length === 0) {
-                        return;
-                    }
-
-                    room.selectParticipant(id);
-                } catch (e) {
-                    sendAnalytics(createSelectParticipantFailedEvent(e));
-                    reportError(e);
-                }
-            });
         }
 
         room.on(JitsiConferenceEvents.CONNECTION_INTERRUPTED, () => {

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -960,7 +960,7 @@ const VideoLayout = {
             // FIXME video type is not the same thing as container type
 
             if (id !== currentId && videoType === VIDEO_CONTAINER_TYPE) {
-                eventEmitter.emit(UIEvents.SELECTED_ENDPOINT, id);
+                APP.API.notifyOnStageParticipantChanged(id);
             }
 
             let oldSmallVideo;

--- a/react/features/large-video/actions.js
+++ b/react/features/large-video/actions.js
@@ -1,13 +1,18 @@
 // @flow
 
+import {
+    createSelectParticipantFailedEvent,
+    sendAnalytics
+} from '../analytics';
 import { _handleParticipantError } from '../base/conference';
-import { MEDIA_TYPE, VIDEO_TYPE } from '../base/media';
-import { getTrackByMediaTypeAndParticipant } from '../base/tracks';
+import { MEDIA_TYPE } from '../base/media';
 
 import {
     SELECT_LARGE_VIDEO_PARTICIPANT,
     UPDATE_KNOWN_LARGE_VIDEO_RESOLUTION
 } from './actionTypes';
+
+declare var APP: Object;
 
 /**
  * Signals conference to select a participant.
@@ -21,22 +26,18 @@ export function selectParticipant() {
 
         if (conference) {
             const largeVideo = state['features/large-video'];
-            const tracks = state['features/base/tracks'];
-
             const id = largeVideo.participantId;
-            const videoTrack
-                = getTrackByMediaTypeAndParticipant(
-                    tracks,
-                    MEDIA_TYPE.VIDEO,
-                    id);
 
             try {
-                conference.selectParticipant(
-                    videoTrack && videoTrack.videoType === VIDEO_TYPE.CAMERA
-                        ? id
-                        : null);
+                conference.selectParticipant(id);
             } catch (err) {
                 _handleParticipantError(err);
+
+                sendAnalytics(createSelectParticipantFailedEvent(err));
+
+                if (typeof APP === 'object' && window.onerror) {
+                    window.onerror('', null, null, null, err);
+                }
             }
         }
     };

--- a/react/features/large-video/actions.js
+++ b/react/features/large-video/actions.js
@@ -36,7 +36,12 @@ export function selectParticipant() {
                 sendAnalytics(createSelectParticipantFailedEvent(err));
 
                 if (typeof APP === 'object' && window.onerror) {
-                    window.onerror('', null, null, null, err);
+                    window.onerror(
+                        `Failed to select participant ${id}`,
+                        null, // source
+                        null, // lineno
+                        null, // colno
+                        err);
                 }
             }
         }

--- a/react/features/large-video/middleware.js
+++ b/react/features/large-video/middleware.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { CONFERENCE_JOINED } from '../base/conference';
 import {
     DOMINANT_SPEAKER_CHANGED,
     PARTICIPANT_JOINED,
@@ -44,6 +45,12 @@ MiddlewareRegistry.register(store => next => action => {
     case TRACK_ADDED:
     case TRACK_REMOVED:
         store.dispatch(selectParticipantInLargeVideo());
+        break;
+
+    case CONFERENCE_JOINED:
+        // Ensure that any tracks updated before the conference has been marked
+        // as joined get selected to receive high quality video.
+        store.dispatch(selectParticipant());
         break;
 
     case TRACK_UPDATED:

--- a/react/features/large-video/middleware.js
+++ b/react/features/large-video/middleware.js
@@ -48,8 +48,9 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case CONFERENCE_JOINED:
-        // Ensure that any tracks updated before the conference has been marked
-        // as joined get selected to receive high quality video.
+        // Ensure a participant is selected on conference join. This addresses
+        // the case where video tracks were received before CONFERENCE_JOINED
+        // fired; without the conference selection may not happen.
         store.dispatch(selectParticipant());
         break;
 

--- a/service/UI/UIEvents.js
+++ b/service/UI/UIEvents.js
@@ -1,6 +1,5 @@
 export default {
     NICKNAME_CHANGED: 'UI.nickname_changed',
-    SELECTED_ENDPOINT: 'UI.selected_endpoint',
     PINNED_ENDPOINT: 'UI.pinned_endpoint',
 
     /**


### PR DESCRIPTION
Currently native/middleware/redux has its own logic for selecting a participant
on the bridge. To have the logic web respect that logic, a few changes are
needed.
- Web no longer has its own call to selectParticipant.
- To keep in line with web logic selectParticipant action should act even when
  there is no track. This makes it so that when a participant does get a track
  that the bridge will send high quality. The bridge can already handle when the
  selected participant does not have a video track.
- The timing of web is such that on joining an existing conference, a
  participant joins and the participant's tracks get updated and then the
  conference is joined. The result is selectParticipant does not get fired
  because it no-ops when there is no conference. To avoid having to make
  uncertain changes (to be lazy), update the selected participant on conference
  join as well.