### PR TITLE
fix(tile-view): thumbnail videos should cover entire thumbnail

### DIFF
--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -301,10 +301,11 @@ const Filmstrip = {
         const initialWidth = viewWidth / columns;
         const aspectRatioHeight = initialWidth / tileAspectRatio;
 
-        const heightOfEach = Math.min(
+        const heightOfEach = Math.floor(Math.min(
             aspectRatioHeight,
-            viewHeight / visibleRows);
-        const widthOfEach = tileAspectRatio * heightOfEach;
+            viewHeight / visibleRows
+        ));
+        const widthOfEach = Math.floor(tileAspectRatio * heightOfEach);
 
         return {
             localVideo: {


### PR DESCRIPTION
Video elements may have problems scaling to cover pixel fractions,
so there could be a 1px black border line displaying in the
thumbnail. It's most visible in tile view. Flooring the sizing
calculations hides the border.