### PR TITLE
feat: allow jitsi meet to be opened in a mobile browser

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -171,7 +171,7 @@ var interfaceConfig = {
      *
      * @type {boolean}
      */
-    RECENT_LIST_ENABLED: true
+    RECENT_LIST_ENABLED: true,
 
     /**
      * How many columns the tile view can expand to. The respected range is
@@ -193,6 +193,12 @@ var interfaceConfig = {
      * Specify mobile app scheme for opening the app from the mobile browser.
      */
     // APP_SCHEME: 'org.jitsi.meet'
+
+    /**
+     * Whether or not the jitsi meet app could be opened in a mobile browser.
+     * Defaults to false.
+     */
+    OPEN_IN_MOBILE_BROWSER: false
 };
 
 /* eslint-enable no-unused-vars, no-var, max-len */

--- a/react/features/deep-linking/functions.js
+++ b/react/features/deep-linking/functions.js
@@ -69,6 +69,11 @@ export function getDeepLinkingPage(state) {
     const isUsingMobileBrowser = OS === 'android' || OS === 'ios';
 
     if (isUsingMobileBrowser) { // mobile
+        const openInBrowser = interfaceConfig.OPEN_IN_MOBILE_BROWSER || false;
+
+        if (openInBrowser) {
+            return Promise.resolve();
+        }
         const mobileAppPromo
             = typeof interfaceConfig === 'object'
                 && interfaceConfig.MOBILE_APP_PROMO;


### PR DESCRIPTION
Allow jitsi meet to run on a mobile browser based on a config parameter in the "interface_config.js".

This topic came up a couple of times in the mailing list and the current solution as suggested  [here](https://github.com/jitsi/jitsi-meet/issues/1662#issuecomment-329813550) is not ideal.

This feature is really useful for audio only requirements in apps that integrate with jitsi meet through the external api.

**Note:** Running jitsi meet in the browser of a device is useless where webrtc is not supported.  