### PR TITLE
fix(pinning): send a participant id on unpin

### DIFF
--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -390,10 +390,18 @@ function _pinParticipant({ getState }, next, action) {
         const local
             = (participantById && participantById.local)
                 || (!id && pinnedParticipant && pinnedParticipant.local);
+        let participantIdForEvent;
+
+        if (local) {
+            participantIdForEvent = local;
+        } else {
+            participantIdForEvent = actionName === ACTION_PINNED
+                ? id : pinnedParticipant && pinnedParticipant.id;
+        }
 
         sendAnalytics(createPinnedEvent(
             actionName,
-            local ? 'local' : id,
+            participantIdForEvent,
             {
                 local,
                 'participant_count': conference.getParticipantCount()


### PR DESCRIPTION
Analytics is erroring when unpinning because the logged
event sends null for the objectId. The objectId should
be the id of the person getting unpinned.