### PR TITLE
fix(thumbnail): re-override atlaskit theme for top toolbar

### DIFF
--- a/css/_atlaskit_overrides.scss
+++ b/css/_atlaskit_overrides.scss
@@ -28,3 +28,11 @@
         border: 1px solid #455166;
     }
 }
+
+/**
+ * Override @atlaskit/theme styling for the top toolbar so it displays over
+ * the video thumbnail while obscuring as little as possible.
+ */
+.videocontainer .tOoji {
+    background: none;
+}

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -80,15 +80,6 @@
             float: left;
             pointer-events: all;
         }
-
-        /**
-         * Need to overwrite the background for the top toolbar dark theme div
-         * wrapper needed before we're able to move all top toolbar indicators
-         * creation to react.
-         */
-        .sc-ifAKCX {
-            background: none;
-        }
     }
 
     &__toolbar {


### PR DESCRIPTION
A CSS override prevents atlaskit theme from setting a
dark background on the top toolbar. With the upgrade
of the theme package the CSS class names changed.