### PR TITLE
Fix processing context root

### DIFF
--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -124,6 +124,8 @@ function _appNavigateToOptionalLocation(
             // FIXME Turn location's host, hostname, and port properties into
             // setters in order to reduce the risks of inconsistent state.
             location.hostname = defaultLocation.hostname;
+            location.pathname
+                = defaultLocation.pathname + location.pathname.substr(1);
             location.port = defaultLocation.port;
             location.protocol = defaultLocation.protocol;
         } else {


### PR DESCRIPTION
Your truly refactored routing in https://github.com/jitsi/jitsi-meet/pull/3222
and broke it. When a bare room is entered the pathname was not updated when
applying the default URL.