### PR TITLE
feat(shortcuts): add shortcut for opening video quality modal

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -343,7 +343,8 @@
         "toggleFilmstrip": "Show or hide video thumbnails",
         "toggleScreensharing": "Switch between camera and screen sharing",
         "toggleShortcuts": "Show or hide keyboard shortcuts",
-        "videoMute": "Start or stop your camera"
+        "videoMute": "Start or stop your camera",
+        "videoQuality": "Manage call quality"
     },
     "liveStreaming": {
         "busy": "We're working on freeing streaming resources. Please try again in a few minutes.",

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -8,7 +8,7 @@ import {
     createToolbarEvent,
     sendAnalytics
 } from '../../../analytics';
-import { openDialog } from '../../../base/dialog';
+import { openDialog, toggleDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import {
     getLocalParticipant,
@@ -221,6 +221,8 @@ class Toolbox extends Component<Props, State> {
             = this._onShortcutToggleRaiseHand.bind(this);
         this._onShortcutToggleScreenshare
             = this._onShortcutToggleScreenshare.bind(this);
+        this._onShortcutToggleVideoQuality
+            = this._onShortcutToggleVideoQuality.bind(this);
         this._onToolbarOpenFeedback
             = this._onToolbarOpenFeedback.bind(this);
         this._onToolbarOpenInvite = this._onToolbarOpenInvite.bind(this);
@@ -259,6 +261,11 @@ class Toolbox extends Component<Props, State> {
      */
     componentDidMount() {
         const KEYBOARD_SHORTCUTS = [
+            this._shouldShowButton('videoquality') && {
+                character: 'A',
+                exec: this._onShortcutToggleVideoQuality,
+                helpDescription: 'keyboardShortcuts.videoQuality'
+            },
             this._shouldShowButton('chat') && {
                 character: 'C',
                 exec: this._onShortcutToggleChat,
@@ -320,7 +327,7 @@ class Toolbox extends Component<Props, State> {
      * @returns {void}
      */
     componentWillUnmount() {
-        [ 'C', 'D', 'R', 'S' ].forEach(letter =>
+        [ 'A', 'C', 'D', 'R', 'S' ].forEach(letter =>
             APP.keyboardshortcut.unregisterShortcut(letter));
 
         window.removeEventListener('resize', this._onResize);
@@ -384,7 +391,7 @@ class Toolbox extends Component<Props, State> {
     }
 
     /**
-     * Dispatches an action to toggle the video quality dialog.
+     * Dispatches an action to open the video quality dialog.
      *
      * @private
      * @returns {void}
@@ -479,6 +486,16 @@ class Toolbox extends Component<Props, State> {
         this.props.dispatch(toggleSharedVideo());
     }
 
+    /**
+     * Dispatches an action to toggle the video quality dialog.
+     *
+     * @private
+     * @returns {void}
+     */
+    _doToggleVideoQuality() {
+        this.props.dispatch(toggleDialog(VideoQualityDialog));
+    }
+
     _onMouseOut: () => void;
 
     /**
@@ -552,6 +569,21 @@ class Toolbox extends Component<Props, State> {
             }));
 
         this._doToggleChat();
+    }
+
+    _onShortcutToggleVideoQuality: () => void;
+
+    /**
+    * Creates an analytics keyboard shortcut event and dispatches an action for
+    * toggling the display of Video Quality.
+    *
+    * @private
+    * @returns {void}
+    */
+    _onShortcutToggleVideoQuality() {
+        sendAnalytics(createShortcutEvent('video.quality'));
+
+        this._doToggleVideoQuality();
     }
 
     _onShortcutToggleFullScreen: () => void;


### PR DESCRIPTION
@saghul, does this give you the change you want?

I think keyboard shortcuts could also be moved out. There might end up being some duplication of function calls between toolbox and keyboard shortcuts but a greater separation of concerns achieved. Let me know if you want that for a follow up commit which would happen within the next year, I promise.