### PR TITLE
misc: fixx off-by-one error

### DIFF
--- a/react/features/deep-linking/functions.js
+++ b/react/features/deep-linking/functions.js
@@ -51,7 +51,7 @@ export function generateDeepLinkingURL() {
     // https://developer.chrome.com/multidevice/android/intents
     if (Platform.OS === 'android') {
         // https://meet.jit.si/foo -> meet.jit.si/foo
-        const url = href.replace(regex, '').substr(3);
+        const url = href.replace(regex, '').substr(2);
         const pkg = interfaceConfig.ANDROID_APP_PACKAGE || 'org.jitsi.meet';
 
         return `intent://${url}/#Intent;scheme=${appScheme};package=${pkg};end`;


### PR DESCRIPTION
e729f0948cc57102bd8406b40cc1f92125c1603f contained an off-by-one error:

URI_PROTOCOL_PATTERN includes the colon, so after applyting the regex we are
left with something like '//example.com/room' thus we only need to strip the
first 2 characters.

🤦