### PR TITLE
participants: skip local participant join notification

### DIFF
--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -1,5 +1,3 @@
-/* global interfaceConfig */
-
 import throttle from 'lodash/throttle';
 
 import { set } from '../redux';
@@ -517,8 +515,7 @@ const _throttledNotifyParticipantConnected = throttle(dispatch => {
  * @returns {Function}
  */
 export function showParticipantJoinedNotification(displayName) {
-    joinedParticipantsNames.push(
-        displayName || interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME);
+    joinedParticipantsNames.push(displayName);
 
     return dispatch => _throttledNotifyParticipantConnected(dispatch);
 }

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -118,10 +118,10 @@ MiddlewareRegistry.register(store => next => action => {
     case PARTICIPANT_JOINED: {
         _maybePlaySounds(store, action);
 
-        const { participant: { name } } = action;
+        const { participant: p } = action;
 
-        if (name) {
-            store.dispatch(showParticipantJoinedNotification(name));
+        if (!p.local) {
+            store.dispatch(showParticipantJoinedNotification(getParticipantDisplayName(store.getState, p.id)));
         }
 
         return _participantJoinedOrUpdated(store, next, action);


### PR DESCRIPTION
Also, use the helper function to get the display name for a participant.