### PR TITLE
Remove some unnecessary Flow annotations

### DIFF
--- a/react/features/authentication/components/WaitForOwnerDialog.native.js
+++ b/react/features/authentication/components/WaitForOwnerDialog.native.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { ConfirmDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import { cancelWaitForOwner, _openLoginDialog } from '../actions';
 

--- a/react/features/base/app/components/BaseApp.js
+++ b/react/features/base/app/components/BaseApp.js
@@ -55,8 +55,6 @@ export default class BaseApp extends Component<*, State> {
 
         this.state = {
             route: {},
-
-            // $FlowFixMe
             store: undefined
         };
     }

--- a/react/features/base/dialog/components/native/BottomSheet.js
+++ b/react/features/base/dialog/components/native/BottomSheet.js
@@ -2,10 +2,10 @@
 
 import React, { Component, type Node } from 'react';
 import { TouchableWithoutFeedback, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../color-scheme';
 import { Modal } from '../../../react';
+import { connect } from '../../../redux';
 import { StyleType } from '../../../styles';
 
 import { bottomSheetStyles as styles } from './styles';
@@ -107,5 +107,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(BottomSheet);

--- a/react/features/base/dialog/components/native/ConfirmDialog.js
+++ b/react/features/base/dialog/components/native/ConfirmDialog.js
@@ -2,9 +2,9 @@
 
 import React from 'react';
 import { Text, TouchableOpacity } from 'react-native';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 import { StyleType } from '../../../styles';
 
 import { _abstractMapStateToProps } from '../../functions';

--- a/react/features/base/dialog/components/native/CustomDialog.js
+++ b/react/features/base/dialog/components/native/CustomDialog.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { connect } from 'react-redux';
+import { connect } from '../../../redux';
 
 import { _abstractMapStateToProps } from '../../functions';
 
@@ -21,5 +21,4 @@ class CustomDialog extends BaseDialog<Props, *> {
     }
 }
 
-// $FlowExpectedError
 export default connect(_abstractMapStateToProps)(CustomDialog);

--- a/react/features/base/dialog/components/native/CustomSubmitDialog.js
+++ b/react/features/base/dialog/components/native/CustomSubmitDialog.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 
 import { _abstractMapStateToProps } from '../../functions';
 

--- a/react/features/base/dialog/components/native/DialogContainer.js
+++ b/react/features/base/dialog/components/native/DialogContainer.js
@@ -1,4 +1,4 @@
-import { connect } from 'react-redux';
+import { connect } from '../../../redux';
 
 import AbstractDialogContainer, {
     abstractMapStateToProps

--- a/react/features/base/dialog/components/native/InputDialog.js
+++ b/react/features/base/dialog/components/native/InputDialog.js
@@ -2,9 +2,9 @@
 
 import React from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 import { StyleType } from '../../../styles';
 
 import { _abstractMapStateToProps } from '../../functions';

--- a/react/features/base/dialog/components/web/Dialog.js
+++ b/react/features/base/dialog/components/web/Dialog.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../redux';
 
 import AbstractDialog from '../AbstractDialog';
 import type { Props as AbstractDialogProps, State } from '../AbstractDialog';
@@ -84,5 +85,4 @@ class Dialog extends AbstractDialog<Props, State> {
     _onSubmit: (?string) => void;
 }
 
-// $FlowExpectedError
 export default connect()(Dialog);

--- a/react/features/base/dialog/components/web/DialogContainer.js
+++ b/react/features/base/dialog/components/web/DialogContainer.js
@@ -1,6 +1,7 @@
 import { ModalTransition } from '@atlaskit/modal-dialog';
 import React from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../redux';
 
 import AbstractDialogContainer, {
     abstractMapStateToProps

--- a/react/features/base/i18n/dateUtil.js
+++ b/react/features/base/i18n/dateUtil.js
@@ -63,13 +63,10 @@ export function getLocalizedDurationFormatter(duration: number) {
     // showing the hour and we want to include the hour if the conference is
     // more than an hour long
 
-    // $FlowFixMe
     if (moment.duration(duration).format('h') !== '0') {
-        // $FlowFixMe
         return moment.duration(duration).format('h:mm:ss');
     }
 
-    // $FlowFixMe
     return moment.duration(duration).format('mm:ss', { trim: false });
 }
 
@@ -97,8 +94,6 @@ function _getSupportedLocale() {
                 // FIXME The flow-type definition of moment is v2.3 while our
                 // package.json states v2.19 so maybe locales on moment was
                 // introduced in between?
-                //
-                // $FlowFixMe
                 = moment.locales().find(lang => currentLocaleRegexp.exec(lang));
         }
     }

--- a/react/features/base/media/components/AbstractAudio.js
+++ b/react/features/base/media/components/AbstractAudio.js
@@ -7,7 +7,7 @@ import { Component } from 'react';
  * playback.
  */
 export type AudioElement = {
-    currentTime?: number,
+    currentTime: number,
     pause: () => void,
     play: () => void,
     setSinkId?: string => void,

--- a/react/features/base/media/components/native/VideoTrack.js
+++ b/react/features/base/media/components/native/VideoTrack.js
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../redux';
 
 import AbstractVideoTrack from '../AbstractVideoTrack';
 import type { Props } from '../AbstractVideoTrack';
@@ -29,5 +30,4 @@ class VideoTrack extends AbstractVideoTrack<Props> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(VideoTrack);

--- a/react/features/base/media/components/native/VideoTransform.js
+++ b/react/features/base/media/components/native/VideoTransform.js
@@ -2,8 +2,9 @@
 
 import React, { Component } from 'react';
 import { PanResponder, PixelRatio, View } from 'react-native';
-import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
+
+import { connect } from '../../../redux';
 
 import type { PanResponderInstance } from 'PanResponder';
 
@@ -727,5 +728,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps, _mapDispatchToProps)(VideoTransform);

--- a/react/features/base/media/components/web/VideoTrack.js
+++ b/react/features/base/media/components/web/VideoTrack.js
@@ -1,7 +1,8 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../redux';
 
 import AbstractVideoTrack from '../AbstractVideoTrack';
 import type { Props as AbstractVideoTrackProps } from '../AbstractVideoTrack';
@@ -63,5 +64,4 @@ class VideoTrack extends AbstractVideoTrack<Props> {
     _onVideoPlaying: () => void;
 }
 
-// $FlowExpectedError
 export default connect()(VideoTrack);

--- a/react/features/base/participants/components/Avatar.native.js
+++ b/react/features/base/participants/components/Avatar.native.js
@@ -2,7 +2,10 @@
 
 import React, { Component, Fragment, PureComponent } from 'react';
 import { Dimensions, Image, Platform, View } from 'react-native';
-import FastImage from 'react-native-fast-image';
+import FastImage, {
+    type CacheControls,
+    type Priorities
+} from 'react-native-fast-image';
 
 import { ColorPalette } from '../../styles';
 
@@ -63,7 +66,12 @@ type State = {
     /**
      * Source for the non-local avatar.
      */
-    source: { uri: ?string }
+    source: {
+        uri?: string,
+        headers?: Object,
+        priority?: Priorities,
+        cache?: CacheControls,
+    }
 };
 
 /**
@@ -261,7 +269,7 @@ class AvatarContent extends Component<Props, State> {
             }
         }
 
-        return (// $FlowFixMe
+        return (
             <FastImage
                 onError = { this._onAvatarLoadError }
                 onLoadEnd = { this._onAvatarLoaded }

--- a/react/features/base/participants/components/ParticipantView.native.js
+++ b/react/features/base/participants/components/ParticipantView.native.js
@@ -3,7 +3,6 @@
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
 import FastImage from 'react-native-fast-image';
-import { connect } from 'react-redux';
 
 import { translate } from '../../i18n';
 import { JitsiParticipantConnectionStatus } from '../../lib-jitsi-meet';
@@ -12,6 +11,7 @@ import {
     VideoTrack
 } from '../../media';
 import { Container, TintedView } from '../../react';
+import { connect } from '../../redux';
 import { StyleType } from '../../styles';
 import { TestHint } from '../../testing/components';
 import { getTrackByMediaTypeAndParticipant } from '../../tracks';

--- a/react/features/base/react/components/native/BackButton.js
+++ b/react/features/base/react/components/native/BackButton.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { TouchableOpacity } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../color-scheme';
 import { Icon } from '../../../font-icons';
+import { connect } from '../../../redux';
 
 /**
  * The type of the React {@code Component} props of {@link BackButton}
@@ -68,5 +68,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(BackButton);

--- a/react/features/base/react/components/native/ForwardButton.js
+++ b/react/features/base/react/components/native/ForwardButton.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { Text, TouchableOpacity } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../color-scheme';
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 
 /**
  * The type of the React {@code Component} props of {@link ForwardButton}

--- a/react/features/base/react/components/native/Header.js
+++ b/react/features/base/react/components/native/Header.js
@@ -2,9 +2,9 @@
 
 import React, { Component, type Node } from 'react';
 import { Platform, SafeAreaView, StatusBar, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../color-scheme';
+import { connect } from '../../../redux';
 import { isDarkColor } from '../../../styles';
 
 import { HEADER_PADDING } from './headerstyles';
@@ -165,5 +165,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Header);

--- a/react/features/base/react/components/native/HeaderLabel.js
+++ b/react/features/base/react/components/native/HeaderLabel.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../color-scheme';
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 
 /**
  * The type of the React {@code Component} props of {@link HeaderLabel}

--- a/react/features/base/react/components/native/LoadingIndicator.js
+++ b/react/features/base/react/components/native/LoadingIndicator.js
@@ -11,7 +11,7 @@ type Props = {
      * Prop to set the size of the indicator. This is the same as the
      * prop of the native component.
      */
-    size: 'large' | 'medium' | 'small'
+    size: 'large' | 'small'
 };
 
 /**
@@ -40,7 +40,7 @@ export default class LoadingIndicator extends Component<Props> {
             size
         };
 
-        return (// $FlowFixMe
+        return (
             <ActivityIndicator
                 animating = { true }
                 color = { ColorPalette.white }

--- a/react/features/base/react/components/native/PagedList.js
+++ b/react/features/base/react/components/native/PagedList.js
@@ -2,9 +2,9 @@
 
 import React, { Component } from 'react';
 import { SafeAreaView, Text, TouchableOpacity, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { Icon } from '../../../font-icons';
+import { connect } from '../../../redux';
 
 import styles from './styles';
 
@@ -283,5 +283,4 @@ class PagedList extends Component<Props, State> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(PagedList);

--- a/react/features/base/react/components/web/Watermarks.js
+++ b/react/features/base/react/components/web/Watermarks.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
+import { connect } from '../../../redux';
 
 declare var interfaceConfig: Object;
 
@@ -242,5 +242,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(translate(Watermarks));

--- a/react/features/base/redux/functions.js
+++ b/react/features/base/redux/functions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import _ from 'lodash';
+import { connect as reduxConnect } from 'react-redux';
 
 /**
  * Sets specific properties of a specific state to specific values and prevents
@@ -23,6 +24,19 @@ export function assign(target: Object, source: Object) {
     }
 
     return t;
+}
+
+/**
+ * Wrapper function for the react-redux connect function to avoid having to
+ * declare function types for flow, but still let flow warn for other errors.
+ *
+ * @param {Function?} mapStateToProps - Redux mapStateToProps function.
+ * @param {Function?} mapDispatchToProps - Redux mapDispatchToProps function.
+ * @returns {Connector}
+ */
+export function connect(
+        mapStateToProps?: Function, mapDispatchToProps?: Function) {
+    return reduxConnect<*, *, *, *, *, *>(mapStateToProps, mapDispatchToProps);
 }
 
 /**

--- a/react/features/base/responsive-ui/components/AspectRatioAware.js
+++ b/react/features/base/responsive-ui/components/AspectRatioAware.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../redux';
 
 import { ASPECT_RATIO_NARROW, ASPECT_RATIO_WIDE } from '../constants';
 
@@ -51,7 +52,6 @@ export function makeAspectRatioAware(
         }
     }
 
-    // $FlowFixMe
     return connect(_mapStateToProps)(AspectRatioAware);
 }
 

--- a/react/features/base/responsive-ui/components/AspectRatioDetector.js
+++ b/react/features/base/responsive-ui/components/AspectRatioDetector.js
@@ -1,8 +1,9 @@
 // @flow
 
 import React, { Component, type Node } from 'react';
-import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
+
+import { connect } from '../../redux';
 
 import { setAspectRatio } from '../actions';
 import DimensionsDetector from './DimensionsDetector';
@@ -69,5 +70,4 @@ function _mapDispatchToProps(dispatch: Dispatch<any>) {
     };
 }
 
-// $FlowExpectedError
 export default connect(undefined, _mapDispatchToProps)(AspectRatioDetector);

--- a/react/features/base/responsive-ui/components/ReducedUIDetector.js
+++ b/react/features/base/responsive-ui/components/ReducedUIDetector.js
@@ -1,8 +1,9 @@
 // @flow
 
 import React, { Component, type Node } from 'react';
-import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
+
+import { connect } from '../../redux';
 
 import { setReducedUI } from '../actions';
 import DimensionsDetector from './DimensionsDetector';
@@ -70,5 +71,4 @@ function _mapDispatchToProps(dispatch: Dispatch<any>) {
     };
 }
 
-// $FlowExpectedError
 export default connect(undefined, _mapDispatchToProps)(ReducedUIDetector);

--- a/react/features/base/sounds/components/SoundCollection.js
+++ b/react/features/base/sounds/components/SoundCollection.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { Audio } from '../../media';
 import type { AudioElement } from '../../media';
+import { connect } from '../../redux';
 
 import { _addAudioElement, _removeAudioElement } from '../actions';
 import type { Sound } from '../reducer';
@@ -153,5 +153,4 @@ export function _mapDispatchToProps(dispatch: Function) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps, _mapDispatchToProps)(SoundCollection);

--- a/react/features/base/testing/components/TestConnectionInfo.js
+++ b/react/features/base/testing/components/TestConnectionInfo.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
 
 import { getLocalParticipant } from '../../participants';
+import { connect } from '../../redux';
 
 // FIXME this imports feature to 'base'
 import { statsEmitter } from '../../../connection-indicator';
@@ -215,5 +215,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(TestConnectionInfo);

--- a/react/features/base/testing/components/TestHint.android.js
+++ b/react/features/base/testing/components/TestHint.android.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Text } from 'react-native';
+
+import { connect } from '../../redux';
 
 import type { TestHintProps } from './AbstractTestHint';
 import { _mapStateToProps } from './AbstractTestHint';

--- a/react/features/base/testing/components/TestHint.ios.js
+++ b/react/features/base/testing/components/TestHint.ios.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Text } from 'react-native';
+
+import { connect } from '../../redux';
 
 import type { TestHintProps } from './AbstractTestHint';
 import { _mapStateToProps } from './AbstractTestHint';
@@ -34,5 +35,4 @@ class TestHint extends Component<TestHintProps> {
     }
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(TestHint);

--- a/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
+++ b/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
@@ -2,7 +2,6 @@
 
 import Tooltip from '@atlaskit/tooltip';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -10,6 +9,7 @@ import {
     sendAnalytics
 } from '../../analytics';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import { updateCalendarEvent } from '../actions';
 

--- a/react/features/calendar-sync/components/CalendarList.native.js
+++ b/react/features/calendar-sync/components/CalendarList.native.js
@@ -2,11 +2,11 @@
 
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { openSettings } from '../../mobile/permissions';
 import { translate } from '../../base/i18n';
 import { AbstractPage } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import { refreshCalendar } from '../actions';
 import { isCalendarEnabled } from '../functions';

--- a/react/features/calendar-sync/components/CalendarList.web.js
+++ b/react/features/calendar-sync/components/CalendarList.web.js
@@ -2,10 +2,10 @@
 
 import Spinner from '@atlaskit/spinner';
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { AbstractPage } from '../../base/react';
+import { connect } from '../../base/redux';
 import { openSettingsDialog, SETTINGS_TABS } from '../../settings';
 import {
     createCalendarClickedEvent,

--- a/react/features/calendar-sync/components/CalendarListContent.native.js
+++ b/react/features/calendar-sync/components/CalendarListContent.native.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { appNavigate } from '../../app';
 import {
@@ -11,6 +10,7 @@ import {
 } from '../../analytics';
 import { getLocalizedDateFormatter, translate } from '../../base/i18n';
 import { NavigateSectionList } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import { refreshCalendar, openUpdateCalendarEventDialog } from '../actions';
 import { isCalendarEnabled } from '../functions';

--- a/react/features/calendar-sync/components/CalendarListContent.web.js
+++ b/react/features/calendar-sync/components/CalendarListContent.web.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { appNavigate } from '../../app';
 import {
@@ -10,6 +9,7 @@ import {
     sendAnalytics
 } from '../../analytics';
 import { MeetingsList } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import { isCalendarEnabled } from '../functions';
 
@@ -173,7 +173,5 @@ function _mapStateToProps(state: Object) {
 }
 
 export default isCalendarEnabled()
-
-    // $FlowExpectedError
     ? connect(_mapStateToProps)(CalendarListContent)
     : undefined;

--- a/react/features/calendar-sync/components/ConferenceNotification.native.js
+++ b/react/features/calendar-sync/components/ConferenceNotification.native.js
@@ -2,12 +2,12 @@
 
 import React, { Component } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { appNavigate } from '../../app';
 import { getURLWithoutParamsNormalized } from '../../base/connection';
 import { Icon } from '../../base/font-icons';
 import { getLocalizedDateFormatter, translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../base/responsive-ui';
 
 import { isCalendarEnabled } from '../functions';

--- a/react/features/calendar-sync/components/UpdateCalendarEventDialog.native.js
+++ b/react/features/calendar-sync/components/UpdateCalendarEventDialog.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import { updateCalendarEvent } from '../actions';
 

--- a/react/features/calendar-sync/functions.any.js
+++ b/react/features/calendar-sync/functions.any.js
@@ -107,15 +107,16 @@ export function _updateCalendarEntries(events: Array<Object>) {
  */
 function _checkPattern(str, positivePattern, negativePattern) {
     const positiveRegExp = new RegExp(positivePattern, 'gi');
-    let positiveMatch;
+    let positiveMatch = positiveRegExp.exec(str);
 
-    while ((positiveMatch = positiveRegExp.exec(str)) !== null) {
-        // $FlowFixMe
+    while (positiveMatch !== null) {
         const url = positiveMatch[0];
 
         if (!new RegExp(negativePattern, 'gi').exec(url)) {
             return url;
         }
+
+        positiveMatch = positiveRegExp.exec(str);
     }
 }
 

--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -63,7 +63,6 @@ isCalendarEnabled()
             // knownDomains. At this point, it should have already been
             // translated into the new state format (namely, base/known-domains)
             // and the app no longer needs it.
-            // $FlowFixMe
             if (typeof state.knownDomains !== 'undefined') {
                 return set(state, 'knownDomains', undefined);
             }

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -3,10 +3,10 @@
 import React from 'react';
 import { SafeAreaView } from 'react-native';
 import { GiftedChat } from 'react-native-gifted-chat';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { BackButton, Header, HeaderLabel, Modal } from '../../../base/react';
+import { connect } from '../../../base/redux';
 
 import AbstractChat, {
     _mapDispatchToProps,

--- a/react/features/chat/components/native/ChatButton.js
+++ b/react/features/chat/components/native/ChatButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { getLocalParticipant } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 import {
     AbstractButton,
     type AbstractButtonProps
@@ -126,5 +125,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps, _mapDispatchToProps)(ChatButton);

--- a/react/features/chat/components/native/ChatMessage.js
+++ b/react/features/chat/components/native/ChatMessage.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { Text, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { getLocalizedDateFormatter, translate } from '../../../base/i18n';
 import { Avatar } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 
 import AbstractChatMessage, {
     _mapStateToProps as _abstractMapStateToProps,

--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 import Transition from 'react-transition-group/Transition';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractChat, {
     _mapDispatchToProps,

--- a/react/features/chat/components/web/ChatCounter.js
+++ b/react/features/chat/components/web/ChatCounter.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../base/redux';
 
 import { getUnreadCount } from '../../functions';
 
@@ -57,5 +58,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(ChatCounter);

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import Emoji from 'react-emoji-render';
 import type { Dispatch } from 'redux';
+
+import { connect } from '../../../base/redux';
 
 import { sendMessage } from '../../actions';
 
@@ -232,5 +233,4 @@ class ChatInput extends Component<Props, State> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(ChatInput);

--- a/react/features/chat/components/web/DisplayNameForm.js
+++ b/react/features/chat/components/web/DisplayNameForm.js
@@ -2,10 +2,10 @@
 
 import { FieldTextStateless } from '@atlaskit/field-text';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { updateSettings } from '../../../base/settings';
 
 /**

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -3,12 +3,12 @@
 import React from 'react';
 
 import { BackHandler, SafeAreaView, StatusBar, View } from 'react-native';
-import { connect as reactReduxConnect } from 'react-redux';
 
 import { appNavigate } from '../../../app';
 import { connect, disconnect } from '../../../base/connection';
 import { getParticipantCount } from '../../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../../base/react';
+import { connect as reactReduxConnect } from '../../../base/redux';
 import {
     isNarrowAspectRatio,
     makeAspectRatioAware
@@ -540,6 +540,5 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowFixMe
 export default reactReduxConnect(_mapStateToProps, _mapDispatchToProps)(
     makeAspectRatioAware(Conference));

--- a/react/features/conference/components/native/DisplayNameLabel.js
+++ b/react/features/conference/components/native/DisplayNameLabel.js
@@ -2,13 +2,13 @@
 
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import {
     getLocalParticipant,
     getParticipantDisplayName,
     shouldRenderParticipantVideo
 } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 
 import { shouldDisplayTileView } from '../../../video-layout';
 
@@ -76,5 +76,4 @@ function _mapStateToProps(state: Object) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(DisplayNameLabel);

--- a/react/features/conference/components/native/Labels.js
+++ b/react/features/conference/components/native/Labels.js
@@ -2,9 +2,9 @@
 
 import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import { connect } from '../../../base/redux';
 import {
     isNarrowAspectRatio,
     makeAspectRatioAware
@@ -370,5 +370,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(makeAspectRatioAware(Labels));

--- a/react/features/conference/components/native/NavigationBar.js
+++ b/react/features/conference/components/native/NavigationBar.js
@@ -4,9 +4,9 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { SafeAreaView, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import { connect } from 'react-redux';
 
 import { getConferenceName } from '../../../base/conference';
+import { connect } from '../../../base/redux';
 import { PictureInPictureButton } from '../../../mobile/picture-in-picture';
 import { isToolboxVisible } from '../../../toolbox';
 
@@ -87,5 +87,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(NavigationBar);

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -2,13 +2,13 @@
 
 import _ from 'lodash';
 import React from 'react';
-import { connect as reactReduxConnect } from 'react-redux';
 
 import VideoLayout from '../../../../../modules/UI/videolayout/VideoLayout';
 
 import { obtainConfig } from '../../../base/config';
 import { connect, disconnect } from '../../../base/connection';
 import { translate } from '../../../base/i18n';
+import { connect as reactReduxConnect } from '../../../base/redux';
 import { Chat } from '../../../chat';
 import { Filmstrip } from '../../../filmstrip';
 import { CalleeInfoContainer } from '../../../invite';
@@ -293,5 +293,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default reactReduxConnect(_mapStateToProps)(translate(Conference));

--- a/react/features/conference/components/web/Labels.js
+++ b/react/features/conference/components/web/Labels.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import { connect } from '../../../base/redux';
 
 import AbstractLabels, {
     _abstractMapStateToProps as _mapStateToProps,
@@ -105,5 +105,4 @@ class Labels extends AbstractLabels<Props, State> {
     _renderVideoQualityLabel: () => React$Element<*>;
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Labels);

--- a/react/features/conference/components/web/Notice.js
+++ b/react/features/conference/components/web/Notice.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 declare var config: Object;
 

--- a/react/features/conference/components/web/Subject.js
+++ b/react/features/conference/components/web/Subject.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
+import { connect } from '../../../base/redux';
 import { isToolboxVisible } from '../../../toolbox';
 
 /**
@@ -65,5 +65,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Subject);

--- a/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
@@ -3,7 +3,7 @@
 import Button, { ButtonGroup } from '@atlaskit/button';
 import { AtlasKitThemeProvider } from '@atlaskit/theme';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 import type { Dispatch } from 'redux';
 
 import { createDeepLinkingPageEvent, sendAnalytics } from '../../analytics';

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 
 import { createDeepLinkingPageEvent, sendAnalytics } from '../../analytics';
 import { translate, translateToHTML } from '../../base/i18n';

--- a/react/features/desktop-picker/components/DesktopPicker.js
+++ b/react/features/desktop-picker/components/DesktopPicker.js
@@ -2,7 +2,7 @@
 
 import Tabs from '@atlaskit/tabs';
 import React, { PureComponent } from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 import type { Dispatch } from 'redux';
 
 import { Dialog, hideDialog } from '../../base/dialog';

--- a/react/features/display-name/components/DisplayName.web.js
+++ b/react/features/display-name/components/DisplayName.web.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 import type { Dispatch } from 'redux';
 
 import { appendSuffix } from '../functions';

--- a/react/features/display-name/components/DisplayNamePrompt.native.js
+++ b/react/features/display-name/components/DisplayNamePrompt.native.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 
 import { InputDialog } from '../../base/dialog';
 
@@ -27,5 +27,4 @@ class DisplayNamePrompt extends AbstractDisplayNamePrompt<*> {
     _onSetDisplayName: string => boolean;
 }
 
-// $FlowExpectedError
 export default connect()(DisplayNamePrompt);

--- a/react/features/display-name/components/DisplayNamePrompt.web.js
+++ b/react/features/display-name/components/DisplayNamePrompt.web.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 import { FieldTextStateless as TextField } from '@atlaskit/field-text';
 
 import { Dialog } from '../../base/dialog';

--- a/react/features/feedback/components/FeedbackDialog.web.js
+++ b/react/features/feedback/components/FeedbackDialog.web.js
@@ -4,7 +4,7 @@ import { FieldTextAreaStateless } from '@atlaskit/field-text-area';
 import StarIcon from '@atlaskit/icon/glyph/star';
 import StarFilledIcon from '@atlaskit/icon/glyph/star-filled';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import { connect } from '../../base/redux';
 import type { Dispatch } from 'redux';
 
 import {

--- a/react/features/filmstrip/components/native/Filmstrip.js
+++ b/react/features/filmstrip/components/native/Filmstrip.js
@@ -2,9 +2,9 @@
 
 import React, { Component } from 'react';
 import { ScrollView } from 'react-native';
-import { connect } from 'react-redux';
 
 import { Container, Platform } from '../../../base/react';
+import { connect } from '../../../base/redux';
 import {
     isNarrowAspectRatio,
     makeAspectRatioAware
@@ -219,5 +219,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(makeAspectRatioAware(Filmstrip));

--- a/react/features/filmstrip/components/native/LocalThumbnail.js
+++ b/react/features/filmstrip/components/native/LocalThumbnail.js
@@ -2,9 +2,9 @@
 
 import React, { Component } from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { getLocalParticipant } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 
 import styles from '../styles';
 import Thumbnail from './Thumbnail';
@@ -60,5 +60,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(LocalThumbnail);

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
@@ -14,6 +13,7 @@ import {
     pinParticipant
 } from '../../../base/participants';
 import { Container } from '../../../base/react';
+import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 import { getTrackByMediaTypeAndParticipant } from '../../../base/tracks';
 
@@ -255,5 +255,4 @@ function _mapStateToProps(state, ownProps) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps, _mapDispatchToProps)(Thumbnail);

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -6,13 +6,13 @@ import {
     TouchableWithoutFeedback,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
     getNearestReceiverVideoQualityLevel,
     setMaxReceiverVideoQuality
 } from '../../../base/conference';
+import { connect } from '../../../base/redux';
 import {
     DimensionsDetector,
     isNarrowAspectRatio,
@@ -335,5 +335,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(makeAspectRatioAware(TileView));

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -2,7 +2,6 @@
 
 import _ from 'lodash';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -10,6 +9,7 @@ import {
     createToolbarEvent,
     sendAnalytics
 } from '../../../analytics';
+import { connect } from '../../../base/redux';
 import { dockToolbox } from '../../../toolbox';
 
 import { setFilmstripHovered, setFilmstripVisible } from '../../actions';
@@ -319,5 +319,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Filmstrip);

--- a/react/features/filmstrip/components/web/Toolbar.js
+++ b/react/features/filmstrip/components/web/Toolbar.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
+import { connect } from '../../../base/redux';
 import { SettingsButton } from '../../../settings';
 import {
     AudioMuteButton,
@@ -90,5 +90,4 @@ function _mapStateToProps(state): Object { // eslint-disable-line no-unused-vars
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Toolbar);

--- a/react/features/invite/components/InfoDialogButton.web.js
+++ b/react/features/invite/components/InfoDialogButton.web.js
@@ -2,7 +2,6 @@
 
 import InlineDialog from '@atlaskit/inline-dialog';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
@@ -11,6 +10,7 @@ import { translate } from '../../base/i18n';
 import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
 import { getParticipantCount } from '../../base/participants';
 import { OverflowMenuItem } from '../../base/toolbox';
+import { connect } from '../../base/redux';
 import { getActiveSession } from '../../recording';
 import { ToolbarButton } from '../../toolbox';
 import { updateDialInNumbers } from '../actions';

--- a/react/features/invite/components/InviteButton.native.js
+++ b/react/features/invite/components/InviteButton.native.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 import { AbstractButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { beginShareRoom } from '../../share-room';

--- a/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
@@ -11,7 +11,6 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import { Icon } from '../../../../base/font-icons';
 import { translate } from '../../../../base/i18n';
@@ -24,6 +23,7 @@ import {
     Modal,
     type Item
 } from '../../../../base/react';
+import { connect } from '../../../../base/redux';
 
 import { setAddPeopleDialogVisible } from '../../../actions';
 

--- a/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.js
@@ -3,7 +3,6 @@
 import Avatar from '@atlaskit/avatar';
 import InlineMessage from '@atlaskit/inline-message';
 import React from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { createInviteDialogEvent, sendAnalytics } from '../../../../analytics';
@@ -11,6 +10,7 @@ import { Dialog, hideDialog } from '../../../../base/dialog';
 import { translate, translateToHTML } from '../../../../base/i18n';
 import { getLocalParticipant } from '../../../../base/participants';
 import { MultiSelectAutocomplete } from '../../../../base/react';
+import { connect } from '../../../../base/redux';
 
 import AbstractAddPeopleDialog, {
     type Props as AbstractProps,

--- a/react/features/invite/components/callee-info/CalleeInfo.js
+++ b/react/features/invite/components/callee-info/CalleeInfo.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { MEDIA_TYPE } from '../../../base/media';
 import {
@@ -12,6 +11,7 @@ import {
     getParticipantPresenceStatus
 } from '../../../base/participants';
 import { Container, Text } from '../../../base/react';
+import { connect } from '../../../base/redux';
 import { isLocalTrackMuted } from '../../../base/tracks';
 import { CALLING, PresenceLabel } from '../../../presence-status';
 
@@ -158,5 +158,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(CalleeInfo);

--- a/react/features/invite/components/callee-info/CalleeInfoContainer.js
+++ b/react/features/invite/components/callee-info/CalleeInfoContainer.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../base/redux';
 
 import CalleeInfo from './CalleeInfo';
 
@@ -61,5 +62,4 @@ function _mapStateToProps(state: Object): Object {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(CalleeInfoContainer);

--- a/react/features/invite/components/info-dialog/InfoDialog.web.js
+++ b/react/features/invite/components/info-dialog/InfoDialog.web.js
@@ -1,13 +1,13 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { setPassword } from '../../../base/conference';
 import { getInviteURL } from '../../../base/connection';
 import { Dialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { isLocalParticipantModerator } from '../../../base/participants';
 
 import { _getDefaultPhoneNumber, getDialInfoPageURL } from '../../functions';

--- a/react/features/large-video/components/LargeVideo.native.js
+++ b/react/features/large-video/components/LargeVideo.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../base/color-scheme';
 import { ParticipantView } from '../../base/participants';
+import { connect } from '../../base/redux';
 import { DimensionsDetector } from '../../base/responsive-ui';
 import { StyleType } from '../../base/styles';
 
@@ -159,5 +159,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(LargeVideo);

--- a/react/features/local-recording/components/LocalRecordingInfoDialog.js
+++ b/react/features/local-recording/components/LocalRecordingInfoDialog.js
@@ -2,7 +2,6 @@
 
 import moment from 'moment';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { Dialog } from '../../base/dialog';
@@ -11,6 +10,7 @@ import {
     PARTICIPANT_ROLE,
     getLocalParticipant
 } from '../../base/participants';
+import { connect } from '../../base/redux';
 
 import { statsUpdate } from '../actions';
 import { recordingController } from '../controller';

--- a/react/features/local-recording/components/LocalRecordingLabel.web.js
+++ b/react/features/local-recording/components/LocalRecordingLabel.web.js
@@ -2,10 +2,10 @@
 
 import Tooltip from '@atlaskit/tooltip';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n/index';
 import { CircularLabel } from '../../base/label/index';
+import { connect } from '../../base/redux';
 
 
 /**

--- a/react/features/mobile/audio-mode/components/AudioRouteButton.js
+++ b/react/features/mobile/audio-mode/components/AudioRouteButton.js
@@ -7,10 +7,10 @@ import {
     requireNativeComponent,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import { openDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
+++ b/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
@@ -3,11 +3,11 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import { NativeModules, Text, TouchableHighlight, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { hideDialog, BottomSheet } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { Icon } from '../../../base/font-icons';
+import { connect } from '../../../base/redux';
 import { ColorPalette } from '../../../base/styles';
 
 import styles from './styles';

--- a/react/features/mobile/incoming-call/components/AnswerButton.js
+++ b/react/features/mobile/incoming-call/components/AnswerButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/mobile/incoming-call/components/DeclineButton.js
+++ b/react/features/mobile/incoming-call/components/DeclineButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/mobile/incoming-call/components/IncomingCallPage.js
+++ b/react/features/mobile/incoming-call/components/IncomingCallPage.js
@@ -3,10 +3,10 @@
 import React, { Component } from 'react';
 import { Image, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { Avatar } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 
 import AnswerButton from './AnswerButton';
 import DeclineButton from './DeclineButton';

--- a/react/features/mobile/network-activity/components/NetworkActivityIndicator.js
+++ b/react/features/mobile/network-activity/components/NetworkActivityIndicator.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { LoadingIndicator } from '../../../base/react';
+import { connect } from '../../../base/redux';
 
 /**
  * The type of the React {@code Component} props of
@@ -52,5 +52,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(NetworkActivityIndicator);

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { getAppProp } from '../../../base/app';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/notifications/components/NotificationsContainer.native.js
+++ b/react/features/notifications/components/NotificationsContainer.native.js
@@ -2,7 +2,8 @@
 
 import React from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
+
+import { connect } from '../../base/redux';
 
 import AbstractNotificationsContainer, {
     _abstractMapStateToProps,
@@ -63,5 +64,4 @@ class NotificationsContainer
     _onDismissed: number => void;
 }
 
-// $FlowExpectedError
 export default connect(_abstractMapStateToProps)(NotificationsContainer);

--- a/react/features/notifications/components/NotificationsContainer.web.js
+++ b/react/features/notifications/components/NotificationsContainer.web.js
@@ -2,7 +2,8 @@
 
 import { FlagGroup } from '@atlaskit/flag';
 import React from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../base/redux';
 
 import AbstractNotificationsContainer, {
     _abstractMapStateToProps as _mapStateToProps,
@@ -63,5 +64,4 @@ class NotificationsContainer extends AbstractNotificationsContainer<Props> {
     }
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(NotificationsContainer);

--- a/react/features/overlay/components/FilmstripOnlyOverlayFrame.js
+++ b/react/features/overlay/components/FilmstripOnlyOverlayFrame.js
@@ -1,13 +1,13 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import {
     Avatar,
     getAvatarURL,
     getLocalParticipant
 } from '../../base/participants';
+import { connect } from '../../base/redux';
 
 import OverlayFrame from './OverlayFrame';
 
@@ -112,5 +112,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(FilmstripOnlyOverlayFrame);

--- a/react/features/overlay/components/OverlayContainer.js
+++ b/react/features/overlay/components/OverlayContainer.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../base/redux';
 
 import { getOverlayToRender } from '../functions';
 
@@ -58,5 +59,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(OverlayContainer);

--- a/react/features/overlay/components/PageReloadFilmstripOnlyOverlay.js
+++ b/react/features/overlay/components/PageReloadFilmstripOnlyOverlay.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import AbstractPageReloadOverlay, { abstractMapStateToProps }
     from './AbstractPageReloadOverlay';

--- a/react/features/overlay/components/PageReloadOverlay.native.js
+++ b/react/features/overlay/components/PageReloadOverlay.native.js
@@ -2,12 +2,12 @@
 
 import React from 'react';
 import { Text } from 'react-native';
-import { connect } from 'react-redux';
 
 import { appNavigate, reloadNow } from '../../app';
 import { ColorSchemeRegistry } from '../../base/color-scheme';
 import { ConfirmDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 import { StyleType } from '../../base/styles';
 
 import AbstractPageReloadOverlay, {

--- a/react/features/overlay/components/PageReloadOverlay.web.js
+++ b/react/features/overlay/components/PageReloadOverlay.web.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import AbstractPageReloadOverlay, {
     abstractMapStateToProps,

--- a/react/features/overlay/components/ReloadButton.js
+++ b/react/features/overlay/components/ReloadButton.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { reloadNow } from '../../app';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 /**
  * The type of the React {@code Component} props of {@link ReloadButton}.

--- a/react/features/overlay/components/UserMediaPermissionsFilmstripOnlyOverlay.js
+++ b/react/features/overlay/components/UserMediaPermissionsFilmstripOnlyOverlay.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate, translateToHTML } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import AbstractUserMediaPermissionsOverlay, { abstractMapStateToProps }
     from './AbstractUserMediaPermissionsOverlay';

--- a/react/features/overlay/components/UserMediaPermissionsOverlay.js
+++ b/react/features/overlay/components/UserMediaPermissionsOverlay.js
@@ -1,9 +1,9 @@
 /* global interfaceConfig */
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate, translateToHTML } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import AbstractUserMediaPermissionsOverlay, { abstractMapStateToProps }
     from './AbstractUserMediaPermissionsOverlay';

--- a/react/features/presence-status/components/PresenceLabel.js
+++ b/react/features/presence-status/components/PresenceLabel.js
@@ -1,11 +1,11 @@
 /* @flow */
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { getParticipantById } from '../../base/participants';
 import { Text } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import { STATUS_TO_I18N_KEY } from '../constants';
 

--- a/react/features/recent-list/components/RecentList.native.js
+++ b/react/features/recent-list/components/RecentList.native.js
@@ -1,13 +1,12 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getDefaultURL } from '../../app';
 import { translate } from '../../base/i18n';
-import { NavigateSectionList } from '../../base/react';
-import type { Section } from '../../base/react';
+import { NavigateSectionList, type Section } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import { deleteRecentListEntry } from '../actions';
 import { isRecentListEnabled, toDisplayableList } from '../functions';

--- a/react/features/recent-list/components/RecentList.web.js
+++ b/react/features/recent-list/components/RecentList.web.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../base/i18n';
 import { MeetingsList } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import AbstractRecentList from './AbstractRecentList';
 import { isRecentListEnabled, toDisplayableList } from '../functions';

--- a/react/features/recording/components/LiveStream/native/GoogleSigninForm.js
+++ b/react/features/recording/components/LiveStream/native/GoogleSigninForm.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 
 import {

--- a/react/features/recording/components/LiveStream/native/LiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/native/LiveStreamButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractLiveStreamButton, {
     _mapStateToProps,

--- a/react/features/recording/components/LiveStream/native/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/native/StartLiveStreamDialog.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { CustomSubmitDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 import { googleApi } from '../../../../google-api';
 
 

--- a/react/features/recording/components/LiveStream/native/StopLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/native/StopLiveStreamDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractStopLiveStreamDialog, {
     _mapStateToProps

--- a/react/features/recording/components/LiveStream/native/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyForm.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { Linking, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 
 import AbstractStreamKeyForm, {

--- a/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
@@ -8,10 +8,10 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 
 import { YOUTUBE_LIVE_DASHBOARD_URL } from '../constants';

--- a/react/features/recording/components/LiveStream/web/LiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/web/LiveStreamButton.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import { Container, Text } from '../../../../base/react';
+import { connect } from '../../../../base/redux';
 
 import AbstractLiveStreamButton, {
     _mapStateToProps as _abstractMapStateToProps,

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
@@ -2,10 +2,10 @@
 
 import Spinner from '@atlaskit/spinner';
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import {
     GOOGLE_API_STATES,

--- a/react/features/recording/components/LiveStream/web/StopLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StopLiveStreamDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractStopLiveStreamDialog, {
     _mapStateToProps

--- a/react/features/recording/components/Recording/StartRecordingDialogContent.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import {
     createRecordingDialogEvent,
@@ -19,6 +18,7 @@ import {
     Switch,
     Text
 } from '../../../base/react';
+import { connect } from '../../../base/redux';
 import { ColorPalette, StyleType } from '../../../base/styles';
 import { authorizeDropbox, updateDropboxToken } from '../../../dropbox';
 
@@ -333,7 +333,7 @@ class StartRecordingDialogContent extends Component<Props> {
         return (
             <LoadingIndicator
                 isCompleting = { false }
-                size = 'medium' />
+                size = 'small' />
         );
     }
 

--- a/react/features/recording/components/Recording/native/RecordButton.js
+++ b/react/features/recording/components/Recording/native/RecordButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractRecordButton, {
     _mapStateToProps,

--- a/react/features/recording/components/Recording/native/StartRecordingDialog.js
+++ b/react/features/recording/components/Recording/native/StartRecordingDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import { CustomSubmitDialog } from '../../../../base/dialog';
+import { connect } from '../../../../base/redux';
 
 import AbstractStartRecordingDialog, {
     mapStateToProps

--- a/react/features/recording/components/Recording/native/StopRecordingDialog.js
+++ b/react/features/recording/components/Recording/native/StopRecordingDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractStopRecordingDialog, {
     type Props,

--- a/react/features/recording/components/Recording/web/RecordButton.js
+++ b/react/features/recording/components/Recording/web/RecordButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../../base/i18n';
+import { connect } from '../../../../base/redux';
 
 import AbstractRecordButton, {
     _mapStateToProps as _abstractMapStateToProps,

--- a/react/features/recording/components/Recording/web/StartRecordingDialog.js
+++ b/react/features/recording/components/Recording/web/StartRecordingDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import { Dialog } from '../../../../base/dialog';
+import { connect } from '../../../../base/redux';
 
 import AbstractStartRecordingDialog, {
     mapStateToProps

--- a/react/features/recording/components/Recording/web/StopRecordingDialog.js
+++ b/react/features/recording/components/Recording/web/StopRecordingDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import { Dialog } from '../../../../base/dialog';
+import { connect } from '../../../../base/redux';
 
 import AbstractStopRecordingDialog, {
     type Props,

--- a/react/features/recording/components/native/RecordingExpandedLabel.js
+++ b/react/features/recording/components/native/RecordingExpandedLabel.js
@@ -1,13 +1,12 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
 import {
     ExpandedLabel,
     type Props as AbstractProps
 } from '../../../base/label';
+import { connect } from '../../../base/redux';
 
 import { getSessionStatusToShow } from '../../functions';
 

--- a/react/features/recording/components/native/RecordingLabel.js
+++ b/react/features/recording/components/native/RecordingLabel.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { CircularLabel } from '../../../base/label';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import { connect } from '../../../base/redux';
 
 import AbstractRecordingLabel, {
     _mapStateToProps

--- a/react/features/recording/components/web/RecordingLabel.js
+++ b/react/features/recording/components/web/RecordingLabel.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { CircularLabel } from '../../../base/label';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractRecordingLabel, {
     _mapStateToProps

--- a/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
+++ b/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog, hideDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
 import { getParticipantById } from '../../base/participants';
+import { connect } from '../../base/redux';
 
 declare var APP: Object;
 

--- a/react/features/remote-video-menu/components/native/KickButton.js
+++ b/react/features/remote-video-menu/components/native/KickButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractKickButton from '../AbstractKickButton';
 

--- a/react/features/remote-video-menu/components/native/KickRemoteParticipantDialog.js
+++ b/react/features/remote-video-menu/components/native/KickRemoteParticipantDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractKickRemoteParticipantDialog
     from '../AbstractKickRemoteParticipantDialog';

--- a/react/features/remote-video-menu/components/native/MuteButton.js
+++ b/react/features/remote-video-menu/components/native/MuteButton.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractMuteButton, { _mapStateToProps } from '../AbstractMuteButton';
 

--- a/react/features/remote-video-menu/components/native/MuteRemoteParticipantDialog.js
+++ b/react/features/remote-video-menu/components/native/MuteRemoteParticipantDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractMuteRemoteParticipantDialog
     from '../AbstractMuteRemoteParticipantDialog';

--- a/react/features/remote-video-menu/components/native/RemoteVideoMenu.js
+++ b/react/features/remote-video-menu/components/native/RemoteVideoMenu.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import {
@@ -13,6 +12,7 @@ import {
     getAvatarURL,
     getParticipantDisplayName
 } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 
 import { hideRemoteVideoMenu } from '../../actions';
@@ -135,5 +135,4 @@ function _mapStateToProps(state, ownProps) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(RemoteVideoMenu);

--- a/react/features/remote-video-menu/components/web/KickButton.js
+++ b/react/features/remote-video-menu/components/web/KickButton.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractKickButton, {
     type Props

--- a/react/features/remote-video-menu/components/web/KickRemoteParticipantDialog.js
+++ b/react/features/remote-video-menu/components/web/KickRemoteParticipantDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractKickRemoteParticipantDialog
     from '../AbstractKickRemoteParticipantDialog';

--- a/react/features/remote-video-menu/components/web/MuteButton.js
+++ b/react/features/remote-video-menu/components/web/MuteButton.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractMuteButton, {
     _mapStateToProps,

--- a/react/features/remote-video-menu/components/web/MuteRemoteParticipantDialog.js
+++ b/react/features/remote-video-menu/components/web/MuteRemoteParticipantDialog.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 
 import AbstractMuteRemoteParticipantDialog
     from '../AbstractMuteRemoteParticipantDialog';

--- a/react/features/room-lock/components/PasswordRequiredPrompt.native.js
+++ b/react/features/room-lock/components/PasswordRequiredPrompt.native.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { setPassword } from '../../base/conference';
 import { InputDialog } from '../../base/dialog';
+import { connect } from '../../base/redux';
 
 import { _cancelPasswordRequiredPrompt } from '../actions';
 
@@ -100,5 +100,4 @@ class PasswordRequiredPrompt extends Component<Props> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(PasswordRequiredPrompt);

--- a/react/features/room-lock/components/PasswordRequiredPrompt.web.js
+++ b/react/features/room-lock/components/PasswordRequiredPrompt.web.js
@@ -2,12 +2,12 @@
 
 import { FieldTextStateless as TextField } from '@atlaskit/field-text';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { setPassword } from '../../base/conference';
 import { Dialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 /**
  * The type of the React {@code Component} props of

--- a/react/features/room-lock/components/RoomLockButton.js
+++ b/react/features/room-lock/components/RoomLockButton.js
@@ -1,9 +1,9 @@
 // @flow
 
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { isLocalParticipantModerator } from '../../base/participants';
+import { connect } from '../../base/redux';
 import { AbstractButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 

--- a/react/features/room-lock/components/RoomLockPrompt.native.js
+++ b/react/features/room-lock/components/RoomLockPrompt.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { InputDialog } from '../../base/dialog';
+import { connect } from '../../base/redux';
 
 import { endRoomLockRequest } from '../actions';
 
@@ -102,5 +102,4 @@ class RoomLockPrompt extends Component<Props> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(RoomLockPrompt);

--- a/react/features/settings/components/native/SettingsView.js
+++ b/react/features/settings/components/native/SettingsView.js
@@ -9,11 +9,11 @@ import {
     TextInput,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { translate } from '../../../base/i18n';
 import { BackButton, Header, Modal } from '../../../base/react';
+import { connect } from '../../../base/redux';
 
 import {
     AbstractSettingsView,

--- a/react/features/settings/components/web/CalendarTab.js
+++ b/react/features/settings/components/web/CalendarTab.js
@@ -3,9 +3,9 @@
 import Button from '@atlaskit/button';
 import Spinner from '@atlaskit/spinner';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import {
     CALENDAR_TYPE,
     MicrosoftSignInButton,

--- a/react/features/settings/components/web/SettingsButton.js
+++ b/react/features/settings/components/web/SettingsButton.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 import { openDeviceSelectionPopup } from '../../../device-selection';

--- a/react/features/settings/components/web/SettingsDialog.js
+++ b/react/features/settings/components/web/SettingsDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { getAvailableDevices } from '../../../base/devices';
 import { DialogWithTabs, hideDialog } from '../../../base/dialog';
+import { connect } from '../../../base/redux';
 import { isCalendarEnabled } from '../../../calendar-sync';
 import {
     DeviceSelection,
@@ -198,5 +198,4 @@ function _mapStateToProps(state) {
     return { _tabs: tabs };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(SettingsDialog);

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -1,11 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { Dialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
 import { getLocalParticipant } from '../../base/participants';
+import { connect } from '../../base/redux';
+
 import SpeakerStatsItem from './SpeakerStatsItem';
 import SpeakerStatsLabels from './SpeakerStatsLabels';
 

--- a/react/features/subtitles/components/Captions.native.js
+++ b/react/features/subtitles/components/Captions.native.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { Container, Text } from '../../base/react';
+import { connect } from '../../base/redux';
 
 import {
     _abstractMapStateToProps,
@@ -65,5 +65,4 @@ class Captions
     }
 }
 
-// $FlowExpectedError
 export default connect(_abstractMapStateToProps)(Captions);

--- a/react/features/subtitles/components/Captions.web.js
+++ b/react/features/subtitles/components/Captions.web.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../base/redux';
 
 import {
     _abstractMapStateToProps,
@@ -52,5 +53,4 @@ class Captions
     }
 }
 
-// $FlowExpectedError
 export default connect(_abstractMapStateToProps)(Captions);

--- a/react/features/subtitles/components/ClosedCaptionButton.native.js
+++ b/react/features/subtitles/components/ClosedCaptionButton.native.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import {
     AbstractClosedCaptionButton,

--- a/react/features/subtitles/components/ClosedCaptionButton.web.js
+++ b/react/features/subtitles/components/ClosedCaptionButton.web.js
@@ -1,8 +1,7 @@
 // @flow
 
-import { connect } from 'react-redux';
-
-import { translate } from '../../base/i18n/index';
+import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 import {
     AbstractClosedCaptionButton,

--- a/react/features/toolbox/components/AudioMuteButton.js
+++ b/react/features/toolbox/components/AudioMuteButton.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import {
     ACTION_SHORTCUT_TRIGGERED,
     AUDIO_MUTE,
@@ -11,6 +9,7 @@ import {
 } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { MEDIA_TYPE, setAudioMuted } from '../../base/media';
+import { connect } from '../../base/redux';
 import { AbstractAudioMuteButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { isLocalTrackMuted } from '../../base/tracks';

--- a/react/features/toolbox/components/HangupButton.js
+++ b/react/features/toolbox/components/HangupButton.js
@@ -1,11 +1,11 @@
 // @flow
 
-import { connect } from 'react-redux';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { appNavigate } from '../../app';
 import { disconnect } from '../../base/connection';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 import { AbstractHangupButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 

--- a/react/features/toolbox/components/VideoMuteButton.js
+++ b/react/features/toolbox/components/VideoMuteButton.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import {
     ACTION_SHORTCUT_TRIGGERED,
     VIDEO_MUTE,
@@ -15,6 +13,7 @@ import {
     VIDEO_MUTISM_AUTHORITY,
     setVideoMuted
 } from '../../base/media';
+import { connect } from '../../base/redux';
 import { AbstractVideoMuteButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { isLocalTrackMuted } from '../../base/tracks';

--- a/react/features/toolbox/components/native/AudioOnlyButton.js
+++ b/react/features/toolbox/components/native/AudioOnlyButton.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { toggleAudioOnly } from '../../../base/conference';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -2,13 +2,13 @@
 
 import React, { Component } from 'react';
 import { Platform } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import {
     BottomSheet,
     hideDialog
 } from '../../../base/dialog';
+import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 import { InviteButton } from '../../../invite';
 import { AudioRouteButton } from '../../../mobile/audio-mode';
@@ -128,7 +128,6 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 OverflowMenu_ = connect(_mapStateToProps)(OverflowMenu);
 
 export default OverflowMenu_;

--- a/react/features/toolbox/components/native/OverflowMenuButton.js
+++ b/react/features/toolbox/components/native/OverflowMenuButton.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { openDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 

--- a/react/features/toolbox/components/native/ToggleCameraButton.js
+++ b/react/features/toolbox/components/native/ToggleCameraButton.js
@@ -1,9 +1,8 @@
 // @flow
 
-import { connect } from 'react-redux';
-
 import { translate } from '../../../base/i18n';
 import { MEDIA_TYPE, toggleCameraFacingMode } from '../../../base/media';
+import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
 import { isLocalTrackMuted } from '../../../base/tracks';

--- a/react/features/toolbox/components/native/Toolbox.js
+++ b/react/features/toolbox/components/native/Toolbox.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { Container } from '../../../base/react';
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
+import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 import { ChatButton } from '../../../chat';
 
@@ -279,5 +279,4 @@ function _mapStateToProps(state: Object): Object {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(Toolbox);

--- a/react/features/toolbox/components/web/OverflowMenuProfileItem.js
+++ b/react/features/toolbox/components/web/OverflowMenuProfileItem.js
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+
+import { connect } from '../../../base/redux';
 
 import {
     Avatar,
@@ -121,5 +122,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(OverflowMenuProfileItem);

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import {
     ACTION_SHORTCUT_TRIGGERED,
@@ -16,6 +15,7 @@ import {
     getParticipants,
     participantUpdated
 } from '../../../base/participants';
+import { connect } from '../../../base/redux';
 import { OverflowMenuItem } from '../../../base/toolbox';
 import { getLocalVideoTrack, toggleScreensharing } from '../../../base/tracks';
 import { ChatCounter, toggleChat } from '../../../chat';

--- a/react/features/transcribing/components/TranscribingLabel.native.js
+++ b/react/features/transcribing/components/TranscribingLabel.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { CircularLabel } from '../../base/label';
+import { connect } from '../../base/redux';
 
 import { _mapStateToProps, type Props } from './AbstractTranscribingLabel';
 

--- a/react/features/transcribing/components/TranscribingLabel.web.js
+++ b/react/features/transcribing/components/TranscribingLabel.web.js
@@ -2,10 +2,10 @@
 
 import Tooltip from '@atlaskit/tooltip';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { CircularLabel } from '../../base/label';
+import { connect } from '../../base/redux';
 
 import { _mapStateToProps, type Props } from './AbstractTranscribingLabel';
 

--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -8,6 +7,7 @@ import {
     sendAnalytics
 } from '../../analytics';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 import {
     AbstractButton,
     type AbstractButtonProps

--- a/react/features/video-quality/components/OverflowMenuVideoQualityItem.web.js
+++ b/react/features/video-quality/components/OverflowMenuVideoQualityItem.web.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { VIDEO_QUALITY_LEVELS } from '../../base/conference';
 import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
 
 /**
  * A map of of selectable receive resolutions to corresponding icons.

--- a/react/features/video-quality/components/VideoQualityLabel.native.js
+++ b/react/features/video-quality/components/VideoQualityLabel.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { CircularLabel } from '../../base/label';
+import { connect } from '../../base/redux';
 import { combineStyles, type StyleType } from '../../base/styles';
 
 import AbstractVideoQualityLabel, {

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -2,11 +2,11 @@
 
 import Tooltip from '@atlaskit/tooltip';
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { CircularLabel } from '../../base/label';
 import { MEDIA_TYPE } from '../../base/media';
+import { connect } from '../../base/redux';
 import { getTrackByMediaTypeAndParticipant } from '../../base/tracks';
 
 import AbstractVideoQualityLabel, {

--- a/react/features/video-quality/components/VideoQualitySlider.web.js
+++ b/react/features/video-quality/components/VideoQualitySlider.web.js
@@ -2,7 +2,6 @@
 
 import InlineMessage from '@atlaskit/inline-message';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -16,6 +15,7 @@ import {
 } from '../../base/conference';
 import { translate } from '../../base/i18n';
 import JitsiMeetJS from '../../base/lib-jitsi-meet';
+import { connect } from '../../base/redux';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
 

--- a/react/features/welcome/components/BlankPage.native.js
+++ b/react/features/welcome/components/BlankPage.native.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import { connect } from '../../base/redux';
 import { destroyLocalTracks } from '../../base/tracks';
 import { NetworkActivityIndicator } from '../../mobile/network-activity';
 
@@ -48,5 +48,4 @@ class BlankPage extends Component<Props> {
     }
 }
 
-// $FlowExpectedError
 export default connect()(BlankPage);

--- a/react/features/welcome/components/LocalVideoTrackUnderlay.native.js
+++ b/react/features/welcome/components/LocalVideoTrackUnderlay.native.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { VideoTrack } from '../../base/media';
 import { TintedView } from '../../base/react';
+import { connect } from '../../base/redux';
 import { getLocalVideoTrack } from '../../base/tracks';
 
 import styles from './styles';
@@ -77,5 +77,4 @@ function _mapStateToProps(state) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(LocalVideoTrackUnderlay);

--- a/react/features/welcome/components/VideoSwitch.js
+++ b/react/features/welcome/components/VideoSwitch.js
@@ -2,11 +2,11 @@
 
 import React, { Component } from 'react';
 import { Switch, TouchableWithoutFeedback, View } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../base/color-scheme';
 import { translate } from '../../base/i18n';
 import { Text } from '../../base/react';
+import { connect } from '../../base/redux';
 import { updateSettings } from '../../base/settings';
 
 import styles, { SWITCH_THUMB_COLOR, SWITCH_UNDER_COLOR } from './styles';

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -8,13 +8,13 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
-import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../base/color-scheme';
 import { translate } from '../../base/i18n';
 import { Icon } from '../../base/font-icons';
 import { MEDIA_TYPE } from '../../base/media';
 import { Header, LoadingIndicator, Text } from '../../base/react';
+import { connect } from '../../base/redux';
 import { ColorPalette } from '../../base/styles';
 import {
     createDesiredLocalTracks,

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -1,10 +1,10 @@
 /* global interfaceConfig */
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { Platform, Watermarks } from '../../base/react';
+import { connect } from '../../base/redux';
 import { CalendarList } from '../../calendar-sync';
 import { RecentList } from '../../recent-list';
 import { SettingsButton, SETTINGS_TABS } from '../../settings';

--- a/react/features/welcome/components/WelcomePageLists.js
+++ b/react/features/welcome/components/WelcomePageLists.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { PagedList } from '../../base/react';
+import { connect } from '../../base/redux';
 import { CalendarList } from '../../calendar-sync';
 import { RecentList } from '../../recent-list';
 

--- a/react/features/welcome/components/WelcomePageSideBar.native.js
+++ b/react/features/welcome/components/WelcomePageSideBar.native.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react';
 import { SafeAreaView, ScrollView, Text } from 'react-native';
-import { connect } from 'react-redux';
 
 import {
     Avatar,
@@ -14,6 +13,7 @@ import {
     Header,
     SideBar
 } from '../../base/react';
+import { connect } from '../../base/redux';
 import { setSettingsViewVisible } from '../../settings';
 
 import { setSideBarVisible } from '../actions';
@@ -169,5 +169,4 @@ function _mapStateToProps(state: Object) {
     };
 }
 
-// $FlowExpectedError
 export default connect(_mapStateToProps)(WelcomePageSideBar);


### PR DESCRIPTION
Suggestion to avoid FlowFixMe annotation on the connect function.

This might seem the same solution, as we just avoid defining the types, but using this solution still lets Flow to warn for other errors in that export line.

This is just an example, if we like it, we need to replace all occurrences before merging the PR