### PR TITLE
rn: ensure the conference terminated event is always sent

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -5,6 +5,9 @@ import {
     sendAnalytics
 } from '../../analytics';
 import { getName } from '../../app';
+import { endpointMessageReceived } from '../../subtitles';
+
+import { JITSI_CONNECTION_CONFERENCE_KEY } from '../connection';
 import { JitsiConferenceEvents } from '../lib-jitsi-meet';
 import { setAudioMuted, setVideoMuted } from '../media';
 import {
@@ -15,7 +18,6 @@ import {
     participantRoleChanged,
     participantUpdated
 } from '../participants';
-import { endpointMessageReceived } from '../../subtitles';
 import { getLocalTracks, trackAdded, trackRemoved } from '../tracks';
 import { getJitsiMeetGlobalNS } from '../util';
 
@@ -378,7 +380,10 @@ export function createConference() {
                     getWiFiStatsMethod: getJitsiMeetGlobalNS().getWiFiStats
                 });
 
+        connection[JITSI_CONNECTION_CONFERENCE_KEY] = conference;
+
         conference[JITSI_CONFERENCE_URL_KEY] = locationURL;
+
         dispatch(_conferenceWillJoin(conference));
 
         _addConferenceListeners(conference, dispatch);

--- a/react/features/base/connection/constants.js
+++ b/react/features/base/connection/constants.js
@@ -1,0 +1,19 @@
+// @flow
+
+/**
+ * The name of the {@code JitsiConnection} property which identifies the {@code JitsiConference} currently associated
+ * with it.
+ *
+ * FIXME: This is a hack. It was introduced to solve the following case: if a user presses hangup quickly, they may
+ * "leave the conference" before the actual conference was ever created. While we might have a connection in place,
+ * there is no conference which can be left, thus no CONFERENCE_LEFT action will ever be fired.
+ *
+ * This is problematic because the external API module used to send events to the native SDK won't know what to send.
+ * So, in order to detect this situation we are attaching the conference object to the connection which runs it.
+ */
+export const JITSI_CONNECTION_CONFERENCE_KEY = Symbol('conference');
+
+/**
+ * The name of the {@code JitsiConnection} property which identifies the location URL where the connection will be made.
+ */
+export const JITSI_CONNECTION_URL_KEY = Symbol('url');

--- a/react/features/base/connection/index.js
+++ b/react/features/base/connection/index.js
@@ -2,6 +2,7 @@
 
 export * from './actions';
 export * from './actionTypes';
+export * from './constants';
 export * from './functions';
 
 import './reducer';

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -199,7 +199,7 @@ class Conference extends AbstractConference<Props, *> {
         } = this.props;
 
         // If the location URL changes we need to reconnect.
-        oldLocationURL !== newLocationURL && this.props._onDisconnect();
+        oldLocationURL !== newLocationURL && newRoom && this.props._onDisconnect();
 
         // Start the connection process when there is a (valid) room.
         oldRoom !== newRoom && newRoom && this.props._onConnect();


### PR DESCRIPTION
Dear reader, I';m not proud at all of what you are about to read, but sometimes
life just gives you lemons, so enjoy some lemonade!

Joining a conference implies first creating the XMPP connection and then joining
the MUC. It's very possible the XMPP connection was made but there was no chance
for the conference to be created.

This patch fixes this case by artificially genrating a conference terminated
event in such case. In order to have all the necessary knowledge for this event
to be sent the connection now keeps track of the conference that runs it.

In addition, there is an even more obscure corner case: it's not impossible to
try to disconnect when there is not even a connection. This was fixed by
creating a fake disconnect event. Alas the location URL is lost at this point,
but it's better than nothing I guess.