### PR TITLE
Mobile in-call notifications

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -458,9 +458,9 @@
     },
     "me": "me",
     "notify": {
-        "connectedOneMember": "__name__ connected",
-        "connectedThreePlusMembers": "__name__ and __count__ others connected",
-        "connectedTwoMembers": "__first__ and __second__ connected",
+        "connectedOneMember": "__name__ joined the meeting",
+        "connectedThreePlusMembers": "__name__ and __count__ others joined the meeting",
+        "connectedTwoMembers": "__first__ and __second__ joined the meeting",
         "disconnected": "disconnected",
         "focus": "Conference focus",
         "focusFail": "__component__ not available - retry in __ms__ sec",

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -14,10 +14,7 @@ import VideoLayout from './videolayout/VideoLayout';
 import Filmstrip from './videolayout/Filmstrip';
 
 import { JitsiTrackErrors } from '../../react/features/base/lib-jitsi-meet';
-import {
-    getLocalParticipant,
-    showParticipantJoinedNotification
-} from '../../react/features/base/participants';
+import { getLocalParticipant } from '../../react/features/base/participants';
 import { toggleChat } from '../../react/features/chat';
 import { openDisplayNamePrompt } from '../../react/features/display-name';
 import { setEtherpadHasInitialzied } from '../../react/features/etherpad';
@@ -380,8 +377,6 @@ UI.addUser = function(user) {
     if (status) {
         // FIXME: move updateUserStatus in participantPresenceChanged action
         UI.updateUserStatus(user, status);
-    } else {
-        APP.store.dispatch(showParticipantJoinedNotification(displayName));
     }
 
     // set initial display name

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -16,7 +16,8 @@ import {
     localParticipantJoined,
     localParticipantLeft,
     participantLeft,
-    participantUpdated
+    participantUpdated,
+    showParticipantJoinedNotification
 } from './actions';
 import {
     DOMINANT_SPEAKER_CHANGED,
@@ -110,10 +111,17 @@ MiddlewareRegistry.register(store => next => action => {
         break;
     }
 
-    case PARTICIPANT_JOINED:
+    case PARTICIPANT_JOINED: {
         _maybePlaySounds(store, action);
 
+        const { participant: { name } } = action;
+
+        if (name) {
+            store.dispatch(showParticipantJoinedNotification(name));
+        }
+
         return _participantJoinedOrUpdated(store, next, action);
+    }
 
     case PARTICIPANT_LEFT:
         _maybePlaySounds(store, action);

--- a/react/features/conference/components/AbstractConference.js
+++ b/react/features/conference/components/AbstractConference.js
@@ -1,11 +1,24 @@
 // @flow
 
+import React, { Component } from 'react';
+
+import { NotificationsContainer } from '../../notifications/components';
+
+import { shouldDisplayNotifications } from '../functions';
 import { shouldDisplayTileView } from '../../video-layout';
 
 /**
  * The type of the React {@code Component} props of {@link AbstractLabels}.
  */
 export type AbstractProps = {
+
+    /**
+     * Set to {@code true} when the notifications are to be displayed.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    _notificationsVisible: boolean,
 
     /**
      * Conference room name.
@@ -25,6 +38,34 @@ export type AbstractProps = {
 };
 
 /**
+ * A container to hold video status labels, including recording status and
+ * current large video quality.
+ *
+ * @extends Component
+ */
+export class AbstractConference<P: AbstractProps, S>
+    extends Component<P, S> {
+
+    /**
+     * Renders the {@code LocalRecordingLabel}.
+     *
+     * @param {Object} props - The properties to be passed to
+     * the {@code NotificationsContainer}.
+     * @protected
+     * @returns {React$Element}
+     */
+    renderNotificationsContainer(props: ?Object) {
+        if (this.props._notificationsVisible) {
+            return (
+                React.createElement(NotificationsContainer, props)
+            );
+        }
+
+        return null;
+    }
+}
+
+/**
  * Maps (parts of) the redux state to the associated props of the {@link Labels}
  * {@code Component}.
  *
@@ -34,6 +75,7 @@ export type AbstractProps = {
  */
 export function abstractMapStateToProps(state: Object) {
     return {
+        _notificationsVisible: shouldDisplayNotifications(state),
         _room: state['features/base/conference'].room,
         _shouldDisplayTileView: shouldDisplayTileView(state)
     };

--- a/react/features/conference/components/AbstractConference.js
+++ b/react/features/conference/components/AbstractConference.js
@@ -1,0 +1,40 @@
+// @flow
+
+import { shouldDisplayTileView } from '../../video-layout';
+
+/**
+ * The type of the React {@code Component} props of {@link AbstractLabels}.
+ */
+export type AbstractProps = {
+
+    /**
+     * Conference room name.
+     *
+     * @protected
+     * @type {string}
+     */
+    _room: string,
+
+    /**
+     * Whether or not the layout should change to support tile view mode.
+     *
+     * @protected
+     * @type {boolean}
+     */
+    _shouldDisplayTileView: boolean
+};
+
+/**
+ * Maps (parts of) the redux state to the associated props of the {@link Labels}
+ * {@code Component}.
+ *
+ * @param {Object} state - The redux state.
+ * @private
+ * @returns {AbstractProps}
+ */
+export function abstractMapStateToProps(state: Object) {
+    return {
+        _room: state['features/base/conference'].room,
+        _shouldDisplayTileView: shouldDisplayTileView(state)
+    };
+}

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -1,8 +1,8 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
 
-import { BackHandler, StatusBar, View } from 'react-native';
+import { BackHandler, SafeAreaView, StatusBar, View } from 'react-native';
 import { connect as reactReduxConnect } from 'react-redux';
 
 import { appNavigate } from '../../../app';
@@ -10,6 +10,7 @@ import { connect, disconnect } from '../../../base/connection';
 import { getParticipantCount } from '../../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../../base/react';
 import {
+    isNarrowAspectRatio,
     makeAspectRatioAware
 } from '../../../base/responsive-ui';
 import { TestConnectionInfo } from '../../../base/testing';
@@ -17,6 +18,7 @@ import { createDesiredLocalTracks } from '../../../base/tracks';
 import { ConferenceNotification } from '../../../calendar-sync';
 import { Chat } from '../../../chat';
 import {
+    FILMSTRIP_SIZE,
     Filmstrip,
     isFilmstripVisible,
     TileView
@@ -26,7 +28,10 @@ import { AddPeopleDialog, CalleeInfoContainer } from '../../../invite';
 import { Captions } from '../../../subtitles';
 import { setToolboxVisible, Toolbox } from '../../../toolbox';
 
-import { abstractMapStateToProps } from '../AbstractConference';
+import {
+    AbstractConference,
+    abstractMapStateToProps
+} from '../AbstractConference';
 import DisplayNameLabel from './DisplayNameLabel';
 import Labels from './Labels';
 import NavigationBar from './NavigationBar';
@@ -134,7 +139,7 @@ type Props = AbstractProps & {
 /**
  * The conference page of the mobile (i.e. React Native) application.
  */
-class Conference extends Component<Props> {
+class Conference extends AbstractConference<Props, *> {
     /**
      * Initializes a new Conference instance.
      *
@@ -296,7 +301,12 @@ class Conference extends Component<Props> {
                     }
                 </View>
 
-                <NavigationBar />
+                <SafeAreaView
+                    pointerEvents = 'box-none'
+                    style = { styles.navBarSafeView }>
+                    <NavigationBar />
+                    { this.renderNotificationsContainer() }
+                </SafeAreaView>
 
                 <TestConnectionInfo />
 
@@ -340,6 +350,37 @@ class Conference extends Component<Props> {
             !this.props._reducedUI && ConferenceNotification
                 ? <ConferenceNotification />
                 : undefined);
+    }
+
+    /**
+     * Renders a container for notifications to be displayed by the
+     * base/notifications feature.
+     *
+     * @private
+     * @returns {React$Element}
+     */
+    renderNotificationsContainer() {
+        const notificationsStyle = {};
+
+        // In the landscape mode (wide) there's problem with notifications being
+        // shadowed by the filmstrip rendered on the right. This makes the "x"
+        // button not clickable. In order to avoid that a margin of the
+        // filmstrip's size is added to the right.
+        //
+        // Pawel: after many attempts I failed to make notifications adjust to
+        // their contents width because of column and rows being used in the
+        // flex layout. The only option that seemed to limit the notification's
+        // size was explicit 'width' value which is not better than the margin
+        // added here.
+        if (this.props._filmstripVisible && !isNarrowAspectRatio(this)) {
+            notificationsStyle.marginRight = FILMSTRIP_SIZE;
+        }
+
+        return super.renderNotificationsContainer(
+            {
+                style: notificationsStyle
+            }
+        );
     }
 }
 

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -25,17 +25,19 @@ import { LargeVideo } from '../../../large-video';
 import { AddPeopleDialog, CalleeInfoContainer } from '../../../invite';
 import { Captions } from '../../../subtitles';
 import { setToolboxVisible, Toolbox } from '../../../toolbox';
-import { shouldDisplayTileView } from '../../../video-layout';
 
+import { abstractMapStateToProps } from '../AbstractConference';
 import DisplayNameLabel from './DisplayNameLabel';
 import Labels from './Labels';
 import NavigationBar from './NavigationBar';
 import styles from './styles';
 
+import type { AbstractProps } from '../AbstractConference';
+
 /**
  * The type of the React {@code Component} props of {@link Conference}.
  */
-type Props = {
+type Props = AbstractProps & {
 
     /**
      * The indicator which determines that we are still connecting to the
@@ -104,13 +106,6 @@ type Props = {
     _reducedUI: boolean,
 
     /**
-     * The current conference room name.
-     *
-     * @private
-     */
-    _room: string,
-
-    /**
      * The handler which dispatches the (redux) action {@link setToolboxVisible}
      * to show/hide the {@link Toolbox}.
      *
@@ -120,13 +115,6 @@ type Props = {
      * @returns {void}
      */
     _setToolboxVisible: Function,
-
-    /**
-     * Whether or not the layout should change to support tile view mode.
-     *
-     * @private
-     */
-    _shouldDisplayTileView: boolean,
 
     /**
      * The indicator which determines whether the Toolbox is visible.
@@ -424,16 +412,7 @@ function _mapDispatchToProps(dispatch) {
  *
  * @param {Object} state - The redux state.
  * @private
- * @returns {{
- *     _connecting: boolean,
- *     _filmstripVisible: boolean,
- *     _locationURL: URL,
- *     _participantCount: number,
- *     _reducedUI: boolean,
- *     _room: string,
- *     _toolboxVisible: boolean,
- *     _toolboxAlwaysVisible: boolean
- * }}
+ * @returns {Props}
  */
 function _mapStateToProps(state) {
     const { connecting, connection, locationURL }
@@ -441,8 +420,7 @@ function _mapStateToProps(state) {
     const {
         conference,
         joining,
-        leaving,
-        room
+        leaving
     } = state['features/base/conference'];
     const { reducedUI } = state['features/base/responsive-ui'];
     const { alwaysVisible, visible } = state['features/toolbox'];
@@ -460,6 +438,8 @@ function _mapStateToProps(state) {
         = connecting || (connection && (joining || (!conference && !leaving)));
 
     return {
+        ...abstractMapStateToProps(state),
+
         /**
          * The indicator which determines that we are still connecting to the
          * conference which includes establishing the XMPP connection and then
@@ -500,22 +480,6 @@ function _mapStateToProps(state) {
          * @type {boolean}
          */
         _reducedUI: reducedUI,
-
-        /**
-         * The current conference room name.
-         *
-         * @private
-         * @type {string}
-         */
-        _room: room,
-
-        /**
-         * Whether or not the layout should change to support tile view mode.
-         *
-         * @private
-         * @type {boolean}
-         */
-        _shouldDisplayTileView: shouldDisplayTileView(state),
 
         /**
          * The indicator which determines whether the Toolbox is visible.

--- a/react/features/conference/components/native/Labels.js
+++ b/react/features/conference/components/native/Labels.js
@@ -21,6 +21,7 @@ import AbstractLabels, {
     _abstractMapStateToProps,
     type Props as AbstractLabelsProps
 } from '../AbstractLabels';
+import { shouldDisplayNotifications } from '../../functions';
 import styles from './styles';
 
 /**
@@ -363,7 +364,9 @@ function _mapStateToProps(state) {
     return {
         ..._abstractMapStateToProps(state),
         _reducedUI: state['features/base/responsive-ui'].reducedUI,
-        _visible: !isToolboxVisible(state) && !shouldDisplayTileView(state)
+        _visible: !isToolboxVisible(state)
+            && !shouldDisplayTileView(state)
+            && !shouldDisplayNotifications(state)
     };
 }
 

--- a/react/features/conference/components/native/NavigationBar.js
+++ b/react/features/conference/components/native/NavigationBar.js
@@ -40,39 +40,33 @@ class NavigationBar extends Component<Props> {
             return null;
         }
 
-        return (
-            <View
-                pointerEvents = 'box-none'
-                style = { styles.navBarContainer }>
-                <LinearGradient
-                    colors = { NAVBAR_GRADIENT_COLORS }
-                    pointerEvents = 'none'
-                    style = { styles.gradient }>
-                    <SafeAreaView>
-                        <View style = { styles.gradientStretch } />
-                    </SafeAreaView>
-                </LinearGradient>
-                <SafeAreaView
-                    pointerEvents = 'box-none'
-                    style = { styles.navBarSafeView }>
-                    <View
-                        pointerEvents = 'box-none'
-                        style = { styles.navBarWrapper }>
-                        <PictureInPictureButton
-                            styles = { styles.navBarButton } />
-                        <View
-                            pointerEvents = 'box-none'
-                            style = { styles.roomNameWrapper }>
-                            <Text
-                                numberOfLines = { 1 }
-                                style = { styles.roomName }>
-                                { this.props._meetingName }
-                            </Text>
-                        </View>
-                    </View>
+        return [
+            <LinearGradient
+                colors = { NAVBAR_GRADIENT_COLORS }
+                key = { 1 }
+                pointerEvents = 'none'
+                style = { styles.gradient }>
+                <SafeAreaView>
+                    <View style = { styles.gradientStretch } />
                 </SafeAreaView>
+            </LinearGradient>,
+            <View
+                key = { 2 }
+                pointerEvents = 'box-none'
+                style = { styles.navBarWrapper }>
+                <PictureInPictureButton
+                    styles = { styles.navBarButton } />
+                <View
+                    pointerEvents = 'box-none'
+                    style = { styles.roomNameWrapper }>
+                    <Text
+                        numberOfLines = { 1 }
+                        style = { styles.roomName }>
+                        { this.props._meetingName }
+                    </Text>
+                </View>
             </View>
-        );
+        ];
     }
 
 }

--- a/react/features/conference/components/native/styles.js
+++ b/react/features/conference/components/native/styles.js
@@ -37,6 +37,10 @@ export default createStyleSheet({
     },
 
     gradient: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
         flex: 1
     },
 

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -1,7 +1,7 @@
 // @flow
 
 import _ from 'lodash';
-import React, { Component } from 'react';
+import React from 'react';
 import { connect as reactReduxConnect } from 'react-redux';
 
 import VideoLayout from '../../../../../modules/UI/videolayout/VideoLayout';
@@ -13,7 +13,6 @@ import { Chat } from '../../../chat';
 import { Filmstrip } from '../../../filmstrip';
 import { CalleeInfoContainer } from '../../../invite';
 import { LargeVideo } from '../../../large-video';
-import { NotificationsContainer } from '../../../notifications';
 import { LAYOUTS, getCurrentLayout } from '../../../video-layout';
 
 import {
@@ -28,7 +27,10 @@ import { maybeShowSuboptimalExperienceNotification } from '../../functions';
 import Labels from './Labels';
 import { default as Notice } from './Notice';
 import { default as Subject } from './Subject';
-import { abstractMapStateToProps } from '../AbstractConference';
+import {
+    AbstractConference,
+    abstractMapStateToProps
+} from '../AbstractConference';
 
 import type { AbstractProps } from '../AbstractConference';
 
@@ -87,7 +89,7 @@ type Props = AbstractProps & {
 /**
  * The conference page of the Web application.
  */
-class Conference extends Component<Props> {
+class Conference extends AbstractConference<Props, *> {
     _onFullScreenChange: Function;
     _onShowToolbar: Function;
     _originalOnShowToolbar: Function;
@@ -218,7 +220,7 @@ class Conference extends Component<Props> {
                 { filmstripOnly || <Toolbox /> }
                 { filmstripOnly || <Chat /> }
 
-                <NotificationsContainer />
+                { this.renderNotificationsContainer() }
 
                 <CalleeInfoContainer />
             </div>

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -14,11 +14,7 @@ import { Filmstrip } from '../../../filmstrip';
 import { CalleeInfoContainer } from '../../../invite';
 import { LargeVideo } from '../../../large-video';
 import { NotificationsContainer } from '../../../notifications';
-import {
-    LAYOUTS,
-    getCurrentLayout,
-    shouldDisplayTileView
-} from '../../../video-layout';
+import { LAYOUTS, getCurrentLayout } from '../../../video-layout';
 
 import {
     Toolbox,
@@ -32,6 +28,9 @@ import { maybeShowSuboptimalExperienceNotification } from '../../functions';
 import Labels from './Labels';
 import { default as Notice } from './Notice';
 import { default as Subject } from './Subject';
+import { abstractMapStateToProps } from '../AbstractConference';
+
+import type { AbstractProps } from '../AbstractConference';
 
 declare var APP: Object;
 declare var config: Object;
@@ -68,7 +67,7 @@ const LAYOUT_CLASSNAMES = {
 /**
  * The type of the React {@code Component} props of {@link Conference}.
  */
-type Props = {
+type Props = AbstractProps & {
 
     /**
      * Whether the local participant is recording the conference.
@@ -80,16 +79,6 @@ type Props = {
      * application layout.
      */
     _layoutClassName: string,
-
-    /**
-     * Conference room name.
-     */
-    _room: string,
-
-    /**
-     * Whether or not the current UI layout should be in tile view.
-     */
-    _shouldDisplayTileView: boolean,
 
     dispatch: Function,
     t: Function
@@ -290,21 +279,15 @@ class Conference extends Component<Props> {
  *
  * @param {Object} state - The Redux state.
  * @private
- * @returns {{
- *     _iAmRecorder: boolean,
- *     _layoutClassName: string,
- *     _room: ?string,
- *     _shouldDisplayTileView: boolean
- * }}
+ * @returns {Props}
  */
 function _mapStateToProps(state) {
     const currentLayout = getCurrentLayout(state);
 
     return {
+        ...abstractMapStateToProps(state),
         _iAmRecorder: state['features/base/config'].iAmRecorder,
-        _layoutClassName: LAYOUT_CLASSNAMES[currentLayout],
-        _room: state['features/base/conference'].room,
-        _shouldDisplayTileView: shouldDisplayTileView(state)
+        _layoutClassName: LAYOUT_CLASSNAMES[currentLayout]
     };
 }
 

--- a/react/features/conference/functions.js
+++ b/react/features/conference/functions.js
@@ -1,7 +1,13 @@
-import { getName } from '../app';
 import { translateToHTML } from '../base/i18n';
 import { browser } from '../base/lib-jitsi-meet';
-import { showWarningNotification } from '../notifications';
+import { toState } from '../base/redux';
+
+import { getName } from '../app';
+import {
+    areThereNotifications,
+    showWarningNotification
+} from '../notifications';
+import { getOverlayToRender } from '../overlay';
 
 /**
  * Shows the suboptimal experience notification if needed.
@@ -35,4 +41,21 @@ export function maybeShowSuboptimalExperienceNotification(dispatch, t) {
             )
         );
     }
+}
+
+/**
+ * Tells whether or not the notifications should be displayed within
+ * the conference feature based on the current Redux state.
+ *
+ * @param {Object|Function} stateful - The redux store state.
+ * @returns {boolean}
+ */
+export function shouldDisplayNotifications(stateful) {
+    const state = toState(stateful);
+    const isAnyOverlayVisible = Boolean(getOverlayToRender(state));
+    const { calleeInfoVisible } = state['features/invite'];
+
+    return areThereNotifications(state)
+            && !isAnyOverlayVisible
+            && !calleeInfoVisible;
 }

--- a/react/features/notifications/components/AbstractNotificationsContainer.js
+++ b/react/features/notifications/components/AbstractNotificationsContainer.js
@@ -52,17 +52,39 @@ export default class AbstractNotificationsContainer<P: Props>
     }
 
     /**
+     * Sets a timeout for the first notification (if applicable).
+     *
+     * @inheritdoc
+     */
+    componentDidMount() {
+        // Set the initial dismiss timeout (if any)
+        this._manageDismissTimeout();
+    }
+
+    /**
      * Sets a timeout if the currently displayed notification has changed.
      *
      * @inheritdoc
      */
     componentDidUpdate(prevProps: P) {
+        this._manageDismissTimeout(prevProps);
+    }
+
+    /**
+     * Sets/clears the dismiss timeout for the top notification.
+     *
+     * @param {P} [prevProps] - The previous properties (if called from
+     * {@code componentDidUpdate}).
+     * @returns {void}
+     * @private
+     */
+    _manageDismissTimeout(prevProps: ?P) {
         const { _notifications } = this.props;
 
         if (_notifications.length) {
             const notification = _notifications[0];
             const previousNotification
-                = prevProps._notifications.length
+                = prevProps && prevProps._notifications.length
                     ? prevProps._notifications[0]
                     : undefined;
 

--- a/react/features/notifications/components/AbstractNotificationsContainer.js
+++ b/react/features/notifications/components/AbstractNotificationsContainer.js
@@ -2,9 +2,8 @@
 
 import { Component } from 'react';
 
-import { getOverlayToRender } from '../../overlay';
-
 import { hideNotification } from '../actions';
+import { areThereNotifications } from '../functions';
 
 export type Props = {
 
@@ -165,12 +164,10 @@ export default class AbstractNotificationsContainer<P: Props>
  * }}
  */
 export function _abstractMapStateToProps(state: Object) {
-    const isAnyOverlayVisible = Boolean(getOverlayToRender(state));
-    const { enabled, notifications } = state['features/notifications'];
-    const { calleeInfoVisible } = state['features/invite'];
+    const { notifications } = state['features/notifications'];
+    const _visible = areThereNotifications(state);
 
     return {
-        _notifications: enabled && !isAnyOverlayVisible && !calleeInfoVisible
-            ? notifications : []
+        _notifications: _visible ? notifications : []
     };
 }

--- a/react/features/notifications/components/AbstractNotificationsContainer.js
+++ b/react/features/notifications/components/AbstractNotificationsContainer.js
@@ -142,7 +142,13 @@ export default class AbstractNotificationsContainer<P: Props>
      * @returns {void}
      */
     _onDismissed(uid) {
-        this._clearNotificationDismissTimeout();
+        const { _notifications } = this.props;
+
+        // Clear the timeout only if it's the top notification that's being
+        // dismissed (the timeout is set only for the top one).
+        if (!_notifications.length || _notifications[0].uid === uid) {
+            this._clearNotificationDismissTimeout();
+        }
 
         this.props.dispatch(hideNotification(uid));
     }

--- a/react/features/notifications/components/Notification.native.js
+++ b/react/features/notifications/components/Notification.native.js
@@ -1,0 +1,92 @@
+// @flow
+
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+
+import { Icon } from '../../base/font-icons';
+import { translate } from '../../base/i18n';
+
+import AbstractNotification, {
+    type Props
+} from './AbstractNotification';
+import styles from './styles';
+
+/**
+ * Implements a React {@link Component} to display a notification.
+ *
+ * @extends Component
+ */
+class Notification extends AbstractNotification<Props> {
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const {
+            isDismissAllowed
+        } = this.props;
+
+        return (
+            <View
+                pointerEvents = 'box-none'
+                style = { styles.notification }>
+                <View style = { styles.contentColumn }>
+                    <View
+                        pointerEvents = 'box-none'
+                        style = { styles.notificationContent }>
+                        {
+                            this._renderContent()
+                        }
+                    </View>
+                </View>
+                {
+                    isDismissAllowed
+                    && <TouchableOpacity onPress = { this._onDismissed }>
+                        <Icon
+                            name = { 'close' }
+                            style = { styles.dismissIcon } />
+                    </TouchableOpacity>
+                }
+            </View>
+        );
+    }
+
+    /**
+     * Renders the notification's content. If the title or title key is present
+     * it will be just the title. Otherwise it will fallback to description.
+     *
+     * @returns {Array<ReactElement>}
+     * @private
+     */
+    _renderContent() {
+        const { t, title, titleArguments, titleKey } = this.props;
+        const titleText = title || (titleKey && t(titleKey, titleArguments));
+
+        if (titleText) {
+            return (
+                <Text
+                    numberOfLines = { 1 }
+                    style = { styles.contentText } >
+                    { titleText }
+                </Text>
+            );
+        }
+
+        return this._getDescription().map((line, index) => (
+            <Text
+                key = { index }
+                numberOfLines = { 1 }
+                style = { styles.contentText }>
+                { line }
+            </Text>
+        ));
+    }
+
+    _getDescription: () => Array<string>;
+
+    _onDismissed: () => void;
+}
+
+export default translate(Notification);

--- a/react/features/notifications/components/NotificationsContainer.native.js
+++ b/react/features/notifications/components/NotificationsContainer.native.js
@@ -1,0 +1,67 @@
+// @flow
+
+import React from 'react';
+import { View } from 'react-native';
+import { connect } from 'react-redux';
+
+import AbstractNotificationsContainer, {
+    _abstractMapStateToProps,
+    type Props as AbstractProps
+} from './AbstractNotificationsContainer';
+import Notification from './Notification';
+import styles from './styles';
+
+type Props = AbstractProps & {
+
+    /**
+     * Any custom styling applied to the notifications container.
+     */
+    style: Object
+};
+
+/**
+ * Implements a React {@link Component} which displays notifications and handles
+ * automatic dismissmal after a notification is shown for a defined timeout
+ * period.
+ *
+ * @extends {Component}
+ */
+class NotificationsContainer
+    extends AbstractNotificationsContainer<Props> {
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     */
+    render() {
+        const { _notifications } = this.props;
+
+        if (!_notifications || !_notifications.length) {
+            return null;
+        }
+
+        return (
+            <View
+                pointerEvents = 'box-none'
+                style = { [
+                    styles.notificationContainer,
+                    this.props.style
+                ] } >
+                {
+                    _notifications.map(
+                        ({ props, uid }) => (
+                            <Notification
+                                { ...props }
+                                key = { uid }
+                                onDismissed = { this._onDismissed }
+                                uid = { uid } />))
+                }
+            </View>
+        );
+    }
+
+    _onDismissed: number => void;
+}
+
+export default connect(_abstractMapStateToProps)(NotificationsContainer);

--- a/react/features/notifications/components/NotificationsContainer.native.js
+++ b/react/features/notifications/components/NotificationsContainer.native.js
@@ -37,7 +37,11 @@ class NotificationsContainer
     render() {
         const { _notifications } = this.props;
 
-        if (!_notifications || !_notifications.length) {
+        // Currently the native container displays only the topmost notification
+        const theNotification
+            = _notifications && _notifications.length && _notifications[0];
+
+        if (!theNotification) {
             return null;
         }
 
@@ -48,15 +52,10 @@ class NotificationsContainer
                     styles.notificationContainer,
                     this.props.style
                 ] } >
-                {
-                    _notifications.map(
-                        ({ props, uid }) => (
-                            <Notification
-                                { ...props }
-                                key = { uid }
-                                onDismissed = { this._onDismissed }
-                                uid = { uid } />))
-                }
+                <Notification
+                    { ...theNotification.props }
+                    onDismissed = { this._onDismissed }
+                    uid = { theNotification.uid } />
             </View>
         );
     }

--- a/react/features/notifications/components/styles.js
+++ b/react/features/notifications/components/styles.js
@@ -1,0 +1,61 @@
+// @flow
+
+import { BoxModel, createStyleSheet, ColorPalette } from '../../base/styles';
+
+/**
+ * The styles of the React {@code Components} of the feature notifications.
+ */
+export default createStyleSheet({
+
+    /**
+     * The content (left) column of the notification.
+     */
+    contentColumn: {
+        justifyContent: 'center',
+        flex: 1,
+        flexDirection: 'column',
+        paddingLeft: 1.5 * BoxModel.padding
+    },
+
+    /**
+     * Test style of the notification.
+     */
+    contentText: {
+        alignSelf: 'flex-start',
+        color: ColorPalette.white
+    },
+
+    /**
+     * Dismiss icon style.
+     */
+    dismissIcon: {
+        color: ColorPalette.white,
+        fontSize: 20,
+        padding: 1.5 * BoxModel.padding
+    },
+
+    /**
+     * Outermost view of a single notification.
+     */
+    notification: {
+        backgroundColor: '#768898',
+        flexDirection: 'row',
+        height: 48,
+        marginTop: 0.5 * BoxModel.margin
+    },
+
+    /**
+     * Outermost container of a list of notifications.
+     */
+    notificationContainer: {
+        flexGrow: 0,
+        justifyContent: 'flex-end'
+    },
+
+    /**
+     * Wrapper for the message.
+     */
+    notificationContent: {
+        flexDirection: 'column'
+    }
+});

--- a/react/features/notifications/functions.js
+++ b/react/features/notifications/functions.js
@@ -1,0 +1,15 @@
+import { toState } from '../base/redux';
+
+/**
+ * Tells whether or not the notifications are enabled and if there are any
+ * notifications to be displayed based on the current Redux state.
+ *
+ * @param {Object|Function} stateful - The redux store state.
+ * @returns {boolean}
+ */
+export function areThereNotifications(stateful) {
+    const state = toState(stateful);
+    const { enabled, notifications } = state['features/notifications'];
+
+    return enabled && notifications.length > 0;
+}

--- a/react/features/notifications/index.js
+++ b/react/features/notifications/index.js
@@ -1,6 +1,7 @@
 export * from './actions';
 export * from './actionTypes';
 export * from './components';
+export * from './functions';
 
 import './middleware';
 import './reducer';


### PR DESCRIPTION
Adds back the in-call notifications on mobile which follow the latest design.

Currently it displays only the title to fit in one line. If there's no title it will use the description. I'm still in the process of reviewing longer notifications across the app, but wanted to show the current structure. I've placed the notifications container inside the navigation bar, because it needs to play well with the bar and the top gradient. I guess eventually the gradient and the notifications container could be moved up to the conference component.

![screenshot_20190208-132140](https://user-images.githubusercontent.com/2965063/52503196-6fb3cd80-2baa-11e9-9cfa-12ea0f360df4.jpg)
![screenshot_20190208-132130](https://user-images.githubusercontent.com/2965063/52503203-75111800-2baa-11e9-86d4-145359df8b81.jpg)
