### PR TITLE
initialize the empty `body` property for document object

### DIFF
--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -143,6 +143,13 @@ function _visitNode(node, callback) {
             document.addEventListener = () => {};
         }
 
+        // document.body
+        // Required by:
+        // - react-devtools
+        if (typeof document.body === 'undefined') {
+            document.body = {};
+        }
+
         // document.cookie
         //
         // Required by:


### PR DESCRIPTION
react-devtolls will check `window.document.body.scrollIntoView ` when it wants to inspect the layout. (Reference: https://github.com/facebook/react-devtools/blob/547916f3ad9b9c1a610f89a51a5a3bcc1923d188/agent/Agent.js#L121). So we also need to initialize the property if we want the react-devtolls working. Fix issue: https://github.com/jitsi/jitsi-meet/issues/3298.