### PR TITLE
Passes confID when initializing JitsiConference.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1241,6 +1241,7 @@ export default {
         const options = config;
 
         const nick = APP.store.getState()['features/base/settings'].displayName;
+        const { locationURL } = APP.store.getState()['features/base/connection'];
 
         if (nick) {
             options.displayName = nick;
@@ -1248,6 +1249,7 @@ export default {
 
         options.applicationName = interfaceConfig.APP_NAME;
         options.getWiFiStatsMethod = this._getWiFiStatsMethod;
+        options.confID = `${locationURL.host}${locationURL.pathname}`;
 
         return options;
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9042,8 +9042,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#8a4d1f1b085131aca3cec5513fa7995cf7508fc2",
-      "from": "github:jitsi/lib-jitsi-meet#8a4d1f1b085131aca3cec5513fa7995cf7508fc2",
+      "version": "github:jitsi/lib-jitsi-meet#24bda8e941c346ccfde6bc1e1bb5dcdbd9450bab",
+      "from": "github:jitsi/lib-jitsi-meet#24bda8e941c346ccfde6bc1e1bb5dcdbd9450bab",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "js-utils": "github:jitsi/js-utils#192b1c996e8c05530eb1f19e82a31069c3021e31",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#8a4d1f1b085131aca3cec5513fa7995cf7508fc2",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#24bda8e941c346ccfde6bc1e1bb5dcdbd9450bab",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.11",
     "moment": "2.19.4",

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -393,7 +393,8 @@ export function createConference() {
                 room.toLowerCase(), {
                     ...state['features/base/config'],
                     applicationName: getName(),
-                    getWiFiStatsMethod: getJitsiMeetGlobalNS().getWiFiStats
+                    getWiFiStatsMethod: getJitsiMeetGlobalNS().getWiFiStats,
+                    confID: `${locationURL.host}${locationURL.pathname}`
                 });
 
         connection[JITSI_CONNECTION_CONFERENCE_KEY] = conference;


### PR DESCRIPTION
The confID is domain.com/RoomName or domain.com/tenant/RoomName, adds the tenant if any and also keeps the room name case.

Depends on https://github.com/jitsi/lib-jitsi-meet/pull/934