### PR TITLE
fix(travis): tail last 500 lines of logs only on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 osx_image: xcode9.4
 language: objective-c
 script:
-- "./ios/travis-ci/build-ipa.sh"
+- "./ios/travis-ci/build-ipa.sh > build_output.txt"
+after_failure:
+- "tail -n 500 build_output.txt"


### PR DESCRIPTION
This is a workaround suggested by Travis support to workaround the
"The job exceeded the maximum log length, and has been terminated."
error.

Another option would be to upload the logs somewhere, but actually it
might be more convenient not having to scroll down all those logs. We
can revisit this case if some problems will be encountered (like for
example if there's need to see something in the middle).