### PR TITLE
rn: fix video unmuting when disabling audio-only

### DIFF
--- a/react/features/toolbox/components/VideoMuteButton.js
+++ b/react/features/toolbox/components/VideoMuteButton.js
@@ -135,13 +135,13 @@ class VideoMuteButton extends AbstractVideoMuteButton<Props, *> {
         if (this.props._audioOnly) {
             this.props.dispatch(
                 setAudioOnly(false, /* ensureTrack */ true));
-        } else {
-            this.props.dispatch(
-                setVideoMuted(
-                    videoMuted,
-                    VIDEO_MUTISM_AUTHORITY.USER,
-                    /* ensureTrack */ true));
         }
+
+        this.props.dispatch(
+            setVideoMuted(
+                videoMuted,
+                VIDEO_MUTISM_AUTHORITY.USER,
+                /* ensureTrack */ true));
 
         // FIXME: The old conference logic still relies on this event being
         // emitted.


### PR DESCRIPTION
When the video unmute button disabled audio-only, also unmute video. This fixes
a weird case in which the user need to "unmute twice" if they were muted beofre
they enabled audio-only mode. That's ok if the audio-only button was used, but
not if the video-unmute button was used, since the expectation is to have video,
of course.