### PR TITLE
feat: use dialog instead of alert when inviting

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -340,9 +340,7 @@
         "label": "Meeting info"
     },
     "inviteDialog": {
-        "alertOk": "Ok",
         "alertText": "Failed to invite some participants.",
-        "alertTitle": "Invite",
         "header": "Invite",
         "searchCallOnlyPlaceholder": "Enter phone number",
         "searchPeopleOnlyPlaceholder": "Search for participants",

--- a/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import React from 'react';
 import {
     ActivityIndicator,
-    Alert,
     FlatList,
     KeyboardAvoidingView,
     Platform,
@@ -14,12 +13,13 @@ import {
     View
 } from 'react-native';
 
+import { AlertDialog, openDialog } from '../../../../base/dialog';
 import { Icon } from '../../../../base/font-icons';
 import { translate } from '../../../../base/i18n';
 import {
     AvatarListItem,
     HeaderWithNavigation,
-    Modal,
+    SlidingView,
     type Item
 } from '../../../../base/react';
 import { connect } from '../../../../base/redux';
@@ -149,9 +149,9 @@ class AddPeopleDialog extends AbstractAddPeopleDialog<Props, State> {
         }
 
         return (
-            <Modal
-                onRequestClose = { this._onCloseAddPeopleDialog }
-                visible = { this.props._isVisible }>
+            <SlidingView
+                position = 'bottom'
+                show = { this.props._isVisible } >
                 <HeaderWithNavigation
                     forwardDisabled = { this._isAddDisabled() }
                     forwardLabelKey = 'inviteDialog.send'
@@ -196,7 +196,7 @@ class AddPeopleDialog extends AbstractAddPeopleDialog<Props, State> {
                             style = { styles.resultList } />
                     </SafeAreaView>
                 </KeyboardAvoidingView>
-            </Modal>
+            </SlidingView>
         );
     }
 
@@ -495,17 +495,11 @@ class AddPeopleDialog extends AbstractAddPeopleDialog<Props, State> {
      * @returns {void}
      */
     _showFailedInviteAlert() {
-        const { t } = this.props;
-
-        Alert.alert(
-            t('inviteDialog.alertTitle'),
-            t('inviteDialog.alertText'),
-            [
-                {
-                    text: t('inviteDialog.alertOk')
-                }
-            ]
-        );
+        this.props.dispatch(openDialog(AlertDialog, {
+            contentKey: {
+                key: 'inviteDialog.alertText'
+            }
+        }));
     }
 }
 


### PR DESCRIPTION
Note: the Android back button misbehaves with the SlidingView (unlike a Modal). I'm going to try to cover that in a follow up PR.