### PR TITLE
android fix: do not enter PiP mode when the permissions alert is shown

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
@@ -41,6 +41,15 @@ public class JitsiMeetActivityDelegate {
     private static Callback permissionsCallback;
 
     /**
+     * Tells whether or not the permissions request is currently in progress.
+     *
+     * @return {@code true} if the permssions are being requested or {@code false} otherwise.
+     */
+    static boolean arePermissionsBeingRequested() {
+        return permissionListener != null;
+    }
+
+    /**
      * {@link Activity} lifecycle method which should be called from
      * {@code Activity#onActivityResult} so we are notified about results of external intents
      * started/finished.

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -123,6 +123,7 @@ public class JitsiMeetView extends BaseReactView<JitsiMeetViewListener> {
                 PictureInPictureModule.class);
         if (pipModule != null
                 && PictureInPictureModule.isPictureInPictureSupported()
+                && !JitsiMeetActivityDelegate.arePermissionsBeingRequested()
                 && this.url != null) {
             try {
                 pipModule.enterPictureInPicture();


### PR DESCRIPTION
Entering PiP mode while the permissions dialog is display will not only fail, but also mess up the Activity lifecycle on some OS versions. We may end up with two activity/fragment instances and a situation where the onStop callback was not called yet on the instance #1 while the onResume has been already called on instance #2.