### PR TITLE
rn: fix losing audio if call is hangup too quickly

### DIFF
--- a/ios/app/src/ViewController.m
+++ b/ios/app/src/ViewController.m
@@ -42,11 +42,11 @@
 
 - (void)_onJitsiMeetViewDelegateEvent:(NSString *)name
                              withData:(NSDictionary *)data {
-#if DEBUG
     NSLog(
         @"[%s:%d] JitsiMeetViewDelegate %@ %@",
         __FILE__, __LINE__, name, data);
 
+#if DEBUG
     NSAssert(
         [NSThread isMainThread],
         @"JitsiMeetViewDelegate %@ method invoked on a non-main thread",

--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -81,16 +81,23 @@ export function appNavigate(uri: ?string) {
 
         let config;
 
-        try {
-            config = await loadConfig(url);
-            dispatch(storeConfig(baseURL, config));
-        } catch (error) {
+        // Avoid (re)loading the config when there is no room.
+        if (!room) {
             config = restoreConfig(baseURL);
+        }
 
-            if (!config) {
-                dispatch(loadConfigError(error, locationURL));
+        if (!config) {
+            try {
+                config = await loadConfig(url);
+                dispatch(storeConfig(baseURL, config));
+            } catch (error) {
+                config = restoreConfig(baseURL);
 
-                return;
+                if (!config) {
+                    dispatch(loadConfigError(error, locationURL));
+
+                    return;
+                }
             }
         }
 

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -370,10 +370,7 @@ export function disconnect() {
         if (connection_) {
             promise = promise.then(() => connection_.disconnect());
         } else {
-            // FIXME: We have no connection! Fake a disconnect. Because of how the current disconnec is implemented
-            // (by doing the diconnect() in the Conference component unmount) we have lost the location URL already.
-            // Oh well, at least send the event.
-            promise.then(() => dispatch(_connectionDisconnected({}, '')));
+            logger.info('No connection found while disconnecting.');
         }
 
         return promise;

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -5,7 +5,6 @@ import React from 'react';
 import { BackHandler, SafeAreaView, StatusBar, View } from 'react-native';
 
 import { appNavigate } from '../../../app';
-import { connect, disconnect } from '../../../base/connection';
 import { getParticipantCount } from '../../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../../base/react';
 import { connect as reactReduxConnect } from '../../../base/redux';
@@ -14,7 +13,6 @@ import {
     makeAspectRatioAware
 } from '../../../base/responsive-ui';
 import { TestConnectionInfo } from '../../../base/testing';
-import { createDesiredLocalTracks } from '../../../base/tracks';
 import { ConferenceNotification } from '../../../calendar-sync';
 import { Chat } from '../../../chat';
 import { DisplayNameLabel } from '../../../display-name';
@@ -65,29 +63,6 @@ type Props = AbstractProps & {
      * The ID of the participant currently on stage (if any)
      */
     _largeVideoParticipantId: string,
-
-    /**
-     * Current conference's full URL.
-     *
-     * @private
-     */
-    _locationURL: URL,
-
-    /**
-     * The handler which dispatches the (redux) action connect.
-     *
-     * @private
-     * @returns {void}
-     */
-    _onConnect: Function,
-
-    /**
-     * The handler which dispatches the (redux) action disconnect.
-     *
-     * @private
-     * @returns {void}
-     */
-    _onDisconnect: Function,
 
     /**
      * Handles a hardware button press for back navigation. Leaves the
@@ -166,8 +141,6 @@ class Conference extends AbstractConference<Props, *> {
      * @returns {void}
      */
     componentDidMount() {
-        this.props._onConnect();
-
         BackHandler.addEventListener(
             'hardwareBackPress',
             this.props._onHardwareBackPress);
@@ -184,25 +157,15 @@ class Conference extends AbstractConference<Props, *> {
      *
      * @inheritdoc
      */
-    componentDidUpdate(pevProps: Props) {
+    componentDidUpdate(prevProps: Props) {
         const {
-            _locationURL: oldLocationURL,
-            _participantCount: oldParticipantCount,
-            _room: oldRoom
-        } = pevProps;
+            _participantCount: oldParticipantCount
+        } = prevProps;
         const {
-            _locationURL: newLocationURL,
             _participantCount: newParticipantCount,
-            _room: newRoom,
             _setToolboxVisible,
             _toolboxVisible
         } = this.props;
-
-        // If the location URL changes we need to reconnect.
-        oldLocationURL !== newLocationURL && newRoom && this.props._onDisconnect();
-
-        // Start the connection process when there is a (valid) room.
-        oldRoom !== newRoom && newRoom && this.props._onConnect();
 
         if (oldParticipantCount === 1
                 && newParticipantCount > 1
@@ -228,8 +191,6 @@ class Conference extends AbstractConference<Props, *> {
         BackHandler.removeEventListener(
             'hardwareBackPress',
             this.props._onHardwareBackPress);
-
-        this.props._onDisconnect();
     }
 
     /**
@@ -396,36 +357,12 @@ class Conference extends AbstractConference<Props, *> {
  * @param {Function} dispatch - Redux action dispatcher.
  * @private
  * @returns {{
- *     _onConnect: Function,
- *     _onDisconnect: Function,
  *     _onHardwareBackPress: Function,
  *     _setToolboxVisible: Function
  * }}
  */
 function _mapDispatchToProps(dispatch) {
     return {
-        /**
-         * Dispatches actions to create the desired local tracks and for
-         * connecting to the conference.
-         *
-         * @private
-         * @returns {void}
-         */
-        _onConnect() {
-            dispatch(createDesiredLocalTracks());
-            dispatch(connect());
-        },
-
-        /**
-         * Dispatches an action disconnecting from the conference.
-         *
-         * @private
-         * @returns {void}
-         */
-        _onDisconnect() {
-            dispatch(disconnect());
-        },
-
         /**
          * Handles a hardware button press for back navigation. Leaves the
          * associated {@code Conference}.
@@ -462,8 +399,7 @@ function _mapDispatchToProps(dispatch) {
  * @returns {Props}
  */
 function _mapStateToProps(state) {
-    const { connecting, connection, locationURL }
-        = state['features/base/connection'];
+    const { connecting, connection } = state['features/base/connection'];
     const {
         conference,
         joining,
@@ -507,14 +443,6 @@ function _mapStateToProps(state) {
          * The ID of the participant currently on stage.
          */
         _largeVideoParticipantId: state['features/large-video'].participantId,
-
-        /**
-         * Current conference's full URL.
-         *
-         * @private
-         * @type {URL}
-         */
-        _locationURL: locationURL,
 
         /**
          * The number of participants in the conference.

--- a/react/features/toolbox/components/HangupButton.js
+++ b/react/features/toolbox/components/HangupButton.js
@@ -1,5 +1,6 @@
 // @flow
 
+import _ from 'lodash';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { appNavigate } from '../../app';
@@ -26,9 +27,32 @@ type Props = AbstractButtonProps & {
  * @extends AbstractHangupButton
  */
 class HangupButton extends AbstractHangupButton<Props, *> {
+    _hangup: Function;
+
     accessibilityLabel = 'toolbar.accessibilityLabel.hangup';
     label = 'toolbar.hangup';
     tooltip = 'toolbar.hangup';
+
+    /**
+     * Initializes a new HangupButton instance.
+     *
+     * @param {Props} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props: Props) {
+        super(props);
+
+        this._hangup = _.once(() => {
+            sendAnalytics(createToolbarEvent('hangup'));
+
+            // FIXME: these should be unified.
+            if (navigator.product === 'ReactNative') {
+                this.props.dispatch(appNavigate(undefined));
+            } else {
+                this.props.dispatch(disconnect(true));
+            }
+        });
+    }
 
     /**
      * Helper function to perform the actual hangup action.
@@ -38,14 +62,7 @@ class HangupButton extends AbstractHangupButton<Props, *> {
      * @returns {void}
      */
     _doHangup() {
-        sendAnalytics(createToolbarEvent('hangup'));
-
-        // FIXME: these should be unified.
-        if (navigator.product === 'ReactNative') {
-            this.props.dispatch(appNavigate(undefined));
-        } else {
-            this.props.dispatch(disconnect(true));
-        }
+        this._hangup();
     }
 }
 


### PR DESCRIPTION
    This PR changes the logic for connecting / disconnecting conferences. Instead of
    doing it in mount / unmount events from the Conference component, it moves the
    logic to the appNavigatee action.

    This fixes a regression introduced in 774c5ecd when trying to make sure the
    conference terminated event is always sent.

    By moving the logic to appNavigate we no longer depend on side-effects for
    connecting / disconnecting, and the code should be more maintainable moving
    forward.

    An improvement to this is the concept of sessions, which, while not tackled
    here, was taken into consideration.

