### PR TITLE
Revert "fix(welcome-page): remove watermark container to avoid z-inde…

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -162,4 +162,10 @@ body.welcome-page {
             font-size: 32px;
         }
     }
+
+    .welcome-watermark {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+    }
 }

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -119,7 +119,9 @@ class WelcomePage extends AbstractWelcomePage {
                 className = { `welcome ${showAdditionalContent
                     ? 'with-content' : 'without-content'}` }
                 id = 'welcome_page'>
-                <Watermarks />
+                <div className = 'welcome-watermark'>
+                    <Watermarks />
+                </div>
                 <div className = 'header'>
                     <div className = 'welcome-page-settings'>
                         <SettingsButton


### PR DESCRIPTION
…x wars"

This reverts commit 890151fa725f713dadc7be2079a8ec1762af8a94.

The change makes the welcome page without content display lower. With the way the watermarks component is build, for now reverting this change is easier for me.