### PR TITLE
Queue replaceLocalTrack

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -216,8 +216,6 @@ export class VideoContainer extends LargeContainer {
         this.emitter = emitter;
         this.resizeContainer = resizeContainer;
 
-        this.isVisible = false;
-
         /**
          * Whether the background should fit the height of the container
          * (portrait) or fit the width of the container (landscape).
@@ -603,17 +601,11 @@ export class VideoContainer extends LargeContainer {
      * TODO: refactor this since Temasys is no longer supported.
      */
     show() {
-        // its already visible
-        if (this.isVisible) {
-            return Promise.resolve();
-        }
-
         return new Promise(resolve => {
             this.$wrapperParent.css('visibility', 'visible').fadeTo(
                 FADE_DURATION_MS,
                 1,
                 () => {
-                    this.isVisible = true;
                     resolve();
                 }
             );
@@ -628,15 +620,9 @@ export class VideoContainer extends LargeContainer {
         // hide its avatar
         this.showAvatar(false);
 
-        // its already hidden
-        if (!this.isVisible) {
-            return Promise.resolve();
-        }
-
         return new Promise(resolve => {
             this.$wrapperParent.fadeTo(FADE_DURATION_MS, 0, () => {
                 this.$wrapperParent.css('visibility', 'hidden');
-                this.isVisible = false;
                 resolve();
             });
         });

--- a/modules/util/TaskQueue.js
+++ b/modules/util/TaskQueue.js
@@ -1,0 +1,63 @@
+const logger = require('jitsi-meet-logger').getLogger(__filename);
+
+/**
+ * Manages a queue of functions where the current function in progress will
+ * automatically execute the next queued function.
+ */
+export class TaskQueue {
+    /**
+     * Creates a new instance of {@link TaskQueue} and sets initial instance
+     * variable values.
+     */
+    constructor() {
+        this._queue = [];
+        this._currentTask = null;
+
+        this._onTaskComplete = this._onTaskComplete.bind(this);
+    }
+
+    /**
+     * Adds a new function to the queue. It will be immediately invoked if no
+     * other functions are queued.
+     *
+     * @param {Function} taskFunction - The function to be queued for execution.
+     * @private
+     * @returns {void}
+     */
+    enqueue(taskFunction) {
+        this._queue.push(taskFunction);
+        this._executeNext();
+    }
+
+    /**
+     * If no queued task is currently executing, invokes the first task in the
+     * queue if any.
+     *
+     * @private
+     * @returns {void}
+     */
+    _executeNext() {
+        if (this._currentTask) {
+            logger.warn('Task queued while a task is in progress.');
+
+            return;
+        }
+
+        this._currentTask = this._queue.shift() || null;
+
+        if (this._currentTask) {
+            this._currentTask(this._onTaskComplete);
+        }
+    }
+
+    /**
+     * Prepares to invoke the next function in the queue.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onTaskComplete() {
+        this._currentTask = null;
+        this._executeNext();
+    }
+}

--- a/modules/util/helpers.js
+++ b/modules/util/helpers.js
@@ -1,3 +1,5 @@
+import { TaskQueue } from './TaskQueue';
+
 /**
  * Create deferred object.
  *
@@ -12,4 +14,13 @@ export function createDeferred() {
     });
 
     return deferred;
+}
+
+/**
+ * Returns an instance of {@link TaskQueue}.
+ *
+ * @returns {Object}
+ */
+export function createTaskQueue() {
+    return new TaskQueue();
 }


### PR DESCRIPTION
Multiple replaceLocalTrack calls can be fired at the same time. If no local track is present, then the replaced track will be null, and this can cause multiple local tracks of the same type to be added (because null is being replaced). So queue calls to the method. Two other issues emerged while looking into this issue:
- When local audio/video is created due to the participant having null tracks and plugging in a device, a media track is created, used in the SDP, and then muted, which can cause a flash of the participant being visible/audible. Get around this by muting the track before using it.
- VideoContainer, which is used to display the video element in large video, has an instance variable of isVisible initially set to false, but actually nothing is setting the large video to be invisible in the dom. The result is when a remote participant without a camera plugs one in, this causes the video track to be added, which can cause the video element autoplay to kick in but display black. Subsequent calls to hide the video element no-op because the instance variable isVisible is set to false.