### PR TITLE
ref(conference): change when the room reference is removed

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2509,6 +2509,9 @@ export default {
             requestFeedbackPromise,
             this.leaveRoomAndDisconnect()
         ]).then(values => {
+            this._room = undefined;
+            room = undefined;
+
             APP.API.notifyReadyToClose();
             maybeRedirectToWelcomePage(values[0]);
         });
@@ -2523,11 +2526,7 @@ export default {
         APP.store.dispatch(conferenceWillLeave(room));
 
         return room.leave()
-            .then(disconnect, disconnect)
-            .then(() => {
-                this._room = undefined;
-                room = undefined;
-            });
+            .then(disconnect, disconnect);
     },
 
     /**


### PR DESCRIPTION
Delay removing the room reference. This is in case a
consumer of the API is attempting to submit feedback
after hangup but before redirecting to another page.
If the room reference is removed, feedback submission
will fail during this period.