### PR TITLE
chore(deps): bump @atlaskit/flag to 9.1.8 from 6.1.0

### DIFF
--- a/css/_atlaskit_overrides.scss
+++ b/css/_atlaskit_overrides.scss
@@ -1,14 +1,18 @@
 /**
- * Move Atlaskit Flag up a little bit so it does not cover the toolbar with the
- * first notification.
+ * Move the @atlaskit/flag container up a little bit so it does not cover the
+ * toolbar with the first notification.
  */
-.cxGWJB{
+.cjMOOK{
     bottom: calc(#{$newToolbarSizeWithPadding}) !important;
 }
-.gXSEsl:nth-child(n+2) {
-    transform: translateX(0) translateY(100%) translateY(16px) !important;
-    -ms-transform: translateX(0) translateY(100%) translateY(16px) !important;
-    -webkit-transform: translateX(0) translateY(100%) translateY(16px) !important;
+
+/**
+ * Disable the slide-in animation for @atlaskit/flag due to the animation
+ * repeating for each queued flag once it becomes the top flag.
+ */
+ .mIBKA:first-child {
+    animation: cbfRuT 0s !important;
+    -webkit-animation: cbfRuT 0s !important;
 }
 
 .modal-dialog-form {

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,78 +536,19 @@
       }
     },
     "@atlaskit/flag": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@atlaskit/flag/-/flag-6.1.0.tgz",
-      "integrity": "sha1-IThcuWL1+Q0vhdTSPfuqmtDleos=",
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@atlaskit/flag/-/flag-9.1.8.tgz",
+      "integrity": "sha512-Uww6dYBZiz9SiRfJXqGgbkmI5YTLmN70f8rGVcD4ntoOGGIuqzDXvWe+MRa4BEOIs2TIkvY6EIUDrUSa8IQM/w==",
       "requires": {
-        "@atlaskit/button": "^5.0.0",
-        "@atlaskit/icon": "^7.1.0",
-        "@atlaskit/theme": "^2.0.0",
-        "@atlaskit/util-shared-styles": "^2.10.3",
-        "babel-runtime": "^6.11.6",
-        "prop-types": "^15.5.10",
-        "react-transition-group": "^1.2.0",
-        "styled-components": "^1.3.0"
-      },
-      "dependencies": {
-        "@atlaskit/button": {
-          "version": "5.4.14",
-          "resolved": "https://registry.npmjs.org/@atlaskit/button/-/button-5.4.14.tgz",
-          "integrity": "sha1-YAl1FB/TVsy/cSiFoA9joTZ90o0=",
-          "requires": {
-            "@atlaskit/theme": "^2.0.0",
-            "babel-runtime": "^6.11.6",
-            "classnames": "^2.2.5",
-            "prop-types": "^15.5.10",
-            "styled-components": "^1.4.6"
-          }
-        },
-        "@atlaskit/icon": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/@atlaskit/icon/-/icon-7.1.0.tgz",
-          "integrity": "sha1-czQVCEhzUmPeShO8mPTUTU8r6N8=",
-          "requires": {
-            "babel-runtime": "^6.11.6",
-            "prop-types": "^15.5.10",
-            "styled-components": "^1.3.0"
-          }
-        },
-        "@atlaskit/theme": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/@atlaskit/theme/-/theme-2.4.1.tgz",
-          "integrity": "sha512-I4AMg+asUUwaruwsWDaUzub2zhEKYHhZ5tRlaNQ+8dhATpO1RSu6g9FSgwnAZ20M4Cf+YITVND/wyNpAON5HCQ==",
-          "requires": {
-            "prop-types": "^15.5.10",
-            "styled-components": "1.4.6 - 3"
-          }
-        },
-        "react-transition-group": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-          "requires": {
-            "chain-function": "^1.0.0",
-            "dom-helpers": "^3.2.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.5.6",
-            "warning": "^3.0.0"
-          }
-        },
-        "styled-components": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-1.4.6.tgz",
-          "integrity": "sha1-WPMuimq1EPsUgekB6DjgR38UiwY=",
-          "requires": {
-            "buffer": "^5.0.2",
-            "css-to-react-native": "^1.0.6",
-            "fbjs": "^0.8.7",
-            "inline-style-prefixer": "^2.0.5",
-            "is-function": "^1.0.1",
-            "is-plain-object": "^2.0.1",
-            "prop-types": "^15.5.4",
-            "supports-color": "^3.1.2"
-          }
-        }
+        "@atlaskit/analytics-next": "^3.1.2",
+        "@atlaskit/button": "^10.1.1",
+        "@atlaskit/icon": "^15.0.2",
+        "@atlaskit/portal": "^0.0.17",
+        "@atlaskit/theme": "^7.0.1",
+        "@babel/runtime": "^7.0.0",
+        "babel-runtime": "^6.26.0",
+        "react-transition-group": "^2.2.1",
+        "uuid": "^3.1.0"
       }
     },
     "@atlaskit/icon": {
@@ -1115,32 +1056,6 @@
       "integrity": "sha512-UY37unuQ8uLkeeMOs281+uUobY4B6YHZe628cn4WJUCJ/sjZH2+6ZLcVTquinwKwK5NcVwx7Lc4gEYxGoL0D6A==",
       "requires": {
         "react": "^16.4.0"
-      }
-    },
-    "@atlaskit/util-shared-styles": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@atlaskit/util-shared-styles/-/util-shared-styles-2.10.6.tgz",
-      "integrity": "sha1-Vqol1ZzvAyT2U6boV9USpwvkfGU=",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "styled-components": "^1.4.6"
-      },
-      "dependencies": {
-        "styled-components": {
-          "version": "1.4.6",
-          "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-1.4.6.tgz",
-          "integrity": "sha1-WPMuimq1EPsUgekB6DjgR38UiwY=",
-          "requires": {
-            "buffer": "^5.0.2",
-            "css-to-react-native": "^1.0.6",
-            "fbjs": "^0.8.7",
-            "inline-style-prefixer": "^2.0.5",
-            "is-function": "^1.0.1",
-            "is-plain-object": "^2.0.1",
-            "prop-types": "^15.5.4",
-            "supports-color": "^3.1.2"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -3441,11 +3356,6 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
-    "bowser": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.2.tgz",
-      "integrity": "sha512-fuiANC1Bqbqa/S4gmvfCt7bGBmNELMsGZj4Wg3PrP6esP66Ttoj1JSlzFlXtHyduMv07kDNmDsX6VsMWT/MLGg=="
-    },
     "bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
@@ -3728,11 +3638,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "chain-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
     },
     "chalk": {
       "version": "1.1.3",
@@ -4117,11 +4022,6 @@
         }
       }
     },
-    "colors": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-      "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
-    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -4503,19 +4403,6 @@
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
-    "css-color-list": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/css-color-list/-/css-color-list-0.0.1.tgz",
-      "integrity": "sha1-hxjoaVrnosyHh76HFfHACKfyixU=",
-      "requires": {
-        "css-color-names": "0.0.1"
-      }
-    },
-    "css-color-names": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.1.tgz",
-      "integrity": "sha1-XQVI+iVkVu3kqaDCrHqxnT6xrYE="
-    },
     "css-element-queries": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-0.3.2.tgz",
@@ -4565,16 +4452,6 @@
             "regjsparser": "^0.1.4"
           }
         }
-      }
-    },
-    "css-to-react-native": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-1.0.6.tgz",
-      "integrity": "sha1-cox+d05WU2VYoOyqmQ2VB8Q6SsQ=",
-      "requires": {
-        "css-color-list": "0.0.1",
-        "fbjs": "^0.8.5",
-        "nearley": "^2.7.7"
       }
     },
     "cssesc": {
@@ -4873,11 +4750,6 @@
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
       }
-    },
-    "discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -7542,11 +7414,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-    },
     "i18next": {
       "version": "8.4.3",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-8.4.3.tgz",
@@ -7802,15 +7669,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "inline-style-prefixer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
-      "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
-      "requires": {
-        "bowser": "^1.0.0",
-        "hyphenate-style-name": "^1.0.1"
-      }
-    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -8044,11 +7902,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-glob": {
       "version": "2.0.1",
@@ -9571,17 +9424,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nearley": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.11.1.tgz",
-      "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
-      "requires": {
-        "nomnom": "~1.6.2",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6",
-        "semver": "^5.4.1"
-      }
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -9854,15 +9696,6 @@
             "strip-ansi": "^3.0.0"
           }
         }
-      }
-    },
-    "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-      "requires": {
-        "colors": "0.5.x",
-        "underscore": "~1.4.4"
       }
     },
     "nopt": {
@@ -11242,20 +11075,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-2.1.2.tgz",
       "integrity": "sha512-Orl0IEvMtUCgPddgSxtxreK77UiQz4nPYJy9RggVzu4mKsZkQWiAaG1y9HlYWdvm9xtN348xRaT37qkvL/+A+g=="
-    },
-    "railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
-    },
-    "randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "requires": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -14644,11 +14463,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@atlaskit/dropdown-menu": "6.1.25",
     "@atlaskit/field-text": "7.0.19",
     "@atlaskit/field-text-area": "4.0.15",
-    "@atlaskit/flag": "6.1.0",
+    "@atlaskit/flag": "9.1.8",
     "@atlaskit/icon": "15.0.3",
     "@atlaskit/inline-dialog": "5.3.0",
     "@atlaskit/inline-message": "7.0.10",


### PR DESCRIPTION
- Change the existing overrides to move the flags
  so the first flag does not cover the toolbar.
- Add a new override to disable the slide in
  animation, as it will play for each flag once
  it becomes the first flag--instead of playing
  only once when the flag queue has items.

With slide in animation
![withslidein](https://user-images.githubusercontent.com/1243084/50604250-22d62c00-0e73-11e9-9953-d5a877168039.gif)

Without slide in animation
![withoutslidein](https://user-images.githubusercontent.com/1243084/50604315-60d35000-0e73-11e9-8c67-1eba063f1c58.gif)
