### PR TITLE
fix(remote-control): do not assume failed query is missing support

### DIFF
--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -893,8 +893,10 @@ const VideoLayout = {
      * will be set.
      */
     _setRemoteControlProperties(user, remoteVideo) {
-        APP.remoteControl.checkUserRemoteControlSupport(user).then(result =>
-            remoteVideo.setRemoteControlSupport(result));
+        APP.remoteControl.checkUserRemoteControlSupport(user)
+            .then(result => remoteVideo.setRemoteControlSupport(result))
+            .catch(error =>
+                logger.warn('could not get remote control properties', error));
     },
 
     /**

--- a/modules/remotecontrol/RemoteControl.js
+++ b/modules/remotecontrol/RemoteControl.js
@@ -91,9 +91,8 @@ class RemoteControl extends EventEmitter {
      * the user supports remote control and with false if not.
      */
     checkUserRemoteControlSupport(user: Object) {
-        return user.getFeatures().then(
-            features => features.has(DISCO_REMOTE_CONTROL_FEATURE),
-            () => false);
+        return user.getFeatures()
+            .then(features => features.has(DISCO_REMOTE_CONTROL_FEATURE));
     }
 }
 


### PR DESCRIPTION
Multiple requests for checkUserRemoteControlSupport can be in
flight simultaneously. Order of promise resolution is not
guaranteed. It is possible for Request A and Request B to be
in flight and then Request B's promise chain resolves first.
Request A could have encountered errors and then resolve. Then
what could happen is checkUserRemoteControlSupport returns true
for remote control support due to Request B and the UI updates.
But then checkUserRemoteControlSupport returns false for
remote control support due to Request A's error and the UI
updates to hide remote control.