### PR TITLE
fix(tile-view): prevent local participant being selected on pin exit

### DIFF
--- a/modules/UI/videolayout/LocalVideo.js
+++ b/modules/UI/videolayout/LocalVideo.js
@@ -11,6 +11,7 @@ import {
     getAvatarURLByParticipantId
 } from '../../../react/features/base/participants';
 import { updateSettings } from '../../../react/features/base/settings';
+import { getLocalVideoTrack } from '../../../react/features/base/tracks';
 import { shouldDisplayTileView } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 
@@ -292,12 +293,14 @@ LocalVideo.prototype._onContainerClick = function(event) {
  */
 LocalVideo.prototype._updateVideoElement = function() {
     const localVideoContainer = document.getElementById('localVideoWrapper');
+    const videoTrack
+        = getLocalVideoTrack(APP.store.getState()['features/base/tracks']);
 
     ReactDOM.render(
         <Provider store = { APP.store }>
             <VideoTrack
                 id = 'localVideo_container'
-                videoTrack = {{ jitsiTrack: this.videoStream }} />
+                videoTrack = { videoTrack } />
         </Provider>,
         localVideoContainer
     );


### PR DESCRIPTION
On tile view enter/exit, local video is moved in the DOM (an effect
of not being reactified and moving being easier) and play is called
on its video element. The race condition setup is such: in tile
view with other participants and local video is on large (not
visible in the UI but visible in the app state and pip popout).
The race is such: pin a remote video, large video update is queued,
tile view is exited, local video is moved, play is called,,
onVideoPlaying callback executed, middleware fires mute update,
which checks if local is on large (it is), previous large video
update is cleared, and local is placed on large.

The fix is ensuring the redux representation of local video is
passed in, which holds the boolean videoStarted, which prevents
the onVideoPlaying callback from firing on subsequent plays.