### PR TITLE
Log the amount of local tracks properly

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -697,7 +697,7 @@ export default {
                         track.mute();
                     }
                 });
-                logger.log('initialized with %s local tracks', tracks.length);
+                logger.log(`initialized with ${tracks.length} local tracks`);
                 this._localTracksInitialized = true;
                 con.addEventListener(
                     JitsiConnectionEvents.CONNECTION_FAILED,


### PR DESCRIPTION
This changes a log message from “initialized with %s local tracks 2” to “initialized with 2 local tracks”.