### PR TITLE
ref(chat): bring in package for text area auto-resizing

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -133,8 +133,6 @@
     font-size: 15px;
     line-height: 30px;
     padding: 5px;
-    max-height:150px;
-    min-height:35px;
     overflow-y: auto;
     resize: none;
     width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2840,7 +2840,7 @@
         "blueimp-md5": "^2.10.0",
         "json3": "^3.3.2",
         "lodash": "^4.17.4",
-        "ua-parser-js": "github:amplitude/ua-parser-js#ed538f1"
+        "ua-parser-js": "github:amplitude/ua-parser-js#ed538f16f5c6ecd8357da989b617d4f156dcf35d"
       },
       "dependencies": {
         "ua-parser-js": {
@@ -6750,8 +6750,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6769,13 +6768,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6788,18 +6785,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6902,8 +6896,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6913,7 +6906,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6926,20 +6918,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6956,7 +6945,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7029,8 +7017,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7040,7 +7027,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7116,8 +7102,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7147,7 +7132,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7165,7 +7149,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7204,13 +7187,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -12396,6 +12377,15 @@
       "integrity": "sha512-ZShCKvt4bxxhqngaegHsZuoTIUDt4QOHd0saJ/cfJAu0LwCOoRaQfRZe9UPT/bpDE944u/GhuTWBmGaW9YER7Q==",
       "requires": {
         "exenv": "^1.2.2"
+      }
+    },
+    "react-textarea-autosize": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz",
+      "integrity": "sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "prop-types": "^15.6.0"
       }
     },
     "react-transform-hmr": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-native-webrtc": "github:jitsi/react-native-webrtc#4064c6f2db4f8b961daaaa8dafc6a896d7cfbc43",
     "react-native-webview": "5.8.1",
     "react-redux": "5.0.7",
+    "react-textarea-autosize": "7.1.0",
     "react-transition-group": "2.4.0",
     "redux": "4.0.0",
     "redux-thunk": "2.2.0",

--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -47,6 +47,9 @@ class Chat extends AbstractChat<Props> {
 
         // Bind event handlers so they are only bound once for every instance.
         this._renderPanelContent = this._renderPanelContent.bind(this);
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onChatInputResize = this._onChatInputResize.bind(this);
     }
 
     /**
@@ -87,6 +90,19 @@ class Chat extends AbstractChat<Props> {
         );
     }
 
+    _onChatInputResize: () => void;
+
+    /**
+     * Callback invoked when {@code ChatInput} changes height. Preserves
+     * displaying the latest message if it is scrolled to.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onChatInputResize() {
+        this._messageContainerRef.current.maybeUpdateBottomScroll();
+    }
+
     /**
      * Returns a React Element for showing chat messages and a form to send new
      * chat messages.
@@ -100,7 +116,7 @@ class Chat extends AbstractChat<Props> {
                 <MessageContainer
                     messages = { this.props._messages }
                     ref = { this._messageContainerRef } />
-                <ChatInput />
+                <ChatInput onResize = { this._onChatInputResize } />
             </>
         );
     }

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -23,6 +23,12 @@ type Props = {
     dispatch: Dispatch<any>,
 
     /**
+     * Optional callback to invoke when the chat textarea has auto-resized to
+     * fit overflowing text.
+     */
+    onResize: ?Function,
+
+    /**
      * Invoked to obtain translated strings.
      */
     t: Function
@@ -120,6 +126,7 @@ class ChatInput extends Component<Props, State> {
                         inputRef = { this._setTextAreaRef }
                         maxRows = { 5 }
                         onChange = { this._onMessageChange }
+                        onHeightChange = { this.props.onResize }
                         onKeyDown = { this._onDetectSubmit }
                         placeholder = { this.props.t('chat.messagebox') }
                         value = { this.state.message } />

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -22,11 +22,6 @@ type Props = {
     dispatch: Dispatch<any>,
 
     /**
-     * Optional callback to get a reference to the chat input element.
-     */
-    getChatInputRef?: Function,
-
-    /**
      * Invoked to obtain translated strings.
      */
     t: Function
@@ -223,10 +218,6 @@ class ChatInput extends Component<Props, State> {
      */
     _setTextAreaRef(textAreaElement: ?HTMLTextAreaElement) {
         this._textArea = textAreaElement;
-
-        if (this.props.getChatInputRef) {
-            this.props.getChatInputRef(textAreaElement);
-        }
     }
 }
 

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -119,7 +119,6 @@ class ChatInput extends Component<Props, State> {
                         id = 'usermsg'
                         inputRef = { this._setTextAreaRef }
                         maxRows = { 5 }
-                        minRows = { 2 }
                         onChange = { this._onMessageChange }
                         onKeyDown = { this._onDetectSubmit }
                         placeholder = { this.props.t('chat.messagebox') }

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import Emoji from 'react-emoji-render';
+import TextareaAutosize from 'react-textarea-autosize';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
@@ -114,12 +115,14 @@ class ChatInput extends Component<Props, State> {
                     </div>
                 </div>
                 <div className = 'usrmsg-form'>
-                    <textarea
+                    <TextareaAutosize
                         id = 'usermsg'
+                        inputRef = { this._setTextAreaRef }
+                        maxRows = { 5 }
+                        minRows = { 2 }
                         onChange = { this._onMessageChange }
                         onKeyDown = { this._onDetectSubmit }
                         placeholder = { this.props.t('chat.messagebox') }
-                        ref = { this._setTextAreaRef }
                         value = { this.state.message } />
                 </div>
             </div>

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -90,7 +90,7 @@ class ChatInput extends Component<Props, State> {
          * HTML Textareas do not support autofocus. Simulate autofocus by
          * manually focusing.
          */
-        this.focus();
+        this._focus();
     }
 
     /**
@@ -132,20 +132,12 @@ class ChatInput extends Component<Props, State> {
     }
 
     /**
-     * Removes cursor focus on this component's text area.
-     *
-     * @returns {void}
-     */
-    blur() {
-        this._textArea && this._textArea.blur();
-    }
-
-    /**
      * Place cursor focus on this component's text area.
      *
+     * @private
      * @returns {void}
      */
-    focus() {
+    _focus() {
         this._textArea && this._textArea.focus();
     }
 
@@ -203,7 +195,7 @@ class ChatInput extends Component<Props, State> {
             showSmileysPanel: false
         });
 
-        this.focus();
+        this._focus();
     }
 
     _onToggleSmileysPanel: () => void;
@@ -217,7 +209,7 @@ class ChatInput extends Component<Props, State> {
     _onToggleSmileysPanel() {
         this.setState({ showSmileysPanel: !this.state.showSmileysPanel });
 
-        this.focus();
+        this._focus();
     }
 
     _setTextAreaRef: (?HTMLTextAreaElement) => void;

--- a/react/features/chat/components/web/MessageContainer.js
+++ b/react/features/chat/components/web/MessageContainer.js
@@ -14,10 +14,23 @@ import ChatMessageGroup from './ChatMessageGroup';
  */
 export default class MessageContainer extends AbstractMessageContainer {
     /**
+     * Whether or not chat has been scrolled to the bottom of the screen. Used
+     * to determine if chat should be scrolled automatically to the bottom when
+     * the {@code ChatInput} resizes.
+     */
+    _isScrolledToBottom: boolean;
+
+    /**
      * Reference to the HTML element at the end of the list of displayed chat
      * messages. Used for scrolling to the end of the chat messages.
      */
     _messagesListEndRef: Object;
+
+    /**
+     * A React ref to the HTML element containing all {@code ChatMessageGroup}
+     * instances.
+     */
+    _messageListRef: Object;
 
     /**
      * Initializes a new {@code MessageContainer} instance.
@@ -28,7 +41,12 @@ export default class MessageContainer extends AbstractMessageContainer {
     constructor(props: Props) {
         super(props);
 
+        this._isScrolledToBottom = true;
+
+        this._messageListRef = React.createRef();
         this._messagesListEndRef = React.createRef();
+
+        this._onChatScroll = this._onChatScroll.bind(this);
     }
 
     /**
@@ -50,11 +68,27 @@ export default class MessageContainer extends AbstractMessageContainer {
         });
 
         return (
-            <div id = 'chatconversation'>
+            <div
+                id = 'chatconversation'
+                onScroll = { this._onChatScroll }
+                ref = { this._messageListRef }>
                 { messages }
                 <div ref = { this._messagesListEndRef } />
             </div>
         );
+    }
+
+    /**
+     * Scrolls to the bottom again if the instance had previously been scrolled
+     * to the bottom. This method is used when a resize has occurred below the
+     * instance and bottom scroll needs to be maintained.
+     *
+     * @returns {void}
+     */
+    maybeUpdateBottomScroll() {
+        if (this._isScrolledToBottom) {
+            this.scrollToBottom(false);
+        }
     }
 
     /**
@@ -71,4 +105,19 @@ export default class MessageContainer extends AbstractMessageContainer {
     }
 
     _getMessagesGroupedBySender: () => Array<Array<Object>>;
+
+    _onChatScroll: () => void;
+
+    /**
+     * Callback invoked to listen to the current scroll location.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onChatScroll() {
+        const element = this._messageListRef.current;
+
+        this._isScrolledToBottom
+            = element.scrollHeight - element.scrollTop === element.clientHeight;
+    }
 }


### PR DESCRIPTION
I got lazy and decided not to roll my own implementation. I think it was a good idea considering how easy it was to integrate to the package "react-textarea-autosize."
![May-07-2019 15-44-49](https://user-images.githubusercontent.com/1243084/57337679-3f16fd80-70df-11e9-9429-fc051378fb0a.gif)
