### PR TITLE
Maps available locales for countries to the doubled languages.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,8 +17,15 @@ override_dh_install: $(LANGUAGES)
 	dh_install -X/config.js -X/package.json
 
 $(LANGUAGES):
+	LOCALE=$$(echo $@ | cut -c1-2) ; \
 	if [ -f $(COUNTRIES_DIR)/$@.json ] ; \
 	then \
 		dh_install -pjitsi-meet-web $(COUNTRIES_DIR)/$@.json usr/share/jitsi-meet/lang/; \
 		mv debian/jitsi-meet-web/usr/share/jitsi-meet/lang/$@.json debian/jitsi-meet-web/usr/share/jitsi-meet/lang/countries-$@.json; \
+	else \
+		if [ -f $(COUNTRIES_DIR)/$$LOCALE.json ] ; \
+		then \
+			dh_install -pjitsi-meet-web $(COUNTRIES_DIR)/$$LOCALE.json usr/share/jitsi-meet/lang/; \
+			mv debian/jitsi-meet-web/usr/share/jitsi-meet/lang/$$LOCALE.json debian/jitsi-meet-web/usr/share/jitsi-meet/lang/countries-$@.json; \
+		fi; \
 	fi;


### PR DESCRIPTION
This maps the tow letter languages as enGB to the country file for en.
Copies countries-en.json as countries-enGB.json.