### PR TITLE
fix(large-video): clear remote video stream on track removal

### DIFF
--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -296,12 +296,6 @@ UI.addLocalStream = track => {
 };
 
 /**
- * Removed remote stream from UI.
- * @param {JitsiTrack} track stream to remove
- */
-UI.removeRemoteStream = track => VideoLayout.onRemoteStreamRemoved(track);
-
-/**
  * Setup and show Etherpad.
  * @param {string} name etherpad id
  */

--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -357,6 +357,11 @@ RemoteVideo.prototype.removeRemoteStreamElement = function(stream) {
     logger.info(`${isVideo ? 'Video' : 'Audio'
     } removed ${this.id}`, select);
 
+
+    if (stream === this.videoStream) {
+        this.videoStream = null;
+    }
+
     this.updateView();
 };
 

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -348,10 +348,6 @@ const VideoLayout = {
             remoteVideo.removeRemoteStreamElement(stream);
         }
 
-        if (stream.isVideoTrack()) {
-            this._updateLargeVideoIfDisplayed(id);
-        }
-
         this.updateMutedForNoTracks(id, stream.getType());
     },
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -15,7 +15,6 @@ import UIEvents from '../../../../service/UI/UIEvents';
 import { createLocalTracksA } from './actions';
 import {
     TOGGLE_SCREENSHARING,
-    TRACK_REMOVED,
     TRACK_UPDATED
 } from './actionTypes';
 import { getLocalTrack, setTrackMuted } from './functions';
@@ -89,14 +88,6 @@ MiddlewareRegistry.register(store => next => action => {
     case TOGGLE_SCREENSHARING:
         if (typeof APP === 'object') {
             APP.UI.emitEvent(UIEvents.TOGGLE_SCREENSHARING);
-        }
-        break;
-
-    case TRACK_REMOVED:
-        // TODO Remove this middleware case once all UI interested in tracks
-        // being removed are converted to react and listening for store changes.
-        if (typeof APP !== 'undefined' && !action.track.local) {
-            APP.UI.removeRemoteStream(action.track.jitsiTrack);
         }
         break;
 

--- a/react/features/video-layout/middleware.web.js
+++ b/react/features/video-layout/middleware.web.js
@@ -12,7 +12,7 @@ import {
     getParticipantById
 } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
-import { TRACK_ADDED } from '../base/tracks';
+import { TRACK_ADDED, TRACK_REMOVED } from '../base/tracks';
 import { SET_FILMSTRIP_VISIBLE } from '../filmstrip';
 
 import './middleware.any';
@@ -81,6 +81,12 @@ MiddlewareRegistry.register(store => next => action => {
     case TRACK_ADDED:
         if (!action.track.local) {
             VideoLayout.onRemoteStreamAdded(action.track.jitsiTrack);
+        }
+
+        break;
+    case TRACK_REMOVED:
+        if (!action.track.local) {
+            VideoLayout.onRemoteStreamRemoved(action.track.jitsiTrack);
         }
 
         break;


### PR DESCRIPTION
VideoLayout schedules a large video update by passing in
the video stream on the small video instance. When a stream
is removed, the UI is removed from the small video instance
but a reference to the stream is left. So when VideoLayout
schedules the large video update after a stream removal,
the old stream from the small video instance is re-used,
even though it has been removed.

This change also brings balance with RemoteVideo method
"addRemoteStreamElement" which sets the stream on the
small video instance, so now "removeRemoteStreamElement
unsets it.