### PR TITLE
fix(modal): override height style to avoid scrollbar

### DIFF
--- a/css/_atlaskit_overrides.scss
+++ b/css/_atlaskit_overrides.scss
@@ -48,3 +48,11 @@
 .toolbox-button-wth-dialog .eYJELv {
     max-height: initial;
 }
+
+/**
+ * @atlaskit/modal-dialog has a flexbox hack to support IE11 appearance, but
+ * this hack is causing scrollbars to display on Chrome 74.
+ */
+.csUVob {
+    max-height: 100% !important;
+}


### PR DESCRIPTION
Use a style override over upgrading the modal-dialog
package with the assumption that usage of the package
will cease soon-ish.