### PR TITLE
Revert "misc: make URL protocol matching regexes non-greedy"

### DIFF
--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -71,7 +71,7 @@ function _fixRoom(room: ?string) {
  * @returns {string}
  */
 function _fixURIStringScheme(uri: string) {
-    const regex = new RegExp(`${URI_PROTOCOL_PATTERN}+`, 'i');
+    const regex = new RegExp(`${URI_PROTOCOL_PATTERN}+`, 'gi');
     const match: Array<string> | null = regex.exec(uri);
 
     if (match) {

--- a/react/features/deep-linking/functions.js
+++ b/react/features/deep-linking/functions.js
@@ -45,7 +45,7 @@ export function generateDeepLinkingURL() {
 
     const appScheme = interfaceConfig.APP_SCHEME || 'org.jitsi.meet';
     const { href } = window.location;
-    const regex = new RegExp(URI_PROTOCOL_PATTERN, 'i');
+    const regex = new RegExp(URI_PROTOCOL_PATTERN, 'gi');
 
     // Android: use an intent link, custom schemes don't work in all browsers.
     // https://developer.chrome.com/multidevice/android/intents


### PR DESCRIPTION
This reverts commit 7c911eca96a6034bc96276e0a491774df52bc2cd.

I'm dumb. We need global mode because otherwise lastIndex is not updated in the
regex object, which we rely upon, so this is intentional.