### PR TITLE
fix(Travis/iOS): use '-quiet' with 'xcodebuild' commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 osx_image: xcode9.4
 language: objective-c
 script:
-- "./ios/travis-ci/build-ipa.sh > build_output.txt"
-after_failure:
-- "tail -n 500 build_output.txt"
+- "./ios/travis-ci/build-ipa.sh"

--- a/ios/travis-ci/build-ipa.sh
+++ b/ios/travis-ci/build-ipa.sh
@@ -136,13 +136,13 @@ cd ..
 
 mkdir -p /tmp/jitsi-meet/
 
-xcodebuild archive -workspace ios/jitsi-meet.xcworkspace -scheme jitsi-meet -configuration Release -archivePath /tmp/jitsi-meet/jitsi-meet.xcarchive
+xcodebuild archive -quiet -workspace ios/jitsi-meet.xcworkspace -scheme jitsi-meet -configuration Release -archivePath /tmp/jitsi-meet/jitsi-meet.xcarchive
 
 sed -e "s/YOUR_TEAM_ID/${IOS_TEAM_ID}/g" ios/travis-ci/build-ipa.plist.template > ios/travis-ci/build-ipa.plist
 
 IPA_EXPORT_DIR=/tmp/jitsi-meet/jitsi-meet-ipa
 
-xcodebuild -exportArchive -archivePath /tmp/jitsi-meet/jitsi-meet.xcarchive -exportPath $IPA_EXPORT_DIR  -exportOptionsPlist ios/travis-ci/build-ipa.plist
+xcodebuild -quiet -exportArchive -archivePath /tmp/jitsi-meet/jitsi-meet.xcarchive -exportPath $IPA_EXPORT_DIR  -exportOptionsPlist ios/travis-ci/build-ipa.plist
 
 echo "Will try deploy the .ipa to: ${IPA_DEPLOY_LOCATION}"
 


### PR DESCRIPTION
This reduces 'xcodebuild' verbosity and fixed problem with exceeding 4MB of logs size imposed by Travis CI.