### PR TITLE
Fix the authenticated name displayed in Settings Profile tab

### DIFF
--- a/react/features/settings/functions.js
+++ b/react/features/settings/functions.js
@@ -122,7 +122,7 @@ export function getProfileTabProps(stateful: Object | Function) {
 
     return {
         authEnabled: Boolean(conference && authEnabled),
-        authLogin: Boolean(conference && authLogin),
+        authLogin: authLogin,
         displayName: localParticipant.name,
         email: localParticipant.email
     };


### PR DESCRIPTION
When we use Jitsi-Meet with authentication, the authenticated name is not display in the Settings Profile tab. So this PR propose to remove the Boolean conversion of authLogin string to display the string value instead of 'true'.