### PR TITLE
fix(large-video): respect update in progress when queuing update

### DIFF
--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -168,6 +168,13 @@ export default class LargeVideoManager {
     get id() {
         const container = this.getCurrentContainer();
 
+        // If a user switch for large video is in progress then provide what
+        // wil be the end result of the update.
+        if (this.updateInProcess
+            && this.newStreamData
+            && this.newStreamData.id !== container.id) {
+            return this.newStreamData.id;
+        }
 
         return container.id;
     }
@@ -184,8 +191,8 @@ export default class LargeVideoManager {
 
         // Include hide()/fadeOut only if we're switching between users
         // eslint-disable-next-line eqeqeq
-        const isUserSwitch = this.newStreamData.id != this.id;
         const container = this.getCurrentContainer();
+        const isUserSwitch = this.newStreamData.id !== container.id;
         const preUpdate = isUserSwitch ? container.hide() : Promise.resolve();
 
         preUpdate.then(() => {

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -169,7 +169,7 @@ export default class LargeVideoManager {
         const container = this.getCurrentContainer();
 
         // If a user switch for large video is in progress then provide what
-        // wil be the end result of the update.
+        // will be the end result of the update.
         if (this.updateInProcess
             && this.newStreamData
             && this.newStreamData.id !== container.id) {


### PR DESCRIPTION
When a fade in/out animation is in progress, another large
video update can be queued but can try to force itself onto
large video. For example a pin can be in progress and while
the fade in/out animation plays, local video can change its
video type during the animation and forcing an update of
large video. This results in local video getting forcible
updated onto large video while the pinned video is left on
small video only.