### PR TITLE
repair language zhCN

### DIFF
--- a/react/features/base/i18n/languageDetector.native.js
+++ b/react/features/base/i18n/languageDetector.native.js
@@ -15,7 +15,7 @@ export default {
     cacheUserLanguage: Function.prototype,
 
     detect() {
-        return locale;
+        return locale.indexOf('zh') === 0 ? 'zhCN' : locale;
     },
 
     init: Function.prototype,


### PR DESCRIPTION
In Android 9, it's `zh-CN_#Hans`, in iOS, it's `zh-Hans` ,  `zh-Hant`, `zh-Hans-CN`, `zh-Hans-US`,etc
I'm sorry for users not in Chinese Mainland, God bless.