### PR TITLE
rn: don't tag builds by default

### DIFF
--- a/android/scripts/release-sdk.sh
+++ b/android/scripts/release-sdk.sh
@@ -10,6 +10,7 @@ MVN_HTTP=0
 DEFAULT_SDK_VERSION=$(grep sdkVersion ${THIS_DIR}/../gradle.properties | cut -d"=" -f2)
 SDK_VERSION=${OVERRIDE_SDK_VERSION:-${DEFAULT_SDK_VERSION}}
 RN_VERSION=$(jq -r '.dependencies."react-native"' ${THIS_DIR}/../../package.json)
+DO_GIT_TAG=${GIT_TAG:-0}
 
 if [[ $THE_MVN_REPO == http* ]]; then
     MVN_HTTP=1
@@ -64,13 +65,11 @@ pushd ${THIS_DIR}/../
 ./gradlew clean assembleRelease publish
 popd
 
-if [[ $MVN_HTTP == 0 ]]; then
+if [[ $DO_GIT_TAG == 1 ]]; then
     # The artifacts are now on the Maven repo, commit them
     pushd ${MVN_REPO_PATH}
-    if [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" == "true" ]]; then
-        git add -A .
-        git commit -m "Jitsi Meet SDK + dependencies: ${SDK_VERSION}"
-    fi
+    git add -A .
+    git commit -m "Jitsi Meet SDK + dependencies: ${SDK_VERSION}"
     popd
 
     # Tag the release

--- a/ios/scripts/release-sdk.sh
+++ b/ios/scripts/release-sdk.sh
@@ -7,6 +7,7 @@ PROJECT_REPO=$(realpath ${THIS_DIR}/../..)
 RELEASE_REPO=$(realpath ${THIS_DIR}/../../../jitsi-meet-ios-sdk-releases)
 DEFAULT_SDK_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" ${THIS_DIR}/../sdk/src/Info.plist)
 SDK_VERSION=${OVERRIDE_SDK_VERSION:-${DEFAULT_SDK_VERSION}}
+DO_GIT_TAG=${GIT_TAG:-0}
 
 
 echo "Releasing Jitsi Meet SDK ${SDK_VERSION}"
@@ -25,7 +26,9 @@ popd
 pushd ${PROJECT_REPO}
 rm -rf ios/sdk/JitsiMeet.framework
 xcodebuild -workspace ios/jitsi-meet.xcworkspace -scheme JitsiMeet -destination='generic/platform=iOS' -configuration Release archive
-git tag ios-sdk-${SDK_VERSION}
+if [[ $DO_GIT_TAG == 1 ]]; then
+    git tag ios-sdk-${SDK_VERSION}
+fi
 popd
 
 pushd ${RELEASE_REPO}
@@ -39,9 +42,11 @@ xcrun bitcode_strip -r Frameworks/JitsiMeet.framework/JitsiMeet -o Frameworks/Ji
 xcrun bitcode_strip -r Frameworks/WebRTC.framework/WebRTC -o Frameworks/WebRTC.framework/WebRTC
 
 # Add all files to git
-git add -A .
-git commit -m "${SDK_VERSION}"
-git tag ${SDK_VERSION}
+if [[ $DO_GIT_TAG == 1 ]]; then
+    git add -A .
+    git commit -m "${SDK_VERSION}"
+    git tag ${SDK_VERSION}
+fi
 
 popd
 


### PR DESCRIPTION
People run these in their own checkout and will run into problems because
tagging will fail.