### PR TITLE
feat(tile-view): initial implementation for tile view

### DIFF
--- a/css/filmstrip/_small_video.scss
+++ b/css/filmstrip/_small_video.scss
@@ -14,9 +14,9 @@
      * Focused video thumbnail.
      */
     &.videoContainerFocused {
-        border: $thumbnailVideoBorder solid $videoThumbnailSelected !important;
+        border: $thumbnailVideoBorder solid $videoThumbnailSelected;
         box-shadow: inset 0 0 3px $videoThumbnailSelected,
-        0 0 3px $videoThumbnailSelected !important;
+        0 0 3px $videoThumbnailSelected;
     }
 
     .remotevideomenu > .icon-menu {
@@ -26,7 +26,7 @@
     /**
      * Hovered video thumbnail.
      */
-    &:hover {
+    &:hover:not(.videoContainerFocused):not(.active-speaker) {
         cursor: hand;
         border: $thumbnailVideoBorder solid $videoThumbnailHovered;
         box-shadow: inset 0 0 3px $videoThumbnailHovered,

--- a/css/filmstrip/_small_video.scss
+++ b/css/filmstrip/_small_video.scss
@@ -14,11 +14,6 @@
      * Focused video thumbnail.
      */
     &.videoContainerFocused {
-        transition-duration: 0.5s;
-        -webkit-transition-duration: 0.5s;
-        -webkit-animation-name: greyPulse;
-        -webkit-animation-duration: 2s;
-        -webkit-animation-iteration-count: 1;
         border: $thumbnailVideoBorder solid $videoThumbnailSelected !important;
         box-shadow: inset 0 0 3px $videoThumbnailSelected,
         0 0 3px $videoThumbnailSelected !important;

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -97,6 +97,10 @@
         align-content: baseline;
     }
 
+    .has-overflow .videocontainer {
+        align-self: baseline;
+    }
+
     /**
      * Firefox flex acts a little differently. To make sure the bottom row of
      * thumbnails is not overlapped by the horizontal toolbar, margin is added

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -13,7 +13,10 @@
     }
 
     #filmstripRemoteVideos {
+        align-items: center;
         box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
         height: 100vh;
         width: 100vw;
     }
@@ -70,7 +73,8 @@
      * and allowing the thumbnails to wrap.
      */
     #filmstripRemoteVideosContainer {
-        align-content: baseline;
+        align-content: center;
+        align-items: center;
         box-sizing: border-box;
         display: flex;
         flex-wrap: wrap;
@@ -81,12 +85,16 @@
         .videocontainer {
             box-sizing: border-box;
             display: block;
-            margin: 0;
+            margin: 5px;
         }
 
         video {
             object-fit: contain;
         }
+    }
+
+    .has-overflow#filmstripRemoteVideosContainer {
+        align-content: baseline;
     }
 
     /**
@@ -95,94 +103,7 @@
      * to the local thumbnail to keep it from the bottom of the screen. It is
      * assumed the local thumbnail will always be on the bottom row.
      */
-    #localVideoContainer {
+    .has-overflow #localVideoContainer {
         margin-bottom: 100px !important;
-    }
-
-    /**
-     * The following styles resize thumbnails to fit a tile layout. !important
-     * is used a lot because javascript resizing logic fires for vertical and
-     * horizontal filmstrip to set inline thumbnail size styling.
-     */
-    $videoThumbnailSelectors: "
-         #filmstripRemoteVideos .videocontainer:not(#localVideoContainer),
-         #localVideoTileViewContainer
-    ";
-
-    .col-1 {
-        #{$videoThumbnailSelectors} {
-            width: 100% !important;
-        }
-    }
-
-    .col-2 {
-        #{$videoThumbnailSelectors} {
-            width: 50% !important;
-        }
-    }
-
-    .col-3 {
-        #{$videoThumbnailSelectors} {
-            width: 33% !important;
-        }
-    }
-
-    .col-4 {
-        #{$videoThumbnailSelectors}{
-            width: 25% !important;
-        }
-    }
-
-    .col-5 {
-        #{$videoThumbnailSelectors} {
-            width: 20% !important;
-        }
-    }
-
-    .row-1 {
-        #{$videoThumbnailSelectors} {
-            height: 100% !important;
-            min-height: 100% !important;
-        }
-    }
-
-    .row-2 {
-        #{$videoThumbnailSelectors} {
-            height: 50% !important;
-            min-height: 50% !important;
-        }
-    }
-
-    .row-3 {
-        #{$videoThumbnailSelectors} {
-            height: 33% !important;
-            min-height: 33% !important;
-        }
-    }
-
-    .row-4 {
-        #{$videoThumbnailSelectors} {
-            height: 25% !important;
-            min-height: 25% !important;
-        }
-    }
-
-    .row-5 {
-        #{$videoThumbnailSelectors} {
-            height: 20% !important;
-            min-height: 20% !important;
-        }
-    }
-
-    /**
-     * The actual thumbnail for local video is already in a wrapper that has
-     * its height and width set with CSS for the tile layout. Local video
-     * should try to fill the container's space. !important needs to be used
-     * to sidestep inline styling set by javascript for vertical and horizontal
-     * filmstrip.
-     */
-    #filmstripRemoteVideosContainer .videocontainer#localVideoContainer {
-        height: 100% !important;
-        width: 100% !important;
     }
 }

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -82,20 +82,19 @@
     }
 
     /**
-     * Firefox flex acts a little differently. To make sure the bottom row
-     * of thumbnails is not overlapped by the horizontal toolbar, margin is
-     * added to the local thumbnail to keep it from the bottom of the screen.
-     * It is assumed the local thumbnail will always be on the bottom row.
+     * Firefox flex acts a little differently. To make sure the bottom row of
+     * thumbnails is not overlapped by the horizontal toolbar, margin is added
+     * to the local thumbnail to keep it from the bottom of the screen. It is
+     * assumed the local thumbnail will always be on the bottom row.
      */
     #localVideoContainer {
         margin-bottom: 100px !important;
     }
 
     /**
-     * The following styles resize thumbnails to fit a tile/grid layout.
-     * !important is used a lot because javascript resizing logic fires
-     * for vertical and horizontal filmstrip to set inline thumbnail size
-     * styling.
+     * The following styles resize thumbnails to fit a tile layout. !important
+     * is used a lot because javascript resizing logic fires for vertical and
+     * horizontal filmstrip to set inline thumbnail size styling.
      */
     $videoThumbnailSelectors: "
          #filmstripRemoteVideos .videocontainer:not(#localVideoContainer),
@@ -138,6 +137,7 @@
             min-height: 100% !important;
         }
     }
+
     .row-2 {
         #{$videoThumbnailSelectors} {
             height: 50% !important;
@@ -148,7 +148,7 @@
     .row-3 {
         #{$videoThumbnailSelectors} {
             height: 33% !important;
-            min-height: 50% !important;
+            min-height: 33% !important;
         }
     }
 
@@ -168,9 +168,9 @@
 
     /**
      * The actual thumbnail for local video is already in a wrapper that has
-     * its height and width set as needed for the tile layout. Local video
+     * its height and width set with CSS for the tile layout. Local video
      * should try to fill the container's space. !important needs to be used
-     * to sidestep inlines styling set by javascript for vertical and horizontal
+     * to sidestep inline styling set by javascript for vertical and horizontal
      * filmstrip.
      */
     #filmstripRemoteVideosContainer .videocontainer#localVideoContainer {

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -1,0 +1,96 @@
+/**
+ * CSS styles that are specific to the filmstrip that shows the thumbnail tiles.
+ */
+.tile-view {
+    /**
+     * Add a border around the active speaker to make the thumbnail easier to
+     * see.
+     */
+    .active-speaker {
+        border: $thumbnailVideoBorder solid $videoThumbnailSelected;
+        box-shadow: inset 0 0 3px $videoThumbnailSelected,
+        0 0 3px $videoThumbnailSelected;
+    }
+
+    #filmstripRemoteVideos {
+        height: 100%;
+        width: 100%;
+    }
+
+    #remoteVideos {
+        /**
+         * Height is modified with an inline style in horizontal filmstrip mode
+         * so !important is used to override that.
+         */
+        height: 100% !important;
+        width: 100%;
+    }
+
+    .filmstrip {
+        align-items: center;
+        display: flex;
+        height: 100%;
+        justify-content: center;
+        left: 0;
+        position: fixed;
+        top: 0;
+        width: 100%;
+        z-index: $filmstripVideosZ
+    }
+
+    /**
+     * Regardless of the user setting, do not let the filmstrip be in a hidden
+     * state.
+     */
+    .filmstrip__videos.hidden {
+        display: block;
+    }
+
+    #filmstripRemoteVideos {
+        box-sizing: border-box;
+
+        /**
+         * Allow scrolling of the thumbnails.
+         */
+        overflow: auto;
+
+        /**
+         * Give top clearing for the thumbnails so labels and watermark are not
+         * overlapped.
+         */
+        padding-top: 100px;
+    }
+
+    /**
+     * The size of the thumbnails should be set with javascript, based on
+     * desired column count and window width. The rows are created using flex
+     * and allowing the thumbnails to wrap.
+     */
+    #filmstripRemoteVideosContainer {
+        align-content: baseline;
+        box-sizing: border-box;
+        display: flex;
+        flex-wrap: wrap;
+        height: auto;
+        justify-content: center;
+
+        .videocontainer {
+            box-sizing: border-box;
+            margin: 0;
+        }
+
+        video {
+            object-fit: contain;
+        }
+    }
+
+    /**
+     * Firefox flex acts a little differently. To make sure the bottom row
+     * of thumbnails is not overlapped by the horizontal toolbar, margin is
+     * added to the local thumbnail to keep it from the bottom of the screen.
+     * It is assumed the local thumbnail will always be on the bottom row.
+     */
+    #localVideoTileViewContainer {
+        margin-bottom: 100px;
+    }
+}

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -13,8 +13,9 @@
     }
 
     #filmstripRemoteVideos {
-        height: 100%;
-        width: 100%;
+        box-sizing: border-box;
+        height: 100vh;
+        width: 100vw;
     }
 
     #remoteVideos {
@@ -53,12 +54,6 @@
          * Allow scrolling of the thumbnails.
          */
         overflow: auto;
-
-        /**
-         * Give top clearing for the thumbnails so labels and watermark are not
-         * overlapped.
-         */
-        padding-top: 100px;
     }
 
     /**
@@ -71,11 +66,13 @@
         box-sizing: border-box;
         display: flex;
         flex-wrap: wrap;
-        height: auto;
+        height: 100vh;
         justify-content: center;
+        padding: 100px 0;
 
         .videocontainer {
             box-sizing: border-box;
+            display: block;
             margin: 0;
         }
 
@@ -90,7 +87,94 @@
      * added to the local thumbnail to keep it from the bottom of the screen.
      * It is assumed the local thumbnail will always be on the bottom row.
      */
-    #localVideoTileViewContainer {
-        margin-bottom: 100px;
+    #localVideoContainer {
+        margin-bottom: 100px !important;
+    }
+
+    /**
+     * The following styles resize thumbnails to fit a tile/grid layout.
+     * !important is used a lot because javascript resizing logic fires
+     * for vertical and horizontal filmstrip to set inline thumbnail size
+     * styling.
+     */
+    $videoThumbnailSelectors: "
+         #filmstripRemoteVideos .videocontainer:not(#localVideoContainer),
+         #localVideoTileViewContainer
+    ";
+
+    .col-1 {
+        #{$videoThumbnailSelectors} {
+            width: 100% !important;
+        }
+    }
+
+    .col-2 {
+        #{$videoThumbnailSelectors} {
+            width: 50% !important;
+        }
+    }
+
+    .col-3 {
+        #{$videoThumbnailSelectors} {
+            width: 33% !important;
+        }
+    }
+
+    .col-4 {
+        #{$videoThumbnailSelectors}{
+            width: 25% !important;
+        }
+    }
+
+    .col-5 {
+        #{$videoThumbnailSelectors} {
+            width: 20% !important;
+        }
+    }
+
+    .row-1 {
+        #{$videoThumbnailSelectors} {
+            height: 100% !important;
+            min-height: 100% !important;
+        }
+    }
+    .row-2 {
+        #{$videoThumbnailSelectors} {
+            height: 50% !important;
+            min-height: 50% !important;
+        }
+    }
+
+    .row-3 {
+        #{$videoThumbnailSelectors} {
+            height: 33% !important;
+            min-height: 50% !important;
+        }
+    }
+
+    .row-4 {
+        #{$videoThumbnailSelectors} {
+            height: 25% !important;
+            min-height: 25% !important;
+        }
+    }
+
+    .row-5 {
+        #{$videoThumbnailSelectors} {
+            height: 20% !important;
+            min-height: 20% !important;
+        }
+    }
+
+    /**
+     * The actual thumbnail for local video is already in a wrapper that has
+     * its height and width set as needed for the tile layout. Local video
+     * should try to fill the container's space. !important needs to be used
+     * to sidestep inlines styling set by javascript for vertical and horizontal
+     * filmstrip.
+     */
+    #filmstripRemoteVideosContainer .videocontainer#localVideoContainer {
+        height: 100% !important;
+        width: 100% !important;
     }
 }

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -18,6 +18,14 @@
         width: 100vw;
     }
 
+    .filmstrip__videos .videocontainer {
+        &:not(.active-speaker),
+        &:hover:not(.active-speaker) {
+            border: none;
+            box-shadow: none;
+        }
+    }
+
     #remoteVideos {
         /**
          * Height is modified with an inline style in horizontal filmstrip mode

--- a/css/filmstrip/_tile_view_overrides.scss
+++ b/css/filmstrip/_tile_view_overrides.scss
@@ -1,0 +1,47 @@
+/**
+ * Various overrides outside of the filmstrip to style the app to support a
+ * tiled thumbnail experience.
+ */
+.tile-view {
+    /**
+     * Let the avatar grow with the tile.
+     */
+    .userAvatar {
+        max-height: initial;
+        max-width: initial;
+    }
+
+    /**
+     * Hide various features that should not be displayed while in tile view.
+     */
+    #dominantSpeaker,
+    #filmstripLocalVideoThumbnail,
+    #largeVideoElementsContainer,
+    #sharedVideo,
+    .filmstrip__toolbar {
+        display: none;
+    }
+
+    #localConnectionMessage,
+    #remoteConnectionMessage,
+    .watermark {
+        z-index: $filmstripVideosZ + 1;
+    }
+
+    /**
+     * The follow styling uses !important to override inline styles set with
+     * javascript.
+     *
+     * TODO: These overrides should be more easy to remove and should be removed
+     * when the components are in react so their rendering done declaratively,
+     * making conditional styling easier to apply.
+     */
+    #largeVideoElementsContainer,
+    #remoteConnectionMessage,
+    #remotePresenceMessage {
+        display: none !important;
+    }
+    #largeVideoContainer {
+        background-color: $defaultBackground !important;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -72,6 +72,8 @@
 @import 'filmstrip/filmstrip_toolbar';
 @import 'filmstrip/horizontal_filmstrip';
 @import 'filmstrip/small_video';
+@import 'filmstrip/tile_view';
+@import 'filmstrip/tile_view_overrides';
 @import 'filmstrip/vertical_filmstrip';
 @import 'filmstrip/vertical_filmstrip_overrides';
 @import 'unsupported-browser/main';

--- a/interface_config.js
+++ b/interface_config.js
@@ -48,7 +48,8 @@ var interfaceConfig = {
         'microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',
         'fodeviceselection', 'hangup', 'profile', 'info', 'chat', 'recording',
         'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
-        'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts'
+        'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
+        'tileview'
     ],
 
     SETTINGS_SECTIONS: [ 'devices', 'language', 'moderator', 'profile' ],

--- a/interface_config.js
+++ b/interface_config.js
@@ -167,6 +167,12 @@ var interfaceConfig = {
     VIDEO_QUALITY_LABEL_DISABLED: false
 
     /**
+     * How many columns the tile view can expand to. The respected range is
+     * between 1 and 5.
+     */
+    // TILE_VIEW_MAX_COLUMNS: 5,
+
+    /**
      * Specify custom URL for downloading android mobile app.
      */
     // MOBILE_DOWNLOAD_LINK_ANDROID: 'https://play.google.com/store/apps/details?id=org.jitsi.meet',

--- a/lang/main.json
+++ b/lang/main.json
@@ -102,6 +102,7 @@
             "shortcuts": "Toggle shortcuts",
             "speakerStats": "Toggle speaker statistics",
             "toggleCamera": "Toggle camera",
+            "tileView": "Toggle tile view",
             "videomute": "Toggle mute video"
         },
         "addPeople": "Add people to your call",
@@ -144,6 +145,7 @@
         "raiseHand": "Raise / Lower your hand",
         "shortcuts": "View shortcuts",
         "speakerStats": "Speaker stats",
+        "tileViewToggle": "Toggle tile view",
         "invite": "Invite people"
     },
     "chat":{

--- a/modules/UI/shared_video/SharedVideoThumb.js
+++ b/modules/UI/shared_video/SharedVideoThumb.js
@@ -1,4 +1,6 @@
-/* global $ */
+/* global $, APP */
+import { shouldDisplayTileView } from '../../../react/features/video-layout';
+
 import SmallVideo from '../videolayout/SmallVideo';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -64,7 +66,9 @@ SharedVideoThumb.prototype.createContainer = function(spanId) {
  * The thumb click handler.
  */
 SharedVideoThumb.prototype.videoClick = function() {
-    this._togglePin();
+    if (!shouldDisplayTileView(APP.store.getState())) {
+        this._togglePin();
+    }
 };
 
 /**

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -3,9 +3,6 @@
 import { setFilmstripVisible } from '../../../react/features/filmstrip';
 import {
     LAYOUTS,
-    TILE_VIEW_CONFIGURATION,
-    calculateColumnCount,
-    calculateVisibleRowCount,
     getCurrentLayout,
     shouldDisplayTileView
 } from '../../../react/features/video-layout';
@@ -279,13 +276,11 @@ const Filmstrip = {
         let availableHeight = interfaceConfig.FILM_STRIP_MAX_HEIGHT;
         let availableWidth = videoAreaAvailableWidth;
 
+        // Tile view thumbnail sizing is handled through CSS. An empty value
+        // is used as a no-op and to side step very large min height/width
+        // values.
         if (isTileView) {
-            const containerWidth = this.filmstrip[0].clientWidth;
-            const columnCount = calculateColumnCount(
-                state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
-
-            availableWidth = (containerWidth / columnCount)
-                - TILE_VIEW_CONFIGURATION.SIDE_MARGINS;
+            availableWidth = 0;
         }
 
         const thumbs = this.getThumbs(true);
@@ -336,14 +331,11 @@ const Filmstrip = {
             );
         }
 
+        // Tile view thumbnail sizing is handled through CSS. An empty value
+        // is used as a no-op and to side step very large min height/width
+        // values.
         if (isTileView) {
-            const visibleRows = calculateVisibleRowCount(
-                state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
-            const containerHeight
-                = this.filmstrip[0].clientHeight
-                    - TILE_VIEW_CONFIGURATION.END_MARGINS;
-
-            availableHeight = containerHeight / visibleRows;
+            availableHeight = 0;
         } else {
             const maxHeight
 

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -296,7 +296,7 @@ LocalVideo.prototype._updateVideoElement = function() {
     ReactDOM.render(
         <Provider store = { APP.store }>
             <VideoTrack
-                id = { this.localVideoId }
+                id = 'localVideo_container'
                 videoTrack = {{ jitsiTrack: this.videoStream }} />
         </Provider>,
         localVideoContainer

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -275,7 +275,9 @@ LocalVideo.prototype._onContainerClick = function(event) {
         = $source.parents('.displayNameContainer').length > 0;
     const clickedOnPopover = $source.parents('.popover').length > 0
             || classList.contains('popover');
-    const ignoreClick = clickedOnDisplayName || clickedOnPopover;
+    const ignoreClick = clickedOnDisplayName
+        || clickedOnPopover
+        || shouldDisplayTileView(APP.store.getState());
 
     if (event.stopPropagation && !ignoreClick) {
         event.stopPropagation();

--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -11,6 +11,7 @@ import {
     getAvatarURLByParticipantId
 } from '../../../react/features/base/participants';
 import { updateSettings } from '../../../react/features/base/settings';
+import { shouldDisplayTileView } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -26,7 +27,7 @@ function LocalVideo(VideoLayout, emitter, streamEndedCallback) {
     this.streamEndedCallback = streamEndedCallback;
     this.container = this.createContainer();
     this.$container = $(this.container);
-    $('#filmstripLocalVideoThumbnail').append(this.container);
+    this.updateDOMLocation();
 
     this.localVideoId = null;
     this.bindHoverHandler();
@@ -109,16 +110,7 @@ LocalVideo.prototype.changeVideo = function(stream) {
 
     this.localVideoId = `localVideo_${stream.getId()}`;
 
-    const localVideoContainer = document.getElementById('localVideoWrapper');
-
-    ReactDOM.render(
-        <Provider store = { APP.store }>
-            <VideoTrack
-                id = { this.localVideoId }
-                videoTrack = {{ jitsiTrack: stream }} />
-        </Provider>,
-        localVideoContainer
-    );
+    this._updateVideoElement();
 
     // eslint-disable-next-line eqeqeq
     const isVideo = stream.videoType != 'desktop';
@@ -128,12 +120,14 @@ LocalVideo.prototype.changeVideo = function(stream) {
     this.setFlipX(isVideo ? settings.localFlipX : false);
 
     const endedHandler = () => {
+        const localVideoContainer
+            = document.getElementById('localVideoWrapper');
 
         // Only remove if there is no video and not a transition state.
         // Previous non-react logic created a new video element with each track
         // removal whereas react reuses the video component so it could be the
         // stream ended but a new one is being used.
-        if (this.videoStream.isEnded()) {
+        if (localVideoContainer && this.videoStream.isEnded()) {
             ReactDOM.unmountComponentAtNode(localVideoContainer);
         }
 
@@ -236,6 +230,29 @@ LocalVideo.prototype._enableDisableContextMenu = function(enable) {
 };
 
 /**
+ * Places the {@code LocalVideo} in the DOM based on the current video layout.
+ *
+ * @returns {void}
+ */
+LocalVideo.prototype.updateDOMLocation = function() {
+    if (!this.container) {
+        return;
+    }
+
+    if (this.container.parentElement) {
+        this.container.parentElement.removeChild(this.container);
+    }
+
+    const appendTarget = shouldDisplayTileView(APP.store.getState())
+        ? document.getElementById('localVideoTileViewContainer')
+        : document.getElementById('filmstripLocalVideoThumbnail');
+
+    appendTarget && appendTarget.appendChild(this.container);
+
+    this._updateVideoElement();
+};
+
+/**
  * Callback invoked when the thumbnail is clicked. Will directly call
  * VideoLayout to handle thumbnail click if certain elements have not been
  * clicked.
@@ -267,6 +284,30 @@ LocalVideo.prototype._onContainerClick = function(event) {
     if (!ignoreClick) {
         this._togglePin();
     }
+};
+
+/**
+ * Renders the React Element for displaying video in {@code LocalVideo}.
+ *
+ */
+LocalVideo.prototype._updateVideoElement = function() {
+    const localVideoContainer = document.getElementById('localVideoWrapper');
+
+    ReactDOM.render(
+        <Provider store = { APP.store }>
+            <VideoTrack
+                id = { this.localVideoId }
+                videoTrack = {{ jitsiTrack: this.videoStream }} />
+        </Provider>,
+        localVideoContainer
+    );
+
+    // Ensure the video gets play() called on it. This may be necessary in the
+    // case where the local video container was moved and re-attached, in which
+    // case video does not autoplay.
+    const video = this.container.querySelector('video');
+
+    video && video.play();
 };
 
 export default LocalVideo;

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -20,6 +20,10 @@ import {
     REMOTE_CONTROL_MENU_STATES,
     RemoteVideoMenuTriggerButton
 } from '../../../react/features/remote-video-menu';
+import {
+    LAYOUTS,
+    getCurrentLayout
+} from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -163,8 +167,17 @@ RemoteVideo.prototype._generatePopupContent = function() {
     const onVolumeChange = this._setAudioVolume;
     const { isModerator } = APP.conference;
     const participantID = this.id;
-    const menuPosition = interfaceConfig.VERTICAL_FILMSTRIP
-        ? 'left bottom' : 'top center';
+
+    const currentLayout = getCurrentLayout(APP.store.getState());
+    let remoteMenuPosition;
+
+    if (currentLayout === LAYOUTS.TILE_VIEW) {
+        remoteMenuPosition = 'left top';
+    } else if (currentLayout === LAYOUTS.VERTICAL_FILMSTRIP_VIEW) {
+        remoteMenuPosition = 'left bottom';
+    } else {
+        remoteMenuPosition = 'top center';
+    }
 
     ReactDOM.render(
         <Provider store = { APP.store }>
@@ -174,7 +187,7 @@ RemoteVideo.prototype._generatePopupContent = function() {
                         initialVolumeValue = { initialVolumeValue }
                         isAudioMuted = { this.isAudioMuted }
                         isModerator = { isModerator }
-                        menuPosition = { menuPosition }
+                        menuPosition = { remoteMenuPosition }
                         onMenuDisplay
                             = {this._onRemoteVideoMenuDisplay.bind(this)}
                         onRemoteControlToggle = { onRemoteControlToggle }

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -22,7 +22,8 @@ import {
 } from '../../../react/features/remote-video-menu';
 import {
     LAYOUTS,
-    getCurrentLayout
+    getCurrentLayout,
+    shouldDisplayTileView
 } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 
@@ -626,7 +627,8 @@ RemoteVideo.prototype._onContainerClick = function(event) {
     const { classList } = event.target;
 
     const ignoreClick = $source.parents('.popover').length > 0
-            || classList.contains('popover');
+            || classList.contains('popover')
+            || shouldDisplayTileView(APP.store.getState());
 
     if (!ignoreClick) {
         this._togglePin();

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -2,6 +2,10 @@
 const logger = require('jitsi-meet-logger').getLogger(__filename);
 
 import {
+    getNearestReceiverVideoQualityLevel,
+    setMaxReceiverVideoQuality
+} from '../../../react/features/base/conference';
+import {
     JitsiParticipantConnectionStatus
 } from '../../../react/features/base/lib-jitsi-meet';
 import { VIDEO_TYPE } from '../../../react/features/base/media';
@@ -9,6 +13,9 @@ import {
     getPinnedParticipant,
     pinParticipant
 } from '../../../react/features/base/participants';
+import {
+    shouldDisplayTileView
+} from '../../../react/features/video-layout';
 import { SHARED_VIDEO_CONTAINER_TYPE } from '../shared_video/SharedVideo';
 import SharedVideoThumb from '../shared_video/SharedVideoThumb';
 
@@ -594,6 +601,14 @@ const VideoLayout = {
 
         Filmstrip.resizeThumbnails(localVideo, remoteVideo, forceUpdate);
 
+        if (shouldDisplayTileView(APP.store.getState())) {
+            const height = (localVideo && localVideo.thumbHeight)
+                || (remoteVideo && remoteVideo.thumbHeight);
+            const qualityLevel = getNearestReceiverVideoQualityLevel(height);
+
+            APP.store.dispatch(setMaxReceiverVideoQuality(qualityLevel));
+        }
+
         if (onComplete && typeof onComplete === 'function') {
             onComplete();
         }
@@ -1139,6 +1154,22 @@ const VideoLayout = {
     setLocalRemoteControlActiveChanged() {
         Object.values(remoteVideos).forEach(
             remoteVideo => remoteVideo.updateRemoteVideoMenu()
+        );
+    },
+
+    /**
+     * Helper method to invoke when the video layout has changed and elements
+     * have to be re-arranged and resized.
+     *
+     * @returns {void}
+     */
+    refreshLayout() {
+        localVideoThumbnail && localVideoThumbnail.updateDOMLocation();
+        VideoLayout.resizeVideoArea();
+
+        localVideoThumbnail && localVideoThumbnail.rerender();
+        Object.values(remoteVideos).forEach(
+            remoteVideo => remoteVideo.rerender()
         );
     },
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -602,8 +602,10 @@ const VideoLayout = {
         Filmstrip.resizeThumbnails(localVideo, remoteVideo, forceUpdate);
 
         if (shouldDisplayTileView(APP.store.getState())) {
-            const height = (localVideo && localVideo.thumbHeight)
-                || (remoteVideo && remoteVideo.thumbHeight);
+            const height
+                = (localVideoThumbnail
+                    && localVideoThumbnail.$container.height())
+                || 0;
             const qualityLevel = getNearestReceiverVideoQualityLevel(height);
 
             APP.store.dispatch(setMaxReceiverVideoQuality(qualityLevel));

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -603,8 +603,8 @@ const VideoLayout = {
 
         if (shouldDisplayTileView(APP.store.getState())) {
             const height
-                = (localVideoThumbnail
-                    && localVideoThumbnail.$container.height())
+                = (localVideo && localVideo.thumbHeight)
+                || (remoteVideo && remoteVideo.thumbnHeight)
                 || 0;
             const qualityLevel = getNearestReceiverVideoQualityLevel(height);
 
@@ -614,9 +614,6 @@ const VideoLayout = {
         if (onComplete && typeof onComplete === 'function') {
             onComplete();
         }
-
-        return { localVideo,
-            remoteVideo };
     },
 
     /**

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -8,7 +8,8 @@ import {
     AVATAR_ID_COMMAND,
     AVATAR_URL_COMMAND,
     EMAIL_COMMAND,
-    JITSI_CONFERENCE_URL_KEY
+    JITSI_CONFERENCE_URL_KEY,
+    VIDEO_QUALITY_LEVELS
 } from './constants';
 
 /**
@@ -98,6 +99,38 @@ export function getCurrentConference(stateful: Function | Object) {
         conference
             ? conference === leaving ? undefined : conference
             : joining);
+}
+
+/**
+ * Finds the nearest match for the passed in {@link availableHeight} to am
+ * enumerated value in {@code VIDEO_QUALITY_LEVELS}.
+ *
+ * @param {number} availableHeight - The height to which a matching video
+ * quality level should be found.
+ * @returns {number} The closest matching value from
+ * {@code VIDEO_QUALITY_LEVELS}.
+ */
+export function getNearestReceiverVideoQualityLevel(availableHeight: number) {
+    const qualityLevels = [
+        VIDEO_QUALITY_LEVELS.HIGH,
+        VIDEO_QUALITY_LEVELS.STANDARD,
+        VIDEO_QUALITY_LEVELS.LOW
+    ];
+
+    let selectedLevel = qualityLevels[0];
+
+    for (let i = 1; i < qualityLevels.length; i++) {
+        const previousValue = qualityLevels[i - 1];
+        const currentValue = qualityLevels[i];
+        const diffWithCurrent = Math.abs(availableHeight - currentValue);
+        const diffWithPrevious = Math.abs(availableHeight - previousValue);
+
+        if (diffWithCurrent < diffWithPrevious) {
+            selectedLevel = currentValue;
+        }
+    }
+
+    return selectedLevel;
 }
 
 /**

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -9,12 +9,6 @@ import { dockToolbox } from '../../../toolbox';
 import { setFilmstripHovered } from '../../actions';
 import { shouldRemoteVideosBeVisible } from '../../functions';
 
-import {
-    calculateColumnCount,
-    calculateVisibleRowCount,
-    getMaxColumnCount,
-    shouldDisplayTileView
-} from '../../../video-layout';
 import Toolbar from './Toolbar';
 
 declare var interfaceConfig: Object;
@@ -192,17 +186,8 @@ function _mapStateToProps(state) {
         && state['features/toolbox'].visible
         && interfaceConfig.TOOLBAR_BUTTONS.length;
     const remoteVideosVisible = shouldRemoteVideosBeVisible(state);
-
-    let className = `${remoteVideosVisible ? '' : 'hide-videos'} ${
+    const className = `${remoteVideosVisible ? '' : 'hide-videos'} ${
         reduceHeight ? 'reduce-height' : ''}`.trim();
-
-    if (shouldDisplayTileView(state)) {
-        const maxColumns = getMaxColumnCount();
-        const columns = calculateColumnCount(state, maxColumns);
-        const rows = calculateVisibleRowCount(state, maxColumns);
-
-        className = `${className} col-${columns} row-${rows}`;
-    }
 
     return {
         _className: className,

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -8,6 +8,13 @@ import { dockToolbox } from '../../../toolbox';
 
 import { setFilmstripHovered } from '../../actions';
 import { shouldRemoteVideosBeVisible } from '../../functions';
+
+import {
+    TILE_VIEW_CONFIGURATION,
+    calculateColumnCount,
+    calculateVisibleRowCount,
+    shouldDisplayTileView
+} from '../../../video-layout';
 import Toolbar from './Toolbar';
 
 declare var interfaceConfig: Object;
@@ -186,8 +193,17 @@ function _mapStateToProps(state) {
         && interfaceConfig.TOOLBAR_BUTTONS.length;
     const remoteVideosVisible = shouldRemoteVideosBeVisible(state);
 
-    const className = `${remoteVideosVisible ? '' : 'hide-videos'} ${
-        reduceHeight ? 'reduce-height' : ''}`;
+    let className = `${remoteVideosVisible ? '' : 'hide-videos'} ${
+        reduceHeight ? 'reduce-height' : ''}`.trim();
+
+    if (shouldDisplayTileView(state)) {
+        const columns = calculateColumnCount(
+            state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
+        const rows = calculateVisibleRowCount(
+            state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
+
+        className = `${className} col-${columns} row-${rows}`;
+    }
 
     return {
         _className: className,

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -10,9 +10,9 @@ import { setFilmstripHovered } from '../../actions';
 import { shouldRemoteVideosBeVisible } from '../../functions';
 
 import {
-    TILE_VIEW_CONFIGURATION,
     calculateColumnCount,
     calculateVisibleRowCount,
+    getMaxColumnCount,
     shouldDisplayTileView
 } from '../../../video-layout';
 import Toolbar from './Toolbar';
@@ -197,10 +197,9 @@ function _mapStateToProps(state) {
         reduceHeight ? 'reduce-height' : ''}`.trim();
 
     if (shouldDisplayTileView(state)) {
-        const columns = calculateColumnCount(
-            state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
-        const rows = calculateVisibleRowCount(
-            state, TILE_VIEW_CONFIGURATION.MAX_COLUMNS);
+        const maxColumns = getMaxColumnCount();
+        const columns = calculateColumnCount(state, maxColumns);
+        const rows = calculateVisibleRowCount(state, maxColumns);
 
         className = `${className} col-${columns} row-${rows}`;
     }

--- a/react/features/large-video/actions.js
+++ b/react/features/large-video/actions.js
@@ -6,7 +6,9 @@ import {
 } from '../analytics';
 import { _handleParticipantError } from '../base/conference';
 import { MEDIA_TYPE } from '../base/media';
+import { getParticipants } from '../base/participants';
 import { reportError } from '../base/util';
+import { shouldDisplayTileView } from '../video-layout';
 
 import {
     SELECT_LARGE_VIDEO_PARTICIPANT,
@@ -26,17 +28,19 @@ export function selectParticipant() {
         const { conference } = state['features/base/conference'];
 
         if (conference) {
-            const largeVideo = state['features/large-video'];
-            const id = largeVideo.participantId;
+            const ids = shouldDisplayTileView(state)
+                ? getParticipants(state).map(participant => participant.id)
+                : [ state['features/large-video'].participantId ];
 
             try {
-                conference.selectParticipant(id);
+                conference.selectParticipants(ids);
             } catch (err) {
                 _handleParticipantError(err);
 
                 sendAnalytics(createSelectParticipantFailedEvent(err));
 
-                reportError(err, `Failed to select participant ${id}`);
+                reportError(
+                    err, `Failed to select participants ${ids.toString()}`);
             }
         }
     };

--- a/react/features/large-video/components/AbstractLabels.js
+++ b/react/features/large-video/components/AbstractLabels.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 
 import { isFilmstripVisible } from '../../filmstrip';
 import { RecordingLabel } from '../../recording';
+import { shouldDisplayTileView } from '../../video-layout';
 import { VideoQualityLabel } from '../../video-quality';
 import { TranscribingLabel } from '../../transcribing/';
 
@@ -17,6 +18,11 @@ export type Props = {
     * determine display classes to set.
     */
     _filmstripVisible: boolean,
+
+    /**
+     * Whether or not the video quality label should be displayed.
+     */
+    _showVideoQualityLabel: boolean
 };
 
 /**
@@ -72,11 +78,13 @@ export default class AbstractLabels<P: Props, S> extends Component<P, S> {
  * @param {Object} state - The Redux state.
  * @private
  * @returns {{
- *     _filmstripVisible: boolean
+ *     _filmstripVisible: boolean,
+ *     _showVideoQualityLabel: boolean
  * }}
  */
 export function _abstractMapStateToProps(state: Object) {
     return {
-        _filmstripVisible: isFilmstripVisible(state)
+        _filmstripVisible: isFilmstripVisible(state),
+        _showVideoQualityLabel: !shouldDisplayTileView(state)
     };
 }

--- a/react/features/large-video/components/Labels.web.js
+++ b/react/features/large-video/components/Labels.web.js
@@ -89,7 +89,8 @@ class Labels extends AbstractLabels<Props, State> {
                     this._renderTranscribingLabel()
                 }
                 {
-                    this._renderVideoQualityLabel()
+                    this.props._showVideoQualityLabel
+                        && this._renderVideoQualityLabel()
                 }
             </div>
         );

--- a/react/features/large-video/components/LargeVideo.web.js
+++ b/react/features/large-video/components/LargeVideo.web.js
@@ -50,7 +50,7 @@ export default class LargeVideo extends Component<*> {
                 </div>
                 <div id = 'remotePresenceMessage' />
                 <span id = 'remoteConnectionMessage' />
-                <div>
+                <div id = 'largeVideoElementsContainer'>
                     <div id = 'largeVideoBackgroundContainer' />
                     {
 

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -40,6 +40,7 @@ import {
 import { toggleSharedVideo } from '../../../shared-video';
 import { toggleChat } from '../../../side-panel';
 import { SpeakerStats } from '../../../speaker-stats';
+import { TileViewButton } from '../../../video-layout';
 import {
     OverflowMenuVideoQualityItem,
     VideoQualityDialog
@@ -369,6 +370,8 @@ class Toolbox extends Component<Props> {
                         visible = { this._shouldShowButton('camera') } />
                 </div>
                 <div className = 'button-group-right'>
+                    { this._shouldShowButton('tileview')
+                        && <TileViewButton /> }
                     { this._shouldShowButton('invite')
                         && !_hideInviteButton
                         && <ToolbarButton

--- a/react/features/video-layout/actionTypes.js
+++ b/react/features/video-layout/actionTypes.js
@@ -1,0 +1,10 @@
+/**
+ * The type of the action which enables or disables the feature for showing
+ * video thumbnails in a two-axis tile view.
+ *
+ * @returns {{
+ *     type: SET_TILE_VIEW,
+ *     enabled: boolean
+ * }}
+ */
+export const SET_TILE_VIEW = Symbol('SET_TILE_VIEW');

--- a/react/features/video-layout/actions.js
+++ b/react/features/video-layout/actions.js
@@ -1,0 +1,20 @@
+// @flow
+
+import { SET_TILE_VIEW } from './actionTypes';
+
+/**
+ * Creates a (redux) action which signals to set the UI layout to be tiled view
+ * or not.
+ *
+ * @param {boolean} enabled - Whether or not tile view should be shown.
+ * @returns {{
+ *     type: SET_TILE_VIEW,
+ *     enabled: boolean
+ * }}
+ */
+export function setTileView(enabled: boolean) {
+    return {
+        type: SET_TILE_VIEW,
+        enabled
+    };
+}

--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -38,7 +38,7 @@ type Props = AbstractButtonProps & {
 class TileViewButton<P: Props> extends AbstractButton<P, *> {
     accessibilityLabel = 'toolbar.accessibilityLabel.tileView';
     iconName = 'icon-tiles-many';
-    toggledIconName = 'icon-tiles-one toggled';
+    toggledIconName = 'icon-tiles-many toggled';
     tooltip = 'toolbar.tileViewToggle';
 
     /**

--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -1,0 +1,90 @@
+// @flow
+
+import { connect } from 'react-redux';
+
+import {
+    createToolbarEvent,
+    sendAnalytics
+} from '../../analytics';
+import { translate } from '../../base/i18n';
+import {
+    AbstractButton,
+    type AbstractButtonProps
+} from '../../base/toolbox';
+
+import { setTileView } from '../actions';
+
+/**
+ * The type of the React {@code Component} props of {@link TileViewButton}.
+ */
+type Props = AbstractButtonProps & {
+
+    /**
+     * Whether or not tile view layout has been enabled as the user preference.
+     */
+    _tileViewEnabled: boolean,
+
+    /**
+     * Used to dispatch actions from the buttons.
+     */
+    dispatch: Dispatch<*>
+};
+
+/**
+ * Component that renders a toolbar button for toggling the tile layout view.
+ *
+ * @extends AbstractButton
+ */
+class TileViewButton<P: Props> extends AbstractButton<P, *> {
+    accessibilityLabel = 'toolbar.accessibilityLabel.tileView';
+    iconName = 'icon-tiles-many';
+    toggledIconName = 'icon-tiles-one toggled';
+    tooltip = 'toolbar.tileViewToggle';
+
+    /**
+     * Handles clicking / pressing the button.
+     *
+     * @override
+     * @protected
+     * @returns {void}
+     */
+    _handleClick() {
+        const { _tileViewEnabled, dispatch } = this.props;
+
+        sendAnalytics(createToolbarEvent(
+            'tileview.button',
+            {
+                'is_enabled': _tileViewEnabled
+            }));
+
+        dispatch(setTileView(!_tileViewEnabled));
+    }
+
+    /**
+     * Indicates whether this button is in toggled state or not.
+     *
+     * @override
+     * @protected
+     * @returns {boolean}
+     */
+    _isToggled() {
+        return this.props._tileViewEnabled;
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated props for the
+ * {@code TileViewButton} component.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {{
+ *     _tileViewEnabled: boolean
+ * }}
+ */
+function _mapStateToProps(state) {
+    return {
+        _tileViewEnabled: state['features/video-layout'].tileViewEnabled
+    };
+}
+
+export default translate(connect(_mapStateToProps)(TileViewButton));

--- a/react/features/video-layout/components/index.js
+++ b/react/features/video-layout/components/index.js
@@ -1,0 +1,1 @@
+export { default as TileViewButton } from './TileViewButton';

--- a/react/features/video-layout/constants.js
+++ b/react/features/video-layout/constants.js
@@ -1,0 +1,29 @@
+/**
+ * An enumeration of the different display layouts supported by the application.
+ *
+ * @type {Object}
+ */
+export const LAYOUTS = {
+    HORIZONTAL_FILMSTRIP_VIEW: 'horizonta-filmstrip-view',
+    TILE_VIEW: 'tile-view',
+    VERTICAL_FILMSTRIP_VIEW: 'vertical-filmstrip-view'
+};
+
+/**
+ * Constants used for calculating how to display the thumbnails in tile view.
+ *
+ * @type {Object}
+ */
+export const TILE_VIEW_CONFIGURATION = {
+    // How much total white space is expected at the top and bottom of the
+    // container that holds the tiles.
+    END_MARGINS: 100 * 2,
+
+    // The maximum number of thumbnails that should display in one row of tile
+    // view.
+    MAX_COLUMNS: 5,
+
+    // How much total white space is expected at the sides of the container that
+    // holds the tiles.
+    SIDE_MARGINS: 10 * 2
+};

--- a/react/features/video-layout/constants.js
+++ b/react/features/video-layout/constants.js
@@ -4,26 +4,7 @@
  * @type {Object}
  */
 export const LAYOUTS = {
-    HORIZONTAL_FILMSTRIP_VIEW: 'horizonta-filmstrip-view',
+    HORIZONTAL_FILMSTRIP_VIEW: 'horizontal-filmstrip-view',
     TILE_VIEW: 'tile-view',
     VERTICAL_FILMSTRIP_VIEW: 'vertical-filmstrip-view'
-};
-
-/**
- * Constants used for calculating how to display the thumbnails in tile view.
- *
- * @type {Object}
- */
-export const TILE_VIEW_CONFIGURATION = {
-    // How much total white space is expected at the top and bottom of the
-    // container that holds the tiles.
-    END_MARGINS: 100 * 2,
-
-    // The maximum number of thumbnails that should display in one row of tile
-    // view.
-    MAX_COLUMNS: 5,
-
-    // How much total white space is expected at the sides of the container that
-    // holds the tiles.
-    SIDE_MARGINS: 10 * 2
 };

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { getParticipantCount } from '../base/participants';
-
 import { LAYOUTS } from './constants';
 
 declare var interfaceConfig: Object;
@@ -27,23 +25,16 @@ export function calculateColumnCount(state: Object, maxColumns: number) {
 }
 
 /**
- * Returns how many tile columns should be visible on the screen. It is assumed
- * non-visible rows will be viewed by scrolling.
+ * Returns how many total rows will be in the tile view grid.
  *
  * @param {Object} state - The redux state.
- * @param {number} maxColumns - The maximum number of columns that can be
- * displayed.
+ * @param {number} columns - The number of columns that will be displayed.
  * @returns {number}
  */
-export function calculateVisibleRowCount(state: Object, maxColumns: number) {
-    const columns = calculateColumnCount(state, maxColumns);
+export function calculateRowCount(state: Object, columns: number) {
     const potentialThumbnails = state['features/base/participants'].length;
-    const totalRowCount = Math.ceil(potentialThumbnails / columns);
 
-    return Math.min(
-        maxColumns,
-        totalRowCount
-    );
+    return Math.ceil(potentialThumbnails / columns);
 }
 
 /**
@@ -70,7 +61,7 @@ export function getCurrentLayout(state: Object) {
  * @returns {number}
  */
 export function getMaxColumnCount() {
-    const configuredMax = interfaceConfig.TILE_VIEW_MAX_COLUMNS || 1;
+    const configuredMax = interfaceConfig.TILE_VIEW_MAX_COLUMNS || 5;
 
     return Math.max(Math.min(configuredMax, 1), 5);
 }
@@ -83,10 +74,10 @@ export function getMaxColumnCount() {
  * @param {Object} state - The redux state.
  * @returns {boolean} True if tile view should be displayed.
  */
-export function shouldDisplayTileView(state: Object) {
+export function shouldDisplayTileView(state: Object = {}) {
     return Boolean(
-        state['features/video-layout'].tileViewEnabled
-            && getParticipantCount(state) > 2
+        state['features/video-layout']
+            && state['features/video-layout'].tileViewEnabled
             && !state['features/etherpad'].editing
     );
 }

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -1,0 +1,81 @@
+// @flow
+
+import { getParticipantCount } from '../base/participants';
+
+import { LAYOUTS } from './constants';
+
+declare var interfaceConfig: Object;
+
+/**
+ * Returns how many tile columns should be displayed for tile view.
+ *
+ * @param {Object} state - The redux state.
+ * @param {number} maxColumns - The maximum number of columns that can be
+ * displayed.
+ * @returns {number}
+ */
+export function calculateColumnCount(state: Object, maxColumns: number) {
+    // Purposefully include all participants, which includes fake participants
+    // that should show a thumbnail.
+    const potentialThumbnails = state['features/base/participants'].length;
+    const columnsToMaintainASquare = Math.ceil(Math.sqrt(potentialThumbnails));
+
+    return Math.min(
+        columnsToMaintainASquare,
+        maxColumns
+    );
+}
+
+/**
+ * Returns how many tile columns should be visible on the screen. It is assumed
+ * non-visible rows will be viewed by scrolling.
+ *
+ * @param {Object} state - The redux state.
+ * @param {number} maxColumns - The maximum number of columns that can be
+ * displayed.
+ * @returns {number}
+ */
+export function calculateVisibleRowCount(state: Object, maxColumns: number) {
+    const columns = calculateColumnCount(state, maxColumns);
+    const potentialThumbnails = state['features/base/participants'].length;
+    const totalRowCount = Math.ceil(potentialThumbnails / columns);
+
+    return Math.min(
+        maxColumns,
+        totalRowCount
+    );
+
+}
+
+/**
+ * Returns the {@code LAYOUTS} constant associated with the layout
+ * the application should currently be in.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {string}
+ */
+export function getCurrentLayout(state: Object) {
+    if (shouldDisplayTileView(state)) {
+        return LAYOUTS.TILE_VIEW;
+    } else if (interfaceConfig.VERTICAL_FILMSTRIP) {
+        return LAYOUTS.VERTICAL_FILMSTRIP_VIEW;
+    }
+
+    return LAYOUTS.HORIZONTAL_FILMSTRIP_VIEW;
+}
+
+/**
+ * Selector for determining if the UI layout should be in tile view. Tile view
+ * is determined by more than just having the tile view setting enabled, as
+ * one-on-one calls should not be in tile view, as well as etherpad editing.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {boolean} True if tile view should be displayed.
+ */
+export function shouldDisplayTileView(state: Object) {
+    return Boolean(
+        state['features/video-layout'].tileViewEnabled
+            && getParticipantCount(state) > 2
+            && !state['features/etherpad'].editing
+    );
+}

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -44,7 +44,6 @@ export function calculateVisibleRowCount(state: Object, maxColumns: number) {
         maxColumns,
         totalRowCount
     );
-
 }
 
 /**
@@ -62,6 +61,18 @@ export function getCurrentLayout(state: Object) {
     }
 
     return LAYOUTS.HORIZONTAL_FILMSTRIP_VIEW;
+}
+
+/**
+ * Returns how many columns should be displayed in tile view. The number
+ * returned will be between 1 and 5, inclusive.
+ *
+ * @returns {number}
+ */
+export function getMaxColumnCount() {
+    const configuredMax = interfaceConfig.TILE_VIEW_MAX_COLUMNS || 1;
+
+    return Math.max(Math.min(configuredMax, 1), 5);
 }
 
 /**

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -5,39 +5,6 @@ import { LAYOUTS } from './constants';
 declare var interfaceConfig: Object;
 
 /**
- * Returns how many tile columns should be displayed for tile view.
- *
- * @param {Object} state - The redux state.
- * @param {number} maxColumns - The maximum number of columns that can be
- * displayed.
- * @returns {number}
- */
-export function calculateColumnCount(state: Object, maxColumns: number) {
-    // Purposefully include all participants, which includes fake participants
-    // that should show a thumbnail.
-    const potentialThumbnails = state['features/base/participants'].length;
-    const columnsToMaintainASquare = Math.ceil(Math.sqrt(potentialThumbnails));
-
-    return Math.min(
-        columnsToMaintainASquare,
-        maxColumns
-    );
-}
-
-/**
- * Returns how many total rows will be in the tile view grid.
- *
- * @param {Object} state - The redux state.
- * @param {number} columns - The number of columns that will be displayed.
- * @returns {number}
- */
-export function calculateRowCount(state: Object, columns: number) {
-    const potentialThumbnails = state['features/base/participants'].length;
-
-    return Math.ceil(potentialThumbnails / columns);
-}
-
-/**
  * Returns the {@code LAYOUTS} constant associated with the layout
  * the application should currently be in.
  *
@@ -64,6 +31,34 @@ export function getMaxColumnCount() {
     const configuredMax = interfaceConfig.TILE_VIEW_MAX_COLUMNS || 5;
 
     return Math.max(Math.min(configuredMax, 1), 5);
+}
+
+/**
+ * Returns the cell count dimensions for tile view. Tile view tries to uphold
+ * equal count of tiles for height and width, until maxColumn is reached in
+ * which rows will be added but no more columns.
+ *
+ * @param {Object} state - The redux state.
+ * @param {number} maxColumns - The maximum number of columns that can be
+ * displayed.
+ * @returns {Object} An object is return with the desired number of columns,
+ * rows, and visible rows (the rest should overflow) for the tile view layout.
+ */
+export function getTileViewGridDimensions(state: Object, maxColumns: number) {
+    // Purposefully include all participants, which includes fake participants
+    // that should show a thumbnail.
+    const potentialThumbnails = state['features/base/participants'].length;
+
+    const columnsToMaintainASquare = Math.ceil(Math.sqrt(potentialThumbnails));
+    const columns = Math.min(columnsToMaintainASquare, maxColumns);
+    const rows = Math.ceil(potentialThumbnails / columns);
+    const visibleRows = Math.min(maxColumns, rows);
+
+    return {
+        columns,
+        rows,
+        visibleRows
+    };
 }
 
 /**

--- a/react/features/video-layout/index.js
+++ b/react/features/video-layout/index.js
@@ -1,1 +1,9 @@
+export * from './actions';
+export * from './actionTypes';
+export * from './components';
+export * from './constants';
+export * from './functions';
+
 import './middleware';
+import './reducer';
+import './subscriber';

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -15,6 +15,8 @@ import {
 import { MiddlewareRegistry } from '../base/redux';
 import { TRACK_ADDED } from '../base/tracks';
 
+import { SET_TILE_VIEW } from './actionTypes';
+
 declare var APP: Object;
 
 /**
@@ -69,6 +71,10 @@ MiddlewareRegistry.register(store => next => action => {
             UIEvents.PINNED_ENDPOINT,
             action.participant.id,
             Boolean(action.participant.id));
+        break;
+
+    case SET_TILE_VIEW:
+        APP.UI.emitEvent(UIEvents.TOGGLED_TILE_VIEW, action.enabled);
         break;
 
     case TRACK_ADDED:

--- a/react/features/video-layout/reducer.js
+++ b/react/features/video-layout/reducer.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { ReducerRegistry } from '../base/redux';
+
+import { SET_TILE_VIEW } from './actionTypes';
+
+ReducerRegistry.register('features/video-layout', (state = {}, action) => {
+    switch (action.type) {
+    case SET_TILE_VIEW:
+        return {
+            ...state,
+            tileViewEnabled: action.enabled
+        };
+    }
+
+    return state;
+});

--- a/react/features/video-layout/subscriber.js
+++ b/react/features/video-layout/subscriber.js
@@ -14,10 +14,10 @@ import { shouldDisplayTileView } from './functions';
  */
 StateListenerRegistry.register(
     /* selector */ state => shouldDisplayTileView(state),
-    /* listener */ (tileViewEnabled, { dispatch }) => {
+    /* listener */ (displayTileView, { dispatch }) => {
         dispatch(selectParticipant());
 
-        if (!tileViewEnabled) {
+        if (!displayTileView) {
             dispatch(setMaxReceiverVideoQuality(VIDEO_QUALITY_LEVELS.HIGH));
         }
     }

--- a/react/features/video-layout/subscriber.js
+++ b/react/features/video-layout/subscriber.js
@@ -1,0 +1,24 @@
+// @flow
+
+import {
+    VIDEO_QUALITY_LEVELS,
+    setMaxReceiverVideoQuality
+} from '../base/conference';
+import { StateListenerRegistry } from '../base/redux';
+import { selectParticipant } from '../large-video';
+import { shouldDisplayTileView } from './functions';
+
+/**
+ * StateListenerRegistry provides a reliable way of detecting changes to
+ * preferred layout state and dispatching additional actions.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => shouldDisplayTileView(state),
+    /* listener */ (tileViewEnabled, { dispatch }) => {
+        dispatch(selectParticipant());
+
+        if (!tileViewEnabled) {
+            dispatch(setMaxReceiverVideoQuality(VIDEO_QUALITY_LEVELS.HIGH));
+        }
+    }
+);

--- a/service/UI/UIEvents.js
+++ b/service/UI/UIEvents.js
@@ -59,6 +59,7 @@ export default {
     TOGGLED_FILMSTRIP: 'UI.toggled_filmstrip',
     TOGGLE_SCREENSHARING: 'UI.toggle_screensharing',
     TOGGLED_SHARED_DOCUMENT: 'UI.toggled_shared_document',
+    TOGGLED_TILE_VIEW: 'UI.toggled_tile_view',
     HANGUP: 'UI.hangup',
     LOGOUT: 'UI.logout',
     VIDEO_DEVICE_CHANGED: 'UI.video_device_changed',


### PR DESCRIPTION
- Modify the classname on the app root so layout can adjust
  depending on the desired layout mode--vertical filmstrip,
  horizontal filmstrip, and tile view.
- Create a button for toggling tile view.
- Add a StateListenerRegistry to automatically update the
  selected participant and max receiver frame height on tile
  view toggle.
- Rezise thumbnails when switching in and out of tile view.
- Move the local video when switching in and out of tile view.
- Update reactified pieces of thumbnails when switching in and
  out of tile view.
- Cap the max receiver video quality in tile view based on tile
  size.
- Use CSS to hide UI components that should not display in tile
  view.
- Signal follow me changes.