### PR TITLE
chore(deps): bump lib for old conference listener cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8431,8 +8431,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#b596bc7d288e1f8f3fa95eace66c6ab13d73a2c3",
-      "from": "github:jitsi/lib-jitsi-meet#b596bc7d288e1f8f3fa95eace66c6ab13d73a2c3",
+      "version": "github:jitsi/lib-jitsi-meet#10290bbdded5b5ed770316d03dd24c81ab2b7000",
+      "from": "github:jitsi/lib-jitsi-meet#10290bbdded5b5ed770316d03dd24c81ab2b7000",
       "requires": {
         "@jitsi/sdp-interop": "0.1.13",
         "@jitsi/sdp-simulcast": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jsc-android": "224109.1.0",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#b596bc7d288e1f8f3fa95eace66c6ab13d73a2c3",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#10290bbdded5b5ed770316d03dd24c81ab2b7000",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.11",
     "moment": "2.19.4",


### PR DESCRIPTION
Brings in https://github.com/jitsi/lib-jitsi-meet/commit/10290bbdded5b5ed770316d03dd24c81ab2b7000