### PR TITLE
fix(chat): workaround for chat scroll causing layout misalignment

### DIFF
--- a/react/features/chat/components/web/MessageContainer.js
+++ b/react/features/chat/components/web/MessageContainer.js
@@ -100,7 +100,8 @@ export default class MessageContainer extends AbstractMessageContainer {
      */
     scrollToBottom(withAnimation: boolean) {
         this._messagesListEndRef.current.scrollIntoView({
-            behavior: withAnimation ? 'smooth' : 'auto'
+            behavior: withAnimation ? 'smooth' : 'auto',
+            block: 'nearest'
         });
     }
 

--- a/react/features/chat/middleware.js
+++ b/react/features/chat/middleware.js
@@ -84,6 +84,15 @@ StateListenerRegistry.register(
         }
     });
 
+StateListenerRegistry.register(
+    state => state['features/chat'].isOpen,
+    (isOpen, { dispatch }) => {
+        if (typeof APP !== 'undefined' && isOpen) {
+            dispatch(showToolbox());
+        }
+    }
+);
+
 /**
  * Registers listener for {@link JitsiConferenceEvents.MESSAGE_RECEIVED} that
  * will perform various chat related activities.


### PR DESCRIPTION
Steps to reproduce:
1. Proceed into a conference.
2. Wait for the toolbar to disappear.
3. Press "c" to open chat.

Result: The layout is moved up.

I don't know the exact cause, admittedly. It has something to do with autoscrolling to the bottom of the chat so I made it scroll a little less. Another workaround would be use position:fixed on the toolbar and chat panel.

Bugged state:
<img width="1187" alt="Screen Shot 2019-07-17 at 3 04 43 PM" src="https://user-images.githubusercontent.com/1243084/61415355-40b22e00-a8a5-11e9-82eb-a2ecc0905386.png">
