### PR TITLE
Revert "feat(screenshare): enable auto-pin of latest and last screens…

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -167,13 +167,7 @@ var interfaceConfig = {
      *
      * @type {boolean}
      */
-    RECENT_LIST_ENABLED: true,
-
-    /**
-     * A UX mode where the last screen share participant is automatically
-     * pinned. Note: this mode is experimental and subject to breakage.
-     */
-    AUTO_PIN_LATEST_SCREEN_SHARE: true
+    RECENT_LIST_ENABLED: true
 
     /**
      * How many columns the tile view can expand to. The respected range is
@@ -200,6 +194,12 @@ var interfaceConfig = {
      * Specify the Android app package name.
      */
     // ANDROID_APP_PACKAGE: 'org.jitsi.meet',
+
+    /**
+     * A UX mode where the last screen share participant is automatically
+     * pinned. Note: this mode is experimental and subject to breakage.
+     */
+    // AUTO_PIN_LATEST_SCREEN_SHARE: false,
 
     /**
      * Override the behavior of some notifications to remain displayed until


### PR DESCRIPTION
…hare"

This reverts commit f42d0411b11c34a7d7bb80e50f2a92776bfb8d8d.

The UX provided by this feature flag in its current state is not
desired. Also, I noticed filmstrip sometimes failing to properly
update small video display mode on pin/unpin. The feature is
being left in for consumers of jitsi-meet to enable as needed.