### PR TITLE
color-scheme: fix React warning

### DIFF
--- a/react/features/base/color-scheme/reducer.js
+++ b/react/features/base/color-scheme/reducer.js
@@ -14,7 +14,7 @@ import { SET_COLOR_SCHEME } from './actionTypes';
 ReducerRegistry.register('features/base/color-scheme', (state = {}, action) => {
     switch (action.type) {
     case SET_COLOR_SCHEME:
-        return _.cloneDeep(action.colorScheme);
+        return _.cloneDeep(action.colorScheme) || state;
     }
 
     return state;


### PR DESCRIPTION
A reducer must always return a state or null to ignore it. When the color scheme
is undefined we should return the previous state.