### PR TITLE
fix: consider firefox sub-optimal experience

### DIFF
--- a/react/features/conference/functions.js
+++ b/react/features/conference/functions.js
@@ -18,7 +18,6 @@ import { getOverlayToRender } from '../overlay';
  */
 export function maybeShowSuboptimalExperienceNotification(dispatch, t) {
     if (!browser.isChrome()
-            && !browser.isFirefox()
             && !browser.isNWJS()
             && !browser.isElectron()
 

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 
 import { translate } from '../../base/i18n';
 
-import { CHROME, FIREFOX } from './browserLinks';
+import { CHROME } from './browserLinks';
 
 /**
  * The namespace of the CSS styles of UnsupportedDesktopBrowser.
@@ -47,10 +47,7 @@ class UnsupportedDesktopBrowser extends Component<Props> {
                     Please try again with the latest version of&nbsp;
                     <a
                         className = { `${_SNS}__link` }
-                        href = { CHROME } >Chrome</a> and&nbsp;
-                    <a
-                        className = { `${_SNS}__link` }
-                        href = { FIREFOX }>Firefox</a>
+                        href = { CHROME } >Chrome</a>
                 </p>
             </div>
         );

--- a/static/recommendedBrowsers.html
+++ b/static/recommendedBrowsers.html
@@ -12,10 +12,7 @@
             We recommend to try with the latest version of&nbsp;
             <a
                 className = 'unsupported-desktop-browser__link'
-                href = 'http://google.com/chrome' >Chrome</a>,&nbsp;
-            <a
-                class = 'unsupported-desktop-browser__link'
-                href = 'http://www.getfirefox.com/'>Firefox</a>&nbsp;or&nbsp;
+                href = 'http://google.com/chrome' >Chrome</a>&nbsp;or
             <a
                 class = 'unsupported-desktop-browser__link'
                 href = 'http://www.chromium.org/'>Chromium</a>


### PR DESCRIPTION
Notification displaying in call:
![Screen Shot 2019-06-17 at 8 17 00 AM](https://user-images.githubusercontent.com/1243084/59616245-e6248700-90d8-11e9-8761-da46b32394d0.png)
The page which is linked in the notification:
![Screen Shot 2019-06-17 at 8 17 17 AM](https://user-images.githubusercontent.com/1243084/59616246-e6bd1d80-90d8-11e9-893a-5ffc050fffa8.png)

The page displayed for unsupported browsers (forced to display to test and get the screenshot):
![Screen Shot 2019-06-17 at 8 17 27 AM](https://user-images.githubusercontent.com/1243084/59616289-fd637480-90d8-11e9-9da0-6bb4b885c543.png)

