### PR TITLE
feat: always show labels

### DIFF
--- a/react/features/conference/components/native/Labels.js
+++ b/react/features/conference/components/native/Labels.js
@@ -12,9 +12,7 @@ import {
 import {
     RecordingExpandedLabel
 } from '../../../recording';
-import { isToolboxVisible } from '../../../toolbox';
 import { TranscribingExpandedLabel } from '../../../transcribing';
-import { shouldDisplayTileView } from '../../../video-layout';
 import { VideoQualityExpandedLabel } from '../../../video-quality';
 
 import AbstractLabels, {
@@ -364,9 +362,7 @@ function _mapStateToProps(state) {
     return {
         ..._abstractMapStateToProps(state),
         _reducedUI: state['features/base/responsive-ui'].reducedUI,
-        _visible: !isToolboxVisible(state)
-            && !shouldDisplayTileView(state)
-            && !shouldDisplayNotifications(state)
+        _visible: !shouldDisplayNotifications(state)
     };
 }
 


### PR DESCRIPTION
Navbar off:

![image](https://user-images.githubusercontent.com/9974975/61289094-703b3a80-a7c0-11e9-81ed-4c8fb18c0284.png)

Navbar on:

![image](https://user-images.githubusercontent.com/9974975/61289109-7a5d3900-a7c0-11e9-86d0-b94f3844c23f.png)

Note 1: It felt more natural for me to place the labels under the gradient, because then they won't collide with a longer room name

Note 2: There is an unrelated landscape mode bug that I'll address in another PR