### PR TITLE
rn: add some cleanup tasks when a conference ends / changes

### DIFF
--- a/react/features/conference/middleware.js
+++ b/react/features/conference/middleware.js
@@ -6,11 +6,15 @@ import {
     KICKED_OUT,
     VIDEO_QUALITY_LEVELS,
     conferenceFailed,
+    getCurrentConference,
     setPreferredReceiverVideoQuality
 } from '../base/conference';
+import { hideDialog, isDialogOpen } from '../base/dialog';
 import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
+import { pinParticipant } from '../base/participants';
 import { SET_REDUCED_UI } from '../base/responsive-ui';
-import { MiddlewareRegistry } from '../base/redux';
+import { MiddlewareRegistry, StateListenerRegistry } from '../base/redux';
+import { FeedbackDialog } from '../feedback';
 import { setFilmstripEnabled } from '../filmstrip';
 import { setToolboxEnabled } from '../toolbox';
 
@@ -48,3 +52,33 @@ MiddlewareRegistry.register(store => next => action => {
 
     return result;
 });
+
+/**
+ * Set up state change listener to perform maintenance tasks when the conference
+ * is left or failed, close all dialogs and unpin any pinned participants.
+ */
+StateListenerRegistry.register(
+    state => getCurrentConference(state),
+    (conference, { dispatch, getState }, prevConference) => {
+        const { authRequired, passwordRequired }
+            = getState()['features/base/conference'];
+
+        if (conference !== prevConference) {
+            // Unpin participant, in order to avoid the local participant
+            // remaining pinned, since it's not destroyed across runs.
+            dispatch(pinParticipant(null));
+
+            // XXX I wonder if there is a better way to do this. At this stage
+            // we do know what dialogs we want to keep but the list of those
+            // we want to hide is a lot longer. Thus we take a bit of a shortcut
+            // and explicitly check.
+            if (typeof authRequired === 'undefined'
+                    && typeof passwordRequired === 'undefined'
+                    && !isDialogOpen(getState(), FeedbackDialog)) {
+                // Conference changed, left or failed... and there is no
+                // pending authentication, nor feedback request, so close any
+                // dialog we might have open.
+                dispatch(hideDialog());
+            }
+        }
+    });


### PR DESCRIPTION
- unpin participant (if the local one was pinned it would remain)
- close any dialog (except if authentication is pending)