### PR TITLE
ios: make sure symbols are uploaded to TestFlight

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :ios do
     build_app(
         scheme: "jitsi-meet",
         include_bitcode: false,
+        include_symbols: true,
         export_xcargs: "-allowProvisioningUpdates"
     )
 


### PR DESCRIPTION
While that option should default to true, let's be explicit about it.