### PR TITLE
[RN] Drop react-native-locale-detector dependency

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation project(':react-native-immersive')
     implementation project(':react-native-keep-awake')
     implementation project(':react-native-linear-gradient')
-    implementation project(':react-native-locale-detector')
     implementation project(':react-native-sound')
     implementation project(':react-native-vector-icons')
     implementation project(':react-native-webrtc')

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright @ 2018-present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based on https://github.com/DylanVann/react-native-locale-detector
+ */
+
+package org.jitsi.meet.sdk;
+
+import android.content.Context;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Module which provides information about the system locale.
+ */
+class LocaleDetector extends ReactContextBaseJavaModule {
+
+    public LocaleDetector(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    /**
+     * Gets a {@code Map} of constants this module exports to JS. Supports JSON
+     * types.
+     *
+     * @return a {@link Map} of constants this module exports to JS
+     */
+    @Override
+    public Map<String, Object> getConstants() {
+        Context context = getReactApplicationContext();
+        HashMap<String,Object> constants = new HashMap<>();
+        constants.put("locale", context.getResources().getConfiguration().locale.toString());
+        return constants;
+    }
+
+    @Override
+    public String getName() {
+        return "LocaleDetector";
+    }
+}

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
@@ -42,6 +42,7 @@ class ReactInstanceManagerHolder {
             new AppInfoModule(reactContext),
             new AudioModeModule(reactContext),
             new ExternalAPIModule(reactContext),
+            new LocaleDetector(reactContext),
             new PictureInPictureModule(reactContext),
             new ProximityModule(reactContext),
             new WiFiStatsModule(reactContext),
@@ -126,7 +127,6 @@ class ReactInstanceManagerHolder {
                 .addPackage(new com.corbt.keepawake.KCKeepAwakePackage())
                 .addPackage(new com.dylanvann.fastimage.FastImageViewPackage())
                 .addPackage(new com.facebook.react.shell.MainReactPackage())
-                .addPackage(new com.i18n.reactnativei18n.ReactNativeI18n())
                 .addPackage(new com.oblador.vectoricons.VectorIconsPackage())
                 .addPackage(new com.ocetnik.timer.BackgroundTimerPackage())
                 .addPackage(new com.oney.WebRTCModule.WebRTCModulePackage())

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,8 +13,6 @@ include ':react-native-keep-awake'
 project(':react-native-keep-awake').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keep-awake/android')
 include ':react-native-linear-gradient'
 project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
-include ':react-native-locale-detector'
-project(':react-native-locale-detector').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-locale-detector/android')
 include ':react-native-sound'
 project(':react-native-sound').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sound/android')
 include ':react-native-vector-icons'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,8 +34,6 @@ target 'JitsiMeet' do
     :path => '../node_modules/react-native-fast-image'
   pod 'react-native-keep-awake',
     :path => '../node_modules/react-native-keep-awake'
-  pod 'react-native-locale-detector',
-    :path => '../node_modules/react-native-locale-detector'
   pod 'react-native-webrtc', :path => '../node_modules/react-native-webrtc'
   pod 'RNGoogleSignin',
     :path => '../node_modules/react-native-google-signin'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -41,8 +41,6 @@ PODS:
     - SDWebImage/GIF
   - react-native-keep-awake (2.0.6):
     - React
-  - react-native-locale-detector (1.0.0):
-    - React
   - react-native-webrtc (1.67.1):
     - React
   - React/Core (0.57.6):
@@ -109,7 +107,6 @@ DEPENDENCIES:
   - react-native-calendar-events (from `../node_modules/react-native-calendar-events`)
   - react-native-fast-image (from `../node_modules/react-native-fast-image`)
   - react-native-keep-awake (from `../node_modules/react-native-keep-awake`)
-  - react-native-locale-detector (from `../node_modules/react-native-locale-detector`)
   - react-native-webrtc (from `../node_modules/react-native-webrtc`)
   - React/Core (from `../node_modules/react-native`)
   - React/CxxBridge (from `../node_modules/react-native`)
@@ -154,8 +151,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fast-image"
   react-native-keep-awake:
     :path: "../node_modules/react-native-keep-awake"
-  react-native-locale-detector:
-    :path: "../node_modules/react-native-locale-detector"
   react-native-webrtc:
     :path: "../node_modules/react-native-webrtc"
   RNGoogleSignin:
@@ -183,7 +178,6 @@ SPEC CHECKSUMS:
   react-native-calendar-events: fe6fbc8ed337a7423c98f2c9012b25f20444de09
   react-native-fast-image: cba3d9bf9c2cf8ddb643d887a686c53a5dd90a2c
   react-native-keep-awake: 0de4bd66de0c23178107dce0c2fcc3354b2a8e94
-  react-native-locale-detector: d1b2c6fe5abb56e3a1efb6c2d6f308c05c4251f1
   react-native-webrtc: 31b6d3f1e3e2ce373aa43fd682b04367250f807d
   RNGoogleSignin: 44debd8c359a662c0e2d585952e88b985bf78008
   RNSound: b360b3862d3118ed1c74bb9825696b5957686ac4
@@ -191,6 +185,6 @@ SPEC CHECKSUMS:
   SDWebImage: 624d6e296c69b244bcede364c72ae0430ac14681
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: cf8276ba4b0933b24c6082a25a5f4eabe0ba4ea6
+PODFILE CHECKSUM: 9b67ed66d62ca004caa7952c3bbfe2693c115333
 
 COCOAPODS: 1.5.3

--- a/ios/sdk/sdk.xcodeproj/project.pbxproj
+++ b/ios/sdk/sdk.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		C6A34261204EF76800E062DD /* DragGestureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A3425E204EF76800E062DD /* DragGestureController.swift */; };
 		C6CC49AF207412CF000DFA42 /* PiPViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CC49AE207412CF000DFA42 /* PiPViewCoordinator.swift */; };
 		C6F99C15204DB63E0001F710 /* JitsiMeetView+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = C6F99C13204DB63D0001F710 /* JitsiMeetView+Private.h */; };
+		DEFC743F21B178FA00E4DD96 /* LocaleDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = DEFC743D21B178FA00E4DD96 /* LocaleDetector.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -104,6 +105,7 @@
 		C6A3425E204EF76800E062DD /* DragGestureController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DragGestureController.swift; sourceTree = "<group>"; };
 		C6CC49AE207412CF000DFA42 /* PiPViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiPViewCoordinator.swift; sourceTree = "<group>"; };
 		C6F99C13204DB63D0001F710 /* JitsiMeetView+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JitsiMeetView+Private.h"; sourceTree = "<group>"; };
+		DEFC743D21B178FA00E4DD96 /* LocaleDetector.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocaleDetector.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +175,7 @@
 				C6F99C13204DB63D0001F710 /* JitsiMeetView+Private.h */,
 				0B412F1B1EDEC80100B1A0A6 /* JitsiMeetViewDelegate.h */,
 				0B7C2CFC200F51D60060D076 /* LaunchOptions.m */,
+				DEFC743D21B178FA00E4DD96 /* LocaleDetector.m */,
 				0B44A0181F902126009D1D64 /* MPVolumeViewManager.m */,
 				C6A3426B204F127900E062DD /* picture-in-picture */,
 				0BCA495D1EC4B6C600B793EE /* POSIX.m */,
@@ -465,6 +468,7 @@
 				0B7C2CFD200F51D60060D076 /* LaunchOptions.m in Sources */,
 				C6CC49AF207412CF000DFA42 /* PiPViewCoordinator.swift in Sources */,
 				B386B85720981A75000DEF7A /* InviteController.m in Sources */,
+				DEFC743F21B178FA00E4DD96 /* LocaleDetector.m in Sources */,
 				B386B85820981A75000DEF7A /* AddPeopleController.m in Sources */,
 				0BCA495F1EC4B6C600B793EE /* AudioMode.m in Sources */,
 				0B44A0191F902126009D1D64 /* MPVolumeViewManager.m in Sources */,

--- a/ios/sdk/src/LocaleDetector.m
+++ b/ios/sdk/src/LocaleDetector.m
@@ -1,0 +1,40 @@
+/*
+ * Copyright @ 2018-present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based on https://github.com/DylanVann/react-native-locale-detector
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <React/RCTBridgeModule.h>
+
+@interface LocaleDetector : NSObject <RCTBridgeModule>
+@end
+
+@implementation LocaleDetector
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup {
+    return NO;
+}
+
+- (NSDictionary *)constantsToExport {
+    return @{ @"locale": [[NSLocale preferredLanguages] objectAtIndex:0] };
+}
+
+@end

--- a/package-lock.json
+++ b/package-lock.json
@@ -11233,10 +11233,6 @@
         "prop-types": "^15.5.10"
       }
     },
-    "react-native-locale-detector": {
-      "version": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9",
-      "from": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9"
-    },
     "react-native-prompt": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-native-prompt/-/react-native-prompt-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react-native-immersive": "1.1.0",
     "react-native-keep-awake": "2.0.6",
     "react-native-linear-gradient": "2.4.0",
-    "react-native-locale-detector": "github:jitsi/react-native-locale-detector#845281e9fd4af756f6d0f64afe5cce08c63e5ee9",
     "react-native-prompt": "1.0.0",
     "react-native-sound": "0.10.9",
     "react-native-swipeout": "2.3.6",

--- a/react/features/base/i18n/languageDetector.native.js
+++ b/react/features/base/i18n/languageDetector.native.js
@@ -1,6 +1,6 @@
-/* @flow */
+// @flow
 
-import locale from 'react-native-locale-detector';
+import { NativeModules } from 'react-native';
 
 /**
  * The singleton language detector for React Native which uses the system-wide
@@ -15,7 +15,9 @@ export default {
     cacheUserLanguage: Function.prototype,
 
     detect() {
-        return locale;
+        const { LocaleDetector } = NativeModules;
+
+        return LocaleDetector.locale.replace(/_/, '-');
     },
 
     init: Function.prototype,


### PR DESCRIPTION
The upstream package has been unmaintained for 2 years now, and making the litle
changes needed as React Native needs them is getting old. The actual
funcionality is a couple of one-liners plus tons of boliterplate, which gets
reduced by quite a bit if we just embed it. So here it goes.