### PR TITLE
android: fix crash if notification is null

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
@@ -82,8 +82,13 @@ public class JitsiMeetOngoingConferenceService extends Service
         final String action = intent.getAction();
         if (action.equals(Actions.START)) {
             Notification notification = OngoingNotification.buildOngoingConferenceNotification();
-            startForeground(OngoingNotification.NOTIFICATION_ID, notification);
-            Log.i(TAG, "Service started");
+            if (notification == null) {
+                stopSelf();
+                Log.w(TAG, "Couldn't start service, notification is null");
+            } else {
+                startForeground(OngoingNotification.NOTIFICATION_ID, notification);
+                Log.i(TAG, "Service started");
+            }
         } else if (action.equals(Actions.HANGUP)) {
             Log.i(TAG, "Hangup requested");
             // Abort all ongoing calls


### PR DESCRIPTION
I cannot see a path leading to it being null, but Crashlytics demonstrated it's
possible (so far in a small subset of old devices). Be defensive then.