### PR TITLE
ref(welcome-page): remove unused atlaskit overrides

### DIFF
--- a/css/_atlaskit_overrides.scss
+++ b/css/_atlaskit_overrides.scss
@@ -11,34 +11,6 @@
     -webkit-transform: translateX(0) translateY(100%) translateY(16px) !important;
 }
 
-/**
- * Welcome page tab color adjustments.
- */
-.welcome {
-    /**
-     * The text color of the selected tab and hovered tabs.
-     */
-    .bVobOt,
-    .bVobOt:hover,
-    .ebveIl:hover {
-        color: #172B4D;
-    }
-
-    /**
-     * The color of the inactive tab text.
-     */
-    .ebveIl {
-        color: #FFFFFF;
-    }
-
-    /**
-     * The color of the underline of a selected tab.
-     */
-    .kByArU {
-        background-color: #172B4D;
-    }
-}
-
 .modal-dialog-form {
     /**
      * Update the @atlaskit/dropdown-menu trigger wrapper to make sure it looks


### PR DESCRIPTION
WelcomePage used to use @atlaskit/tabs to switch between
recent meetings and calendar meetings. @atlaskit/tabs is
no longer used there so remove the css hacks which made
it look more presentable.