### PR TITLE
Add some live stream key validation

### DIFF
--- a/css/_recording.scss
+++ b/css/_recording.scss
@@ -65,6 +65,8 @@
     }
 
     .form-footer {
+        display: flex;
+        margin-top: 5px;
         text-align: right;
     }
 
@@ -95,9 +97,15 @@
 
     .stream-key-form {
         .helper-link {
-            display: inline-block;
             cursor: pointer;
-            margin-top: 5px;
+            display: inline-block;
+            flex-shrink: 0;
+            margin-left: auto;
+        }
+
+        .validation-error {
+            color:#FFD740;
+            font-size: 12px;
         }
     }
 }

--- a/lang/main.json
+++ b/lang/main.json
@@ -515,6 +515,7 @@
         "expandedOn": "The meeting is currently being streamed to YouTube.",
         "expandedPending": "The live streaming is being started...",
         "failedToStart": "Live Streaming failed to start",
+        "invalidStreamKey": "Live stream key may be incorrect.",
         "off": "Live Streaming stopped",
         "on": "Live Streaming",
         "pending": "Starting Live Stream...",

--- a/react/features/recording/components/LiveStream/AbstractStartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/AbstractStartLiveStreamDialog.js
@@ -194,7 +194,8 @@ export default class AbstractStartLiveStreamDialog<P: Props>
      */
     _onSubmit() {
         const { broadcasts, selectedBoundStreamID } = this.state;
-        const key = this.state.streamKey || this.props._streamKey;
+        const key
+            = (this.state.streamKey || this.props._streamKey || '').trim();
 
         if (!key) {
             return false;

--- a/react/features/recording/components/LiveStream/AbstractStreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/AbstractStreamKeyForm.js
@@ -1,5 +1,6 @@
 // @flow
 
+import debounce from 'lodash/debounce';
 import { Component } from 'react';
 
 declare var interfaceConfig: Object;
@@ -34,13 +35,26 @@ export type Props = {
 };
 
 /**
+ * The state of the component.
+ */
+type State = {
+
+    /**
+     * Whether or not to show the warnings that the passed in value seems like
+     * an improperly formatted stream key.
+     */
+    showValidationError: boolean
+};
+
+/**
  * An abstract React Component for entering a key for starting a YouTube live
  * stream.
  *
  * @extends Component
  */
-export default class AbstractStreamKeyForm extends Component<Props> {
+export default class AbstractStreamKeyForm extends Component<Props, State> {
     helpURL: string;
+    _debouncedUpdateValidationErrorVisibility: Function;
 
     /**
      * Constructor for the component.
@@ -50,12 +64,43 @@ export default class AbstractStreamKeyForm extends Component<Props> {
     constructor(props: Props) {
         super(props);
 
+        this.state = {
+            showValidationError: Boolean(this.props.value)
+                && !this._validateStreamKey(this.props.value)
+        };
+
         this.helpURL = (typeof interfaceConfig !== 'undefined'
             && interfaceConfig.LIVE_STREAMING_HELP_LINK)
             || LIVE_STREAMING_HELP_LINK;
 
+        this._debouncedUpdateValidationErrorVisibility = debounce(
+            this._updateValidationErrorVisibility.bind(this),
+            800,
+            { leading: false }
+        );
+
         // Bind event handlers so they are only bound once per instance.
         this._onInputChange = this._onInputChange.bind(this);
+    }
+
+    /**
+     * Implements React Component's componentDidUpdate.
+     *
+     * @inheritdoc
+     */
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.value !== prevProps.value) {
+            this._debouncedUpdateValidationErrorVisibility();
+        }
+    }
+
+    /**
+     * Implements React Component's componentWillUnmount.
+     *
+     * @inheritdoc
+     */
+    componentWillUnmount() {
+        this._debouncedUpdateValidationErrorVisibility.cancel();
     }
 
     _onInputChange: Object => void
@@ -74,5 +119,39 @@ export default class AbstractStreamKeyForm extends Component<Props> {
         const value = typeof change === 'object' ? change.target.value : change;
 
         this.props.onChange(value);
+    }
+
+    /**
+     * Checks if the stream key value seems like a valid stream key and sets the
+     * state for showing or hiding the notification about the stream key seeming
+     * invalid.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _updateValidationErrorVisibility() {
+        const newShowValidationError = Boolean(this.props.value)
+            && !this._validateStreamKey(this.props.value);
+
+        if (newShowValidationError !== this.state.showValidationError) {
+            this.setState({
+                showValidationError: newShowValidationError
+            });
+        }
+    }
+
+    /**
+     * Checks if a passed in stream key appears to be in a valid format.
+     *
+     * @param {string} streamKey - The stream key to check for valid formatting.
+     * @returns {void}
+     * @returns {boolean}
+     */
+    _validateStreamKey(streamKey = '') {
+        const trimmedKey = streamKey.trim();
+        const fourGroupsDashSeparated = /^(?:[a-zA-Z0-9]{4}(?:-(?!$)|$)){4}/;
+        const match = fourGroupsDashSeparated.exec(trimmedKey);
+
+        return Boolean(match);
     }
 }

--- a/react/features/recording/components/LiveStream/native/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyForm.js
@@ -52,15 +52,28 @@ class StreamKeyForm extends AbstractStreamKeyForm {
                     placeholderTextColor = { PLACEHOLDER_COLOR }
                     style = { styles.streamKeyInput }
                     value = { this.props.value } />
-                <TouchableOpacity
-                    onPress = { this._onOpenHelp }
-                    style = { styles.streamKeyHelp } >
-                    <Text style = { styles.text }>
-                        {
-                            t('liveStreaming.streamIdHelp')
-                        }
-                    </Text>
-                </TouchableOpacity>
+                <View style = { styles.formFooter }>
+                    {
+                        this.state.showValidationError
+                            ? <View style = { styles.formFooterItem }>
+                                <Text style = { styles.warningText }>
+                                    { t('liveStreaming.invalidStreamKey') }
+                                </Text>
+                            </View>
+                            : null
+                    }
+                    <View style = { styles.formFooterItem }>
+                        <TouchableOpacity
+                            onPress = { this._onOpenHelp }
+                            style = { styles.streamKeyHelp } >
+                            <Text style = { styles.text }>
+                                {
+                                    t('liveStreaming.streamIdHelp')
+                                }
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                </View>
             </View>
         );
     }

--- a/react/features/recording/components/LiveStream/native/styles.js
+++ b/react/features/recording/components/LiveStream/native/styles.js
@@ -49,6 +49,20 @@ export default createStyleSheet({
     },
 
     /**
+     * Wrapper for the last element in the form.
+     */
+    formFooter: {
+        flexDirection: 'row'
+    },
+
+    /**
+     * Wrapper for individual children in the last element of the form.
+     */
+    formFooterItem: {
+        flex: 1
+    },
+
+    /**
      * Explaining text on the top of the sign in form.
      */
     helpText: {
@@ -133,6 +147,12 @@ export default createStyleSheet({
 
     text: {
         color: ColorPalette.white
-    }
+    },
 
+    /**
+     * A different colored text to indicate information needing attention.
+     */
+    warningText: {
+        color: ColorPalette.Y200
+    }
 });

--- a/react/features/recording/components/LiveStream/web/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyForm.js
@@ -53,11 +53,12 @@ class StreamKeyForm extends AbstractStreamKeyForm {
                     type = 'text'
                     value = { this.props.value } />
                 <div className = 'form-footer'>
-                    { this.state.showValidationError
-                        ? <span className = 'validation-error'>
-                            { t('liveStreaming.invalidStreamKey') }
-                        </span>
-                        : null
+                    {
+                        this.state.showValidationError
+                            ? <span className = 'validation-error'>
+                                { t('liveStreaming.invalidStreamKey') }
+                            </span>
+                            : null
                     }
                     { this.helpURL
                         ? <a

--- a/react/features/recording/components/LiveStream/web/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyForm.js
@@ -36,7 +36,7 @@ class StreamKeyForm extends AbstractStreamKeyForm {
      * @returns {ReactElement}
      */
     render() {
-        const { value, t } = this.props;
+        const { t, value } = this.props;
 
         return (
             <div className = 'stream-key-form'>
@@ -52,16 +52,22 @@ class StreamKeyForm extends AbstractStreamKeyForm {
                     shouldFitContainer = { true }
                     type = 'text'
                     value = { this.props.value } />
-                { this.helpURL
-                    ? <div className = 'form-footer'>
-                        <a
+                <div className = 'form-footer'>
+                    { this.state.showValidationError
+                        ? <span className = 'validation-error'>
+                            { t('liveStreaming.invalidStreamKey') }
+                        </span>
+                        : null
+                    }
+                    { this.helpURL
+                        ? <a
                             className = 'helper-link'
                             onClick = { this._onOpenHelp }>
                             { t('liveStreaming.streamIdHelp') }
                         </a>
-                    </div>
-                    : null
-                }
+                        : null
+                    }
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
~~I've avoided implementing this on mobile for now as I had trouble getting the styling right. I'll re-visit soon but decided to make the PR now to get feedback on the copy and design.~~

web
![stream_key_warning](https://user-images.githubusercontent.com/1243084/50128329-6ef55f80-0229-11e9-83aa-002e96f4f675.gif)
(I did reset the stream key in the gif after capturing the gif.)

mobile
![mobile-warning](https://user-images.githubusercontent.com/1243084/50187018-a0296a80-02d1-11e9-892d-e87e64321d92.gif)
