### PR TITLE
feat(unsupported): provide custom blacklist for branding

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -121,6 +121,7 @@
     "deepLinking": {
         "appNotInstalled": "You need the __app__ mobile app to join this meeting on your phone.",
         "description": "Nothing happened? We tried launching your meeting in the __app__ desktop app. Try again or launch it in the __app__ web app.",
+        "descriptionWithoutWeb": "Nothing happened? We tried launching your meeting in the __app__ desktop app.",
         "downloadApp": "Download the app",
         "launchWebButton": "Launch in web",
         "openApp": "Continue to the app",

--- a/react/features/app/getRouteToRender.js
+++ b/react/features/app/getRouteToRender.js
@@ -40,69 +40,128 @@ export type Route = {
  */
 export function _getRouteToRender(stateful: Function | Object): Promise<Route> {
     const state = toState(stateful);
-    const { room } = state['features/base/conference'];
-    const isMobileApp = navigator.product === 'ReactNative';
-    const isMobileBrowser
-        = !isMobileApp && (Platform.OS === 'android' || Platform.OS === 'ios');
-    const route: Route = {
+
+    if (navigator.product === 'ReactNative') {
+        return _getMobileRoute(state);
+    }
+
+    return _getWebConferenceRoute(state) || _getWebWelcomePageRoute(state);
+}
+
+/**
+ * Returns the {@code Route} to display on the React Native app.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>}
+ */
+function _getMobileRoute(state): Promise<Route> {
+    const route = _getEmptyRoute();
+
+    if (isRoomValid(state['features/base/conference'].room)) {
+        route.component = Conference;
+    } else if (isWelcomePageAppEnabled(state)) {
+        route.component = WelcomePage;
+    } else {
+        route.component = BlankPage;
+    }
+
+    return Promise.resolve(route);
+}
+
+/**
+ * Returns the {@code Route} to display when trying to access a conference if
+ * a valid conference is being joined.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>|undefined}
+ */
+function _getWebConferenceRoute(state): ?Promise<Route> {
+    if (!isRoomValid(state['features/base/conference'].room)) {
+        return;
+    }
+
+    const route = _getEmptyRoute();
+
+    // Update the location if it doesn't match. This happens when a room is
+    // joined from the welcome page. The reason for doing this instead of using
+    // the history API is that we want to load the config.js which takes the
+    // room into account.
+    const { locationURL } = state['features/base/connection'];
+
+    if (window.location.href !== locationURL.href) {
+        route.href = locationURL.href;
+
+        return Promise.resolve(route);
+    }
+
+    return getDeepLinkingPage(state)
+        .then(deepLinkComponent => {
+            if (deepLinkComponent) {
+                route.component = deepLinkComponent;
+            } else if (_isSupportedBrowser()) {
+                route.component = Conference;
+            } else {
+                route.component = UnsupportedDesktopBrowser;
+            }
+
+            return route;
+        });
+}
+
+/**
+ * Returns the {@code Route} to display when trying to access the welcome page.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Promise<Route>}
+ */
+function _getWebWelcomePageRoute(state): Promise<Route> {
+    const route = _getEmptyRoute();
+
+    if (isWelcomePageUserEnabled(state)) {
+        if (_isSupportedBrowser()) {
+            route.component = WelcomePage;
+        } else {
+            route.component = UnsupportedDesktopBrowser;
+        }
+    } else {
+        // Web: if the welcome page is disabled, go directly to a random room.
+
+        let href = window.location.href;
+
+        href.endsWith('/') || (href += '/');
+        route.href = href + generateRoomWithoutSeparator();
+    }
+
+    return Promise.resolve(route);
+}
+
+/**
+ * Returns whether or not the current browser should allow the app to display.
+ *
+ * @returns {boolean}
+ */
+function _isSupportedBrowser() {
+    if (navigator.product === 'ReactNative') {
+        return false;
+    }
+
+    // We are intentionally allow mobile browsers because:
+    // - the WelcomePage is mobile ready;
+    // - if the URL points to a conference, getDeepLinkingPage will take
+    //   care of it.
+    return Platform.OS === 'android'
+        || Platform.OS === 'ios'
+        || JitsiMeetJS.isWebRtcSupported();
+}
+
+/**
+ * Returns the default {@code Route}.
+ *
+ * @returns {Route}
+ */
+function _getEmptyRoute(): Route {
+    return {
         component: BlankPage,
         href: undefined
     };
-
-    return new Promise(resolve => {
-        // First, check if the current endpoint supports WebRTC. We are
-        // intentionally not performing the check for mobile browsers because:
-        // - the WelcomePage is mobile ready;
-        // - if the URL points to a conference, getDeepLinkingPage will take
-        //   care of it.
-        if (!isMobileBrowser && !JitsiMeetJS.isWebRtcSupported()) {
-            route.component = UnsupportedDesktopBrowser;
-            resolve(route);
-
-            return;
-        }
-
-        if (isRoomValid(room)) {
-            if (isMobileApp) {
-                route.component = Conference;
-                resolve(route);
-            } else {
-                // Update the location if it doesn't match. This happens when a
-                // room is joined from the welcome page. The reason for doing
-                // this instead of using the history API is that we want to load
-                // the config.js which takes the room into account.
-                const { locationURL } = state['features/base/connection'];
-
-                // eslint-disable-next-line no-negated-condition
-                if (window.location.href !== locationURL.href) {
-                    route.href = locationURL.href;
-                    resolve(route);
-                } else {
-                    // Maybe show deep-linking, otherwise go to Conference.
-                    getDeepLinkingPage(state).then(component => {
-                        route.component = component || Conference;
-                        resolve(route);
-                    });
-                }
-            }
-
-            return;
-        }
-
-        if (!isWelcomePageUserEnabled(state)) {
-            // Web: if the welcome page is disabled, go directly to a random
-            // room.
-
-            let href = window.location.href;
-
-            href.endsWith('/') || (href += '/');
-            route.href = href + generateRoomWithoutSeparator();
-        } else if (isWelcomePageAppEnabled(state)) {
-            // Mobile: only go to the welcome page if enabled.
-
-            route.component = WelcomePage;
-        }
-
-        resolve(route);
-    });
 }

--- a/react/features/app/getRouteToRender.js
+++ b/react/features/app/getRouteToRender.js
@@ -4,9 +4,8 @@ import { generateRoomWithoutSeparator } from 'js-utils/random';
 import type { Component } from 'react';
 
 import { isRoomValid } from '../base/conference';
-import JitsiMeetJS from '../base/lib-jitsi-meet';
-import { Platform } from '../base/react';
 import { toState } from '../base/redux';
+import { isSupportedBrowser } from '../base/environment';
 import { Conference } from '../conference';
 import { getDeepLinkingPage } from '../deep-linking';
 import { UnsupportedDesktopBrowser } from '../unsupported-browser';
@@ -98,7 +97,7 @@ function _getWebConferenceRoute(state): ?Promise<Route> {
         .then(deepLinkComponent => {
             if (deepLinkComponent) {
                 route.component = deepLinkComponent;
-            } else if (_isSupportedBrowser()) {
+            } else if (isSupportedBrowser()) {
                 route.component = Conference;
             } else {
                 route.component = UnsupportedDesktopBrowser;
@@ -118,7 +117,7 @@ function _getWebWelcomePageRoute(state): Promise<Route> {
     const route = _getEmptyRoute();
 
     if (isWelcomePageUserEnabled(state)) {
-        if (_isSupportedBrowser()) {
+        if (isSupportedBrowser()) {
             route.component = WelcomePage;
         } else {
             route.component = UnsupportedDesktopBrowser;
@@ -133,25 +132,6 @@ function _getWebWelcomePageRoute(state): Promise<Route> {
     }
 
     return Promise.resolve(route);
-}
-
-/**
- * Returns whether or not the current browser should allow the app to display.
- *
- * @returns {boolean}
- */
-function _isSupportedBrowser() {
-    if (navigator.product === 'ReactNative') {
-        return false;
-    }
-
-    // We are intentionally allow mobile browsers because:
-    // - the WelcomePage is mobile ready;
-    // - if the URL points to a conference, getDeepLinkingPage will take
-    //   care of it.
-    return Platform.OS === 'android'
-        || Platform.OS === 'ios'
-        || JitsiMeetJS.isWebRtcSupported();
 }
 
 /**

--- a/react/features/base/environment/environment.js
+++ b/react/features/base/environment/environment.js
@@ -1,0 +1,25 @@
+// @flow
+
+import JitsiMeetJS from '../lib-jitsi-meet';
+import { Platform } from '../react';
+
+import { isBlacklistedEnvironment } from './isBlacklistedEnvironment';
+
+/**
+ * Returns whether or not the current browser should allow the app to display.
+ *
+ * @returns {boolean}
+ */
+export function isSupportedBrowser() {
+    if (navigator.product === 'ReactNative' || isBlacklistedEnvironment()) {
+        return false;
+    }
+
+    // We are intentionally allow mobile browsers because:
+    // - the WelcomePage is mobile ready;
+    // - if the URL points to a conference then deep-linking will take
+    //   care of it.
+    return Platform.OS === 'android'
+        || Platform.OS === 'ios'
+        || JitsiMeetJS.isWebRtcSupported();
+}

--- a/react/features/base/environment/index.js
+++ b/react/features/base/environment/index.js
@@ -1,0 +1,1 @@
+export * from './environment';

--- a/react/features/base/environment/isBlacklistedEnvironment.js
+++ b/react/features/base/environment/isBlacklistedEnvironment.js
@@ -1,0 +1,11 @@
+/**
+ * Returns whether or not the current browser is supported for showing meeting
+ * based on any custom overrides. This file should be overridden with branding
+ * as needed to fit deployment needs.
+ *
+ * @returns {boolean} True the browser is unsupported due to being  blacklisted
+ * by the logic within this function.
+ */
+export function isBlacklistedEnvironment() {
+    return false;
+}

--- a/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
@@ -7,6 +7,7 @@ import { connect } from '../../base/redux';
 import type { Dispatch } from 'redux';
 
 import { createDeepLinkingPageEvent, sendAnalytics } from '../../analytics';
+import { isSupportedBrowser } from '../../base/environment';
 import { translate } from '../../base/i18n';
 
 import {
@@ -107,8 +108,12 @@ class DeepLinkingDesktopPage<P : Props> extends Component<P> {
                                 </h1>
                                 <p className = 'description'>
                                     {
-                                        t(`${_TNS}.description`,
-                                            { app: NATIVE_APP_NAME })
+                                        t(
+                                            `${_TNS}.${isSupportedBrowser()
+                                                ? 'description'
+                                                : 'descriptionWithoutWeb'}`,
+                                            { app: NATIVE_APP_NAME }
+                                        )
                                     }
                                 </p>
                                 <div className = 'buttons'>
@@ -118,9 +123,12 @@ class DeepLinkingDesktopPage<P : Props> extends Component<P> {
                                             onClick = { this._onTryAgain }>
                                             { t(`${_TNS}.tryAgainButton`) }
                                         </Button>
-                                        <Button onClick = { this._onLaunchWeb }>
-                                            { t(`${_TNS}.launchWebButton`) }
-                                        </Button>
+                                        {
+                                            isSupportedBrowser()
+                                                && <Button onClick = { this._onLaunchWeb }>
+                                                    { t(`${_TNS}.launchWebButton`) }
+                                                </Button>
+                                        }
                                     </ButtonGroup>
                                 </div>
                             </div>

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -3,9 +3,8 @@
 import React, { Component } from 'react';
 
 import { translate } from '../../base/i18n';
-import { Platform } from '../../base/react';
 
-import { CHROME, /* EDGE, */ FIREFOX, SAFARI } from './browserLinks';
+import { CHROME, FIREFOX } from './browserLinks';
 
 /**
  * The namespace of the CSS styles of UnsupportedDesktopBrowser.
@@ -51,54 +50,10 @@ class UnsupportedDesktopBrowser extends Component<Props> {
                         href = { CHROME } >Chrome</a> and&nbsp;
                     <a
                         className = { `${_SNS}__link` }
-                        href = { FIREFOX }>Firefox</a>&nbsp;
-                    {
-                        this._renderOSSpecificBrowserDownloadLink()
-                    }
+                        href = { FIREFOX }>Firefox</a>
                 </p>
             </div>
         );
-    }
-
-    /**
-     * Depending on the platform returns the link to Safari browser.
-     *
-     * @returns {ReactElement|null}
-     * @private
-     */
-    _renderOSSpecificBrowserDownloadLink() {
-        let link;
-        let text;
-
-        switch (Platform.OS) {
-        case 'macos':
-            link = SAFARI;
-            text = 'Safari';
-            break;
-
-        /*
-        case 'windows':
-            link = EDGE;
-            text = 'Edge';
-            break;
-        */
-        }
-        if (typeof link !== 'undefined') {
-            return (
-                <span>
-                    or&nbsp;
-                    <a
-                        className = { `${_SNS}__link` }
-                        href = { link }>
-                        {
-                            text
-                        }
-                    </a>
-                </span>
-            );
-        }
-
-        return null;
     }
 }
 


### PR DESCRIPTION
Built on top of #4306. ~This PR can supersede it if that's easier.~ Supersedes that PR because this one has gone further with the requirements and it'll just be easier for me to handle comments.

Screenshot of deep-linking page with unsupported browsers not showing a button to launch on web.
<img width="1486" alt="Screen Shot 2019-06-06 at 8 00 49 PM" src="https://user-images.githubusercontent.com/1243084/59078860-d8c7fb00-8895-11e9-9806-bc040065662e.png">

Unsupported browser page with Safari removed.
<img width="1374" alt="Screen Shot 2019-06-06 at 8 02 47 PM" src="https://user-images.githubusercontent.com/1243084/59078907-19c00f80-8896-11e9-99af-1b501f244762.png">
