### PR TITLE
fix(notifications): show notifications after reducers update to get name

### DIFF
--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -118,13 +118,15 @@ MiddlewareRegistry.register(store => next => action => {
     case PARTICIPANT_JOINED: {
         _maybePlaySounds(store, action);
 
+        const result = _participantJoinedOrUpdated(store, next, action);
+
         const { participant: p } = action;
 
         if (!p.local) {
             store.dispatch(showParticipantJoinedNotification(getParticipantDisplayName(store.getState, p.id)));
         }
 
-        return _participantJoinedOrUpdated(store, next, action);
+        return result;
     }
 
     case PARTICIPANT_LEFT:


### PR DESCRIPTION
Otherwise the participant will not have been added yet
to state so the participant name will not display in
the notification.

Quick fix for now. Will follow up by moving the notification logic out
of base/participants/middleware.