### PR TITLE
fix(filmstrip): show thumbnails in 1-on-1 with a fake participant

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -126,6 +126,20 @@ export function getParticipantCount(stateful: Object | Function) {
 }
 
 /**
+ * Returns a count of the known participants in the passed in redux state,
+ * including fake participants.
+ *
+ * @param {(Function|Object|Participant[])} stateful - The redux state
+ * features/base/participants, the (whole) redux state, or redux's
+ * {@code getState} function to be used to retrieve the state
+ * features/base/participants.
+ * @returns {number}
+ */
+export function getParticipantCountWithFake(stateful: Object | Function) {
+    return _getAllParticipants(stateful).length;
+}
+
+/**
  * Returns participant's display name.
  *
  * FIXME: Remove the hardcoded strings once interfaceConfig is stored in redux

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {
-    getParticipantCount,
+    getParticipantCountWithFake,
     getPinnedParticipant
 } from '../base/participants';
 import { toState } from '../base/redux';
@@ -36,7 +36,10 @@ export function shouldRemoteVideosBeVisible(state: Object) {
         return false;
     }
 
-    const participantCount = getParticipantCount(state);
+    // Include fake participants to derive how many thumbnails are dispalyed,
+    // as it is assumed all participants, including fake, will be displayed
+    // in the filmstrip.
+    const participantCount = getParticipantCountWithFake(state);
     let pinnedParticipant;
 
     return Boolean(


### PR DESCRIPTION
Filmstrip remote thumbnails display under certain conditions, as
defined in filmstrip/functions.web.js. Previously the raw
participant count was used, which included fake participants.
Using the selector getParticipantCount excludes fake participants,
causing YouTube thumbnails to remain hidden in a 1-on-1 call.