### PR TITLE
nested iframe mobile button fix (for ios)

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -138,7 +138,7 @@ class DeepLinkingMobilePage extends Component<*, *> {
                         href = { this._generateDownloadURL() }
                         onClick = { this._onDownloadApp } 
                         target = "_blank">
-                        <button cgassName = { downloadButtonClassName }>
+                        <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
                     </a>

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -136,6 +136,7 @@ class DeepLinkingMobilePage extends Component<*, *> {
                     </p>
                     <a
                         href = { this._generateDownloadURL() }
+                        target = "_blank"
                         onClick = { this._onDownloadApp } >
                         <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
@@ -144,6 +145,7 @@ class DeepLinkingMobilePage extends Component<*, *> {
                     <a
                         className = { `${_SNS}__href` }
                         href = { this.state.joinURL }
+                        target = "_blank"
                         onClick = { this._onOpenApp }>
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -136,17 +136,17 @@ class DeepLinkingMobilePage extends Component<*, *> {
                     </p>
                     <a
                         href = { this._generateDownloadURL() }
-                        target = "_blank"
-                        onClick = { this._onDownloadApp } >
-                        <button className = { downloadButtonClassName }>
+                        onClick = { this._onDownloadApp } 
+                        target = "_blank">
+			<button cgassName = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
                     </a>
                     <a
                         className = { `${_SNS}__href` }
                         href = { this.state.joinURL }
-                        target = "_blank"
-                        onClick = { this._onOpenApp }>
+                        onClick = { this._onOpenApp }
+                        target = "_blank">
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }
                         {/* </button> */}

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -138,7 +138,7 @@ class DeepLinkingMobilePage extends Component<*, *> {
                         href = { this._generateDownloadURL() }
                         onClick = { this._onDownloadApp } 
                         target = "_blank">
-			<button cgassName = { downloadButtonClassName }>
+                        <button cgassName = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
                     </a>


### PR DESCRIPTION
When Jitsi Meet is invoked in an iframe (as via our plugin), there is a bug on ios which prevents anything from happening when the buttons are pressed. To duplicate, invoke jitsi in an iframe embedded in a page (so there are 2 iframes, the parent and the Jitsi frame itself). Open page in Safari on an iPhone or iPad. Observe that the buttons are non-functional. This PR fixes it. Tested on ios & Android.