### PR TITLE
Tile view toggles some features and some features toggle tile view

### DIFF
--- a/react/features/video-layout/middleware.any.js
+++ b/react/features/video-layout/middleware.any.js
@@ -4,6 +4,7 @@ import {
     pinParticipant
 } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
+import { SET_DOCUMENT_EDITING_STATUS, toggleDocument } from '../etherpad';
 
 import { SET_TILE_VIEW } from './actionTypes';
 import { setTileView } from './actions';
@@ -27,12 +28,28 @@ MiddlewareRegistry.register(store => next => action => {
         break;
     }
 
-    case SET_TILE_VIEW:
-        if (getPinnedParticipant(store.getState()) && action.enabled) {
-            store.dispatch(pinParticipant(null));
+    case SET_DOCUMENT_EDITING_STATUS:
+        if (action.editing) {
+            store.dispatch(setTileView(false));
         }
 
         break;
+
+    case SET_TILE_VIEW: {
+        const state = store.getState();
+
+        if (action.enabled) {
+            if (getPinnedParticipant(state)) {
+                store.dispatch(pinParticipant(null));
+            }
+
+            if (state['features/etherpad'].editing) {
+                store.dispatch(toggleDocument());
+            }
+        }
+
+        break;
+    }
     }
 
     return next(action);

--- a/react/features/video-layout/middleware.any.js
+++ b/react/features/video-layout/middleware.any.js
@@ -1,0 +1,39 @@
+import {
+    PIN_PARTICIPANT,
+    getPinnedParticipant,
+    pinParticipant
+} from '../base/participants';
+import { MiddlewareRegistry } from '../base/redux';
+
+import { SET_TILE_VIEW } from './actionTypes';
+import { setTileView } from './actions';
+
+/**
+ * Middleware which intercepts actions and updates tile view related state.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case PIN_PARTICIPANT: {
+        const isPinning = Boolean(action.participant.id);
+        const { tileViewEnabled } = store.getState()['features/video-layout'];
+
+        if (isPinning && tileViewEnabled) {
+            store.dispatch(setTileView(false));
+        }
+
+        break;
+    }
+
+    case SET_TILE_VIEW:
+        if (getPinnedParticipant(store.getState()) && action.enabled) {
+            store.dispatch(pinParticipant(null));
+        }
+
+        break;
+    }
+
+    return next(action);
+});

--- a/react/features/video-layout/middleware.native.js
+++ b/react/features/video-layout/middleware.native.js
@@ -1,0 +1,1 @@
+import './middleware.any';

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -17,6 +17,7 @@ import { TRACK_ADDED } from '../base/tracks';
 import { SET_FILMSTRIP_VISIBLE } from '../filmstrip';
 
 import { SET_TILE_VIEW } from './actionTypes';
+import './middleware.any';
 
 declare var APP: Object;
 


### PR DESCRIPTION
When entering etherpad or pinning, filmstrip mode is displayed with tile view still enabled. Now, disable tile view. For symmetry, hide etherpad and clear pins when entering tile view.

Updated torture tests: https://github.com/jitsi/jitsi-meet-torture/pull/215