### PR TITLE
calendar-sync: fix loading calendar entries

### DIFF
--- a/react/features/calendar-sync/reducer.js
+++ b/react/features/calendar-sync/reducer.js
@@ -13,7 +13,6 @@ import {
     SET_CALENDAR_PROFILE_EMAIL,
     SET_LOADING_CALENDAR_EVENTS
 } from './actionTypes';
-import { isCalendarEnabled } from './functions';
 
 /**
  * The default state of the calendar feature.
@@ -50,10 +49,6 @@ PersistenceRegistry.register(STORE_NAME, {
 });
 
 ReducerRegistry.register(STORE_NAME, (state = DEFAULT_STATE, action) => {
-    if (!isCalendarEnabled(state)) {
-        return state;
-    }
-
     switch (action.type) {
     case CLEAR_CALENDAR_INTEGRATION:
         return DEFAULT_STATE;


### PR DESCRIPTION
Checking if the calendar support in the reducer is not only useless but wrong,
since we don't have access to the entire store (the calendar support is checked
in the base/config feature). If calendar support is not enabled the actions
being reduced won't be dispatched anyway, so no harm is done by removing the
check.