### PR TITLE
ios: remove no longer needed code

### DIFF
--- a/ios/sdk/src/callkit/JMCallKitProxy.swift
+++ b/ios/sdk/src/callkit/JMCallKitProxy.swift
@@ -156,14 +156,6 @@ import Foundation
             completion: @escaping (Error?) -> Swift.Void) {
         guard enabled else { return }
 
-        // XXX keep track of muted actions to avoid "ping-pong"ing. See
-        // JMCallKitEmitter for details on the CXSetMutedCallAction handling.
-        for action in transaction.actions {
-            if (action as? CXSetMutedCallAction) != nil {
-                emitter.addMuteAction(action.uuid)
-            }
-        }
-
         callController.request(transaction, completion: completion)
     }
 
@@ -191,4 +183,3 @@ import Foundation
         return update
     }
 }
-


### PR DESCRIPTION
Ever since we switched to handling track events instead of mute actions this has
been dead code. It was also added in the wrong place, since it's responsibility
of the JS code to solve the ping-pong problem.