### PR TITLE
Add conference URL parameter to GET Dialin Numbers API Query

### DIFF
--- a/react/features/invite/actions.js
+++ b/react/features/invite/actions.js
@@ -174,7 +174,7 @@ export function updateDialInNumbers() {
         const { room } = state['features/base/conference'];
 
         Promise.all([
-            getDialInNumbers(dialInNumbersUrl),
+            getDialInNumbers(dialInNumbersUrl, room, mucURL),
             getDialInConferenceID(dialInConfCodeUrl, room, mucURL)
         ])
             .then(([ dialInNumbers, { conference, id, message } ]) => {

--- a/react/features/invite/components/dial-in-summary/DialInSummary.web.js
+++ b/react/features/invite/components/dial-in-summary/DialInSummary.web.js
@@ -190,13 +190,18 @@ class DialInSummary extends Component<Props, State> {
      * @returns {Promise}
      */
     _getNumbers() {
-        const { dialInNumbersUrl } = config;
+        const { room } = this.props;
+        const { dialInNumbersUrl, hosts } = config;
+        const mucURL = hosts && hosts.muc;
 
-        if (!dialInNumbersUrl) {
+        if (!dialInNumbersUrl || !mucURL || !room) {
             return Promise.reject(this.props.t('info.dialInNotSupported'));
         }
 
-        return fetch(dialInNumbersUrl)
+        const dialInNumbersFullURL
+            = `${dialInNumbersUrl}?conference=${room}@${mucURL}`;
+
+        return fetch(dialInNumbersFullURL)
             .then(response => response.json())
             .catch(() => Promise.reject(this.props.t('info.genericError')));
     }

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -56,11 +56,15 @@ export function getDialInConferenceID(
  * Sends a GET request for phone numbers used to dial into a conference.
  *
  * @param {string} url - The service that returns confernce dial-in numbers.
+ * @param {string} roomName - The conference name to find the associated
+ * conference ID.
+ * @param {string} mucURL - In which MUC the conference exists.
  * @returns {Promise} - The promise created by the request. The returned numbers
  * may be an array of numbers or an object with countries as keys and arrays of
  * phone number strings.
  */
-export function getDialInNumbers(url: string): Promise<*> {
+export function getDialInNumbers(url: string, roomName: string, mucURL: string): Promise<*> {
+    const dialInNumbersFullURL = `${url}?conference=${roomName}@${mucURL}`;
     return doGetJSON(url);
 }
 
@@ -442,7 +446,7 @@ export function getShareInfoText(
             }
 
             numbersPromise = Promise.all([
-                getDialInNumbers(dialInNumbersUrl),
+                getDialInNumbers(dialInNumbersUrl, room, mucURL),
                 getDialInConferenceID(dialInConfCodeUrl, room, mucURL)
             ]).then(([ { defaultCountry, numbers }, {
                 conference, id, message } ]) => {

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -65,7 +65,7 @@ export function getDialInConferenceID(
  */
 export function getDialInNumbers(url: string, roomName: string, mucURL: string): Promise<*> {
     const dialInNumbersFullURL = `${url}?conference=${roomName}@${mucURL}`;
-    return doGetJSON(url);
+    return doGetJSON(dialInNumbersFullURL);
 }
 
 /**


### PR DESCRIPTION
Add conference UIRL parameter to GET API query so that endpoint may filter dialin numbers by conference.  If no conference parameter is provided, API can return default numbers.  Therefore, there is no break in existing functionality.

The use case for this is so that an API endpoint may filter the dialin numbers returned based on who's requesting the conference.