### PR TITLE
Fix spelling mistake on pragma mark

### DIFF
--- a/ios/sdk/src/JitsiMeet.h
+++ b/ios/sdk/src/JitsiMeet.h
@@ -42,7 +42,7 @@
  */
 @property (nonatomic, nullable) JitsiMeetConferenceOptions *defaultConferenceOptions;
 
-#pragma mak - This class is a singleton
+#pragma mark - This class is a singleton
 
 + (instancetype _Nonnull)sharedInstance;
 


### PR DESCRIPTION
It causes a compiler error in Xcode 11 beta 2  because it doesn't know how to parse it.