### PR TITLE
[RN] Update react-native-calendar-events lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11730,8 +11730,8 @@
       "integrity": "sha512-vLNJIedXQZN4p3ChFsAgVHacnJqQMnLl+wBsnZuliRkmsjEHo8kQOA9fnLih/OoiDi1O3eHQvXC5L8f+RYiKgw=="
     },
     "react-native-calendar-events": {
-      "version": "github:wmcmahan/react-native-calendar-events#cb2731db6684a49b4343e09de7f9c2fcc68bcd9b",
-      "from": "github:wmcmahan/react-native-calendar-events#cb2731db6684a49b4343e09de7f9c2fcc68bcd9b"
+      "version": "github:wmcmahan/react-native-calendar-events#056807286da610d884fb6b4c8ca187a767b261f7",
+      "from": "github:wmcmahan/react-native-calendar-events#056807286da610d884fb6b4c8ca187a767b261f7"
     },
     "react-native-callstats": {
       "version": "3.53.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-i18next": "7.13.0",
     "react-native": "0.57.1",
     "react-native-background-timer": "2.0.0",
-    "react-native-calendar-events": "github:wmcmahan/react-native-calendar-events#cb2731db6684a49b4343e09de7f9c2fcc68bcd9b",
+    "react-native-calendar-events": "github:wmcmahan/react-native-calendar-events#056807286da610d884fb6b4c8ca187a767b261f7",
     "react-native-callstats": "3.53.4",
     "react-native-fast-image": "github:jitsi/react-native-fast-image#1f8c93a5584869848d75cc9b946beb9688efe285",
     "react-native-google-signin": "1.0.0-rc6",


### PR DESCRIPTION
This is required to get rid of a warning after react native update. See related commit in lib.

https://github.com/wmcmahan/react-native-calendar-events/commit/056807286da610d884fb6b4c8ca187a767b261f7