### PR TITLE
fix(chat): allow smiley opener to expand in width

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -219,8 +219,6 @@
 
 #smileys {
     font-size: 20pt;
-    display: inline-block;
-    height: 26px;
     margin: auto;
     cursor: pointer;
 }
@@ -232,18 +230,14 @@
 
 #smileysarea {
     background-color: $newToolbarBackgroundColor;
-    border: 0px none;
     display: flex;
-    height: 70px;
     max-height: 150px;
     min-height: 35px;
-    min-width: 31px;
-    padding: 0px;
     overflow: hidden;
-    width: 17%;
 }
 
 .smiley-input {
+    display: flex;
     position: relative;
 }
 


### PR DESCRIPTION
The chat icons are different on windows and mac, with
windows icons being bigger. By settings a specific
width on the smiley container, windows would see
part of the smiley cut off.