### PR TITLE
fix: only access nested json values when corrent payload type

### DIFF
--- a/react/features/subtitles/middleware.js
+++ b/react/features/subtitles/middleware.js
@@ -67,6 +67,12 @@ MiddlewareRegistry.register(store => next => action => {
  * @returns {Object} The value returned by {@code next(action)}.
  */
 function _endpointMessageReceived({ dispatch, getState }, next, action) {
+    if (!(action.json
+        && (action.json.type === JSON_TYPE_TRANSCRIPTION_RESULT
+            || action.json.type === JSON_TYPE_TRANSLATION_RESULT))) {
+        return next(action);
+    }
+
     const json = action.json;
     const translationLanguage
         = getState()['features/base/conference'].conference


### PR DESCRIPTION
Due to e2e also using json messages for sharing stats, this was broken due to merging https://github.com/jitsi/jitsi-meet/pull/3276 .... my bad :(