### PR TITLE
android: fix exception when sending events without URL

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
@@ -73,6 +73,7 @@ class ExternalAPIModule
         BaseReactView view = BaseReactView.findViewByExternalAPIScope(scope);
 
         if (view != null) {
+            Log.d(TAG, "Sending event: " + name + " with data: " + data);
             try {
                 view.onExternalAPIEvent(name, data);
             } catch(Exception e) {

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -181,7 +181,7 @@ public class JitsiMeetView extends BaseReactView<JitsiMeetViewListener> {
      * by/associated with the specified {@code eventName}.
      */
     private void maybeSetViewURL(String eventName, ReadableMap eventData) {
-        String url = eventData.getString("url");
+        String url = eventData.hasKey("url") ? eventData.getString("url") : null;
 
         switch(eventName) {
         case "CONFERENCE_WILL_JOIN":


### PR DESCRIPTION
ENTER_PIP_MODE, for example, does not have it.