### PR TITLE
fix(invite): decode the meeting name

### DIFF
--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -160,7 +160,11 @@ export function getConferenceName(stateful: Function | Object): string {
     const { callDisplayName } = state['features/base/config'];
     const { pendingSubjectChange, room, subject } = state['features/base/conference'];
 
-    return pendingSubjectChange || subject || callDisplayName || (callee && callee.name) || _.startCase(room);
+    return pendingSubjectChange
+        || subject
+        || callDisplayName
+        || (callee && callee.name)
+        || _.startCase(decodeURIComponent(room));
 }
 
 /**

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -217,7 +217,7 @@ class DeepLinkingMobilePage extends Component<Props> {
  */
 function _mapStateToProps(state) {
     return {
-        _room: state['features/base/conference'].room
+        _room: decodeURIComponent(state['features/base/conference'].room)
     };
 }
 

--- a/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.js
+++ b/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.js
@@ -21,7 +21,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 ? <DialInSummary
                     className = 'dial-in-page'
                     clickableNumbers = { isUsingMobileBrowser }
-                    room = { room } />
+                    room = { decodeURIComponent(room) } />
                 : <NoRoomError className = 'dial-in-page' /> }
         </I18nextProvider>,
         document.getElementById('react')

--- a/react/features/invite/components/info-dialog/web/InfoDialog.js
+++ b/react/features/invite/components/info-dialog/web/InfoDialog.js
@@ -13,7 +13,11 @@ import {
     getLocalParticipant
 } from '../../../../base/participants';
 
-import { _getDefaultPhoneNumber, getDialInfoPageURL } from '../../../functions';
+import {
+    _decodeRoomURI,
+    _getDefaultPhoneNumber,
+    getDialInfoPageURL
+} from '../../../functions';
 import DialInNumber from './DialInNumber';
 import PasswordForm from './PasswordForm';
 
@@ -295,8 +299,9 @@ class InfoDialog extends Component<Props, State> {
      * @returns {string}
      */
     _getTextToCopy() {
-        const { _inviteURL, _localParticipant, liveStreamViewURL, t } = this.props;
+        const { _localParticipant, liveStreamViewURL, t } = this.props;
         const shouldDisplayDialIn = this._shouldDisplayDialIn();
+        const _inviteURL = _decodeRoomURI(this.props._inviteURL);
 
         let invite = _localParticipant && _localParticipant.name
             ? t('info.inviteURLFirstPartPersonal', { name: _localParticipant.name })

--- a/react/features/invite/components/info-dialog/web/InfoDialog.js
+++ b/react/features/invite/components/info-dialog/web/InfoDialog.js
@@ -237,7 +237,7 @@ class InfoDialog extends Component<Props, State> {
                                 className = 'info-dialog-url-text'
                                 href = { this.props._inviteURL }
                                 onClick = { this._onClickURLText } >
-                                { this._getURLToDisplay() }
+                                { decodeURI(this._getURLToDisplay()) }
                             </a>
                         </span>
                     </div>
@@ -289,25 +289,13 @@ class InfoDialog extends Component<Props, State> {
     }
 
     /**
-     * Generates the URL for the static dial in info page.
-     *
-     * @private
-     * @returns {string}
-     */
-    _getDialInfoPageURL() {
-        return getDialInfoPageURL(
-            encodeURIComponent(this.props._conferenceName),
-            this.props._locationURL);
-    }
-
-    /**
      * Creates a message describing how to dial in to the conference.
      *
      * @private
      * @returns {string}
      */
     _getTextToCopy() {
-        const { _localParticipant, liveStreamViewURL, t } = this.props;
+        const { _inviteURL, _localParticipant, liveStreamViewURL, t } = this.props;
         const shouldDisplayDialIn = this._shouldDisplayDialIn();
 
         let invite = _localParticipant && _localParticipant.name
@@ -315,7 +303,7 @@ class InfoDialog extends Component<Props, State> {
             : t('info.inviteURLFirstPartGeneral');
 
         invite += t('info.inviteURLSecondPart', {
-            url: this.props._inviteURL
+            url: _inviteURL
         });
 
         if (liveStreamViewURL) {
@@ -332,8 +320,11 @@ class InfoDialog extends Component<Props, State> {
                 conferenceID: this.props.dialIn.conferenceID
             });
             const moreNumbers = t('info.invitePhoneAlternatives', {
-                url: this._getDialInfoPageURL(),
-                silentUrl: `${this.props._inviteURL}#config.startSilent=true`
+                url: getDialInfoPageURL(
+                    this.props._conferenceName,
+                    this.props._locationURL
+                ),
+                silentUrl: `${_inviteURL}#config.startSilent=true`
             });
 
             invite = `${invite}\n${dial}\n${moreNumbers}`;
@@ -457,7 +448,12 @@ class InfoDialog extends Component<Props, State> {
                     phoneNumber = { this.state.phoneNumber } />
                 <a
                     className = 'more-numbers'
-                    href = { this._getDialInfoPageURL() }
+                    href = {
+                        getDialInfoPageURL(
+                            this.props._conferenceName,
+                            this.props._locationURL
+                        )
+                    }
                     rel = 'noopener noreferrer'
                     target = '_blank'>
                     { this.props.t('info.moreNumbers') }

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -401,7 +401,7 @@ export function searchDirectory( // eslint-disable-line max-params
  */
 export function getShareInfoText(
         state: Object, inviteUrl: string, useHtml: ?boolean): Promise<string> {
-    let roomUrl = inviteUrl;
+    let roomUrl = _decodeRoomURI(inviteUrl);
     const includeDialInfo = state['features/base/config'] !== undefined;
 
     if (useHtml) {
@@ -505,7 +505,7 @@ export function getDialInfoPageURL(
         return accumulator;
     }, '');
 
-    return `${origin}${newPath}/static/dialInInfo.html?room=${conferenceName}`;
+    return `${origin}${newPath}/static/dialInInfo.html?room=${_decodeRoomURI(conferenceName)}`;
 }
 
 /**
@@ -559,4 +559,23 @@ export function _getDefaultPhoneNumber(
     }
 
     return null;
+}
+
+/**
+ * Decodes URI only if doesn't contain a space(' ').
+ *
+ * @param {string} url - The string to decode.
+ * @returns {string} - It the string contains space, encoded value is '%20' returns
+ * same string, otherwise decoded one.
+ * @private
+ */
+export function _decodeRoomURI(url: string) {
+    let roomUrl = url;
+
+    // we want to decode urls when the do not contain space, ' ', which url encoded is %20
+    if (roomUrl && !roomUrl.includes('%20')) {
+        roomUrl = decodeURI(roomUrl);
+    }
+
+    return roomUrl;
 }

--- a/react/features/recent-list/functions.native.js
+++ b/react/features/recent-list/functions.native.js
@@ -31,7 +31,7 @@ function toDisplayableItem(item, defaultServerURL, t) {
             _toDurationString(item.duration),
             serverName
         ],
-        title: location.room,
+        title: decodeURIComponent(location.room),
         url: item.conference
     };
 }

--- a/react/features/recent-list/functions.web.js
+++ b/react/features/recent-list/functions.web.js
@@ -18,7 +18,7 @@ export function toDisplayableList(recentList) {
                     date: item.date,
                     duration: item.duration,
                     time: [ item.date ],
-                    title: parseURIString(item.conference).room,
+                    title: decodeURIComponent(parseURIString(item.conference).room),
                     url: item.conference
                 };
             }));

--- a/react/features/welcome/components/AbstractWelcomePage.js
+++ b/react/features/welcome/components/AbstractWelcomePage.js
@@ -192,7 +192,7 @@ export class AbstractWelcomePage extends Component<Props, *> {
             const onAppNavigateSettled
                 = () => this._mounted && this.setState({ joining: false });
 
-            this.props.dispatch(appNavigate(room))
+            this.props.dispatch(appNavigate(encodeURI(room)))
                 .then(onAppNavigateSettled, onAppNavigateSettled);
         }
     }


### PR DESCRIPTION
It would be nice to have someone also test this because for whatever reason my confidence is not high. I called decode near where the room name gets shown in the UI as I, maybe erroneously, felt unsafe storing the decoded version in redux itself.

<img width="501" alt="phone_recent" src="https://user-images.githubusercontent.com/1243084/60740740-adc7da00-9f1b-11e9-98e4-cffddc6ed98f.png">
<img width="501" alt="phone_in_call" src="https://user-images.githubusercontent.com/1243084/60740747-b1f3f780-9f1b-11e9-828f-db3b4d6565d2.png">
<img width="1129" alt="web_recent" src="https://user-images.githubusercontent.com/1243084/60740759-b6b8ab80-9f1b-11e9-8db9-7760bf0ad6a2.png">
<img width="988" alt="web_summary" src="https://user-images.githubusercontent.com/1243084/60740765-bc15f600-9f1b-11e9-89e8-c5fc48b71486.png">
<img width="1136" alt="web_invite" src="https://user-images.githubusercontent.com/1243084/60740767-c20bd700-9f1b-11e9-9fae-19b300fdf65b.png">
<img width="988" alt="web_info" src="https://user-images.githubusercontent.com/1243084/60740775-c7692180-9f1b-11e9-9eb6-5947408ccaf4.png">
