### PR TITLE
fix(chat): save chat error messages into redux

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -438,8 +438,8 @@ class ConferenceConnector {
                     hasRead: true,
                     error: code,
                     message: msg,
-                    timestamp: Date.now(),
-                    type: 'error'
+                    messageType: 'error',
+                    timestamp: Date.now()
                 }));
             }
             break;


### PR DESCRIPTION
The proper field name is "messageType",
not "type." Also using "type" would
override the actionType.