### PR TITLE
[RN] Fix streaming on mobile

### DIFF
--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -11,6 +11,7 @@ import {
     AspectRatioDetector,
     ReducedUIDetector
 } from '../../base/responsive-ui';
+import '../../google-api';
 import '../../mobile/audio-mode';
 import '../../mobile/background';
 import '../../mobile/callkit';


### PR DESCRIPTION
The new google-api feature was not referenced anywhere on mobile since the refactor, and opening the start dialog failed when the abstract class tried to access the feature's Redux state