### PR TITLE
[RN] Fix duplicated notifications

### DIFF
--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -336,8 +336,6 @@ class Conference extends Component<Props> {
                 {
                     this._renderConferenceNotification()
                 }
-
-                <NotificationsContainer />
             </Container>
         );
     }


### PR DESCRIPTION
The NotificationsContainer was mounted twice, probably after a merge