### PR TITLE
fix(local-recording): allow config override to enable

### DIFF
--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -119,6 +119,7 @@ const WHITELISTED_KEYS = [
     'iceTransportPolicy',
     'ignoreStartMuted',
     'liveStreamingEnabled',
+    'localRecording',
     'minParticipants',
     'nick',
     'openBridgeChannel',

--- a/react/features/local-recording/middleware.js
+++ b/react/features/local-recording/middleware.js
@@ -64,7 +64,7 @@ MiddlewareRegistry.register(({ getState, dispatch }) => next => action => {
                 dispatch(toggleDialog(LocalRecordingInfoDialog));
             }, 'keyboardShortcuts.localRecording');
 
-        if (localRecording && localRecording.format) {
+        if (localRecording.format) {
             recordingController.switchFormat(localRecording.format);
         }
 

--- a/react/features/local-recording/middleware.js
+++ b/react/features/local-recording/middleware.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { createShortcutEvent, sendAnalytics } from '../analytics';
-import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../base/app';
+import { APP_WILL_UNMOUNT } from '../base/app';
 import { CONFERENCE_JOINED } from '../base/conference';
 import { toggleDialog } from '../base/dialog';
 import { i18next } from '../base/i18n';
@@ -15,28 +15,22 @@ import { LocalRecordingInfoDialog } from './components';
 import { recordingController } from './controller';
 
 declare var APP: Object;
-declare var config: Object;
 
-const isFeatureEnabled = typeof config === 'object' && config.localRecording
-    && config.localRecording.enabled === true;
-
-isFeatureEnabled
-&& MiddlewareRegistry.register(({ getState, dispatch }) => next => action => {
+MiddlewareRegistry.register(({ getState, dispatch }) => next => action => {
     const result = next(action);
 
     switch (action.type) {
     case CONFERENCE_JOINED: {
-        const { conference } = getState()['features/base/conference'];
         const { localRecording } = getState()['features/base/config'];
+        const isLocalRecordingEnabled = Boolean(
+            localRecording
+            && localRecording.enabled
+            && typeof APP === 'object'
+        );
 
-        if (localRecording && localRecording.format) {
-            recordingController.switchFormat(localRecording.format);
+        if (!isLocalRecordingEnabled) {
+            break;
         }
-
-        recordingController.registerEvents(conference);
-        break;
-    }
-    case APP_WILL_MOUNT:
 
         // realize the delegates on recordingController, allowing the UI to
         // react to state changes in recordingController.
@@ -69,7 +63,17 @@ isFeatureEnabled
                 sendAnalytics(createShortcutEvent('local.recording'));
                 dispatch(toggleDialog(LocalRecordingInfoDialog));
             }, 'keyboardShortcuts.localRecording');
+
+        if (localRecording && localRecording.format) {
+            recordingController.switchFormat(localRecording.format);
+        }
+
+        const { conference } = getState()['features/base/conference'];
+
+        recordingController.registerEvents(conference);
+
         break;
+    }
     case APP_WILL_UNMOUNT:
         recordingController.onStateChanged = null;
         recordingController.onNotify = null;


### PR DESCRIPTION
Config overrides are not set until some time after
APP_WILL_MOUNT has completed and not in the same execution
context as when APP_WILL_MOUNT is called. So instead
choose recording controller initialization at a later time.
The time chosen is after conference join because the
controller needs the conference instance to work.

Fixes #3613.