### PR TITLE
feat(screenshare): use camera as a screenshare source

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1488,6 +1488,8 @@ export default {
         const wasVideoMuted = this.isLocalVideoMuted();
 
         return createLocalTracksF({
+            desktopSharingSourceDevice: options.desktopSharingSources
+                ? null : config._desktopSharingSourceDevice,
             desktopSharingSources: options.desktopSharingSources,
             devices: [ 'desktop' ],
             desktopSharingExtensionExternalInstallation: {
@@ -1645,6 +1647,7 @@ export default {
         // Handling:
         // JitsiTrackErrors.PERMISSION_DENIED
         // JitsiTrackErrors.CHROME_EXTENSION_INSTALLATION_ERROR
+        // JitsiTrackErrors.CONSTRAINT_FAILED
         // JitsiTrackErrors.GENERAL
         // and any other
         let descriptionKey;
@@ -1668,6 +1671,9 @@ export default {
                 descriptionKey = 'dialog.screenSharingPermissionDeniedError';
                 titleKey = 'dialog.screenSharingFailedToInstallTitle';
             }
+        } else if (error.name === JitsiTrackErrors.CONSTRAINT_FAILED) {
+            descriptionKey = 'dialog.cameraConstraintFailedError';
+            titleKey = 'deviceError.cameraError';
         } else {
             descriptionKey = 'dialog.screenSharingFailedToInstall';
             titleKey = 'dialog.screenSharingFailedToInstallTitle';

--- a/config.js
+++ b/config.js
@@ -386,6 +386,13 @@ var config = {
     //   analyticsInterval: 60000,
     //   }
 
+    // If set, will attempt to use the provided video input device label when
+    // triggering a screenshare, instead of proceeding through the normal flow
+    // for obtaining a desktop stream.
+    // NOTE: This option is experimental and is currently intended for internal
+    // use only.
+    // _desktopSharingSourceDevice: 'sample-id-or-label'
+
     // List of undocumented settings used in jitsi-meet
     /**
      _immediateReloadThreshold

--- a/react/features/base/config/functions.js
+++ b/react/features/base/config/functions.js
@@ -17,6 +17,7 @@ declare var $: Object;
  * @type Array
  */
 const WHITELISTED_KEYS = [
+    '_desktopSharingSourceDevice',
     '_peerConnStatusOutOfLastNTimeout',
     '_peerConnStatusRtcMuteTimeout',
     'abTesting',

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -62,6 +62,8 @@ export function createLocalTracksF(
                 desktopSharingExtensionExternalInstallation:
                     options.desktopSharingExtensionExternalInstallation,
                 desktopSharingFrameRate,
+                desktopSharingSourceDevice:
+                    options.desktopSharingSourceDevice,
                 desktopSharingSources: options.desktopSharingSources,
 
                 // Copy array to avoid mutations inside library.


### PR DESCRIPTION
This feature is intended for spot. Spot can have an
HDMI -> usb adapter hooked up to it. In that case,
attempting to screenshare should use that adapter
as a screensharing source. Jitsi-Meet should pass
a configured screenshare source into lib-jitsi-meet
so it can be used as a source.

lib-jitsi-meet changes: https://github.com/jitsi/lib-jitsi-meet/pull/855