### PR TITLE
fix(base/conference/reducer): check if room is defined

### DIFF
--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -213,7 +213,8 @@ function _conferenceJoined(state, { conference }) {
     // i.e. password-protected is private to lib-jitsi-meet. However, the
     // library does not fire LOCK_STATE_CHANGED upon joining a JitsiConference
     // with a password.
-    const locked = conference.room.locked ? LOCKED_REMOTELY : undefined;
+    // FIXME Technically JitsiConference.room is a private field.
+    const locked = conference.room && conference.room.locked ? LOCKED_REMOTELY : undefined;
 
     return assign(state, {
         authRequired: undefined,


### PR DESCRIPTION
This was hit on a corner case when ConnectionService will deny the request to start the call. I am not sure, but it could have been that the conference object has been disposed or closed or something else, but the fact is that 'conference.room' was not defined and things crashed. It is not safe to access conference's private field 'room'. It is true JitsiConference doesn't follow the practice of marking this field as private with the underscore '_', but it is not a public field.