### PR TITLE
rn: disable touch feedback on Thumbnail

### DIFF
--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -137,7 +137,8 @@ class Thumbnail extends Component<Props> {
                     participant.pinned && !disablePin
                         ? styles.thumbnailPinned : null,
                     this.props.styleOverrides || null
-                ] }>
+                ] }
+                touchFeedback = { false }>
 
                 { renderAudio
                     && <Audio


### PR DESCRIPTION
Touch feedback manifests in some ugly black border bleeding out of the thumbnail
itself. Since we already provide feedback (be that by adding the blue border in
case of pinning, or showing the menu in case of long press) the perception is
the same, without the graphical glitch.