### PR TITLE
ref(app): move initialization into componentDidMount

### DIFF
--- a/react/features/app/components/AbstractApp.js
+++ b/react/features/app/components/AbstractApp.js
@@ -45,8 +45,8 @@ export class AbstractApp extends BaseApp<Props, *> {
      *
      * @inheritdoc
      */
-    componentWillMount() {
-        super.componentWillMount();
+    componentDidMount() {
+        super.componentDidMount();
 
         this._init.then(() => {
             // If a URL was explicitly specified to this React Component, then

--- a/react/features/app/components/App.native.js
+++ b/react/features/app/components/App.native.js
@@ -93,8 +93,8 @@ export class App extends AbstractApp {
      * @returns {void}
      * @see https://facebook.github.io/react-native/docs/linking.html
      */
-    componentWillMount() {
-        super.componentWillMount();
+    componentDidMount() {
+        super.componentDidMount();
 
         Linking.addEventListener('url', this._onLinkingURL);
     }

--- a/react/features/base/app/components/BaseApp.js
+++ b/react/features/base/app/components/BaseApp.js
@@ -59,7 +59,14 @@ export default class BaseApp extends Component<*, State> {
             // $FlowFixMe
             store: undefined
         };
+    }
 
+    /**
+     * Initializes the app.
+     *
+     * @inheritdoc
+     */
+    componentDidMount() {
         /**
          * Make the mobile {@code BaseApp} wait until the {@code AsyncStorage}
          * implementation of {@code Storage} initializes fully.
@@ -68,22 +75,15 @@ export default class BaseApp extends Component<*, State> {
          * @see {@link #_initStorage}
          * @type {Promise}
          */
-        this._init
-            = this._initStorage()
-                .catch(() => { /* AbstractApp should always initialize! */ })
-                .then(() =>
-                    this.setState({
-                        store: this._createStore()
-                    }));
-    }
-
-    /**
-     * Initializes the app.
-     *
-     * @inheritdoc
-     */
-    componentWillMount() {
-        this._init.then(() => this.state.store.dispatch(appWillMount(this)));
+        this._init = this._initStorage()
+            .catch(() => { /* BaseApp should always initialize! */ })
+            .then(() => new Promise(resolve => {
+                this.setState({
+                    store: this._createStore()
+                }, resolve);
+            }))
+            .then(() => this.state.store.dispatch(appWillMount(this)))
+            .catch(() => { /* BaseApp should always initialize! */ });
     }
 
     /**

--- a/react/features/mobile/incoming-call/components/IncomingCallApp.js
+++ b/react/features/mobile/incoming-call/components/IncomingCallApp.js
@@ -43,8 +43,8 @@ export default class IncomingCallApp extends BaseApp<Props> {
      *
      * @returns {void}
      */
-    componentWillMount() {
-        super.componentWillMount();
+    componentDidMount() {
+        super.componentDidMount();
 
         this._init.then(() => {
             const { dispatch } = this.state.store;


### PR DESCRIPTION
componentWillMount is a deprecated lifecycle method;
componentDidMount should be used to kick off things
like ajax. In the case of the _App hierarchy, a promise
chain is used to perform initialization, and it is
first started in the constructor by initializing
storage. However, by the time storage is initialized,
resolving the first promise, _App has already mounted.
So, move it all to the componentDidMount lifecycle.

I'm not as confident about this safety of this change but iOS and web were able to get into the meeting view okay and load saved state. If this approach does seem okay, I'll do another PR to rename the action appWillMount.