### PR TITLE
ref(filmstrip): create an empty container for local filmstrip move

### DIFF
--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -52,10 +52,10 @@ SharedVideoThumb.prototype.createContainer = function(spanId) {
 
     const remoteVideosContainer
         = document.getElementById('filmstripRemoteVideosContainer');
-    const remoteVideosEnd
-        = document.getElementById('filmstripRemoteVideosContainerEnd');
+    const localVideoContainer
+        = document.getElementById('localVideoTileViewContainer');
 
-    remoteVideosContainer.insertBefore(container, remoteVideosEnd);
+    remoteVideosContainer.insertBefore(container, localVideoContainer);
 
     return container;
 };

--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -50,10 +50,14 @@ SharedVideoThumb.prototype.createContainer = function(spanId) {
     displayNameContainer.className = 'displayNameContainer';
     container.appendChild(displayNameContainer);
 
-    const remotes = document.getElementById('filmstripRemoteVideosContainer');
+    const remoteVideosContainer
+        = document.getElementById('filmstripRemoteVideosContainer');
+    const remoteVideosEnd
+        = document.getElementById('filmstripRemoteVideosContainerEnd');
 
+    remoteVideosContainer.insertBefore(container, remoteVideosEnd);
 
-    return remotes.appendChild(container);
+    return container;
 };
 
 /**

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -644,10 +644,10 @@ RemoteVideo.createContainer = function(spanId) {
 
     const remoteVideosContainer
         = document.getElementById('filmstripRemoteVideosContainer');
-    const remoteVideosEnd
-        = document.getElementById('filmstripRemoteVideosContainerEnd');
+    const localVideoContainer
+        = document.getElementById('localVideoTileViewContainer');
 
-    remoteVideosContainer.insertBefore(container, remoteVideosEnd);
+    remoteVideosContainer.insertBefore(container, localVideoContainer);
 
     return container;
 };

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -642,10 +642,14 @@ RemoteVideo.createContainer = function(spanId) {
         <div class ='presence-label-container'></div>
         <span class = 'remotevideomenu'></span>`;
 
-    const remotes = document.getElementById('filmstripRemoteVideosContainer');
+    const remoteVideosContainer
+        = document.getElementById('filmstripRemoteVideosContainer');
+    const remoteVideosEnd
+        = document.getElementById('filmstripRemoteVideosContainerEnd');
 
+    remoteVideosContainer.insertBefore(container, remoteVideosEnd);
 
-    return remotes.appendChild(container);
+    return container;
 };
 
 export default RemoteVideo;

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -119,7 +119,9 @@ class Filmstrip extends Component <Props> {
                             className = 'remote-videos-container'
                             id = 'filmstripRemoteVideosContainer'
                             onMouseOut = { this._onMouseOut }
-                            onMouseOver = { this._onMouseOver } />
+                            onMouseOver = { this._onMouseOver }>
+                            <div id = 'filmstripRemoteVideosEnd' />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -120,7 +120,7 @@ class Filmstrip extends Component <Props> {
                             id = 'filmstripRemoteVideosContainer'
                             onMouseOut = { this._onMouseOut }
                             onMouseOver = { this._onMouseOver }>
-                            <div id = 'filmstripRemoteVideosEnd' />
+                            <div id = 'localVideoTileViewContainer' />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This might be necessary for tile view. To support making the
local video display at the end of remote videos while in tile
view, but separateed from scrollable remote videos, moving
the local video might be necessary. By creating an empty
container, there is a target for local video to move to.