### PR TITLE
[RN] Avoid adding undefined in the invite

### DIFF
--- a/react/features/calendar-sync/functions.native.js
+++ b/react/features/calendar-sync/functions.native.js
@@ -26,7 +26,10 @@ export function addLinkToCalendarEntry(
     return new Promise((resolve, reject) => {
         getShareInfoText(state, link, true).then(shareInfoText => {
             RNCalendarEvents.findEventById(id).then(event => {
-                const updateText = `${event.description}\n\n${shareInfoText}`;
+                const updateText
+                    = event.description
+                        ? `${event.description}\n\n${shareInfoText}`
+                        : shareInfoText;
                 const updateObject = {
                     id: event.id,
                     ...Platform.select({


### PR DESCRIPTION
This change avoids adding "undefined" in the calendar invite text