### PR TITLE
fix(android-sdk): Recover audio device if the OS changes it

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
@@ -457,6 +457,10 @@ class AudioModeModule extends ReactContextBaseJavaModule
                     // Reset user selection
                     userSelectedDevice = null;
 
+                    // If the OS changes the Audio Route or Devices we could have lost
+                    // the selected audio device
+                    selectedDevice = null;
+
                     if (mode != -1) {
                         updateAudioRoute(mode);
                     }


### PR DESCRIPTION
If the OS make an Audio Status update, and the device (or route) differs from the selected by the user (or the default for a video call), the SDK does not adapt itself for that change as described: https://github.com/jitsi/jitsi-meet/issues/3912

With this fix, the selected devices will be marked as null when the AudioModule receives an AudioStateChange event related with a change of the Audio Route or Devices.

The selected devices marked as null will provoke that when the Module update the Audio Route, it will set the DEVICE correspondant to that Call type (being the device setted by the OS or not)