### PR TITLE
deps: update react-native-sound

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11306,9 +11306,8 @@
       }
     },
     "react-native-sound": {
-      "version": "0.10.9",
-      "resolved": "https://registry.npmjs.org/react-native-sound/-/react-native-sound-0.10.9.tgz",
-      "integrity": "sha1-awCw9K/QF83gn7udFx3xtdW4Uag="
+      "version": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08",
+      "from": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08"
     },
     "react-native-swipeout": {
       "version": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-native-immersive": "1.1.0",
     "react-native-keep-awake": "4.0.0",
     "react-native-linear-gradient": "2.4.0",
-    "react-native-sound": "0.10.9",
+    "react-native-sound": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08",
     "react-native-swipeout": "2.3.6",
     "react-native-vector-icons": "6.0.2",
     "react-native-webrtc": "github:jitsi/react-native-webrtc#6322a9b5a38ce590cfaea4041072ea87c8dbf558",


### PR DESCRIPTION
The avid reader may notice we have switched to using our own fork. That is
indeed the case. The upstream author hasn't maintained the library in months,
and changes to the Android build system are required at this point, hence the
fork.