### PR TITLE
Update docs for AbstractRecordButton _mapStateToProps

### DIFF
--- a/react/features/recording/components/Recording/AbstractRecordButton.js
+++ b/react/features/recording/components/Recording/AbstractRecordButton.js
@@ -107,6 +107,7 @@ export default class AbstractRecordButton<P: Props>
  * @private
  * @returns {{
  *     _isRecordingRunning: boolean,
+ *     disabledByFeatures: boolean,
  *     visible: boolean
  * }}
  */


### PR DESCRIPTION
Missing return value in docs.