### PR TITLE
fix(chat): ensure really long words can trigger wrapping

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -173,8 +173,10 @@
 .chatmessage {
     background-color: $chatRemoteMessageBackgroundColor;
     border-radius: 0px 6px 6px 6px;
-    margin-top: 3px;
+    box-sizing: border-box;
     color: white;
+    margin-top: 3px;
+    max-width: 100%;
     padding-bottom: 3px;
     position: relative;
 

--- a/react/features/chat/components/web/ChatMessageGroup.js
+++ b/react/features/chat/components/web/ChatMessageGroup.js
@@ -49,12 +49,11 @@ class ChatMessageGroup extends Component<Props> {
             <div className = { `chat-message-group ${className}` }>
                 {
                     messages.map((message, i) => (
-                        <div key = { i }>
-                            <ChatMessage
-                                key = { i }
-                                message = { message }
-                                showDisplayName = { i === 0 } />
-                        </div>))
+                        <ChatMessage
+                            key = { i }
+                            message = { message }
+                            showDisplayName = { i === 0 } />
+                    ))
                 }
                 <div className = 'chat-message-group-footer'>
                     { getLocalizedDateFormatter(


### PR DESCRIPTION
before:
<img width="374" alt="before" src="https://user-images.githubusercontent.com/1243084/57464283-4817e400-7231-11e9-8351-1f762547df6b.png">

after:
<img width="374" alt="after" src="https://user-images.githubusercontent.com/1243084/57464290-4b12d480-7231-11e9-89fd-3a0d7c63b10f.png">
