### PR TITLE
android: fix publishing new async storage package

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     implementation project(':react-native-background-timer')
     implementation project(':react-native-calendar-events')
+    implementation project(':react-native-community-async-storage')
     implementation(project(':react-native-fast-image')) {
         exclude group: 'com.android.support'
     }
@@ -63,7 +64,6 @@ dependencies {
     implementation project(':react-native-vector-icons')
     implementation project(':react-native-webrtc')
     implementation project(':react-native-webview')
-    implementation project(':@react-native-community_async-storage')
 
     testImplementation 'junit:junit:4.12'
 }
@@ -207,8 +207,7 @@ publishing {
                     def groupId = it.moduleGroup
                     def artifactId = it.moduleName
 
-                    if ((artifactId.startsWith('react-native-') || artifactId.startsWith('@react-native-community'))
-                            && groupId.equals('jitsi-meet')) {
+                    if (artifactId.startsWith('react-native-') && groupId.equals('jitsi-meet')) {
                         groupId = rootProject.ext.moduleGroupId
                     }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,6 +5,8 @@ include ':react-native-background-timer'
 project(':react-native-background-timer').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-background-timer/android')
 include ':react-native-calendar-events'
 project(':react-native-calendar-events').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-calendar-events/android')
+include ':react-native-community-async-storage'
+project(':react-native-community-async-storage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/async-storage/android')
 include ':react-native-fast-image'
 project(':react-native-fast-image').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fast-image/android')
 include ':react-native-google-signin'
@@ -23,5 +25,3 @@ include ':react-native-webrtc'
 project(':react-native-webrtc').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webrtc/android')
 include ':react-native-webview'
 project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
-include ':@react-native-community_async-storage'
-project(':@react-native-community_async-storage').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/async-storage/android')


### PR DESCRIPTION
The naming didn't match, so adjust it. @ cannot be used for maven artifact
names.