### PR TITLE
fix(calendar): show error message if authorization fails on event fetch

### DIFF
--- a/css/_meetings_list.scss
+++ b/css/_meetings_list.scss
@@ -29,11 +29,17 @@
         background: #0074E0;
         border-radius: 4px;
         color: #FFFFFF;
-        display: flex;
+        display: inline-block;
         justify-content: center;
         align-items: center;
         padding: 5px 10px;
         cursor: pointer;
+    }
+
+    .calendar-action-buttons {
+        .button {
+            margin: 0px 10px;
+        }
     }
 
     .item {

--- a/lang/main.json
+++ b/lang/main.json
@@ -662,6 +662,11 @@
         "addMeetingURL": "Add a meeting link",
         "confirmAddLink": "Do you want to add a Jitsi link to this event?",
         "confirmAddLinkTitle": "Calendar",
+        "error": {
+            "appConfiguration": "Calendar integration is not properly configured.",
+            "generic": "An error has occurred. Please check your calendar settings or try refreshing the calendar.",
+            "notSignedIn": "An error occurred while authenticating to see calendar events. Please check your calendar settings and try logging in again."
+        },
         "join": "Join",
         "joinTooltip": "Join the meeting",
         "nextMeeting": "next meeting",

--- a/react/features/calendar-sync/actionTypes.js
+++ b/react/features/calendar-sync/actionTypes.js
@@ -34,6 +34,17 @@ export const REFRESH_CALENDAR = Symbol('REFRESH_CALENDAR');
 export const SET_CALENDAR_AUTHORIZATION = Symbol('SET_CALENDAR_AUTHORIZATION');
 
 /**
+ * Action to update the last error that occurred while trying to authenticate
+ * with or fetch data from the calendar integration.
+ *
+ * {
+ *     type: SET_CALENDAR_ERROR,
+ *     error: ?Object
+ * }
+ */
+export const SET_CALENDAR_ERROR = Symbol('SET_CALENDAR_ERROR');
+
+/**
  * Action to update the current calendar entry list in the store.
  *
  * {

--- a/react/features/calendar-sync/actions.web.js
+++ b/react/features/calendar-sync/actions.web.js
@@ -8,6 +8,7 @@ import { createCalendarConnectedEvent, sendAnalytics } from '../analytics';
 import {
     CLEAR_CALENDAR_INTEGRATION,
     SET_CALENDAR_AUTH_STATE,
+    SET_CALENDAR_ERROR,
     SET_CALENDAR_INTEGRATION,
     SET_CALENDAR_PROFILE_EMAIL,
     SET_LOADING_CALENDAR_EVENTS
@@ -116,6 +117,22 @@ export function setCalendarAPIAuthState(newState: ?Object) {
     return {
         type: SET_CALENDAR_AUTH_STATE,
         msAuthState: newState
+    };
+}
+
+/**
+ * Sends an action to update the calendar error state in redux.
+ *
+ * @param {Object} error - An object with error details.
+ * @returns {{
+ *     type: SET_CALENDAR_ERROR,
+ *     error: Object
+ * }}
+ */
+export function setCalendarError(error: ?Object) {
+    return {
+        type: SET_CALENDAR_ERROR,
+        error
     };
 }
 

--- a/react/features/calendar-sync/constants.js
+++ b/react/features/calendar-sync/constants.js
@@ -11,6 +11,17 @@ export const CALENDAR_TYPE = {
 };
 
 /**
+ * An enumeration of known errors that can occur while interacting with the
+ * calendar integration.
+ *
+ * @enum {string}
+ */
+export const ERRORS = {
+    AUTH_FAILED: 'sign_in_failed',
+    GOOGLE_APP_MISCONFIGURED: 'idpiframe_initialization_failed'
+};
+
+/**
  * The number of days to fetch.
  */
 export const FETCH_END_DAYS = 10;

--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -8,6 +8,7 @@ import {
     CLEAR_CALENDAR_INTEGRATION,
     SET_CALENDAR_AUTH_STATE,
     SET_CALENDAR_AUTHORIZATION,
+    SET_CALENDAR_ERROR,
     SET_CALENDAR_EVENTS,
     SET_CALENDAR_INTEGRATION,
     SET_CALENDAR_PROFILE_EMAIL,
@@ -85,6 +86,9 @@ isCalendarEnabled()
 
         case SET_CALENDAR_AUTHORIZATION:
             return set(state, 'authorization', action.authorization);
+
+        case SET_CALENDAR_ERROR:
+            return set(state, 'error', action.error);
 
         case SET_CALENDAR_EVENTS:
             return set(state, 'events', action.events);


### PR DESCRIPTION
I'm not set up anymore to properly test the miscellaneous errors that occur with Microsoft and Google calendar fetch requests. As such I limited the error handling to the two I can consistently reproduce: logging out of Google and not whitelisting localhost in my Google calendar integration. All other errors drop down to a generic error message.

Google app configuration does not allow current site to use it.
<img width="1347" alt="misconfigured" src="https://user-images.githubusercontent.com/1243084/48091798-959e9000-e1bf-11e8-91ca-62363d8cb6ef.png">

Error message when signed out and refreshing the calendar:
<img width="1347" alt="sign_out_error" src="https://user-images.githubusercontent.com/1243084/48091256-0b096100-e1be-11e8-8d5a-1fd474c3ddbd.png">

Generic error message to catch all other errors. Triggered by not having calendar api permissions in the google app.
<img width="1347" alt="generic_no_cal_api" src="https://user-images.githubusercontent.com/1243084/48091274-15c3f600-e1be-11e8-9019-0200d65c6297.png">

