### PR TITLE
Move DeviceSelectionPopup to its right place

### DIFF
--- a/react/features/settings/components/web/DeviceSelectionPopup.js
+++ b/react/features/settings/components/web/DeviceSelectionPopup.js
@@ -9,10 +9,11 @@ import { I18nextProvider } from 'react-i18next';
 import {
     PostMessageTransportBackend,
     Transport
-} from '../../../modules/transport';
-import { parseURLParams } from '../base/config';
-import { DeviceSelection } from '../device-selection';
-import { DialogWithTabs } from '../base/dialog';
+} from '../../../../../modules/transport';
+
+import { parseURLParams } from '../../../base/config';
+import { DialogWithTabs } from '../../../base/dialog';
+import { DeviceSelection } from '../../../device-selection';
 
 const logger = Logger.getLogger(__filename);
 

--- a/react/features/settings/popup.js
+++ b/react/features/settings/popup.js
@@ -1,6 +1,6 @@
 /* global JitsiMeetJS */
 
-import DeviceSelectionPopup from './DeviceSelectionPopup';
+import DeviceSelectionPopup from './components/web/DeviceSelectionPopup';
 
 let deviceSelectionPopup;
 


### PR DESCRIPTION
This PR just relocates the DeviceSelectionPopup to be in the components folder of the feature. Not sure why it wasn't there originally.