### PR TITLE
ios: switch back to the "legacy" build system in Xcode

### DIFF
--- a/ios/jitsi-meet.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ios/jitsi-meet.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
Xcode 10 introduced a new build system. Alas, it breaks a number of important
flows, such as creating an archive for the framework (ie SDK) target.

In order to "fix" this, switch back to the former (Xcode 9) build system for the
time being.