### PR TITLE
fix(always-on-top): enforce circle avatar

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -541,13 +541,17 @@
 #videoNotAvailableScreen {
     text-align: center;
     #avatarContainer {
+        border-radius: 50%;
+        display: inline-block;
         height: 50vh;
-        display:inline-block;
         margin-top: 25vh;
+        overflow: hidden;
+        width: 50vh;
 
         #avatar {
-            border-radius: 50%;
             height: 100%;
+            object-fit: cover;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
before ![Screen Shot 2019-06-14 at 2 37 46 PM](https://user-images.githubusercontent.com/1243084/59539592-b4ca7200-8eb2-11e9-9862-188939f13d71.png)

after
![Screen Shot 2019-06-14 at 2 37 19 PM](https://user-images.githubusercontent.com/1243084/59539595-b8f68f80-8eb2-11e9-80de-f9f656332b5c.png)
