### PR TITLE
ios: fix CallKit crash in development mode

### DIFF
--- a/ios/sdk/src/callkit/CallKit.m
+++ b/ios/sdk/src/callkit/CallKit.m
@@ -324,4 +324,14 @@ RCT_EXPORT_METHOD(updateCall:(NSString *)callUUID
 
 #endif
 
+// The bridge might already be invalidated by the time a CallKit event is processed,
+// just ignore it and don't emit it.
+- (void)sendEventWithName:(NSString *)name body:(id)body {
+    if (!self.bridge) {
+        return;
+    }
+
+    [super sendEventWithName:name body:body];
+}
+
 @end


### PR DESCRIPTION
It's possible a CallKit event arrives when the React Bridge has been torn down
and there is an assert that checks this. In order to avoid a crash, just skip
the event.