### PR TITLE
fix(api): enable the external api before the first redux update

### DIFF
--- a/react/features/base/app/actions.js
+++ b/react/features/base/app/actions.js
@@ -17,11 +17,6 @@ declare var APP;
  */
 export function appWillMount(app: Object) {
     return (dispatch: Dispatch<any>) => {
-        dispatch({
-            type: APP_WILL_MOUNT,
-            app
-        });
-
         // TODO There was a redux action creator appInit which I did not like
         // because we already had the redux action creator appWillMount and,
         // respectively, the redux action APP_WILL_MOUNT. So I set out to remove
@@ -30,6 +25,11 @@ export function appWillMount(app: Object) {
         // API module into its own feature yet so we're bound to work on that in
         // the future.
         typeof APP === 'object' && APP.API.init();
+
+        dispatch({
+            type: APP_WILL_MOUNT,
+            app
+        });
     };
 }
 


### PR DESCRIPTION
For the external api to fire update events out of the iframe, it
must first be initialized within the jitsi app. Any invocations
by the app to send updates events before initialization will
cause the api to swallow the events. The chosen fix is to
initialize the api earlier so the first update of app's redux
store fires update events that the api will also fire out of
the iframe.

This change will affect current behavior in that right now
the update event of the initial set of the avatar url is
blocked, but the change will make that event fire out of the
iframe.