### PR TITLE
fix(live-streaming): show message if no broadcasts are found

### DIFF
--- a/css/_recording.scss
+++ b/css/_recording.scss
@@ -95,17 +95,15 @@
         padding-bottom: 10px;
     }
 
-    .stream-key-form {
-        .helper-link {
-            cursor: pointer;
-            display: inline-block;
-            flex-shrink: 0;
-            margin-left: auto;
-        }
+    .helper-link {
+        cursor: pointer;
+        display: inline-block;
+        flex-shrink: 0;
+        margin-left: auto;
+    }
 
-        .validation-error {
-            color:#FFD740;
-            font-size: 12px;
-        }
+    .warning-text {
+        color:#FFD740;
+        font-size: 12px;
     }
 }

--- a/lang/main.json
+++ b/lang/main.json
@@ -516,6 +516,7 @@
         "expandedPending": "The live streaming is being started...",
         "failedToStart": "Live Streaming failed to start",
         "invalidStreamKey": "Live stream key may be incorrect.",
+        "getStreamKeyManually": "We weren’t able to fetch any live streams. Try getting your live stream key from YouTube.",
         "off": "Live Streaming stopped",
         "on": "Live Streaming",
         "pending": "Starting Live Stream...",

--- a/react/features/recording/components/LiveStream/constants.js
+++ b/react/features/recording/components/LiveStream/constants.js
@@ -1,0 +1,6 @@
+/**
+ * The URL that is the main landing page for YouTube live streaming and should
+ * have a user's live stream key.
+ */
+export const YOUTUBE_LIVE_DASHBOARD_URL
+    = 'https://www.youtube.com/live_dashboard';

--- a/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
@@ -1,9 +1,17 @@
 // @flow
 
 import React, { Component } from 'react';
-import { Text, TouchableHighlight, View } from 'react-native';
+import {
+    Linking,
+    Text,
+    TouchableHighlight,
+    TouchableOpacity,
+    View
+} from 'react-native';
 
 import { translate } from '../../../../base/i18n';
+
+import { YOUTUBE_LIVE_DASHBOARD_URL } from '../constants';
 
 import styles, { ACTIVE_OPACITY, TOUCHABLE_UNDERLAY } from './styles';
 
@@ -56,6 +64,7 @@ class StreamKeyPicker extends Component<Props, State> {
             streamKey: null
         };
 
+        this._onOpenYoutubeDashboard = this._onOpenYoutubeDashboard.bind(this);
         this._onStreamPick = this._onStreamPick.bind(this);
     }
 
@@ -67,8 +76,22 @@ class StreamKeyPicker extends Component<Props, State> {
     render() {
         const { broadcasts } = this.props;
 
-        if (!broadcasts || !broadcasts.length) {
+        if (!broadcasts) {
             return null;
+        }
+
+        if (!broadcasts.length) {
+            return (
+                <View style = { styles.formWrapper }>
+                    <TouchableOpacity
+                        onPress = { this._onOpenYoutubeDashboard }>
+                        <Text style = { styles.warningText }>
+                            { this.props.t(
+                                'liveStreaming.getStreamKeyManually') }
+                        </Text>
+                    </TouchableOpacity>
+                </View>
+            );
         }
 
         return (
@@ -98,6 +121,19 @@ class StreamKeyPicker extends Component<Props, State> {
                 </View>
             </View>
         );
+    }
+
+    _onOpenYoutubeDashboard: () => void;
+
+    /**
+     * Opens the link which should display the YouTube broadcast live stream
+     * key.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onOpenYoutubeDashboard() {
+        Linking.openURL(YOUTUBE_LIVE_DASHBOARD_URL);
     }
 
     _onStreamPick: string => Function

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
@@ -280,12 +280,21 @@ class StartLiveStreamDialog
             break;
 
         case GOOGLE_API_STATES.SIGNED_IN:
-            googleContent = (
-                <StreamKeyPicker
-                    broadcasts = { broadcasts }
-                    onBroadcastSelected = { this._onYouTubeBroadcastIDSelected }
-                    selectedBoundStreamID = { selectedBoundStreamID } />
-            );
+            if (broadcasts) {
+                googleContent = (
+                    <StreamKeyPicker
+                        broadcasts = { broadcasts }
+                        onBroadcastSelected
+                            = { this._onYouTubeBroadcastIDSelected }
+                        selectedBoundStreamID = { selectedBoundStreamID } />
+                );
+            } else {
+                googleContent = (
+                    <Spinner
+                        isCompleting = { false }
+                        size = 'medium' />
+                );
+            }
 
             /**
              * FIXME: Ideally this help text would be one translation string

--- a/react/features/recording/components/LiveStream/web/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyForm.js
@@ -55,7 +55,7 @@ class StreamKeyForm extends AbstractStreamKeyForm {
                 <div className = 'form-footer'>
                     {
                         this.state.showValidationError
-                            ? <span className = 'validation-error'>
+                            ? <span className = 'warning-text'>
                                 { t('liveStreaming.invalidStreamKey') }
                             </span>
                             : null

--- a/react/features/recording/components/LiveStream/web/StreamKeyPicker.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyPicker.js
@@ -9,6 +9,8 @@ import React, { PureComponent } from 'react';
 
 import { translate } from '../../../../base/i18n';
 
+import { YOUTUBE_LIVE_DASHBOARD_URL } from '../constants';
+
 /**
  * The type of the React {@code Component} props of {@link StreamKeyPicker}.
  */
@@ -94,6 +96,18 @@ class StreamKeyPicker extends PureComponent<Props, State> {
      */
     render() {
         const { broadcasts, selectedBoundStreamID, t } = this.props;
+
+        if (!broadcasts.length) {
+            return (
+                <a
+                    className = 'warning-text'
+                    href = { YOUTUBE_LIVE_DASHBOARD_URL }
+                    rel = 'noopener noreferrer'
+                    target = '_blank'>
+                    { t('liveStreaming.getStreamKeyManually') }
+                </a>
+            );
+        }
 
         const dropdownItems
             = broadcasts.map(broadcast => (


### PR DESCRIPTION
It's possible for the YouTube api to return zero broadcasts
or broadcasts without any streams--streams are what are
associated with stream keys. In this case, instead of showing
an empty selector on web, show an error message with a link
to where the stream key can be obtained. On mobile, there
is no link because the url requires authentication.

Screenshot of web.
![screen shot 2018-12-17 at 8 18 30 pm](https://user-images.githubusercontent.com/1243084/50132077-19757e80-023a-11e9-995b-d403a17d891b.png)

Screenshot of android. The error message was synthetically forced to display. There are several steps to get google auth into a local build so I faked it for now; I'll try to get that set up for a real test.
![screen shot 2018-12-17 at 8 16 26 pm](https://user-images.githubusercontent.com/1243084/50132081-1c706f00-023a-11e9-9ebe-621f5068b8c6.png)
