### PR TITLE
android: fix getting permission request results

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -151,6 +151,11 @@ public class JitsiMeetActivity extends FragmentActivity
         JitsiMeetActivityDelegate.requestPermissions(this, permissions, requestCode, listener);
     }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        JitsiMeetActivityDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
     // JitsiMeetViewListener
     //
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetFragment.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetFragment.java
@@ -81,15 +81,6 @@ public class JitsiMeetFragment extends Fragment {
         JitsiMeetActivityDelegate.onHostDestroy(getActivity());
     }
 
-    // https://developer.android.com/reference/android/support/v4/app/ActivityCompat.OnRequestPermissionsResultCallback
-    @Override
-    public void onRequestPermissionsResult(
-            final int requestCode,
-            final String[] permissions,
-            final int[] grantResults) {
-        JitsiMeetActivityDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
     @Override
     public void onResume() {
         super.onResume();


### PR DESCRIPTION
Now that we have both a Fragment and an Activity there are lifecycle methods
that overlap. If a Fragment requests permission by calling requestPermissions
then the result handler will be called on itself. React Native's permissions
module, however, calls ActivityCompat.requestPermissions on the Activity, thus
we need to handle the results at the Activity level and not at the Fragment
level.