### PR TITLE
lint: relax jsdocs validation

### DIFF
--- a/react/.eslintrc.js
+++ b/react/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
         '.eslintrc-react-native.js'
     ],
     'rules': {
+        'jsdoc/require-description-complete-sentence': 0,
         'react/no-deprecated': 0
     }
 };


### PR DESCRIPTION
Due to how we write jsdocs there are > 50 false positives (warnings) about this
rule. So disable it.

I'm keeping it on in the eslint-config-jitsi project for now, since this may not
be needed in other projects.