### PR TITLE
[RN] Render a ConfirmDialog for start recording when dropbox is off

### DIFF
--- a/react/features/recording/components/Recording/StartRecordingDialogContent.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.js
@@ -144,10 +144,7 @@ class StartRecordingDialogContent extends Component<Props> {
                     style = { styles.header }>
                     <Text
                         className = 'recording-title'
-                        style = {{
-                            ..._dialogStyles.text,
-                            ...styles.title
-                        }}>
+                        style = { _dialogStyles.text }>
                         { t('recording.authDropboxText') }
                     </Text>
                     <Switch

--- a/react/features/recording/components/Recording/native/StartRecordingDialog.js
+++ b/react/features/recording/components/Recording/native/StartRecordingDialog.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
-import { CustomSubmitDialog } from '../../../../base/dialog';
+import { ConfirmDialog, CustomSubmitDialog } from '../../../../base/dialog';
 
 import AbstractStartRecordingDialog, {
     mapStateToProps
@@ -27,17 +27,26 @@ class StartRecordingDialog extends AbstractStartRecordingDialog {
         const { isTokenValid, isValidating, spaceLeft, userName } = this.state;
         const { _isDropboxEnabled } = this.props;
 
+        // Explicit true is needed, see StartRecordingDialogContent
+        if (_isDropboxEnabled === true) {
+            return (
+                <CustomSubmitDialog
+                    okDisabled = { _isDropboxEnabled && !isTokenValid }
+                    onSubmit = { this._onSubmit } >
+                    <StartRecordingDialogContent
+                        integrationsEnabled = { _isDropboxEnabled }
+                        isTokenValid = { isTokenValid }
+                        isValidating = { isValidating }
+                        spaceLeft = { spaceLeft }
+                        userName = { userName } />
+                </CustomSubmitDialog>
+            );
+        }
+
         return (
-            <CustomSubmitDialog
-                okDisabled = { _isDropboxEnabled && !isTokenValid }
-                onSubmit = { this._onSubmit } >
-                <StartRecordingDialogContent
-                    integrationsEnabled = { _isDropboxEnabled }
-                    isTokenValid = { isTokenValid }
-                    isValidating = { isValidating }
-                    spaceLeft = { spaceLeft }
-                    userName = { userName } />
-            </CustomSubmitDialog>
+            <ConfirmDialog
+                contentKey = 'recording.startRecordingBody'
+                onSubmit = { this._onSubmit } />
         );
     }
 

--- a/react/features/recording/components/Recording/styles.native.js
+++ b/react/features/recording/components/Recording/styles.native.js
@@ -37,11 +37,6 @@ export default createStyleSheet({
         paddingRight: BoxModel.padding
     },
 
-    title: {
-        fontSize: 16,
-        fontWeight: 'bold'
-    },
-
     text: {
         color: ColorPalette.white
     }


### PR DESCRIPTION
On mobile we need to render a confirm dialog when there is no integration enabled for recording, otherwise it looks weird.

So instead of:

![image](https://user-images.githubusercontent.com/9974975/53898317-1f5c4e00-4038-11e9-8d11-a0a59c7ca77c.png)

We need to have these two states:

![screenshot 2019-03-06 at 17 41 14](https://user-images.githubusercontent.com/9974975/53898246-ffc52580-4037-11e9-9ca2-3e3f398e441b.png)
![screenshot 2019-03-06 at 17 41 50](https://user-images.githubusercontent.com/9974975/53898252-0358ac80-4038-11e9-970f-edc2dc3ad892.png)
