### PR TITLE
Fix eslint/jsdoc warnings (doc change only!)

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -462,55 +462,57 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * the event and value - the listener.
      * Currently we support the following
      * events:
-     * incomingMessage - receives event notifications about incoming
+     * {@code incomingMessage} - receives event notifications about incoming
      * messages. The listener will receive object with the following structure:
      * {{
      *  'from': from,//JID of the user that sent the message
      *  'nick': nick,//the nickname of the user that sent the message
      *  'message': txt//the text of the message
      * }}
-     * outgoingMessage - receives event notifications about outgoing
+     * {@code outgoingMessage} - receives event notifications about outgoing
      * messages. The listener will receive object with the following structure:
      * {{
      *  'message': txt//the text of the message
      * }}
-     * displayNameChanged - receives event notifications about display name
-     * change. The listener will receive object with the following structure:
+     * {@code displayNameChanged} - receives event notifications about display
+     * name change. The listener will receive object with the following
+     * structure:
      * {{
      * jid: jid,//the JID of the participant that changed his display name
      * displayname: displayName //the new display name
      * }}
-     * participantJoined - receives event notifications about new participant.
+     * {@code participantJoined} - receives event notifications about new
+     * participant.
      * The listener will receive object with the following structure:
      * {{
      * jid: jid //the jid of the participant
      * }}
-     * participantLeft - receives event notifications about the participant that
-     * left the room.
+     * {@code participantLeft} - receives event notifications about the
+     * participant that left the room.
      * The listener will receive object with the following structure:
      * {{
      * jid: jid //the jid of the participant
      * }}
-     * video-conference-joined - receives event notifications about the local
-     * user has successfully joined the video conference.
+     * {@code video-conference-joined} - receives event notifications about the
+     * local user has successfully joined the video conference.
      * The listener will receive object with the following structure:
      * {{
      * roomName: room //the room name of the conference
      * }}
-     * video-conference-left - receives event notifications about the local user
-     * has left the video conference.
+     * {@code video-conference-left} - receives event notifications about the
+     * local user has left the video conference.
      * The listener will receive object with the following structure:
      * {{
      * roomName: room //the room name of the conference
      * }}
-     * screenSharingStatusChanged - receives event notifications about
+     * {@code screenSharingStatusChanged} - receives event notifications about
      * turning on/off the local user screen sharing.
      * The listener will receive object with the following structure:
      * {{
      * on: on //whether screen sharing is on
      * }}
-     * readyToClose - all hangup operations are completed and Jitsi Meet is
-     * ready to be disposed.
+     * {@code readyToClose} - all hangup operations are completed and Jitsi Meet
+     * is ready to be disposed.
      * @returns {void}
      *
      * @deprecated
@@ -537,11 +539,12 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
     /**
      * Executes command. The available commands are:
-     * displayName - sets the display name of the local participant to the value
-     * passed in the arguments array.
-     * toggleAudio - mutes / unmutes audio with no arguments.
-     * toggleVideo - mutes / unmutes video with no arguments.
-     * toggleFilmStrip - hides / shows the filmstrip with no arguments.
+     * {@code displayName} - Sets the display name of the local participant to
+     * the value passed in the arguments array.
+     * {@code toggleAudio} - Mutes / unmutes audio with no arguments.
+     * {@code toggleVideo} - Mutes / unmutes video with no arguments.
+     * {@code toggleFilmStrip} - Hides / shows the filmstrip with no arguments.
+     *
      * If the command doesn't require any arguments the parameter should be set
      * to empty array or it may be omitted.
      *
@@ -562,13 +565,13 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
     /**
      * Executes commands. The available commands are:
-     * displayName - sets the display name of the local participant to the value
-     * passed in the arguments array.
-     * toggleAudio - mutes / unmutes audio. no arguments
-     * toggleVideo - mutes / unmutes video. no arguments
-     * toggleFilmStrip - hides / shows the filmstrip. no arguments
-     * toggleChat - hides / shows chat. no arguments.
-     * toggleShareScreen - starts / stops screen sharing. no arguments.
+     * {@code displayName} - Sets the display name of the local participant to
+     * the value passed in the arguments array.
+     * {@code toggleAudio} - Mutes / unmutes audio. No arguments.
+     * {@code toggleVideo} - Mutes / unmutes video. No arguments.
+     * {@code toggleFilmStrip} - Hides / shows the filmstrip. No arguments.
+     * {@code toggleChat} - Hides / shows chat. No arguments.
+     * {@code toggleShareScreen} - Starts / stops screen sharing. No arguments.
      *
      * @param {Object} commandList - The object with commands to be executed.
      * The keys of the object are the commands that will be executed and the

--- a/react/features/analytics/AnalyticsEvents.js
+++ b/react/features/analytics/AnalyticsEvents.js
@@ -413,7 +413,7 @@ export function createRemoteVideoMenuButtonEvent(buttonName, attributes) {
 
 /**
  * Creates an event indicating that an action related to screen sharing
- * occurred (e.g. it was started or stopped).
+ * occurred (e.g. It was started or stopped).
  *
  * @param {string} action - The action which occurred.
  * @returns {Object} The event in a format suitable for sending via
@@ -466,7 +466,7 @@ export function createSharedVideoEvent(action, attributes = {}) {
  * Creates an event associated with a shortcut being pressed, released or
  * triggered. By convention, where appropriate an attribute named 'enable'
  * should be used to indicate the action which resulted by the shortcut being
- * pressed (e.g. whether screen sharing was enabled or disabled).
+ * pressed (e.g. Whether screen sharing was enabled or disabled).
  *
  * @param {string} shortcut - The identifier of the shortcut which produced
  * an action.
@@ -512,7 +512,7 @@ export function createStartAudioOnlyEvent(audioOnly) {
  *
  * @param {string} source - The source of the configuration, 'local' or
  * 'remote' depending on whether it comes from the static configuration (i.e.
- * config.js) or comes dynamically from Jicofo.
+ * {@code config.js}) or comes dynamically from Jicofo.
  * @param {boolean} audioMute - Whether the configuration requests that audio
  * is muted.
  * @param {boolean} videoMute - Whether the configuration requests that video
@@ -573,7 +573,7 @@ export function createSyncTrackStateEvent(mediaType, muted) {
  * Creates an event associated with a toolbar button being clicked/pressed. By
  * convention, where appropriate an attribute named 'enable' should be used to
  * indicate the action which resulted by the shortcut being pressed (e.g.
- * whether screen sharing was enabled or disabled).
+ * Whether screen sharing was enabled or disabled).
  *
  * @param {string} buttonName - The identifier of the toolbar button which was
  * clicked/pressed.
@@ -595,9 +595,9 @@ export function createToolbarEvent(buttonName, attributes = {}) {
  * Creates an event which indicates that a local track was muted.
  *
  * @param {string} mediaType - The track's media type ('audio' or 'video').
- * @param {string} reason - The reason the track was muted (e.g. it was
+ * @param {string} reason - The reason the track was muted (e.g. It was
  * triggered by the "initial mute" option, or a previously muted track was
- * replaced (e.g. when a new device was used)).
+ * replaced (e.g. When a new device was used)).
  * @param {boolean} muted - Whether the track was muted or unmuted.
  * @returns {Object} The event in a format suitable for sending via
  * sendAnalytics.

--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -128,10 +128,10 @@ export class AbstractApp extends BaseApp<Props, *> {
     }
 
     /**
-     * Navigates this {@code AbstractApp} to (i.e. opens) a specific URL.
+     * Navigates this {@code AbstractApp} to (i.e. Opens) a specific URL.
      *
      * @param {Object|string} url - The URL to navigate this {@code AbstractApp}
-     * to (i.e. the URL to open).
+     * to (i.e. The URL to open).
      * @protected
      * @returns {void}
      */

--- a/react/features/authentication/actions.js
+++ b/react/features/authentication/actions.js
@@ -23,7 +23,7 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  * password + guest access configuration. Refer to {@link LoginDialog} for more
  * info.
  *
- * @param {string} id - The XMPP user's ID (e.g. user@domain.com).
+ * @param {string} id - The XMPP user's ID (e.g. {@code user@domain.com}).
  * @param {string} password - The XMPP user's password.
  * @param {JitsiConference} conference - The conference for which the local
  * participant's role will be upgraded.

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -198,8 +198,8 @@ export function getNearestReceiverVideoQualityLevel(availableHeight: number) {
 }
 
 /**
- * Handle an error thrown by the backend (i.e. lib-jitsi-meet) while
- * manipulating a conference participant (e.g. pin or select participant).
+ * Handle an error thrown by the backend (i.e. {@code lib-jitsi-meet}) while
+ * manipulating a conference participant (e.g. Pin or select participant).
  *
  * @param {Error} err - The Error which was thrown by the backend while
  * manipulating a conference participant and which is to be handled.

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -71,7 +71,7 @@ export type ConnectionFailedError = {
 /**
  * Opens new connection.
  *
- * @param {string} [id] - The XMPP user's ID (e.g. user@server.com).
+ * @param {string} [id] - The XMPP user's ID (e.g. {@code user@server.com}).
  * @param {string} [password] - The XMPP user's password.
  * @returns {Function}
  */

--- a/react/features/base/connection/functions.js
+++ b/react/features/base/connection/functions.js
@@ -4,7 +4,7 @@ import { toState } from '../redux';
 
 /**
  * Retrieves a simplified version of the conference/location URL stripped of URL
- * params (i.e. query/search and hash) which should be used for sending invites.
+ * params (i.e. Query/search and hash) which should be used for sending invites.
  *
  * @param {Function|Object} stateOrGetState - The redux state or redux's
  * {@code getState} function.

--- a/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
+++ b/react/features/base/lib-jitsi-meet/native/RTCPeerConnection.js
@@ -32,7 +32,7 @@ const SOCK_STREAM = 1; /* stream socket */
  * The RTCPeerConnection provided by react-native-webrtc fires onaddstream
  * before it remembers remotedescription (and thus makes it available to API
  * clients). Because that appears to be a problem for lib-jitsi-meet which has
- * been successfully running on Chrome, Firefox, etc. for a very long
+ * been successfully running on Chrome, Firefox and others for a very long
  * time, attempt to meet its expectations (by extending RTCPPeerConnection).
  *
  * @class

--- a/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
+++ b/react/features/base/lib-jitsi-meet/native/polyfills-browser.js
@@ -39,9 +39,10 @@ function _getCommonPrototype(a, b) {
 }
 
 /**
- * Implements an absolute minimum of the common logic of Document.querySelector
- * and Element.querySelector. Implements the most simple of selectors necessary
- * to satisfy the call sites at the time of this writing i.e. select by tagName.
+ * Implements an absolute minimum of the common logic of
+ * {@code Document.querySelector} and {@code Element.querySelector}. Implements
+ * the most simple of selectors necessary to satisfy the call sites at the time
+ * of this writing (i.e. Select by tagName).
  *
  * @param {Node} node - The Node which is the root of the tree to query.
  * @param {string} selectors - The group of CSS selectors to match on.

--- a/react/features/base/media/components/web/Video.js
+++ b/react/features/base/media/components/web/Video.js
@@ -98,10 +98,10 @@ class Video extends Component {
     /**
      * Updates the video display only if a new track is added. This component's
      * updating is blackboxed from React to prevent re-rendering of video
-     * element, as the lib uses track.attach(videoElement) instead.
+     * element, as the lib uses {@code track.attach(videoElement)} instead.
      *
      * @inheritdoc
-     * @returns {boolean} - False is always returned to blackbox this component.
+     * @returns {boolean} - False is always returned to blackbox this component
      * from React.
      */
     shouldComponentUpdate(nextProps) {

--- a/react/features/base/participants/components/Avatar.native.js
+++ b/react/features/base/participants/components/Avatar.native.js
@@ -146,11 +146,11 @@ export default class Avatar extends Component<Props, State> {
     }
 
     /**
-     * Notifies this {@code Component} that it will be unmounted and destroyed
-     * and, most importantly, that it should no longer call
-     * {@link #setState(Object)}. {@code Avatar} needs it because it downloads
-     * images via {@link ImageCache} which will asynchronously notify about
-     * success.
+     * Notifies this {@code Component} that it will be unmounted and destroyed,
+     * and most importantly, that it should no longer call
+     * {@link #setState(Object)}. The {@code Avatar} needs it because it
+     * downloads images via {@link ImageCache} which will asynchronously notify
+     * about success.
      *
      * @inheritdoc
      * @returns {void}

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -127,8 +127,9 @@ export function getParticipantCount(stateful: Object | Function) {
 
 /**
  * Returns participant's display name.
- * FIXME: remove the hardcoded strings once interfaceConfig is stored in redux
- * and merge with a similarly named method in conference.js.
+ *
+ * FIXME: Remove the hardcoded strings once interfaceConfig is stored in redux
+ * and merge with a similarly named method in {@code conference.js}.
  *
  * @param {(Function|Object)} stateful - The (whole) redux state, or redux's
  * {@code getState} function to be used to retrieve the state.

--- a/react/features/base/react/components/AbstractPage.js
+++ b/react/features/base/react/components/AbstractPage.js
@@ -12,7 +12,7 @@ export default class AbstractPage<P> extends Component<P> {
      * content of the component.
      *
      * Note: It is a static method as the {@code Component} may not be
-     * initialized yet when the UI invokes refresh (e.g. tab change).
+     * initialized yet when the UI invokes refresh (e.g. Tab change).
      *
      * @returns {void}
      */

--- a/react/features/base/react/components/NavigateSectionList.js
+++ b/react/features/base/react/components/NavigateSectionList.js
@@ -91,8 +91,8 @@ class NavigateSectionList extends Component<Props> {
     }
 
     /**
-     * Implements React's Component.render.
-     * Note: we don't use the refreshing value yet, because refreshing of these
+     * Implements React's {@code Component.render}.
+     * Note: We don't use the refreshing value yet, because refreshing of these
      * lists is super quick, no need to complicate the code - yet.
      *
      * @inheritdoc

--- a/react/features/base/redux/functions.js
+++ b/react/features/base/redux/functions.js
@@ -113,7 +113,7 @@ function _set(
 
 /**
  * Returns redux state from the specified {@code stateful} which is presumed to
- * be related to the redux state (e.g. the redux store, the redux
+ * be related to the redux state (e.g. The redux store, the redux
  * {@code getState} function).
  *
  * @param {Function|Object} stateful - The entity such as the redux store or the

--- a/react/features/base/settings/reducer.js
+++ b/react/features/base/settings/reducer.js
@@ -57,7 +57,7 @@ ReducerRegistry.register(STORE_NAME, (state = DEFAULT_STATE, action) => {
  * Retrieves the legacy profile values regardless of it's being in pre or
  * post-flattening format.
  *
- * FIXME: Let's remove this after a predefined time (e.g. by July 2018) to avoid
+ * FIXME: Let's remove this after a predefined time (e.g. By July 2018) to avoid
  * garbage in the source.
  *
  * @private

--- a/react/features/base/storage/native/Storage.js
+++ b/react/features/base/storage/native/Storage.js
@@ -73,7 +73,7 @@ export default class Storage {
      * Returns the value associated with a specific key in this {@code Storage}
      * in an async manner. The method is required for the cases where we need
      * the stored data but we're not sure yet whether this {@code Storage} is
-     * already initialized (e.g. on app start).
+     * already initialized (e.g. On app start).
      *
      * @param {string} key - The name of the key to retrieve the value of.
      * @returns {Promise}

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -418,7 +418,7 @@ function _addTracks(tracks) {
  * @returns {Promise} - A {@code Promise} resolved once all
  * {@code gumProcess.cancel()} {@code Promise}s are settled because all we care
  * about here is to be sure that the {@code getUserMedia} callbacks have
- * completed (i.e. returned from the native side).
+ * completed (i.e. Returned from the native side).
  */
 function _cancelGUMProcesses(getState) {
     const logError

--- a/react/features/calendar-sync/components/CalendarListContent.native.js
+++ b/react/features/calendar-sync/components/CalendarListContent.native.js
@@ -115,7 +115,7 @@ class CalendarListContent extends Component<Props> {
      *
      * @private
      * @param {string} url - The url string to navigate to.
-     * @param {string} analyticsEventName - Тhe name of the analytics event.
+     * @param {string} analyticsEventName - Тhe name of the analytics event
      * associated with this action.
      * @returns {void}
      */

--- a/react/features/calendar-sync/components/CalendarListContent.web.js
+++ b/react/features/calendar-sync/components/CalendarListContent.web.js
@@ -121,7 +121,7 @@ class CalendarListContent extends Component<Props> {
      *
      * @private
      * @param {string} url - The url string to navigate to.
-     * @param {string} analyticsEventName - Тhe name of the analytics event.
+     * @param {string} analyticsEventName - Тhe name of the analytics event
      * associated with this action.
      * @returns {void}
      */

--- a/react/features/calendar-sync/functions.any.js
+++ b/react/features/calendar-sync/functions.any.js
@@ -30,7 +30,7 @@ function _isDisplayableCalendarEntry(entry) {
 /**
  * Updates the calendar entries in redux when new list is received. The feature
  * calendar-sync doesn't display all calendar events, it displays unique
- * title, URL, and start time tuples i.e. it doesn't display subsequent
+ * title, URL, and start time tuples, and it doesn't display subsequent
  * occurrences of recurring events, and the repetitions of events coming from
  * multiple calendars.
  *

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -433,9 +433,9 @@ function _mapDispatchToProps(dispatch) {
         /**
          * Dispatches an action changing the visibility of the {@link Toolbox}.
          *
-         * @param {boolean} visible - {@code true} to show the {@code Toolbox}
-         * or {@code false} to hide it.
          * @private
+         * @param {boolean} visible - Pass {@code true} to show the
+         * {@code Toolbox} or {@code false} to hide it.
          * @returns {void}
          */
         _setToolboxVisible(visible) {

--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -37,14 +37,14 @@ export function beginAddPeople() {
 
 
 /**
- * Invites (i.e. sends invites to) an array of invitees (which may be a
- * combination of users, rooms, phone numbers, and video rooms).
+ * Invites (i.e. Sends invites to) an array of invitees (which may be a
+ * combination of users, rooms, phone numbers, and video rooms.
  *
  * @param  {Array<Object>} invitees - The recepients to send invites to.
  * @param  {Array<Object>} showCalleeInfo - Indicates whether the
  * {@code CalleeInfo} should be displayed or not.
  * @returns {Promise<Array<Object>>} A {@code Promise} resolving with an array
- * of invitees who were not invited (i.e. invites were not sent to them).
+ * of invitees who were not invited (i.e. Invites were not sent to them).
  */
 export function invite(
         invitees: Array<Object>,

--- a/react/features/invite/middleware.native.js
+++ b/react/features/invite/middleware.native.js
@@ -121,7 +121,7 @@ function _beginAddPeople(store, next, action) {
 }
 
 /**
- * Handles the {@code invite} event of the feature invite i.e. invites specific
+ * Handles the {@code invite} event of the feature invite and invites specific
  * invitees to the current, ongoing conference.
  *
  * @param {Object} event - The details of the event.
@@ -146,7 +146,7 @@ function _onInvite({ addPeopleControllerScope, externalAPIScope, invitees }) {
 }
 
 /**
- * Handles the {@code performQuery} event of the feature invite i.e. queries for
+ * Handles the {@code performQuery} event of the feature invite and queries for
  * invitees who may subsequently be invited to the current, ongoing conference.
  *
  * @param {Object} event - The details of the event.

--- a/react/features/large-video/actions.js
+++ b/react/features/large-video/actions.js
@@ -48,7 +48,7 @@ export function selectParticipant() {
 
 /**
  * Action to select the participant to be displayed in LargeVideo based on a
- * variety of factors: if there is a dominant or pinned speaker, or if there are
+ * variety of factors: If there is a dominant or pinned speaker, or if there are
  * remote tracks, etc.
  *
  * @returns {Function}
@@ -105,7 +105,7 @@ function _electLastVisibleRemoteVideo(tracks) {
 }
 
 /**
- * Returns the identifier of the participant who is to be on the stage i.e.
+ * Returns the identifier of the participant who is to be on the stage and
  * should be displayed in {@code LargeVideo}.
  *
  * @param {Object} state - The Redux state from which the participant to be

--- a/react/features/local-recording/components/LocalRecordingInfoDialog.js
+++ b/react/features/local-recording/components/LocalRecordingInfoDialog.js
@@ -288,7 +288,7 @@ class LocalRecordingInfoDialog extends Component<Props, State> {
     }
 
     /**
-     * Renders the moderator-only controls, i.e. stats of all users and the
+     * Renders the moderator-only controls: The stats of all users and the
      * action links.
      *
      * @private

--- a/react/features/local-recording/controller/RecordingController.js
+++ b/react/features/local-recording/controller/RecordingController.js
@@ -221,7 +221,7 @@ class RecordingController {
     /**
      * Registers listeners for XMPP events.
      *
-     * @param {JitsiConference} conference - {@code JitsiConference} instance.
+     * @param {JitsiConference} conference - A {@code JitsiConference} instance.
      * @returns {void}
      */
     registerEvents(conference: Object) {
@@ -633,7 +633,7 @@ class RecordingController {
         }
 
         /* eslint-disable */
-        return (Promise.resolve(): Promise<void>); 
+        return (Promise.resolve(): Promise<void>);
         // FIXME: better ways to satisfy flow and ESLint at the same time?
         /* eslint-enable */
 

--- a/react/features/local-recording/recording/flac/flacEncodeWorker.js
+++ b/react/features/local-recording/recording/flac/flacEncodeWorker.js
@@ -161,7 +161,7 @@ class Encoder {
 
     /**
      * Constructor.
-     * Note: only create instance when Flac.isReady() returns true.
+     * Note: Only create instance when Flac.isReady() returns true.
      *
      * @param {number} sampleRate - Sample rate of the raw audio data.
      * @param {number} bitDepth - Bit depth (bit per sample).

--- a/react/features/recording/actions.js
+++ b/react/features/recording/actions.js
@@ -31,7 +31,8 @@ export function clearRecordingSessions() {
  * Signals that the pending recording notification should be removed from the
  * screen.
  *
- * @param {string} streamType - The type of the stream (e.g. file or stream).
+ * @param {string} streamType - The type of the stream ({@code 'file'} or
+ * {@code 'stream'}).
  * @returns {Function}
  */
 export function hidePendingRecordingNotification(streamType: string) {
@@ -52,7 +53,6 @@ export function hidePendingRecordingNotification(streamType: string) {
  * Sets the stream key last used by the user for later reuse.
  *
  * @param {string} streamKey - The stream key to set.
- * redux.
  * @returns {{
  *     type: SET_STREAM_KEY,
  *     streamKey: string
@@ -69,7 +69,8 @@ export function setLiveStreamKey(streamKey: string) {
  * Signals that the pending recording notification should be shown on the
  * screen.
  *
- * @param {string} streamType - The type of the stream (e.g. file or stream).
+ * @param {string} streamType - The type of the stream ({@code file} or
+ * {@code stream}).
  * @returns {Function}
  */
 export function showPendingRecordingNotification(streamType: string) {
@@ -109,7 +110,8 @@ export function showRecordingError(props: Object) {
  * Signals that the stopped recording notification should be shown on the
  * screen for a given period.
  *
- * @param {string} streamType - The type of the stream (e.g. file or stream).
+ * @param {string} streamType - The type of the stream ({@code file} or
+ * {@code stream}).
  * @returns {showNotification}
  */
 export function showStoppedRecordingNotification(streamType: string) {
@@ -162,8 +164,8 @@ export function updateRecordingSessionData(session: Object) {
  * passed.
  *
  * @param {?number} uid - The UID of the notification.
- * redux.
- * @param {string} streamType - The type of the stream (e.g. file or stream).
+ * @param {string} streamType - The type of the stream ({@code file} or
+ * {@code stream}).
  * @returns {{
  *     type: SET_PENDING_RECORDING_NOTIFICATION_UID,
  *     streamType: string,

--- a/react/features/recording/components/LiveStream/AbstractStartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/AbstractStartLiveStreamDialog.js
@@ -194,7 +194,6 @@ export default class AbstractStartLiveStreamDialog<P: Props>
      * display of the entered YouTube stream key.
      *
      * @param {string} streamKey - The stream key entered in the field.
-     * changed text.
      * @private
      * @returns {void}
      */

--- a/react/features/recording/components/LiveStream/StartLiveStreamDialog.native.js
+++ b/react/features/recording/components/LiveStream/StartLiveStreamDialog.native.js
@@ -47,7 +47,7 @@ class StartLiveStreamDialog extends AbstractStartLiveStreamDialog<Props> {
      *
      * FIXME: This is a temporary method to store the streaming key on mobile
      * for easier use, until the Google sign-in is implemented. We don't store
-     * the key on web for security reasons (e.g. we don't want to have the key
+     * the key on web for security reasons (e.g. We don't want to have the key
      * stored if the used signed out).
      *
      * @private
@@ -80,7 +80,7 @@ class StartLiveStreamDialog extends AbstractStartLiveStreamDialog<Props> {
      * A callback to be invoked when an authenticated user changes, so
      * then we can get (or clear) the YouTube stream key.
      *
-     * TODO: handle errors by showing some indication to the user.
+     * TODO: Handle errors by showing some indication to the user.
      *
      * @private
      * @param {Object} response - The retreived signin response.

--- a/react/features/recording/functions.js
+++ b/react/features/recording/functions.js
@@ -47,7 +47,7 @@ export function getSessionById(state: Object, id: string) {
 }
 
 /**
- * Returns the recording session status that is to be shown in a label. E.g. if
+ * Returns the recording session status that is to be shown in a label. E.g. If
  * there is a session with the status OFF and one with PENDING, then the PENDING
  * one will be shown, because that is likely more important for the user to see.
  *

--- a/react/features/transcribing/actions.js
+++ b/react/features/transcribing/actions.js
@@ -126,11 +126,10 @@ export function showPendingTranscribingNotification() {
 
 /**
  * Sets UID of the the pending transcribing notification to use it when hiding
- * the notification is necessary, or unsets it when
- * undefined (or no param) is passed.
+ * the notification is necessary, or unsets it when undefined (or no param) is
+ * passed.
  *
  * @param {?number} uid - The UID of the notification.
- * redux.
  * @returns {{
  *     type: SET_PENDING_TRANSCRIBING_NOTIFICATION_UID,
  *     uid: number
@@ -185,5 +184,3 @@ export function showTranscribingError() {
         titleKey: 'transcribing.failedToStart'
     });
 }
-
-

--- a/react/features/welcome/components/AbstractWelcomePage.js
+++ b/react/features/welcome/components/AbstractWelcomePage.js
@@ -149,7 +149,7 @@ export class AbstractWelcomePage extends Component<Props, *> {
     }
 
     /**
-     * Determines whether the 'Join' button is (to be) disabled i.e. there's no
+     * Determines whether the 'Join' button is (to be) disabled i.e. There's no
      * valid room name typed into the respective text input field.
      *
      * @protected

--- a/react/features/welcome/components/WelcomePageSideBar.native.js
+++ b/react/features/welcome/components/WelcomePageSideBar.native.js
@@ -123,7 +123,7 @@ class WelcomePageSideBar extends Component<Props> {
     _onHideSideBar: () => void;
 
     /**
-     * Invoked when the sidebar has closed itself (e.g. overlay pressed).
+     * Invoked when the sidebar has closed itself (e.g. Overlay pressed).
      *
      * @private
      * @returns {void}

--- a/react/features/welcome/functions.js
+++ b/react/features/welcome/functions.js
@@ -10,7 +10,7 @@ export * from './roomnameGenerator';
 
 /**
  * Determines whether the {@code WelcomePage} is enabled by the app itself
- * (e.g. programmatically via the Jitsi Meet SDK for Android and iOS). Not to be
+ * (e.g. Programmatically via the Jitsi Meet SDK for Android and iOS). Not to be
  * confused with {@link isWelcomePageUserEnabled}.
  *
  * @param {Function|Object} stateful - The redux state or {@link getState}


### PR DESCRIPTION
This commit fixes recent jsdoc warnings.

Disabling the affected ```jsdoc/require-description-complete-sentence``` rule may also be a solution, but then we are not notified by real doc issues, such as the merge issues in
https://github.com/jitsi/jitsi-meet/blob/56100d0d5c99826495fbab5eec8e4010a71ac947/react/features/recording/actions.js#L55
or
https://github.com/jitsi/jitsi-meet/blob/56100d0d5c99826495fbab5eec8e4010a71ac947/react/features/transcribing/actions.js#L133
