### PR TITLE
android: simplify handling of the back button

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -37,7 +37,7 @@ Also, enable 32bit mode for react-native, since react-native only supports 32bit
 
 ```gradle
 android {
-    ... 
+    ...
     defaultConfig {
         ndk {
             abiFilters "armeabi-v7a", "x86"
@@ -75,7 +75,7 @@ In the same way, copy the JavaScriptCore dependency:
 
 Alternatively, you can use the scripts located in the android/scripts directory to publish these dependencies to your Maven repo.
 
-Third-party React Native _modules_, which Jitsi Meet SDK for Android depends on, are download by NPM in source code form. These need to be assembled into Maven artifacts, and then published to your local Maven repository. The SDK project facilitates this. 
+Third-party React Native _modules_, which Jitsi Meet SDK for Android depends on, are download by NPM in source code form. These need to be assembled into Maven artifacts, and then published to your local Maven repository. The SDK project facilitates this.
 
 To prepare, Configure the Maven repositories in which you are going to publish the SDK artifacts/binaries. In `android/sdk/build.gradle` as well as in `android/build.gradle` modify the lines that contain:
 
@@ -89,7 +89,7 @@ Make sure to do this in both files! Each file should require one line to be chan
 
 To create the release assembly for any _specific_ third-party React Native module that you need, you can execture the following commands, replace the module name in the examples below.
 
-    $ ./gradlew :react-native-webrtc:assembleRelease 
+    $ ./gradlew :react-native-webrtc:assembleRelease
     $ ./gradlew :react-native-webrtc:publish
 
 You build and publish the SDK itself in the same way:
@@ -184,10 +184,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (!ReactActivityLifecycleCallbacks.onBackPressed()) {
-            // Invoke the default handler if it wasn't handled by React.
-            super.onBackPressed();
-        }
+        ReactActivityLifecycleCallbacks.onBackPressed();
     }
 
     @Override

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/DefaultHardwareBackBtnHandlerImpl.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/DefaultHardwareBackBtnHandlerImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright @ 2017-present Atlassian Pty Ltd
+ * Copyright @ 2019-present 8x8, Inc.
+ * Copyright @ 2017-2018 Atlassian Pty Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +29,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
  * during a conference by leaving the conference and (2) not handle the
  * invocation when not in a conference.
  */
-public class DefaultHardwareBackBtnHandlerImpl
-    implements DefaultHardwareBackBtnHandler {
+class DefaultHardwareBackBtnHandlerImpl implements DefaultHardwareBackBtnHandler {
 
     /**
      * The {@code Activity} to which the default handling of the back button

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -1,5 +1,6 @@
 /*
- * Copyright @ 2017-present Atlassian Pty Ltd
+ * Copyright @ 2019-present 8x8, Inc.
+ * Copyright @ 2017-2018 Atlassian Pty Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +27,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
 
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionListener;
 
 import java.net.URL;
@@ -51,12 +51,6 @@ public class JitsiMeetActivity
      */
     private static final int OVERLAY_PERMISSION_REQUEST_CODE
         = (int) (Math.random() * Short.MAX_VALUE);
-
-    /**
-     * The default behavior of this {@code JitsiMeetActivity} upon invoking the
-     * back button if {@link #view} does not handle the invocation.
-     */
-    private DefaultHardwareBackBtnHandler defaultBackButtonImpl;
 
     /**
      * The default base {@code URL} used to join a conference when a partial URL
@@ -185,19 +179,7 @@ public class JitsiMeetActivity
 
     @Override
     public void onBackPressed() {
-        if (!ReactActivityLifecycleCallbacks.onBackPressed()) {
-            // JitsiMeetView didn't handle the invocation of the back button.
-            // Generally, an Activity extender would very likely want to invoke
-            // Activity#onBackPressed(). For the sake of consistency with
-            // JitsiMeetView and within the Jitsi Meet SDK for Android though,
-            // JitsiMeetActivity does what JitsiMeetView would've done if it
-            // were able to handle the invocation.
-            if (defaultBackButtonImpl == null) {
-                super.onBackPressed();
-            } else {
-                defaultBackButtonImpl.invokeDefaultOnBackPressed();
-            }
-        }
+        ReactActivityLifecycleCallbacks.onBackPressed();
     }
 
     @Override
@@ -279,8 +261,7 @@ public class JitsiMeetActivity
     protected void onResume() {
         super.onResume();
 
-        defaultBackButtonImpl = new DefaultHardwareBackBtnHandlerImpl(this);
-        ReactActivityLifecycleCallbacks.onHostResume(this, defaultBackButtonImpl);
+        ReactActivityLifecycleCallbacks.onHostResume(this);
     }
 
     @Override
@@ -288,7 +269,6 @@ public class JitsiMeetActivity
         super.onStop();
 
         ReactActivityLifecycleCallbacks.onHostPause(this);
-        defaultBackButtonImpl = null;
     }
 
     @Override

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactActivityLifecycleCallbacks.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactActivityLifecycleCallbacks.java
@@ -1,5 +1,6 @@
 /*
- * Copyright @ 2018-present Atlassian Pty Ltd
+ * Copyright @ 2019-present 8x8, Inc.
+ * Copyright @ 2018 Atlassian Pty Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +25,6 @@ import android.os.Build;
 import com.calendarevents.CalendarEventsPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Callback;
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionListener;
 
 /**
@@ -73,15 +73,12 @@ public class ReactActivityLifecycleCallbacks {
      * otherwise. If {@code false}, the application should call the
      * {@code super}'s implementation.
      */
-    public static boolean onBackPressed() {
+    public static void onBackPressed() {
         ReactInstanceManager reactInstanceManager
             = ReactInstanceManagerHolder.getReactInstanceManager();
 
-        if (reactInstanceManager == null) {
-            return false;
-        } else {
+        if (reactInstanceManager != null) {
             reactInstanceManager.onBackPressed();
-            return true;
         }
     }
 
@@ -123,25 +120,11 @@ public class ReactActivityLifecycleCallbacks {
      * @param activity {@code Activity} being resumed.
      */
     public static void onHostResume(Activity activity) {
-        onHostResume(activity, new DefaultHardwareBackBtnHandlerImpl(activity));
-    }
-
-    /**
-     * {@link Activity} lifecycle method which should be called from
-     * {@code Activity#onResume} so we can do the required internal processing.
-     *
-     * @param activity {@code Activity} being resumed.
-     * @param defaultBackButtonImpl a {@link DefaultHardwareBackBtnHandler} to
-     * handle invoking the back button if no {@link BaseReactView} handles it.
-     */
-    public static void onHostResume(
-            Activity activity,
-            DefaultHardwareBackBtnHandler defaultBackButtonImpl) {
         ReactInstanceManager reactInstanceManager
             = ReactInstanceManagerHolder.getReactInstanceManager();
 
         if (reactInstanceManager != null) {
-            reactInstanceManager.onHostResume(activity, defaultBackButtonImpl);
+            reactInstanceManager.onHostResume(activity, new DefaultHardwareBackBtnHandlerImpl(activity));
         }
 
         if (permissionsCallback != null) {

--- a/react/features/conference/components/Conference.native.js
+++ b/react/features/conference/components/Conference.native.js
@@ -2,8 +2,7 @@
 
 import React, { Component } from 'react';
 
-// eslint-disable-next-line react-native/split-platform-components
-import { BackAndroid, BackHandler, StatusBar, View } from 'react-native';
+import { BackHandler, StatusBar, View } from 'react-native';
 import { connect as reactReduxConnect } from 'react-redux';
 
 import { appNavigate } from '../../app';
@@ -144,8 +143,6 @@ type Props = {
  * The conference page of the mobile (i.e. React Native) application.
  */
 class Conference extends Component<Props> {
-    _backHandler: ?BackHandler;
-
     /**
      * Initializes a new Conference instance.
      *
@@ -157,7 +154,6 @@ class Conference extends Component<Props> {
 
         // Bind event handlers so they are only bound once per instance.
         this._onClick = this._onClick.bind(this);
-        this._onHardwareBackPress = this._onHardwareBackPress.bind(this);
     }
 
     /**
@@ -170,15 +166,9 @@ class Conference extends Component<Props> {
     componentDidMount() {
         this.props._onConnect();
 
-        // Set handling any hardware button presses for back navigation up.
-        const backHandler = BackHandler || BackAndroid;
-
-        if (backHandler) {
-            this._backHandler = backHandler;
-            backHandler.addEventListener(
-                'hardwareBackPress',
-                this._onHardwareBackPress);
-        }
+        BackHandler.addEventListener(
+            'hardwareBackPress',
+            this.props._onHardwareBackPress);
 
         // Show the toolbox if we are the only participant; otherwise, the whole
         // UI looks too unpopulated the LargeVideo visible.
@@ -233,14 +223,9 @@ class Conference extends Component<Props> {
      */
     componentWillUnmount() {
         // Tear handling any hardware button presses for back navigation down.
-        const backHandler = this._backHandler;
-
-        if (backHandler) {
-            this._backHandler = undefined;
-            backHandler.removeEventListener(
-                'hardwareBackPress',
-                this._onHardwareBackPress);
-        }
+        BackHandler.removeEventListener(
+            'hardwareBackPress',
+            this.props._onHardwareBackPress);
 
         this.props._onDisconnect();
     }
@@ -339,19 +324,6 @@ class Conference extends Component<Props> {
         const toolboxVisible = !this.props._toolboxVisible;
 
         this.props._setToolboxVisible(toolboxVisible);
-    }
-
-    _onHardwareBackPress: () => boolean;
-
-    /**
-     * Handles a hardware button press for back navigation.
-     *
-     * @returns {boolean} If the hardware button press for back navigation was
-     * handled by this {@code Conference}, then {@code true}; otherwise,
-     * {@code false}.
-     */
-    _onHardwareBackPress() {
-        return this._backHandler && this.props._onHardwareBackPress();
     }
 
     /**


### PR DESCRIPTION
Provide a default and builtin default implementation which finishes the
Activity, same as before.

What this PR removes is the ability to provide a custom default handler because
applications can already take this decision when calling `onBackPressed`. In
addition, make `onBackPressed` return `void` because it's virtually impossible
for it to return `false` (that would mean that there is no
`ReactInstanceManager`, which means there is no app to begin with).

In addition, remove the use of `BackAndroid` since `BackHandler` contains an iOS
shim now.