### PR TITLE
fix(device-selection): search for device by label and kind

### DIFF
--- a/react/features/base/devices/actions.js
+++ b/react/features/base/devices/actions.js
@@ -72,7 +72,7 @@ export function configureInitialDevices() {
 
                 Object.keys(deviceLabels).forEach(key => {
                     const label = deviceLabels[key];
-                    const deviceId = getDeviceIdByLabel(state, label);
+                    const deviceId = getDeviceIdByLabel(state, label, key);
 
                     if (deviceId) {
                         newSettings[devicesKeysToSettingsKeys[key]] = deviceId;

--- a/react/features/base/devices/functions.js
+++ b/react/features/base/devices/functions.js
@@ -44,19 +44,26 @@ export function getAudioOutputDeviceId() {
  *
  * @param {Object} state - The redux state.
  * @param {string} label - The label.
+ * @param {string} kind - The type of the device. One of "audioInput",
+ * "audioOutput", and "videoInput". Also supported is all lowercase versions
+ * of the preceding types.
  * @returns {string|undefined}
  */
-export function getDeviceIdByLabel(state: Object, label: string) {
-    const types = [ 'audioInput', 'audioOutput', 'videoInput' ];
+export function getDeviceIdByLabel(state: Object, label: string, kind: string) {
+    const webrtcKindToJitsiKindTranslator = {
+        audioinput: 'audioInput',
+        audiooutput: 'audioOutput',
+        videoinput: 'videoInput'
+    };
 
-    for (const type of types) {
-        const device
-            = (state['features/base/devices'].availableDevices[type] || [])
-                .find(d => d.label === label);
+    const kindToSearch = webrtcKindToJitsiKindTranslator[kind] || kind;
 
-        if (device) {
-            return device.deviceId;
-        }
+    const device
+        = (state['features/base/devices'].availableDevices[kindToSearch] || [])
+            .find(d => d.label === label);
+
+    if (device) {
+        return device.deviceId;
     }
 }
 

--- a/react/features/device-selection/functions.js
+++ b/react/features/device-selection/functions.js
@@ -155,7 +155,9 @@ export function processExternalDeviceRequest( // eslint-disable-line max-params
         }
 
         const { label, id } = device;
-        const deviceId = label ? getDeviceIdByLabel(state, device.label) : id;
+        const deviceId = label
+            ? getDeviceIdByLabel(state, device.label, device.kind)
+            : id;
 
         if (deviceId) {
             switch (device.kind) {


### PR DESCRIPTION
Searching for a device (id) by label alone can result in
false results when devices share labels, such as a mic
and speaker having the same label. To prevent such,
specify the device kind to be found instead of iterating
over all device kinds.