### PR TITLE
ref(filmstrip): apply filmstrip class to Conference root

### DIFF
--- a/css/filmstrip/_vertical_filmstrip.scss
+++ b/css/filmstrip/_vertical_filmstrip.scss
@@ -127,7 +127,7 @@
 /**
  * Override other styles to support vertical filmstrip mode.
  */
-.vertical-filmstrip.filmstrip-only {
+.filmstrip-only .vertical-filmstrip {
     .filmstrip {
         flex-direction: row-reverse;
     }

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -320,11 +320,6 @@ UI.start = function() {
         SidePanels.init(eventEmitter);
     }
 
-    const filmstripTypeClassname = interfaceConfig.VERTICAL_FILMSTRIP
-        ? 'vertical-filmstrip' : 'horizontal-filmstrip';
-
-    $('body').addClass(filmstripTypeClassname);
-
     document.title = interfaceConfig.APP_NAME;
 };
 

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -42,6 +42,18 @@ const FULL_SCREEN_EVENTS = [
 ];
 
 /**
+ * The CSS class to apply to the root element of the conference so CSS can
+ * modify the app layout.
+ *
+ * @private
+ * @type {Object}
+ */
+const LAYOUT_CLASSES = {
+    HORIZONTAL_FILSTRIP: 'horizontal-filmstrip',
+    VERTICAL_FILMSTRIP: 'vertical-filmstrip'
+};
+
+/**
  * The type of the React {@code Component} props of {@link Conference}.
  */
 type Props = {
@@ -50,6 +62,12 @@ type Props = {
      * Whether the local participant is recording the conference.
      */
     _iAmRecorder: boolean,
+
+    /**
+     * The CSS class to apply to the root of {@link Conference} to modify the
+     * application layout.
+     */
+    _layoutModeClassName: string,
 
     /**
      * Conference room name.
@@ -161,6 +179,7 @@ class Conference extends Component<Props> {
 
         return (
             <div
+                className = { this.props._layoutModeClassName }
                 id = 'videoconference_page'
                 onMouseMove = { this._onShowToolbar }>
                 <div id = 'videospace'>
@@ -250,6 +269,10 @@ function _mapStateToProps(state) {
          * @private
          */
         _iAmRecorder: iAmRecorder,
+
+        _layoutModeClassName: interfaceConfig.VERTICAL_FILMSTRIP
+            ? LAYOUT_CLASSES.VERTICAL_FILMSTRIP
+            : LAYOUT_CLASSES.HORIZONTAL_FILSTRIP,
 
         /**
          * Conference room name.

--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -49,7 +49,7 @@ const FULL_SCREEN_EVENTS = [
  * @type {Object}
  */
 const LAYOUT_CLASSES = {
-    HORIZONTAL_FILSTRIP: 'horizontal-filmstrip',
+    HORIZONTAL_FILMSTRIP: 'horizontal-filmstrip',
     VERTICAL_FILMSTRIP: 'vertical-filmstrip'
 };
 
@@ -272,7 +272,7 @@ function _mapStateToProps(state) {
 
         _layoutModeClassName: interfaceConfig.VERTICAL_FILMSTRIP
             ? LAYOUT_CLASSES.VERTICAL_FILMSTRIP
-            : LAYOUT_CLASSES.HORIZONTAL_FILSTRIP,
+            : LAYOUT_CLASSES.HORIZONTAL_FILMSTRIP,
 
         /**
          * Conference room name.


### PR DESCRIPTION
Instead of apply the layout class to the body, it can be
applied to Conference. This will allow easier switching
between tile filmstrip and horizontal/vertical filmstrip.