### PR TITLE
[RN] Fix InviteButton translation

### DIFF
--- a/react/features/invite/components/InviteButton.native.js
+++ b/react/features/invite/components/InviteButton.native.js
@@ -3,6 +3,7 @@
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import { translate } from '../../base/i18n';
 import { AbstractButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { beginShareRoom } from '../../share-room';
@@ -161,4 +162,5 @@ function _mapStateToProps(state) {
     };
 }
 
-export default connect(_mapStateToProps, _mapDispatchToProps)(InviteButton);
+export default translate(
+    connect(_mapStateToProps, _mapDispatchToProps)(InviteButton));


### PR DESCRIPTION
The translate wrapper was missing from this button, which doesn't cause any issues until we start to render the label of this button (currently there is no label)