### PR TITLE
fix(participant): update local name only on explicit update

### DIFF
--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -673,7 +673,7 @@ function _updateLocalParticipantInConference({ getState }, next, action) {
     const { participant } = action;
     const result = next(action);
 
-    if (conference && participant.local) {
+    if (conference && participant.local && 'name' in participant) {
         conference.setDisplayName(participant.name);
     }
 


### PR DESCRIPTION
Dominant speaker events can trigger local participant updates
without a display name. Do not update the name unless there
is an explicit update in the action.