### PR TITLE
fix(external_api): detect and skip params for hash routers

### DIFF
--- a/react/features/base/config/parseURLParams.js
+++ b/react/features/base/config/parseURLParams.js
@@ -19,9 +19,18 @@ export default function parseURLParams(
         source: string = 'hash'): Object {
     const paramStr = source === 'search' ? url.search : url.hash;
     const params = {};
+    const paramParts = (paramStr && paramStr.substr(1).split('&')) || [];
 
-    // eslint-disable-next-line newline-per-chained-call
-    paramStr && paramStr.substr(1).split('&').forEach(part => {
+    // Detect and ignore hash params for hash routers.
+    if (source === 'hash' && paramParts.length === 1) {
+        const firstParam = paramParts[0];
+
+        if (firstParam.startsWith('/') && firstParam.split('&').length === 1) {
+            return params;
+        }
+    }
+
+    paramParts.forEach(part => {
         const param = part.split('=');
         const key = param[0];
 


### PR DESCRIPTION
Not sure if there is a better way to avoid this error. I was also thinking of an early in the forEach loop if there is no value defined.