### PR TITLE
chore: update LJM to 5a9fc76739bcf0bed50676c7be160f688f3a19b5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8456,8 +8456,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#2e1436e20d4d8fb6020497a87b2714dff38a6c86",
-      "from": "github:jitsi/lib-jitsi-meet#2e1436e20d4d8fb6020497a87b2714dff38a6c86",
+      "version": "github:jitsi/lib-jitsi-meet#5a9fc76739bcf0bed50676c7be160f688f3a19b5",
+      "from": "github:jitsi/lib-jitsi-meet#5a9fc76739bcf0bed50676c7be160f688f3a19b5",
       "requires": {
         "@jitsi/sdp-interop": "0.1.13",
         "@jitsi/sdp-simulcast": "0.2.1",
@@ -8467,7 +8467,7 @@
         "js-utils": "github:jitsi/js-utils#446497893023aa8dec403e0e4e35a22cae6bc87d",
         "lodash.isequal": "4.5.0",
         "sdp-transform": "2.3.0",
-        "strophe.js": "1.2.15",
+        "strophe.js": "1.2.16",
         "strophejs-plugin-disco": "0.0.2",
         "webrtc-adapter": "github:webrtc/adapter#1eec19782b4058d186341263e7d049cea3e3290a",
         "yaeti": "1.0.1"
@@ -13929,9 +13929,9 @@
       "dev": true
     },
     "strophe.js": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.2.15.tgz",
-      "integrity": "sha512-aM5SCLltSLKubPNil28ieJ03I+15jcVX02c1/7SBVIUWRfwfxwondRJSMJpB7OBss5b3jCNxpTqig8nXncJ5yg=="
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.2.16.tgz",
+      "integrity": "sha512-r/Uq7aqrusg25Y0qHwV48cFnMY6K/CuZdGt3EggRx3kY4sMv8lG+AFoMlrmTcYVMG1BaJvQfv9Cthw4Ll8z7fQ=="
     },
     "strophejs-plugin-disco": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jsc-android": "224109.1.0",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#2e1436e20d4d8fb6020497a87b2714dff38a6c86",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#5a9fc76739bcf0bed50676c7be160f688f3a19b5",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.11",
     "moment": "2.19.4",


### PR DESCRIPTION
Updates lib-jitsi-meet to get https://github.com/jitsi/lib-jitsi-meet/pull/876 released and available to spot.