### PR TITLE
rn: fix share sheet not displaying sometimes in iOS

### DIFF
--- a/react/features/share-room/middleware.js
+++ b/react/features/share-room/middleware.js
@@ -19,13 +19,19 @@ const logger = require('jitsi-meet-logger').getLogger(__filename);
  * @returns {Function}
  */
 MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+
     switch (action.type) {
     case BEGIN_SHARE_ROOM:
-        _shareRoom(action.roomURL, store);
+        // XXX This is a hack so the action sheet doesn't get automagically closed
+        // when the modal displaying the bottom sheet disappears.
+        setTimeout(() => {
+            _shareRoom(action.roomURL, store);
+        }, 250);
         break;
     }
 
-    return next(action);
+    return result;
 });
 
 /**


### PR DESCRIPTION
This is a hack, there, I said it.

When the request is processed very quickly, it's possible we try to display the
sheet over the bottom sheet's modal, but then when the modal disappears, the
controller we were using to present the share sheet disappears so it doesn't
have time to be displayed.

The fix consists of delaying the share action for a bit. How much "a bit" is
was measured using careful thought and randomness.