### PR TITLE
fix(deep-linking): deep link first, then show unsupported

### DIFF
--- a/react/features/app/getRouteToRender.js
+++ b/react/features/app/getRouteToRender.js
@@ -40,71 +40,88 @@ export type Route = {
  */
 export function _getRouteToRender(stateful: Function | Object): Promise<Route> {
     const state = toState(stateful);
-    const { room } = state['features/base/conference'];
-    const isMobileApp = navigator.product === 'ReactNative';
-    const isMobileBrowser
-        = !isMobileApp && (Platform.OS === 'android' || Platform.OS === 'ios');
-    const route: Route = {
-        component: BlankPage,
-        href: undefined
-    };
 
-    const joiningValidRoom = isRoomValid(room);
+    if (navigator.product === 'ReactNative') {
+        return _getMobileRoute(state);
+    }
 
-    // Mobile custom routing
-    if (isMobileApp) {
-        if (joiningValidRoom) {
-            route.component = Conference;
-        } else if (isWelcomePageAppEnabled(state)) {
-            route.component = WelcomePage;
-        }
+    return _getWebConferenceRoute(state) || _getWebWelcomePageRoute(state);
+}
+
+/**
+ * Returns the {@code Route} to display on the React Native app.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>}
+ */
+function _getMobileRoute(state): Promise<Route> {
+    const route = _getEmptyRoute();
+
+    if (isRoomValid(state['features/base/conference'].room)) {
+        route.component = Conference;
+    } else if (isWelcomePageAppEnabled(state)) {
+        route.component = WelcomePage;
+    } else {
+        route.component = BlankPage;
+    }
+
+    return Promise.resolve(route);
+}
+
+/**
+ * Returns the {@code Route} to display when trying to access a conference if
+ * a valid conference is being joined.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>|undefined}
+ */
+function _getWebConferenceRoute(state): ?Promise<Route> {
+    if (!isRoomValid(state['features/base/conference'].room)) {
+        return;
+    }
+
+    const route = _getEmptyRoute();
+
+    // Update the location if it doesn't match. This happens when a room is
+    // joined from the welcome page. The reason for doing this instead of using
+    // the history API is that we want to load the config.js which takes the
+    // room into account.
+    const { locationURL } = state['features/base/connection'];
+
+    if (window.location.href !== locationURL.href) {
+        route.href = locationURL.href;
 
         return Promise.resolve(route);
     }
 
-    // Web custom routing when trying to join a meeting. There are essentially
-    // two possible handled routes here: welcome page and conference.
+    return getDeepLinkingPage(state)
+        .then(deepLinkComponent => {
+            if (deepLinkComponent) {
+                route.component = deepLinkComponent;
+            } else if (_isSupportedBrowser()) {
+                route.component = Conference;
+            } else {
+                route.component = UnsupportedDesktopBrowser;
+            }
 
-    // We are intentionally not performing the check for mobile browsers because:
-    // - the WelcomePage is mobile ready;
-    // - if the URL points to a conference, getDeepLinkingPage will take
-    //   care of it.
-    const isUnsupportedBrowser
-        = !isMobileBrowser && !JitsiMeetJS.isWebRtcSupported();
+            return route;
+        });
+}
 
-    if (joiningValidRoom) {
-        // Update the location if it doesn't match. This happens when a room is
-        // joined from the welcome page. The reason for doing this instead of
-        // using the history API is that we want to load the config.js which
-        // takes the room into account.
-        const { locationURL } = state['features/base/connection'];
+/**
+ * Returns the {@code Route} to display when trying to access the welcome page.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>}
+ */
+function _getWebWelcomePageRoute(state): Promise<Route> {
+    const route = _getEmptyRoute();
 
-        if (window.location.href !== locationURL.href) {
-            route.href = locationURL.href;
-
-            return Promise.resolve(route);
-        }
-
-        return getDeepLinkingPage(state)
-            .then(component => {
-                if (component) {
-                    route.component = component;
-                } else if (isUnsupportedBrowser) {
-                    route.component = UnsupportedDesktopBrowser;
-                } else {
-                    route.component = Conference;
-                }
-
-                return Promise.resolve(route);
-            });
-    }
-
-    // Web custom routing when trying to view the welcome page
     if (isWelcomePageUserEnabled(state)) {
-        if (isUnsupportedBrowser) {
-            route.component = UnsupportedDesktopBrowser;
-        } else {
+        if (_isSupportedBrowser()) {
             route.component = WelcomePage;
+        } else {
+            route.component = UnsupportedDesktopBrowser;
         }
     } else {
         // Web: if the welcome page is disabled, go directly to a random room.
@@ -116,4 +133,35 @@ export function _getRouteToRender(stateful: Function | Object): Promise<Route> {
     }
 
     return Promise.resolve(route);
+}
+
+/**
+ * Returns whether or not the current browser should allow the app to display.
+ *
+ * @returns {boolean}
+ */
+function _isSupportedBrowser() {
+    if (navigator.product === 'ReactNative') {
+        return false;
+    }
+
+    // We are intentionally allow mobile browsers because:
+    // - the WelcomePage is mobile ready;
+    // - if the URL points to a conference, getDeepLinkingPage will take
+    //   care of it.
+    return Platform.OS === 'android'
+        || Platform.OS === 'ios'
+        || JitsiMeetJS.isWebRtcSupported();
+}
+
+/**
+ * Returns the default {@code Route}.
+ *
+ * @returns {Route}
+ */
+function _getEmptyRoute(): Route {
+    return {
+        component: BlankPage,
+        href: undefined
+    };
 }


### PR DESCRIPTION
Re-structure the custom routing to split between
platforms instead of between intended route features.
This made it easier for me to understand where to
do the checks for unsupported browser after deep-linking
had been checked.