### PR TITLE
fix(calendar): allow text to wrap and grow tile

### DIFF
--- a/css/_navigate_section_list.scss
+++ b/css/_navigate_section_list.scss
@@ -17,9 +17,9 @@
     border-radius: 4px;
     box-sizing: border-box;
     display: inline-flex;
-    height: 100px;
     margin-bottom: 8px;
     margin-right: 8px;
+    min-height: 100px;
     padding: 16px;
     width: 100%;
 
@@ -56,6 +56,7 @@
 }
 .navigate-section-list-tile-info {
     flex: 1;
+    word-break: break-word;
 }
 .navigate-section-tile-title {
     @extend %navigate-section-list-tile-text;


### PR DESCRIPTION
Long meeting titles and urls can force text outside of the
tile.