### PR TITLE
[Android] Change the type of the color scheme

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -27,7 +27,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.KeyEvent;
 
 import com.facebook.react.ReactInstanceManager;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.PermissionListener;
 
 import java.net.URL;
@@ -56,7 +55,7 @@ public class JitsiMeetActivity
     /**
      * A color scheme object to override the default color is the SDK.
      */
-    private WritableMap colorScheme;
+    private Bundle colorScheme;
 
     /**
      * The default base {@code URL} used to join a conference when a partial URL
@@ -294,9 +293,9 @@ public class JitsiMeetActivity
     }
 
     /**
-     * @see JitsiMeetView#setColorScheme(WritableMap)
+     * @see JitsiMeetView#setColorScheme(Bundle)
      */
-    public void setColorScheme(WritableMap colorScheme) {
+    public void setColorScheme(Bundle colorScheme) {
         if (view == null) {
             this.colorScheme = colorScheme;
         } else {

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -22,9 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
 
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -74,7 +72,7 @@ public class JitsiMeetView
     /**
      * A color scheme object to override the default color is the SDK.
      */
-    private WritableMap colorScheme;
+    private Bundle colorScheme;
 
     /**
      * The default base {@code URL} used to join a conference when a partial URL
@@ -142,7 +140,7 @@ public class JitsiMeetView
      *
      * @return The color scheme map.
      */
-    public WritableMap getColorScheme() {
+    public Bundle getColorScheme() {
         return colorScheme;
     }
 
@@ -226,7 +224,7 @@ public class JitsiMeetView
 
         // color scheme
         if (colorScheme != null) {
-            props.putBundle("colorScheme", Arguments.toBundle(colorScheme));
+            props.putBundle("colorScheme", colorScheme);
         }
 
         // defaultURL
@@ -331,7 +329,7 @@ public class JitsiMeetView
      *
      * @param colorScheme The color scheme map.
      */
-    public void setColorScheme(WritableMap colorScheme) {
+    public void setColorScheme(Bundle colorScheme) {
         this.colorScheme = colorScheme;
     }
 


### PR DESCRIPTION
This PR changes the color scheme type to a generic Android object instead of a React specific one