### PR TITLE
fix(recording): support passing styles in firefox

### DIFF
--- a/react/features/recording/components/Recording/StartRecordingDialogContent.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.js
@@ -144,10 +144,10 @@ class StartRecordingDialogContent extends Component<Props> {
                     style = { styles.header }>
                     <Text
                         className = 'recording-title'
-                        style = { [
-                            _dialogStyles.text,
-                            styles.title
-                        ] }>
+                        style = {{
+                            ..._dialogStyles.text,
+                            ...styles.title
+                        }}>
                         { t('recording.authDropboxText') }
                     </Text>
                     <Switch


### PR DESCRIPTION
Using an array of styles in Firefox causes an error
that triggers jitsi-meet to redirect to a static page.