### PR TITLE
config: default to 720p

### DIFF
--- a/config.js
+++ b/config.js
@@ -99,13 +99,13 @@ var config = {
     // used by browsers that return true from lib-jitsi-meet's
     // util#browser#usesNewGumFlow. The constraints are independency from
     // this config's resolution value. Defaults to requesting an ideal aspect
-    // ratio of 16:9 with an ideal resolution of 1080p.
+    // ratio of 16:9 with an ideal resolution of 720.
     // constraints: {
     //     video: {
     //         aspectRatio: 16 / 9,
     //         height: {
-    //             ideal: 1080,
-    //             max: 1080,
+    //             ideal: 720,
+    //             max: 720,
     //             min: 240
     //         }
     //     }


### PR DESCRIPTION
This needs to go in first: https://github.com/jitsi/lib-jitsi-meet/pull/782

Why this? Well, we switched to 1080 for the new gum flow (which IMHO was a mistake) and then reconfigured all our deployments back to 720p. Let's keep defaults sane and reasonable.