### PR TITLE
chore(deps): update react-i18next from 4.8.0 to 7.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7460,9 +7460,9 @@
       "dev": true
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -7533,6 +7533,14 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
+    },
+    "html-parse-stringify2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz",
+      "integrity": "sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=",
+      "requires": {
+        "void-elements": "^2.0.1"
+      }
     },
     "htmlparser2": {
       "version": "3.8.3",
@@ -11547,11 +11555,13 @@
       }
     },
     "react-i18next": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-4.8.0.tgz",
-      "integrity": "sha1-kvDSgcXzmsjzw/OBVi1SPp2DAlQ=",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-7.13.0.tgz",
+      "integrity": "sha512-35M+MZFPqHwVIas7tXWQKFrf+ozCJukNplUTiGqL8mczSk+VRBsHxxXuuQKRkz/4CcWkONGWbp/AzxfM6wZncg==",
       "requires": {
-        "hoist-non-react-statics": "1.2.0"
+        "hoist-non-react-statics": "^2.3.1",
+        "html-parse-stringify2": "2.0.1",
+        "prop-types": "^15.6.0"
       }
     },
     "react-is": {
@@ -15144,6 +15154,11 @@
       "requires": {
         "indexof": "0.0.1"
       }
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prop-types": "15.6.0",
     "react": "16.5.0",
     "react-dom": "16.5.0",
-    "react-i18next": "4.8.0",
+    "react-i18next": "7.13.0",
     "react-native": "0.57.1",
     "react-native-background-timer": "2.0.0",
     "react-native-calendar-events": "github:wmcmahan/react-native-calendar-events#cb2731db6684a49b4343e09de7f9c2fcc68bcd9b",


### PR DESCRIPTION
None of the breaking changes seemed to affect current
usage of react-i18next and light testing of features
and language switching did not produce issues.

This update is a pre-requisite for removing deprecated react
lifecycle methods, as older versions of react-i18next
have a higher order component that uses the deprecated
componentWillMount, and that issue has been fixed since 7.8.0.