### PR TITLE
Avoid top of screen

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -42,7 +42,7 @@
     flex: 1;
     font-size: 10pt;
     line-height: 20px;
-    margin-top: 15px;
+    margin-top: 30px;
     overflow: auto;
     padding: 5px;
     text-align: left;
@@ -104,7 +104,7 @@
     position: absolute;
     right: 5px;
     text-align: center;
-    top: 5px;
+    top: 25px;
     width: 10px;
     z-index: 1;
 }

--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -120,7 +120,6 @@
 
 .usrmsg-form {
     flex: 1;
-    margin-left: 5px;
 }
 
 #usermsg {
@@ -131,7 +130,7 @@
     color: white;
     font-size: 10pt;
     line-height: 30px;
-    padding: 5px 5px 5px 0px;
+    padding: 5px;
     max-height:150px;
     min-height:35px;
     overflow-y: auto;

--- a/css/filmstrip/_vertical_filmstrip.scss
+++ b/css/filmstrip/_vertical_filmstrip.scss
@@ -25,7 +25,7 @@
     display: flex;
     flex-direction: column-reverse;
     height: 100%;
-    padding: 10px 5px;
+    padding: 20px 5px 10px;
     /**
      * fixed positioning is necessary for remote menus and tooltips to pop
      * out of the scrolling filmstrip. AtlasKit dialogs and tooltips use


### PR DESCRIPTION
For filmstrip and chat. Tweaked chat textarea in the process to avoid a gap in background color.

Old chat placement
![Screen Shot 2019-04-12 at 1 56 53 PM](https://user-images.githubusercontent.com/1243084/56065998-4ee33200-5d2b-11e9-92d0-314ff3745571.png)

New chat placement without text
![Screen Shot 2019-04-12 at 1 50 30 PM](https://user-images.githubusercontent.com/1243084/56065798-bba9fc80-5d2a-11e9-97b1-82ab96f6d913.png)

New chat placement with text
![Screen Shot 2019-04-12 at 1 50 37 PM](https://user-images.githubusercontent.com/1243084/56065808-c06eb080-5d2a-11e9-882b-eb36b4b54779.png)

Old filmstrip top
![Screen Shot 2019-04-12 at 1 55 04 PM](https://user-images.githubusercontent.com/1243084/56065816-c795be80-5d2a-11e9-9653-1f228dca5735.png)

New filmstrip top
![Screen Shot 2019-04-12 at 1 55 14 PM](https://user-images.githubusercontent.com/1243084/56065828-ce243600-5d2a-11e9-9f7b-357ddda12714.png)

Old textarea
![Screen Shot 2019-04-12 at 1 57 47 PM](https://user-images.githubusercontent.com/1243084/56065892-fca21100-5d2a-11e9-9ff6-eacc8df715df.png)

New textarea
![Screen Shot 2019-04-12 at 1 57 52 PM](https://user-images.githubusercontent.com/1243084/56065895-01ff5b80-5d2b-11e9-9ad2-7a8da729295b.png)
