### PR TITLE
rn: fix CallKit failure screen flash when kicked

### DIFF
--- a/react/features/conference/middleware.js
+++ b/react/features/conference/middleware.js
@@ -5,12 +5,11 @@ import {
     CONFERENCE_JOINED,
     KICKED_OUT,
     VIDEO_QUALITY_LEVELS,
-    conferenceFailed,
+    conferenceLeft,
     getCurrentConference,
     setPreferredReceiverVideoQuality
 } from '../base/conference';
 import { hideDialog, isDialogOpen } from '../base/dialog';
-import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
 import { pinParticipant } from '../base/participants';
 import { SET_REDUCED_UI } from '../base/responsive-ui';
 import { MiddlewareRegistry, StateListenerRegistry } from '../base/redux';
@@ -46,8 +45,7 @@ MiddlewareRegistry.register(store => next => action => {
         dispatch(notifyKickedOut(
             action.participant,
             () => {
-                dispatch(
-                    conferenceFailed(action.conference, JitsiConferenceEvents.KICKED));
+                dispatch(conferenceLeft(action.conference));
                 dispatch(appNavigate(undefined));
             }
         ));


### PR DESCRIPTION
Pretend we have left instead of triggering a call failure. The user was already
told in the dialog.