### PR TITLE
fix(toolbar): let click through gradient

### DIFF
--- a/css/_subject.scss
+++ b/css/_subject.scss
@@ -3,6 +3,7 @@
     transition: top .3s ease-in;
     height: 95px;
     width: 100%;
+    pointer-events: none;
     position: absolute;
     padding: 25px 140px 0 140px;
     text-align: center;

--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -48,6 +48,7 @@
         height: 160px;
         width: 100%;
         bottom: -160px;
+        pointer-events: none;
         position: absolute;
         z-index: $toolbarBackgroundZ;
     }


### PR DESCRIPTION
Otherwise it can eat clicks on elements it is above,
like YouTube and Etherpad controls.