### PR TITLE
No calendar notification, audio-only label in Picture-in-Picture

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -339,14 +339,16 @@ class Conference extends Component<Props> {
     /**
      * Renders the conference notification badge if the feature is enabled.
      *
-     * Note: If the calendar feature is disabled on a platform, then we don't
-     * have its components exported so an undefined check is necessary.
-     *
      * @private
      * @returns {React$Node}
      */
     _renderConferenceNotification() {
-        return ConferenceNotification ? <ConferenceNotification /> : undefined;
+        // XXX If the calendar feature is disabled on a platform, then we don't
+        // have its components exported so an undefined check is necessary.
+        return (
+            !this.props._reducedUI && ConferenceNotification
+                ? <ConferenceNotification />
+                : undefined);
     }
 }
 

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -9,7 +9,6 @@ import { connect as reactReduxConnect } from 'react-redux';
 import { appNavigate } from '../../app';
 import { connect, disconnect } from '../../base/connection';
 import { DialogContainer } from '../../base/dialog';
-import { CalleeInfoContainer } from '../../invite';
 import { getParticipantCount } from '../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../base/react';
 import { TestConnectionInfo } from '../../base/testing';
@@ -17,6 +16,7 @@ import { createDesiredLocalTracks } from '../../base/tracks';
 import { ConferenceNotification } from '../../calendar-sync';
 import { Filmstrip } from '../../filmstrip';
 import { LargeVideo } from '../../large-video';
+import { CalleeInfoContainer } from '../../invite';
 import { NotificationsContainer } from '../../notifications';
 import { setToolboxVisible, Toolbox } from '../../toolbox';
 
@@ -30,8 +30,8 @@ type Props = {
     /**
      * The indicator which determines that we are still connecting to the
      * conference which includes establishing the XMPP connection and then
-     * joining the room. If truthy, then an activity/loading indicator will
-     * be rendered.
+     * joining the room. If truthy, then an activity/loading indicator will be
+     * rendered.
      *
      * @private
      */
@@ -48,6 +48,7 @@ type Props = {
      * The handler which dispatches the (redux) action connect.
      *
      * @private
+     * @returns {void}
      */
     _onConnect: Function,
 
@@ -55,6 +56,7 @@ type Props = {
      * The handler which dispatches the (redux) action disconnect.
      *
      * @private
+     * @returns {void}
      */
     _onDisconnect: Function,
 
@@ -63,9 +65,9 @@ type Props = {
      * associated {@code Conference}.
      *
      * @private
-     * @returns {boolean} As the associated conference is unconditionally
-     * left and exiting the app while it renders a {@code Conference} is
-     * undesired, {@code true} is always returned.
+     * @returns {boolean} As the associated conference is unconditionally left
+     * and exiting the app while it renders a {@code Conference} is undesired,
+     * {@code true} is always returned.
      */
     _onHardwareBackPress: Function,
 
@@ -92,10 +94,13 @@ type Props = {
     _room: string,
 
     /**
-     * The handler which dispatches the (redux) action setToolboxVisible to
-     * show/hide the Toolbox.
+     * The handler which dispatches the (redux) action {@link setToolboxVisible}
+     * to show/hide the {@link Toolbox}.
      *
+     * @param {boolean} visible - {@code true} to show the {@code Toolbox} or
+     * {@code false} to hide it.
      * @private
+     * @returns {void}
      */
     _setToolboxVisible: Function,
 
@@ -281,6 +286,7 @@ class Conference extends Component<Props> {
                       */}
                     <Filmstrip />
                 </View>
+
                 <TestConnectionInfo />
 
                 {
@@ -362,8 +368,8 @@ function _mapDispatchToProps(dispatch) {
          * Dispatches actions to create the desired local tracks and for
          * connecting to the conference.
          *
-         * @returns {void}
          * @private
+         * @returns {void}
          */
         _onConnect() {
             dispatch(createDesiredLocalTracks());
@@ -373,8 +379,8 @@ function _mapDispatchToProps(dispatch) {
         /**
          * Dispatches an action disconnecting from the conference.
          *
-         * @returns {void}
          * @private
+         * @returns {void}
          */
         _onDisconnect() {
             dispatch(disconnect());
@@ -395,12 +401,12 @@ function _mapDispatchToProps(dispatch) {
         },
 
         /**
-         * Dispatches an action changing the visibility of the Toolbox.
+         * Dispatches an action changing the visibility of the {@link Toolbox}.
          *
-         * @param {boolean} visible - True to show the Toolbox or false to hide
-         * it.
-         * @returns {void}
+         * @param {boolean} visible - {@code true} to show the {@code Toolbox}
+         * or {@code false} to hide it.
          * @private
+         * @returns {void}
          */
         _setToolboxVisible(visible) {
             dispatch(setToolboxVisible(visible));

--- a/react/features/large-video/components/AbstractLabels.js
+++ b/react/features/large-video/components/AbstractLabels.js
@@ -5,9 +5,9 @@ import React, { Component } from 'react';
 import { isFilmstripVisible } from '../../filmstrip';
 import { LocalRecordingLabel } from '../../local-recording';
 import { RecordingLabel } from '../../recording';
+import { TranscribingLabel } from '../../transcribing';
 import { shouldDisplayTileView } from '../../video-layout';
 import { VideoQualityLabel } from '../../video-quality';
-import { TranscribingLabel } from '../../transcribing/';
 
 /**
  * The type of the React {@code Component} props of {@link AbstractLabels}.
@@ -15,13 +15,13 @@ import { TranscribingLabel } from '../../transcribing/';
 export type Props = {
 
     /**
-    * Whether or not the filmstrip is displayed with remote videos. Used to
-    * determine display classes to set.
-    */
+     * Whether the filmstrip is displayed with remote videos. Used to determine
+     * display classes to set.
+     */
     _filmstripVisible: boolean,
 
     /**
-     * Whether or not the video quality label should be displayed.
+     * Whether the video quality label should be displayed.
      */
     _showVideoQualityLabel: boolean
 };
@@ -34,16 +34,40 @@ export type Props = {
  */
 export default class AbstractLabels<P: Props, S> extends Component<P, S> {
     /**
-     * Renders the {@code RecordingLabel} that is platform independent.
+     * Renders the {@code LocalRecordingLabel}.
      *
      * @protected
+     * @returns {React$Element}
+     */
+    _renderLocalRecordingLabel() {
+        return (
+            <LocalRecordingLabel />
+        );
+    }
+
+    /**
+     * Renders the {@code RecordingLabel} that is platform independent.
+     *
      * @param {string} mode - The recording mode that this label is rendered
      * for.
+     * @protected
      * @returns {React$Element}
      */
     _renderRecordingLabel(mode: string) {
         return (
             <RecordingLabel mode = { mode } />
+        );
+    }
+
+    /**
+     * Renders the {@code TranscribingLabel}.
+     *
+     * @protected
+     * @returns {React$Element}
+     */
+    _renderTranscribingLabel() {
+        return (
+            <TranscribingLabel />
         );
     }
 
@@ -58,37 +82,13 @@ export default class AbstractLabels<P: Props, S> extends Component<P, S> {
             <VideoQualityLabel />
         );
     }
-
-    /**
-     * Renders the {@code TranscribingLabel}.
-     *
-     * @returns {React$Element}
-     * @protected
-     */
-    _renderTranscribingLabel() {
-        return (
-            <TranscribingLabel />
-        );
-    }
-
-    /**
-     * Renders the {@code LocalRecordingLabel}.
-     *
-     * @returns {React$Element}
-     * @protected
-     */
-    _renderLocalRecordingLabel() {
-        return (
-            <LocalRecordingLabel />
-        );
-    }
 }
 
 /**
- * Maps (parts of) the Redux state to the associated props for the
- * {@code Labels} component.
+ * Maps (parts of) the redux state to the associated props of the {@link Labels}
+ * {@code Component}.
  *
- * @param {Object} state - The Redux state.
+ * @param {Object} state - The redux state.
  * @private
  * @returns {{
  *     _filmstripVisible: boolean,

--- a/react/features/large-video/components/Labels.native.js
+++ b/react/features/large-video/components/Labels.native.js
@@ -1,4 +1,5 @@
 // @flow
+
 import React from 'react';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
@@ -23,7 +24,7 @@ class Labels extends AbstractLabels<Props, *> {
      * @inheritdoc
      */
     render() {
-        const _wide = !isNarrowAspectRatio(this);
+        const wide = !isNarrowAspectRatio(this);
         const { _filmstripVisible } = this.props;
 
         return (
@@ -31,7 +32,7 @@ class Labels extends AbstractLabels<Props, *> {
                 pointerEvents = 'box-none'
                 style = { [
                     styles.indicatorContainer,
-                    _wide && _filmstripVisible && styles.indicatorContainerWide
+                    wide && _filmstripVisible && styles.indicatorContainerWide
                 ] }>
                 {
                     this._renderRecordingLabel(
@@ -48,10 +49,9 @@ class Labels extends AbstractLabels<Props, *> {
         );
     }
 
-    _renderRecordingLabel: string => React$Element<*>
+    _renderRecordingLabel: string => React$Element<*>;
 
-    _renderVideoQualityLabel: () => React$Element<*>
-
+    _renderVideoQualityLabel: () => React$Element<*>;
 }
 
 /**
@@ -76,6 +76,4 @@ function _mapStateToProps(state) {
     };
 }
 
-export default connect(_mapStateToProps)(
-    makeAspectRatioAware(Labels)
-);
+export default connect(_mapStateToProps)(makeAspectRatioAware(Labels));

--- a/react/features/large-video/components/Labels.native.js
+++ b/react/features/large-video/components/Labels.native.js
@@ -9,10 +9,26 @@ import {
     isNarrowAspectRatio,
     makeAspectRatioAware
 } from '../../base/responsive-ui';
-import { isFilmstripVisible } from '../../filmstrip';
 
-import AbstractLabels, { type Props } from './AbstractLabels';
+import AbstractLabels, {
+    _abstractMapStateToProps,
+    type Props as AbstractLabelsProps
+} from './AbstractLabels';
 import styles from './styles';
+
+/**
+ * The type of the React {@code Component} props of {@link Labels}.
+ */
+type Props = AbstractLabelsProps & {
+
+    /**
+     * The indicator which determines whether the UI is reduced (to accommodate
+     * smaller display areas).
+     *
+     * @private
+     */
+    _reducedUI: boolean
+};
 
 /**
  * A container that renders the conference indicators, if any.
@@ -25,7 +41,7 @@ class Labels extends AbstractLabels<Props, *> {
      */
     render() {
         const wide = !isNarrowAspectRatio(this);
-        const { _filmstripVisible } = this.props;
+        const { _filmstripVisible, _reducedUI } = this.props;
 
         return (
             <View
@@ -42,8 +58,14 @@ class Labels extends AbstractLabels<Props, *> {
                     this._renderRecordingLabel(
                         JitsiRecordingConstants.mode.STREAM)
                 }
-                {
-                    this._renderVideoQualityLabel()
+                {/*
+                  * Emil, Lyubomir, Nichole, and Zoli said that the Labels
+                  * should not be rendered in Picture-in-Picture. Saul argued
+                  * that the recording Labels should be rendered. As a temporary
+                  * compromise, don't render the VideoQualityLabel at least
+                  * because it's not that important.
+                  */
+                    _reducedUI || this._renderVideoQualityLabel()
                 }
             </View>
         );
@@ -61,18 +83,14 @@ class Labels extends AbstractLabels<Props, *> {
  * @param {Object} state - The redux state.
  * @private
  * @returns {{
- *     _filmstripVisible: boolean
+ *     _filmstripVisible: boolean,
+ *     _reducedUI: boolean
  * }}
  */
 function _mapStateToProps(state) {
     return {
-        /**
-         * The indicator which determines whether the filmstrip is visible.
-         *
-         * @private
-         * @type {boolean}
-         */
-        _filmstripVisible: isFilmstripVisible(state)
+        ..._abstractMapStateToProps(state),
+        _reducedUI: state['features/base/responsive-ui'].reducedUI
     };
 }
 

--- a/react/features/large-video/components/Labels.web.js
+++ b/react/features/large-video/components/Labels.web.js
@@ -23,7 +23,7 @@ type State = {
      * @type {boolean}
      */
     filmstripBecomingVisible: boolean
-}
+};
 
 /**
  * A container to hold video status labels, including recording status and
@@ -99,13 +99,13 @@ class Labels extends AbstractLabels<Props, State> {
         );
     }
 
-    _renderRecordingLabel: string => React$Element<*>
+    _renderLocalRecordingLabel: () => React$Element<*>;
 
-    _renderVideoQualityLabel: () => React$Element<*>
+    _renderRecordingLabel: string => React$Element<*>;
 
-    _renderTranscribingLabel: () => React$Element<*>
+    _renderTranscribingLabel: () => React$Element<*>;
 
-    _renderLocalRecordingLabel: () => React$Element<*>
+    _renderVideoQualityLabel: () => React$Element<*>;
 }
 
 export default connect(_mapStateToProps)(Labels);


### PR DESCRIPTION
1. The calendar notification which alerts that there's an upcoming or ongoing meeting takes nearly half of the Picture-in-Picture rectangle. Emil and I don't want it in PiP.

2. Some of us have talked that we don't want the audio-only label in Picture-in-Picture. Well, most of us wanted no labels whatsover. But let's start by meeting on common ground and not display the audio-only label at least.