### PR TITLE
ref(notifications): do not notify of local participant left

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1781,11 +1781,6 @@ export default {
 
             logger.log(`USER ${id} LEFT:`, user);
             APP.API.notifyUserLeft(id);
-            APP.UI.messageHandler.participantNotification(
-                user.getDisplayName(),
-                'notify.somebody',
-                'disconnected',
-                'notify.disconnected');
             APP.UI.onSharedVideoStop(id);
         });
 

--- a/react/features/notifications/middleware.js
+++ b/react/features/notifications/middleware.js
@@ -3,14 +3,20 @@
 import { getCurrentConference } from '../base/conference';
 import {
     PARTICIPANT_JOINED,
+    PARTICIPANT_LEFT,
+    getParticipantById,
     getParticipantDisplayName
 } from '../base/participants';
 import { MiddlewareRegistry, StateListenerRegistry } from '../base/redux';
 
 import {
     clearNotifications,
+    showNotification,
     showParticipantJoinedNotification
 } from './actions';
+import { NOTIFICATION_TIMEOUT } from './constants';
+
+declare var interfaceConfig: Object;
 
 /**
  * Middleware that captures actions to display notifications.
@@ -19,10 +25,10 @@ import {
  * @returns {Function}
  */
 MiddlewareRegistry.register(store => next => action => {
-    const result = next(action);
-
     switch (action.type) {
     case PARTICIPANT_JOINED: {
+        const result = next(action);
+
         const { participant: p } = action;
 
         if (!p.local) {
@@ -30,10 +36,31 @@ MiddlewareRegistry.register(store => next => action => {
                 getParticipantDisplayName(store.getState, p.id)
             ));
         }
+
+        return result;
+    }
+    case PARTICIPANT_LEFT: {
+        const participant = getParticipantById(
+            store.getState(),
+            action.participant.id
+        );
+
+        if (typeof interfaceConfig === 'object'
+            && participant
+            && !participant.local) {
+            store.dispatch(showNotification({
+                descriptionKey: 'notify.disconnected',
+                titleKey: 'notify.somebody',
+                title: participant.name
+            },
+            NOTIFICATION_TIMEOUT));
+        }
+
+        return next(action);
     }
     }
 
-    return result;
+    return next(action);
 });
 
 /**


### PR DESCRIPTION
Join notifications are already supressed for the local
participant, so hide the left notification. For now
the notification is not being shown on mobile to keep
the same existing behavior and because a copy change
will be needed, but will be added once batching is
implemented.