### PR TITLE
android: be explicit about starting a foreground service

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
@@ -21,6 +21,7 @@ import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 
@@ -47,7 +48,12 @@ public class JitsiMeetOngoingConferenceService extends Service
         Intent intent = new Intent(context, JitsiMeetOngoingConferenceService.class);
         intent.setAction(Actions.START);
 
-        ComponentName componentName = context.startService(intent);
+        ComponentName componentName;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            componentName = context.startForegroundService(intent);
+        } else {
+            componentName = context.startService(intent);
+        }
         if (componentName == null) {
             Log.w(TAG, "Ongoing conference service not started");
         }


### PR DESCRIPTION
After calling startService we are supposed to have a bit of time before turning
the service into a foreground service, but certain devices seem to be more
spartan and we've seen the following failure:

Caused by java.lang.IllegalStateException: Not allowed to start service Intent { act=JitsiMeetOngoingConferenceService:START cmp=org.jitsi.meet/.sdk.JitsiMeetOngoingConferenceService }: app is in background uid UidRecord{f6778d5 u0a220 CAC  bg:+1m1s417ms idle change:idle procs:1 proclist:15604, seq(0,0,0)}
       at android.app.ContextImpl.startServiceCommon + 1600(ContextImpl.java:1600)
       at android.app.ContextImpl.startService + 1546(ContextImpl.java:1546)
       at android.content.ContextWrapper.startService + 669(ContextWrapper.java:669)
       at org.jitsi.meet.sdk.JitsiMeetOngoingConferenceService.launch + 50(JitsiMeetOngoingConferenceService.java:50)

Be expliocit and call startForegroundService, on supported platforms.