### PR TITLE
rn: fix bottom offset in chat dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11568,6 +11568,14 @@
         "prop-types": "^15.5.10"
       }
     },
+    "react-native-safe-area-view": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.13.1.tgz",
+      "integrity": "sha512-d/pu2866jApSwLtK/xWAvMXZkNTIQcFrjjbcTATBrmIfFNnu8TNFUcMRFpfJ+eOn5nmx7uGmDvs9B53Ft7JGpQ==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1"
+      }
+    },
     "react-native-sound": {
       "version": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08",
       "from": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-native-immersive": "2.0.0",
     "react-native-keep-awake": "4.0.0",
     "react-native-linear-gradient": "2.5.3",
+    "react-native-safe-area-view": "0.13.1",
     "react-native-sound": "github:jitsi/react-native-sound#e4260ed7f641eeb0377d76eac7987aba72e1cf08",
     "react-native-swipeout": "2.3.6",
     "react-native-vector-icons": "6.0.2",

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React from 'react';
-import { SafeAreaView } from 'react-native';
 import { GiftedChat } from 'react-native-gifted-chat';
+import SafeAreaView from 'react-native-safe-area-view';
 import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';


### PR DESCRIPTION
The native SafeAreaView doesn't quite work if elements placed inside it use
absolute positioning, so switch to a pure JS implementation for this case.

In addition to behaving as expected it has some nice props we could use
elsewhere too, which allow us to force or not the inset in a given edge.

This package is recommended by RN maintainers when the extra flexibility is
required:
https://github.com/facebook/react-native/issues/23279#issuecomment-460355164