### PR TITLE
ios: disable recording

### DIFF
--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { Platform } from 'react-native';
 import { connect } from 'react-redux';
 
 import { BottomSheet, hideDialog } from '../../../base/dialog';
@@ -72,7 +73,14 @@ class OverflowMenu extends Component<Props> {
                 <AudioOnlyButton { ...buttonProps } />
                 <RoomLockButton { ...buttonProps } />
                 <ClosedCaptionButton { ...buttonProps } />
-                <RecordButton { ...buttonProps } />
+                {
+
+                    // Apple rejected our app because they claim requiring a
+                    // Dropbox account for recording is not acceptable.
+                    // Ddisable it until we can find a way around it.
+                    Platform.OS !== 'ios'
+                        && <RecordButton { ...buttonProps } />
+                }
                 <LiveStreamButton { ...buttonProps } />
                 <TileViewButton { ...buttonProps } />
                 <PictureInPictureButton { ...buttonProps } />


### PR DESCRIPTION
Apple rejected our app on account of requiring Dropbox not being acceptable. Oh
well! Disable it until we find a way around it. Sigh.