### PR TITLE
fix(ConnectionService): history and audio focus on Samsung devices

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ConnectionService.java
@@ -82,6 +82,13 @@ public class ConnectionService extends android.telecom.ConnectionService {
     }
 
     /**
+     * @return {@code true} if running a Samsung device.
+     */
+    static boolean isSamsungDevice() {
+        return android.os.Build.MANUFACTURER.toLowerCase().contains("samsung");
+    }
+
+    /**
      * Registers a start call promise.
      *
      * @param uuid - the call UUID to which the start call promise belongs to.
@@ -129,6 +136,14 @@ public class ConnectionService extends android.telecom.ConnectionService {
         ConnectionImpl connection = connections.get(callUUID);
 
         if (connection != null) {
+            if (isSamsungDevice()) {
+                // Required to release the audio focus correctly.
+                connection.setOnHold();
+                // Prevents from including in the native phone calls history
+                connection.setConnectionProperties(
+                    Connection.PROPERTY_SELF_MANAGED
+                        | Connection.PROPERTY_IS_EXTERNAL_CALL);
+            }
             // Note that the connection is not removed from the list here, but
             // in ConnectionImpl's state changed callback. It's a safer
             // approach, because in case the app would crash on the JavaScript


### PR DESCRIPTION
On some Samsung devices the call done with the ConnectionService end up in the native call history which we don't want. That's fixable by marking the Connection as "external" just before the call is disconnected.

Another issue specific to Samsung devices about the audio focus not always being release when that call ends. That's fixable by marking the call as holding just before disconnecting it.