### PR TITLE
fix(welcome-page): remove watermark container to avoid z-index wars

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -162,10 +162,4 @@ body.welcome-page {
             font-size: 32px;
         }
     }
-
-    .welcome-watermark {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-    }
 }

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -119,9 +119,7 @@ class WelcomePage extends AbstractWelcomePage {
                 className = { `welcome ${showAdditionalContent
                     ? 'with-content' : 'without-content'}` }
                 id = 'welcome_page'>
-                <div className = 'welcome-watermark'>
-                    <Watermarks />
-                </div>
+                <Watermarks />
                 <div className = 'header'>
                     <div className = 'welcome-page-settings'>
                         <SettingsButton


### PR DESCRIPTION
By making the container 100% height and position relative, that
would cause it to overlap any static-positioned  elements below it.
The 100% makes it so that any watermarks intended for the bottom
of the page show up on the bottom of the page. However, it's not
needed because watermark stylings already try to position the
watermarks at the bottom.