### PR TITLE
Adds specific class name to kick button.

### DIFF
--- a/react/features/remote-video-menu/components/web/KickButton.js
+++ b/react/features/remote-video-menu/components/web/KickButton.js
@@ -45,6 +45,7 @@ class KickButton extends AbstractKickButton {
         return (
             <RemoteVideoMenuButton
                 buttonText = { t('videothumbnail.kick') }
+                displayClass = 'kicklink'
                 iconClass = 'icon-kick'
                 id = { `ejectlink_${participantID}` }
                 // eslint-disable-next-line react/jsx-handler-names


### PR DESCRIPTION
The class name is similar to the one used for the mute button and is used by the tests to locate and click the button.