### PR TITLE
microsoftCalendar: add showing calendar events in local timezone.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "redux-thunk": "2.2.0",
     "styled-components": "3.4.9",
     "uuid": "3.1.0",
+    "windows-iana": "^3.1.0",
     "xmldom": "0.1.27"
   },
   "devDependencies": {

--- a/react/features/calendar-sync/web/microsoftCalendar.js
+++ b/react/features/calendar-sync/web/microsoftCalendar.js
@@ -12,6 +12,8 @@ import { getShareInfoText } from '../../invite';
 
 import { setCalendarAPIAuthState } from '../actions';
 
+import { findWindows } from 'windows-iana';
+
 /**
  * Constants used for interacting with the Microsoft API.
  *
@@ -560,9 +562,13 @@ function requestCalendarEvents( // eslint-disable-line max-params
         startDate.toISOString()}' and End/DateTime lt '${
         endDate.toISOString()}'`;
 
+    const ianaTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const windowsTimeZone = findWindows(ianaTimeZone);
+
     return client
         .api(`/me/calendars/${calendarId}/events`)
         .filter(filter)
+        .header('Prefer', `outlook.timezone="${windowsTimeZone}"`)
         .select('id,subject,start,end,location,body')
         .orderby('createdDateTime DESC')
         .get()


### PR DESCRIPTION
PR adds possibility to show calendar events from MS api in local timezone.
Issue started in https://community.jitsi.org/t/ms-calendar-events-time-in-gmt-only/18428
