### PR TITLE
chore(deps): bump lib-jitsi-meet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2829,7 +2829,7 @@
     },
     "async": {
       "version": "0.9.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
       "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
     },
     "async-each": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2829,7 +2829,7 @@
     },
     "async": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-0.9.0.tgz",
       "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
     },
     "async-each": {
@@ -8379,8 +8379,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#81dac6051eb7e86e51a94eca96eae10add9dc7fb",
-      "from": "github:jitsi/lib-jitsi-meet#81dac6051eb7e86e51a94eca96eae10add9dc7fb",
+      "version": "github:jitsi/lib-jitsi-meet#efa099a2890f9b090422f734ab1509ffbb328285",
+      "from": "github:jitsi/lib-jitsi-meet#efa099a2890f9b090422f734ab1509ffbb328285",
       "requires": {
         "@jitsi/sdp-interop": "0.1.13",
         "@jitsi/sdp-simulcast": "0.2.1",
@@ -12488,9 +12488,9 @@
       "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "rtcpeerconnection-shim": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.14.tgz",
-      "integrity": "sha512-/sl1vgarkFPU2rbXy+EMmytMQIzCKNbIm3fChjPnsdytKAROgoivB0KLE7PQRjKx/d/nr/Yx+6qu0/eCpoxn/A==",
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
       "requires": {
         "sdp": "^2.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jsc-android": "224109.1.0",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#81dac6051eb7e86e51a94eca96eae10add9dc7fb",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#efa099a2890f9b090422f734ab1509ffbb328285",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.11",
     "moment": "2.19.4",


### PR DESCRIPTION
Brings in a fix for getDisplayMedia being moved onto
navigator.mediaDevices and a hack fix for SDP
interop between Chrome and Firefox.