### PR TITLE
noticeMessage is not shown (refs #3295)

### DIFF
--- a/react/features/conference/components/Conference.web.js
+++ b/react/features/conference/components/Conference.web.js
@@ -13,6 +13,7 @@ import { CalleeInfoContainer } from '../../invite';
 import { LargeVideo } from '../../large-video';
 import { NotificationsContainer } from '../../notifications';
 import { SidePanel } from '../../side-panel';
+import { default as Notice } from './Notice';
 import {
     Toolbox,
     fullScreenChanged,
@@ -163,6 +164,7 @@ class Conference extends Component<Props> {
             <div
                 id = 'videoconference_page'
                 onMouseMove = { this._onShowToolbar }>
+                <Notice />
                 <div id = 'videospace'>
                     <LargeVideo
                         hideVideoQualityLabel = { hideVideoQualityLabel } />

--- a/react/features/conference/components/Notice.web.js
+++ b/react/features/conference/components/Notice.web.js
@@ -1,0 +1,61 @@
+/* @flow */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../base/i18n';
+
+declare var config: Object;
+
+type Props = {
+    _message?: string,
+};
+
+/**
+ * Notice react component.
+ *
+ * @class Notice
+ */
+class Notice extends Component<Props> {
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        if (!this.props._message) {
+            return null;
+        }
+
+        return (
+            <div className = 'notice'>
+                <span className = 'notice__message' >
+                    { this.props._message }
+                </span>
+            </div>
+        );
+    }
+}
+
+/**
+ * Maps (parts of) the Redux state to the associated
+ * {@code Notice}'s props.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {{
+ *     _message: string,
+ * }}
+ */
+function _mapStateToProps(state) {
+    const {
+        noticeMessage
+    } = state['features/base/config'];
+
+    return {
+        _message: noticeMessage
+    };
+}
+export default translate(connect(_mapStateToProps)(Notice));

--- a/react/features/conference/components/index.js
+++ b/react/features/conference/components/index.js
@@ -1,1 +1,3 @@
+// @flow
+
 export { default as Conference } from './Conference';


### PR DESCRIPTION
* get back the Notice class
* add Notice component in the Conference web view

This patch is partially based in the removed logic included originally
in:

    commit 59a74153dc9ec0432cbc6f1fac5ef9c1b3566cd4
    (tag: jitsi-meet_1886, tag: jitsi-meet_1885, tag: 1797, tag: 1796)
    Author: Ilya Daynatovich <shupuercha@gmail.com>
    Date:   Mon Mar 20 11:04:54 2017 -0500

    Toolbar notice as React Component

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>