### PR TITLE
[iOS] Fix warning

### DIFF
--- a/ios/sdk/src/dropbox/Dropbox.m
+++ b/ios/sdk/src/dropbox/Dropbox.m
@@ -45,6 +45,10 @@ RCTPromiseRejectBlock currentReject = nil;
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
 - (NSDictionary *)constantsToExport {
     BOOL enabled = [Dropbox getAppKey] != nil;
     


### PR DESCRIPTION
When a native iOS module implements `constantsToExport` it must define
`requiresMainQueueSetup`. In this case we don't do any UI stuff so it doesn't
need to be initialized in the main thread.