### PR TITLE
[iOS] Fix Jitsi Meet v1.18.x "Missing Purpose String in Info.plist Fi…

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -152,7 +152,7 @@ SPEC CHECKSUMS:
   react-native-keep-awake: 0de4bd66de0c23178107dce0c2fcc3354b2a8e94
   react-native-locale-detector: d1b2c6fe5abb56e3a1efb6c2d6f308c05c4251f1
   react-native-webrtc: 31b6d3f1e3e2ce373aa43fd682b04367250f807d
-  ReactNativePermissions: 9f2d9c45c98800795e6c2ed330e25d11a66a8169
+  ReactNativePermissions: 9ef3f0c74a373fdbfae21c067098a8348d9aa15f
   RNSound: b360b3862d3118ed1c74bb9825696b5957686ac4
   RNVectorIcons: c0dbfbf6068fefa240c37b0f71bd03b45dddac44
   SDWebImage: 624d6e296c69b244bcede364c72ae0430ac14681

--- a/package-lock.json
+++ b/package-lock.json
@@ -12787,9 +12787,8 @@
       "from": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9"
     },
     "react-native-permissions": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-1.1.1.tgz",
-      "integrity": "sha512-t0Ujm177bagjUOSzhpmkSz+LqFW04HnY9TeZFavDCmV521fQvFz82aD+POXqWsAdsJVOK3umJYBNNqCjC3g0hQ=="
+      "version": "github:lyubomir/react-native-permissions#3462430addce3f2c8297c15da14182568194a216",
+      "from": "github:lyubomir/react-native-permissions#3462430addce3f2c8297c15da14182568194a216"
     },
     "react-native-prompt": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-native-keep-awake": "2.0.6",
     "react-native-linear-gradient": "2.4.0",
     "react-native-locale-detector": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9",
-    "react-native-permissions": "1.1.1",
+    "react-native-permissions": "github:lyubomir/react-native-permissions#3462430addce3f2c8297c15da14182568194a216",
     "react-native-prompt": "1.0.0",
     "react-native-sound": "0.10.9",
     "react-native-vector-icons": "4.4.2",


### PR DESCRIPTION
…le" issues reported by App Store Connect

App Store Connect reported the following issues in (and rejected the binary
of) Jitsi Meet 1.18.x:

NSBluetoothPeripheralUsageDescription
NSAppleMusicUsageDescription
NSMotionUsageDescription
NSSpeechRecognitionUsageDescription

Starting spring 2019, all apps submitted to the App Store that access user
data will be required to include a purpose string for the following:

NSLocationAlwaysUsageDescription
NSLocationWhenInUseUsageDescription

Note: This is a git cherry-pick of the commit with which Jitsi Meet for iOS 1.18.6 was released in App Store.