### PR TITLE
feat(external_api): notify when api is disposed

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -256,7 +256,7 @@ changes. The listener will receive an object with the following structure:
 
 * **readyToClose** - event notification fired when Jitsi Meet is ready to be closed (hangup operations are completed).
 
-* **subjectChange** - event notifications about subject of conference changes. 
+* **subjectChange** - event notifications about subject of conference changes.
 The listener will receive an object with the following structure:
 ```javascript
 {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -534,6 +534,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {void}
      */
     dispose() {
+        this.emit('_willDispose');
         this._transport.dispose();
         this.removeAllListeners();
         if (this._frame) {


### PR DESCRIPTION
There are times when a developer would want to take some actions when the api instanced is getting disposed (analogous to when a conference is left - cleanup etc.). Added such an event.