### PR TITLE
fix(screensharing): do not sync camera device id on start

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2315,7 +2315,8 @@ export default {
                         }));
                     }
 
-                    if (this.localVideo) {
+                    if (this.localVideo
+                        && this.localVideo.videoType === 'camera') {
                         dispatch(updateSettings({
                             cameraDeviceId: this.localVideo.getDeviceId()
                         }));


### PR DESCRIPTION
When a conference is started, the currently used
camera device id is saved. I believe this is happening
because lib-jitsi-meet does not use exact device id
matching when calling getUserMedia, so it's possible
to request camera A but get camera B back because
camera A is not available. When config.startScreenSharing
is true, the syncing occurs and saves the desktop
source id. So when screensharing is stopped, jitsi-meet
requests that desktop source id instead of the preferred
camera.

~~There might be a better fix available. I'll look more tomorrow.~~