### PR TITLE
feat(tile-view): initial implementation for mobile

### DIFF
--- a/react/features/base/react/components/AbstractContainer.js
+++ b/react/features/base/react/components/AbstractContainer.js
@@ -31,7 +31,10 @@ export default class AbstractContainer extends Component<*> {
          * The style (as in stylesheet) to be applied to this
          * {@code AbstractContainer}.
          */
-        style: PropTypes.object,
+        style: PropTypes.oneOfType([
+            PropTypes.array,
+            PropTypes.object
+        ]),
 
         /**
          * If this instance is to provide visual feedback when touched, then

--- a/react/features/base/react/components/AbstractContainer.js
+++ b/react/features/base/react/components/AbstractContainer.js
@@ -1,7 +1,63 @@
 /* @flow */
 
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+
+/**
+ * {@code AbstractContainer} component's property types.
+ */
+export type Props = {
+
+    /**
+     * An optional accessibility label to apply to the container root.
+     */
+    accessibilityLabel?: string,
+
+    /**
+     * Whether or not this element is an accessibility element.
+     */
+    accessible?: boolean,
+
+    /**
+     * React Elements to display within the component.
+     */
+    children: React$Node | Object,
+
+    /**
+     * The event handler/listener to be invoked when this
+     * {@code AbstractContainer} is clicked on Web or pressed on React
+     * Native. If {@code onClick} is defined and {@link touchFeedback} is
+     * undefined, {@code touchFeedback} is considered defined as
+     * {@code true}.
+     */
+    onClick?: ?Function,
+
+    /**
+     * The style (as in stylesheet) to be applied to this
+     * {@code AbstractContainer}.
+     */
+    style?: Array<?string> | Object,
+
+    /**
+     * If this instance is to provide visual feedback when touched, then
+     * {@code true}; otherwise, {@code false}. If {@code touchFeedback} is
+     * undefined and {@link onClick} is defined, {@code touchFeedback} is
+     * considered defined as {@code true}.
+     */
+    touchFeedback?: ?Function,
+
+    /**
+     * Color to display when clicked.
+     */
+    underlayColor?: string,
+
+    /**
+     * If this {@code AbstractContainer} is to be visible, then {@code true}
+     * or {@code false} if this instance is to be hidden or not rendered at
+     * all.
+     */
+    visible?: ?boolean
+};
+
 
 /**
  * Abstract (base) class for container of React {@link Component} children with
@@ -9,49 +65,7 @@ import React, { Component } from 'react';
  *
  * @extends Component
  */
-export default class AbstractContainer extends Component<*> {
-    /**
-     * {@code AbstractContainer} component's property types.
-     *
-     * @static
-     */
-    static propTypes = {
-        children: PropTypes.node,
-
-        /**
-         * The event handler/listener to be invoked when this
-         * {@code AbstractContainer} is clicked on Web or pressed on React
-         * Native. If {@code onClick} is defined and {@link touchFeedback} is
-         * undefined, {@code touchFeedback} is considered defined as
-         * {@code true}.
-         */
-        onClick: PropTypes.func,
-
-        /**
-         * The style (as in stylesheet) to be applied to this
-         * {@code AbstractContainer}.
-         */
-        style: PropTypes.oneOfType([
-            PropTypes.array,
-            PropTypes.object
-        ]),
-
-        /**
-         * If this instance is to provide visual feedback when touched, then
-         * {@code true}; otherwise, {@code false}. If {@code touchFeedback} is
-         * undefined and {@link onClick} is defined, {@code touchFeedback} is
-         * considered defined as {@code true}.
-         */
-        touchFeedback: PropTypes.bool,
-
-        /**
-         * If this {@code AbstractContainer} is to be visible, then {@code true}
-         * or {@code false} if this instance is to be hidden or not rendered at
-         * all.
-         */
-        visible: PropTypes.bool
-    };
-
+export default class AbstractContainer<P: Props> extends Component<P> {
     /**
      * Renders this {@code AbstractContainer} as a React {@code Component} of a
      * specific type.
@@ -64,7 +78,7 @@ export default class AbstractContainer extends Component<*> {
      * @protected
      * @returns {ReactElement}
      */
-    _render(type, props) {
+    _render(type, props?: P) {
         const {
             children,
 

--- a/react/features/base/react/components/native/Container.js
+++ b/react/features/base/react/components/native/Container.js
@@ -8,20 +8,14 @@ import {
 } from 'react-native';
 
 import AbstractContainer from '../AbstractContainer';
+import type { Props } from '../AbstractContainer';
 
 /**
  * Represents a container of React Native/mobile {@link Component} children.
  *
  * @extends AbstractContainer
  */
-export default class Container extends AbstractContainer {
-    /**
-     * {@code Container} component's property types.
-     *
-     * @static
-     */
-    static propTypes = AbstractContainer.propTypes;
-
+export default class Container<P: Props> extends AbstractContainer<P> {
     /**
      * Implements React's {@link Component#render()}.
      *

--- a/react/features/base/react/components/web/Container.js
+++ b/react/features/base/react/components/web/Container.js
@@ -1,13 +1,14 @@
 /* @flow */
 
 import AbstractContainer from '../AbstractContainer';
+import type { Props } from '../AbstractContainer';
 
 /**
  * Represents a container of React/Web {@link Component} children with a style.
  *
  * @extends AbstractContainer
  */
-export default class Container extends AbstractContainer {
+export default class Container<P: Props> extends AbstractContainer<P> {
     /**
      * {@code Container} component's property types.
      *

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -283,7 +283,7 @@ class Conference extends Component<Props> {
                   */
                     _shouldDisplayTileView
                         ? <TileView onClick = { this._onClick } />
-                        : <LargeVideo onPress = { this._onClick } />
+                        : <LargeVideo onClick = { this._onClick } />
                 }
 
                 {/*

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -17,12 +17,18 @@ import {
 import { TestConnectionInfo } from '../../base/testing';
 import { createDesiredLocalTracks } from '../../base/tracks';
 import { ConferenceNotification } from '../../calendar-sync';
-import { FILMSTRIP_SIZE, Filmstrip, isFilmstripVisible } from '../../filmstrip';
+import {
+    FILMSTRIP_SIZE,
+    Filmstrip,
+    isFilmstripVisible,
+    TileView
+} from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
 import { CalleeInfoContainer } from '../../invite';
 import { NotificationsContainer } from '../../notifications';
 import { Captions } from '../../subtitles';
 import { setToolboxVisible, Toolbox } from '../../toolbox';
+import { shouldDisplayTileView } from '../../video-layout';
 
 import styles from './styles';
 
@@ -114,6 +120,13 @@ type Props = {
      * @returns {void}
      */
     _setToolboxVisible: Function,
+
+    /**
+     * Whether or not the layout should change to support tile view mode.
+     *
+     * @private
+     */
+    _shouldDisplayTileView: boolean,
 
     /**
      * The indicator which determines whether the Toolbox is visible.
@@ -252,6 +265,12 @@ class Conference extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
+        const {
+            _connecting,
+            _reducedUI,
+            _shouldDisplayTileView
+        } = this.props;
+
         return (
             <Container style = { styles.conference }>
                 <StatusBar
@@ -261,20 +280,23 @@ class Conference extends Component<Props> {
 
                 {/*
                   * The LargeVideo is the lowermost stacking layer.
-                  */}
-                <LargeVideo onPress = { this._onClick } />
+                  */
+                    _shouldDisplayTileView
+                        ? <TileView onClick = { this._onClick } />
+                        : <LargeVideo onPress = { this._onClick } />
+                }
 
                 {/*
                   * If there is a ringing call, show the callee's info.
                   */
-                    this.props._reducedUI || <CalleeInfoContainer />
+                    _reducedUI || <CalleeInfoContainer />
                 }
 
                 {/*
                   * The activity/loading indicator goes above everything, except
                   * the toolbox/toolbars and the dialogs.
                   */
-                    this.props._connecting
+                    _connecting
                         && <TintedView>
                             <LoadingIndicator />
                         </TintedView>
@@ -304,8 +326,9 @@ class Conference extends Component<Props> {
                       * name and grouping stem from the fact that these two
                       * React Components depict the videos of the conference's
                       * participants.
-                      */}
-                    <Filmstrip />
+                      */
+                        _shouldDisplayTileView ? undefined : <Filmstrip />
+                    }
                 </View>
 
                 <TestConnectionInfo />
@@ -547,6 +570,14 @@ function _mapStateToProps(state) {
          * @type {string}
          */
         _room: room,
+
+        /**
+         * Whether or not the layout should change to support tile view mode.
+         *
+         * @private
+         * @type {boolean}
+         */
+        _shouldDisplayTileView: shouldDisplayTileView(state),
 
         /**
          * The indicator which determines whether the Toolbox is visible.

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -1,4 +1,5 @@
-import PropTypes from 'prop-types';
+// @flow
+
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -19,30 +20,30 @@ import styles from './styles';
 import VideoMutedIndicator from './VideoMutedIndicator';
 
 /**
+ * Thumbnail component's property types.
+ */
+type Props = {
+    _audioTrack: Object,
+    _largeVideo: Object,
+    _videoTrack: Object,
+    disablePin?: boolean,
+    dispatch: Function,
+    participant: Object,
+    styleOverrides?: Object
+};
+
+/**
  * React component for video thumbnail.
  *
  * @extends Component
  */
-class Thumbnail extends Component {
-    /**
-     * Thumbnail component's property types.
-     *
-     * @static
-     */
-    static propTypes = {
-        _audioTrack: PropTypes.object,
-        _largeVideo: PropTypes.object,
-        _videoTrack: PropTypes.object,
-        dispatch: PropTypes.func,
-        participant: PropTypes.object
-    };
-
+class Thumbnail extends Component<Props> {
     /**
      * Initializes new Video Thumbnail component.
      *
      * @param {Object} props - Component props.
      */
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
 
         // Bind event handlers so they are only bound once for every instance.
@@ -57,16 +58,24 @@ class Thumbnail extends Component {
      */
     render() {
         const audioTrack = this.props._audioTrack;
+        const disablePin = this.props.disablePin;
         const largeVideo = this.props._largeVideo;
         const participant = this.props.participant;
         const videoTrack = this.props._videoTrack;
 
         let style = styles.thumbnail;
 
-        if (participant.pinned) {
+        if (participant.pinned && !disablePin) {
             style = {
                 ...style,
                 ...styles.thumbnailPinned
+            };
+        }
+
+        if (this.props.styleOverrides) {
+            style = {
+                ...style,
+                ...this.props.styleOverrides
             };
         }
 
@@ -85,7 +94,7 @@ class Thumbnail extends Component {
 
         return (
             <Container
-                onClick = { this._onClick }
+                onClick = { disablePin ? undefined : this._onClick }
                 style = { style }>
 
                 { renderAudio
@@ -96,7 +105,7 @@ class Thumbnail extends Component {
                 <ParticipantView
                     avatarSize = { AVATAR_SIZE }
                     participantId = { participantId }
-                    tintEnabled = { participantInLargeVideo }
+                    tintEnabled = { participantInLargeVideo && !disablePin }
                     zOrder = { 1 } />
 
                 { participant.role === PARTICIPANT_ROLE.MODERATOR
@@ -116,6 +125,8 @@ class Thumbnail extends Component {
             </Container>
         );
     }
+
+    _onClick: () => void;
 
     /**
      * Handles click/tap event on the thumbnail.

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -23,6 +23,7 @@ import VideoMutedIndicator from './VideoMutedIndicator';
  * Thumbnail component's property types.
  */
 type Props = {
+
     /**
      * The Redux representation of the participant's audio track.
      */
@@ -45,7 +46,7 @@ type Props = {
     disablePin?: boolean,
 
     /**
-     * If true, there will be no color overlay (a tint) on the thumbnail
+     * If true, there will be no color overlay (tint) on the thumbnail
      * indicating the participant associated with the thumbnail is displayed on
      * large video. By default there will be a tint.
      */

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -23,13 +23,47 @@ import VideoMutedIndicator from './VideoMutedIndicator';
  * Thumbnail component's property types.
  */
 type Props = {
+    /**
+     * The Redux representation of the participant's audio track.
+     */
     _audioTrack: Object,
+
+    /**
+     * The Redux representation of the state "features/large-video".
+     */
     _largeVideo: Object,
+
+    /**
+     * The Redux representation of the participant's video track.
+     */
     _videoTrack: Object,
+
+    /**
+     * If true, tapping on the thumbnail will not pin the participant to large
+     * video. By default tapping does pin the participant.
+     */
     disablePin?: boolean,
+
+    /**
+     * If true, there will be no color overlay (a tint) on the thumbnail
+     * indicating the participant associated with the thumbnail is displayed on
+     * large video. By default there will be a tint.
+     */
     disableTint?: boolean,
-    dispatch: Function,
+
+    /**
+     * Invoked to trigger state changes in Redux.
+     */
+    dispatch: Dispatch<*>,
+
+    /**
+     * The Redux representation of the participant to display.
+     */
     participant: Object,
+
+    /**
+     * Optional styling to add or override on the Thumbnail component root.
+     */
     styleOverrides?: Object
 };
 

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -27,6 +27,7 @@ type Props = {
     _largeVideo: Object,
     _videoTrack: Object,
     disablePin?: boolean,
+    disableTint?: boolean,
     dispatch: Function,
     participant: Object,
     styleOverrides?: Object
@@ -57,12 +58,14 @@ class Thumbnail extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const audioTrack = this.props._audioTrack;
-        const disablePin = this.props.disablePin;
-        const largeVideo = this.props._largeVideo;
-        const participant = this.props.participant;
-        const videoTrack = this.props._videoTrack;
-
+        const {
+            _audioTrack: audioTrack,
+            _largeVideo: largeVideo,
+            _videoTrack: videoTrack,
+            disablePin,
+            disableTint,
+            participant
+        } = this.props;
 
         // We don't render audio in any of the following:
         // 1. The audio (source) is muted. There's no practical reason (that we
@@ -95,7 +98,7 @@ class Thumbnail extends Component<Props> {
                 <ParticipantView
                     avatarSize = { AVATAR_SIZE }
                     participantId = { participantId }
-                    tintEnabled = { participantInLargeVideo && !disablePin }
+                    tintEnabled = { participantInLargeVideo && !disableTint }
                     zOrder = { 1 } />
 
                 { participant.role === PARTICIPANT_ROLE.MODERATOR

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -63,21 +63,6 @@ class Thumbnail extends Component<Props> {
         const participant = this.props.participant;
         const videoTrack = this.props._videoTrack;
 
-        let style = styles.thumbnail;
-
-        if (participant.pinned && !disablePin) {
-            style = {
-                ...style,
-                ...styles.thumbnailPinned
-            };
-        }
-
-        if (this.props.styleOverrides) {
-            style = {
-                ...style,
-                ...this.props.styleOverrides
-            };
-        }
 
         // We don't render audio in any of the following:
         // 1. The audio (source) is muted. There's no practical reason (that we
@@ -95,7 +80,12 @@ class Thumbnail extends Component<Props> {
         return (
             <Container
                 onClick = { disablePin ? undefined : this._onClick }
-                style = { style }>
+                style = { [
+                    styles.thumbnail,
+                    participant.pinned && !disablePin
+                        ? styles.thumbnailPinned : null,
+                    this.props.styleOverrides || null
+                ] }>
 
                 { renderAudio
                     && <Audio

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -1,0 +1,285 @@
+// @flow
+
+import React, { Component } from 'react';
+import {
+    Dimensions,
+    ScrollView,
+    TouchableWithoutFeedback,
+    View
+} from 'react-native';
+import { connect } from 'react-redux';
+
+import {
+    getNearestReceiverVideoQualityLevel,
+    setMaxReceiverVideoQuality
+} from '../../../base/conference';
+import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui';
+
+import Thumbnail from './Thumbnail';
+import styles from './styles';
+
+/**
+ * TileView component's property types.
+ */
+type Props = {
+
+    /**
+     * Whether or not the screen is currently in portrait orientation.
+     */
+    _isNarrowAspectRatio: boolean,
+
+    /**
+     * The participants in the conference.
+     */
+    _participants: Array<any>,
+
+    /**
+     * Invoked to update the receiver video quality.
+     */
+    dispatch: Dispatch<*>,
+
+    /**
+     * Callback to invoke when tile view is tapped.
+     */
+    onClick: Function
+};
+
+const TILE_ASPECT_RATIO = 1;
+
+/**
+ * Implements a React {@link Component} which represents the filmstrip on
+ * mobile/React Native.
+ *
+ * @extends Component
+ */
+class TileView extends Component<Props> {
+    /**
+     * Updates the receiver video quality.
+     *
+     * @inheritdoc
+     */
+    componentDidMount() {
+        this._updateReceiverQuality();
+    }
+
+    /**
+     * Updates the receiver video quality.
+     *
+     * @inheritdoc
+     */
+    componentDidUpdate() {
+        this._updateReceiverQuality();
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { onClick } = this.props;
+        const { height, width } = this._getScreenDimensions();
+        const rowElements = this._groupIntoRows(
+            this._renderThumbnails(), this._getColumnCount());
+
+        return (
+            <ScrollView
+                style = {{
+                    ...styles.tileView,
+                    height,
+                    width
+                }}>
+                <TouchableWithoutFeedback onPress = { onClick }>
+                    <View
+                        style = {{
+                            ...styles.tileViewRows,
+                            minHeight: height,
+                            minWidth: width
+                        }}>
+                        { rowElements }
+                    </View>
+                </TouchableWithoutFeedback>
+            </ScrollView>
+        );
+    }
+
+    /**
+     * Returns how many columns should be displayed for tile view.
+     *
+     * @returns {number}
+     * @private
+     */
+    _getColumnCount() {
+        const participantCount = this.props._participants.length;
+
+        // For narrow view, tiles should stack on top of each other for a lonely
+        // call and a 1:1 call. Otherwise tiles should be grouped into rows of
+        // two.
+        if (this.props._isNarrowAspectRatio) {
+            return participantCount >= 3 ? 2 : 1;
+        }
+
+        if (participantCount === 4) {
+            // In wide view, a four person call should display as a 2x2 grid.
+            return 2;
+        }
+
+        return participantCount >= 3 ? 3 : participantCount;
+    }
+
+    /**
+     * Returns the current height and width of the screen.
+     *
+     * @private
+     * @returns {Object}
+     */
+    _getScreenDimensions() {
+        return Dimensions.get('window');
+    }
+
+    /**
+     * Returns all participants with the local participant at the end.
+     *
+     * @private
+     * @returns {Participant[]}
+     */
+    _getSortedParticipants() {
+        const participants = [];
+        let localParticipant;
+
+        this.props._participants.forEach(participant => {
+            if (participant.local) {
+                localParticipant = participant;
+            } else {
+                participants.push(participant);
+            }
+        });
+
+        if (localParticipant) {
+            participants.push(localParticipant);
+        }
+
+        return participants;
+    }
+
+    /**
+     * Calculate the height and width for the tiles.
+     *
+     * @private
+     * @returns {Object}
+     */
+    _getTileDimensions() {
+        const { _participants } = this.props;
+        const { height, width } = this._getScreenDimensions();
+        const columns = this._getColumnCount();
+        const participantCount = _participants.length;
+        const heightToUse = height - 20;
+        const widthToUse = width - 20;
+        let tileWidth;
+
+        // If there is going to be at least two rows, ensure that at least two
+        // rows display fully on screen.
+        if (participantCount / columns > 1) {
+            tileWidth
+                = Math.min(widthToUse / columns, heightToUse / 2);
+        } else {
+            tileWidth = Math.min(widthToUse / columns, heightToUse);
+        }
+
+        return {
+            height: tileWidth / TILE_ASPECT_RATIO,
+            width: tileWidth
+        };
+    }
+
+    /**
+     * Splits a list of thumbnails into React Elements with a maximum of
+     * {@link rowLength} thumbnails in each.
+     *
+     * @param {Array} thumbnails - The list of thumbnails that should be split
+     * into separate row groupings.
+     * @param {number} rowLength - How many thumbnails should be in each row.
+     * @private
+     * @returns {ReactElement[]}
+     */
+    _groupIntoRows(thumbnails, rowLength) {
+        const rowElements = [];
+
+        for (let i = 0; i < thumbnails.length; i++) {
+            if (i % rowLength === 0) {
+                const thumbnailsInRow
+                    = thumbnails.slice(i, i + rowLength);
+
+                rowElements.push(
+                    <View
+                        key = { rowElements.length }
+                        style = { styles.tileViewRow }>
+                        { thumbnailsInRow }
+                    </View>
+                );
+            }
+        }
+
+        return rowElements;
+    }
+
+    /**
+     * Creates React Elements to display each participant in a thumbnail. Each
+     * tile will be.
+     *
+     * @private
+     * @returns {ReactElement[]}
+     */
+    _renderThumbnails() {
+        const styleOverrides = {
+            aspectRatio: TILE_ASPECT_RATIO,
+            flex: 0,
+            height: this._getTileDimensions().height,
+            width: null
+        };
+
+        return this._getSortedParticipants()
+            .map(participant => (
+                <Thumbnail
+                    disablePin = { true }
+                    key = { participant.id }
+                    participant = { participant }
+                    styleOverrides = { styleOverrides } />));
+    }
+
+    /**
+     * Sets the receiver video quality based on the dimensions of the thumbnails
+     * that are displayed.
+     *
+     * @private
+     * @returns {void}
+     */
+    _updateReceiverQuality() {
+        const { height } = this._getTileDimensions();
+        const qualityLevel = getNearestReceiverVideoQualityLevel(height);
+
+        this.props.dispatch(setMaxReceiverVideoQuality(qualityLevel));
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated {@code TileView}'s props.
+ *
+ * @param {Object} state - The redux state.
+ * @private
+ * @returns {{
+ *     _isNarrowAspectRatio: string,
+ *     _participants: Participant[]
+ * }}
+ */
+function _mapStateToProps(state) {
+    const { aspectRatio } = state['features/base/responsive-ui'];
+
+    return {
+        _isNarrowAspectRatio: aspectRatio === ASPECT_RATIO_NARROW,
+        _participants: state['features/base/participants']
+    };
+}
+
+export default connect(_mapStateToProps)(TileView);

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -86,8 +86,7 @@ class TileView extends Component<Props, State> {
     }
 
     /**
-     * Implements React's {@link Component#componentWillMount()}. Invoked
-     * immediately before mounting occurs.
+     * Implements React's {@link Component#componentDidMount}.
      *
      * @inheritdoc
      */
@@ -96,8 +95,7 @@ class TileView extends Component<Props, State> {
     }
 
     /**
-     * Implements React's {@link Component#componentWillUnmount()}. Invoked
-     * immediately before this component is unmounted and destroyed.
+     * Implements React's {@link Component#componentDidUpdate}.
      *
      * @inheritdoc
      */

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -173,13 +173,13 @@ class TileView extends Component<Props, State> {
         const participants = [];
         let localParticipant;
 
-        this.props._participants.forEach(participant => {
+        for (const participant of this.props._participants) {
             if (participant.local) {
                 localParticipant = participant;
             } else {
                 participants.push(participant);
             }
-        });
+        }
 
         if (localParticipant) {
             participants.push(localParticipant);

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -181,9 +181,7 @@ class TileView extends Component<Props, State> {
             }
         }
 
-        if (localParticipant) {
-            participants.push(localParticipant);
-        }
+        localParticipant && participants.push(localParticipant);
 
         return participants;
     }

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -13,8 +13,9 @@ import {
     setMaxReceiverVideoQuality
 } from '../../../base/conference';
 import {
-    ASPECT_RATIO_NARROW,
-    DimensionsDetector
+    DimensionsDetector,
+    isNarrowAspectRatio,
+    makeAspectRatioAware
 } from '../../../base/responsive-ui';
 
 import Thumbnail from './Thumbnail';
@@ -24,11 +25,6 @@ import styles from './styles';
  * The type of the React {@link Component} props of {@link TileView}.
  */
 type Props = {
-
-    /**
-     * Whether or not the screen is currently in portrait orientation.
-     */
-    _isNarrowAspectRatio: boolean,
 
     /**
      * The participants in the conference.
@@ -155,7 +151,7 @@ class TileView extends Component<Props, State> {
         // For narrow view, tiles should stack on top of each other for a lonely
         // call and a 1:1 call. Otherwise tiles should be grouped into rows of
         // two.
-        if (this.props._isNarrowAspectRatio) {
+        if (isNarrowAspectRatio(this)) {
             return participantCount >= 3 ? 2 : 1;
         }
 
@@ -316,17 +312,13 @@ class TileView extends Component<Props, State> {
  * @param {Object} state - The redux state.
  * @private
  * @returns {{
- *     _isNarrowAspectRatio: string,
  *     _participants: Participant[]
  * }}
  */
 function _mapStateToProps(state) {
-    const { aspectRatio } = state['features/base/responsive-ui'];
-
     return {
-        _isNarrowAspectRatio: aspectRatio === ASPECT_RATIO_NARROW,
         _participants: state['features/base/participants']
     };
 }
 
-export default connect(_mapStateToProps)(TileView);
+export default connect(_mapStateToProps)(makeAspectRatioAware(TileView));

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -29,7 +29,7 @@ type Props = {
     /**
      * The participants in the conference.
      */
-    _participants: Array<any>,
+    _participants: Array<Object>,
 
     /**
      * Invoked to update the receiver video quality.
@@ -61,8 +61,8 @@ type State = {
 const TILE_ASPECT_RATIO = 1;
 
 /**
- * Implements a React {@link Component} which represents the filmstrip on
- * mobile/React Native.
+ * Implements a React {@link Component} which displays thumbnails in a two
+ * dimensional grid.
  *
  * @extends Component
  */
@@ -86,7 +86,8 @@ class TileView extends Component<Props, State> {
     }
 
     /**
-     * Updates the receiver video quality.
+     * Implements React's {@link Component#componentWillMount()}. Invoked
+     * immediately before mounting occurs.
      *
      * @inheritdoc
      */
@@ -95,7 +96,8 @@ class TileView extends Component<Props, State> {
     }
 
     /**
-     * Updates the receiver video quality.
+     * Implements React's {@link Component#componentWillUnmount()}. Invoked
+     * immediately before this component is unmounted and destroyed.
      *
      * @inheritdoc
      */

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -289,6 +289,7 @@ class TileView extends Component<Props, State> {
             .map(participant => (
                 <Thumbnail
                     disablePin = { true }
+                    disableTint = { true }
                     key = { participant.id }
                     participant = { participant }
                     styleOverrides = { styleOverrides } />));

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -125,7 +125,7 @@ class TileView extends Component<Props> {
             return 2;
         }
 
-        return participantCount >= 3 ? 3 : participantCount;
+        return Math.min(3, participantCount);
     }
 
     /**

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -58,6 +58,21 @@ type State = {
     width: number
 };
 
+/**
+ * The margin for each side of the tile view. Taken away from the available
+ * height and width for the tile container to display in.
+ *
+ * @private
+ * @type {number}
+ */
+const MARGIN = 10;
+
+/**
+ * The aspect ratio the tiles should display in.
+ *
+ * @private
+ * @type {number}
+ */
 const TILE_ASPECT_RATIO = 1;
 
 /**
@@ -197,8 +212,8 @@ class TileView extends Component<Props, State> {
         const { height, width } = this.state;
         const columns = this._getColumnCount();
         const participantCount = _participants.length;
-        const heightToUse = height - 20;
-        const widthToUse = width - 20;
+        const heightToUse = height - (MARGIN * 2);
+        const widthToUse = width - (MARGIN * 2);
         let tileWidth;
 
         // If there is going to be at least two rows, ensure that at least two

--- a/react/features/filmstrip/components/native/index.js
+++ b/react/features/filmstrip/components/native/index.js
@@ -1,2 +1,3 @@
 export { default as Filmstrip } from './Filmstrip';
+export { default as TileView } from './TileView';
 export { default as styles } from './styles';

--- a/react/features/filmstrip/components/styles.js
+++ b/react/features/filmstrip/components/styles.js
@@ -145,5 +145,18 @@ export default {
             width: 5
         },
         shadowRadius: 5
+    },
+
+    tileView: {
+        alignSelf: 'center'
+    },
+
+    tileViewRows: {
+        justifyContent: 'center'
+    },
+
+    tileViewRow: {
+        flexDirection: 'row',
+        justifyContent: 'center'
     }
 };

--- a/react/features/large-video/components/LargeVideo.native.js
+++ b/react/features/large-video/components/LargeVideo.native.js
@@ -17,7 +17,7 @@ type Props = {
     /**
      * Callback to invoke when the {@code LargeVideo} is clicked/pressed.
      */
-    onPress: Function,
+    onClick: Function,
 
     /**
      * The ID of the participant (to be) depicted by LargeVideo.
@@ -114,8 +114,8 @@ class LargeVideo extends Component<Props, State> {
             useConnectivityInfoLabel
         } = this.state;
         const {
-            onPress,
-            _participantId
+            _participantId,
+            onClick
         } = this.props;
 
         return (
@@ -123,7 +123,7 @@ class LargeVideo extends Component<Props, State> {
                 onDimensionsChanged = { this._onDimensionsChanged }>
                 <ParticipantView
                     avatarSize = { avatarSize }
-                    onPress = { onPress }
+                    onPress = { onClick }
                     participantId = { _participantId }
                     style = { styles.largeVideo }
                     testHintId = 'org.jitsi.meet.LargeVideo'

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -74,8 +74,8 @@ class OverflowMenu extends Component<Props> {
                 <ClosedCaptionButton { ...buttonProps } />
                 <RecordButton { ...buttonProps } />
                 <LiveStreamButton { ...buttonProps } />
-                <PictureInPictureButton { ...buttonProps } />
                 <TileViewButton { ...buttonProps } />
+                <PictureInPictureButton { ...buttonProps } />
             </BottomSheet>
         );
     }

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -9,6 +9,7 @@ import { PictureInPictureButton } from '../../../mobile/picture-in-picture';
 import { LiveStreamButton, RecordButton } from '../../../recording';
 import { RoomLockButton } from '../../../room-lock';
 import { ClosedCaptionButton } from '../../../subtitles';
+import { TileViewButton } from '../../../video-layout';
 
 import AudioOnlyButton from './AudioOnlyButton';
 import { overflowMenuItemStyles } from './styles';
@@ -74,6 +75,7 @@ class OverflowMenu extends Component<Props> {
                 <RecordButton { ...buttonProps } />
                 <LiveStreamButton { ...buttonProps } />
                 <PictureInPictureButton { ...buttonProps } />
+                <TileViewButton { ...buttonProps } />
             </BottomSheet>
         );
     }

--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -38,6 +38,7 @@ type Props = AbstractButtonProps & {
 class TileViewButton<P: Props> extends AbstractButton<P, *> {
     accessibilityLabel = 'toolbar.accessibilityLabel.tileView';
     iconName = 'icon-tiles-many';
+    label = 'toolbar.tileViewToggle';
     toggledIconName = 'icon-tiles-many toggled';
     tooltip = 'toolbar.tileViewToggle';
 

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -74,7 +74,8 @@ export function shouldDisplayTileView(state: Object = {}) {
     return Boolean(
         state['features/video-layout']
             && state['features/video-layout'].tileViewEnabled
-            && !state['features/etherpad'].editing
+            && (!state['features/etherpad']
+                || !state['features/etherpad'].editing)
 
             // Truthy check is needed for interfaceConfig to prevent errors on
             // mobile which does not have interfaceConfig. On web, tile view


### PR DESCRIPTION
- Create a tile view component for displaying thumbnails in a
  two-dimensional grid.
- Update the existing TileViewButton so it shows a label in the
  overflow menu.
- Modify conference so it can display TileView while hiding
  Filmstrip.
- Modify Thumbnail so its width/height can be set and to prevent
  pinning while in tile view mode.