### PR TITLE
[RN] Dialogs: Replace legacy common style with common container

### DIFF
--- a/react/features/recording/components/LiveStream/StopLiveStreamDialog.native.js
+++ b/react/features/recording/components/LiveStream/StopLiveStreamDialog.native.js
@@ -1,12 +1,10 @@
 // @flow
 
 import React from 'react';
-import { Text, View } from 'react-native';
 import { connect } from 'react-redux';
 
+import { DialogContent } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-
-import styles from '../styles';
 
 import AbstractStopLiveStreamDialog, {
     _mapStateToProps
@@ -27,13 +25,11 @@ class StopLiveStreamDialog extends AbstractStopLiveStreamDialog {
      */
     _renderDialogContent() {
         return (
-            <View style = { styles.messageContainer }>
-                <Text>
-                    {
-                        this.props.t('dialog.stopStreamingWarning')
-                    }
-                </Text>
-            </View>
+            <DialogContent>
+                {
+                    this.props.t('dialog.stopStreamingWarning')
+                }
+            </DialogContent>
         );
     }
 }

--- a/react/features/recording/components/Recording/StartRecordingDialogContent.native.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.native.js
@@ -1,11 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
-import { Text, View } from 'react-native';
 
+import { DialogContent } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-
-import styles from '../styles';
 
 type Props = {
 
@@ -30,11 +28,9 @@ class StartRecordingDialogContent extends Component<Props> {
         const { t } = this.props;
 
         return (
-            <View style = { styles.messageContainer }>
-                <Text>
-                    { t('recording.startRecordingBody') }
-                </Text>
-            </View>
+            <DialogContent>
+                { t('recording.startRecordingBody') }
+            </DialogContent>
         );
     }
 }

--- a/react/features/recording/components/Recording/StopRecordingDialog.native.js
+++ b/react/features/recording/components/Recording/StopRecordingDialog.native.js
@@ -1,12 +1,10 @@
 // @flow
 
 import React from 'react';
-import { Text, View } from 'react-native';
 import { connect } from 'react-redux';
 
+import { DialogContent } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-
-import styles from '../styles';
 
 import AbstractStopRecordingDialog, {
     type Props,
@@ -30,11 +28,9 @@ class StopRecordingDialog extends AbstractStopRecordingDialog<Props> {
         const { t } = this.props;
 
         return (
-            <View style = { styles.messageContainer }>
-                <Text>
-                    { t('dialog.stopRecordingWarning') }
-                </Text>
-            </View>
+            <DialogContent>
+                { t('dialog.stopRecordingWarning') }
+            </DialogContent>
         );
     }
 }

--- a/react/features/recording/components/styles.js
+++ b/react/features/recording/components/styles.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { BoxModel, ColorPalette, createStyleSheet } from '../../base/styles';
+import { ColorPalette, createStyleSheet } from '../../base/styles';
 
 /**
  * The styles of the React {@code Components} of the feature recording.
@@ -19,10 +19,5 @@ export default createStyleSheet({
      */
     indicatorRecording: {
         backgroundColor: ColorPalette.red
-    },
-
-    messageContainer: {
-        paddingHorizontal: BoxModel.padding,
-        paddingVertical: 1.5 * BoxModel.padding
     }
 });


### PR DESCRIPTION
During the recording and live streaming development I re-used a common style that was good for building consistent look and feel for simple (text only) confirm dialogs. But I couldn't use the same style object for the calendar invite feature, so I decided to extract that into a component back then.

This commit is to make sure all the older confirm dialogs use this new, more flexible component, instead of the style.