### PR TITLE
removed superfluous button from mobile meeting page. changed verbiage of remaining button.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -627,7 +627,7 @@
         "tryAgainButton": "Try again in desktop",
         "launchWebButton": "Launch in web",
         "appNotInstalled": "You need the __app__ mobile app to join this meeting on your phone.",
-        "downloadApp": "Download the app",
+        "downloadApp": "Download/Open the app",
         "openApp": "Continue to the app"
     },
     "presenceStatus": {

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -141,14 +141,6 @@ class DeepLinkingMobilePage extends Component<*, *> {
                             { t(`${_TNS}.downloadApp`) }
                         </button>
                     </a>
-                    <a
-                        className = { `${_SNS}__href` }
-                        href = { this.state.joinURL }
-                        onClick = { this._onOpenApp }>
-                        {/* <button className = { `${_SNS}__button` }> */}
-                        { t(`${_TNS}.openApp`) }
-                        {/* </button> */}
-                    </a>
                     <DialInSummary
                         className = 'deep-linking-dial-in'
                         clickableNumbers = { true }


### PR DESCRIPTION
Our tests show that only one button is needed (tested on Android and Iphone). The button takes the user to the app download page if it's not already installed, and if it is, it simply opens the app.