### PR TITLE
conference: don't pin participants on the JVB 

### DIFF
--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -435,30 +435,27 @@ function _pinParticipant({ getState }, next, action) {
     const participants = state['features/base/participants'];
     const id = action.participant.id;
     const participantById = getParticipantById(participants, id);
+    const pinnedParticipant = getPinnedParticipant(participants);
+    const actionName = id ? ACTION_PINNED : ACTION_UNPINNED;
+    const local
+        = (participantById && participantById.local)
+            || (!id && pinnedParticipant && pinnedParticipant.local);
+    let participantIdForEvent;
 
-    if (typeof APP !== 'undefined') {
-        const pinnedParticipant = getPinnedParticipant(participants);
-        const actionName = id ? ACTION_PINNED : ACTION_UNPINNED;
-        const local
-            = (participantById && participantById.local)
-                || (!id && pinnedParticipant && pinnedParticipant.local);
-        let participantIdForEvent;
-
-        if (local) {
-            participantIdForEvent = local;
-        } else {
-            participantIdForEvent = actionName === ACTION_PINNED
-                ? id : pinnedParticipant && pinnedParticipant.id;
-        }
-
-        sendAnalytics(createPinnedEvent(
-            actionName,
-            participantIdForEvent,
-            {
-                local,
-                'participant_count': conference.getParticipantCount()
-            }));
+    if (local) {
+        participantIdForEvent = local;
+    } else {
+        participantIdForEvent
+            = actionName === ACTION_PINNED ? id : pinnedParticipant && pinnedParticipant.id;
     }
+
+    sendAnalytics(createPinnedEvent(
+        actionName,
+        participantIdForEvent,
+        {
+            local,
+            'participant_count': conference.getParticipantCount()
+        }));
 
     return next(action);
 }

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -14,7 +14,6 @@ import { CONNECTION_ESTABLISHED, CONNECTION_FAILED } from '../connection';
 import { JitsiConferenceErrors } from '../lib-jitsi-meet';
 import { setVideoMuted, VIDEO_MUTISM_AUTHORITY } from '../media';
 import {
-    getLocalParticipant,
     getParticipantById,
     getPinnedParticipant,
     PARTICIPANT_UPDATED,
@@ -46,7 +45,6 @@ import {
     _addLocalTracksToConference,
     forEachConference,
     getCurrentConference,
-    _handleParticipantError,
     _removeLocalTracksFromConference
 } from './functions';
 
@@ -460,30 +458,6 @@ function _pinParticipant({ getState }, next, action) {
                 local,
                 'participant_count': conference.getParticipantCount()
             }));
-    }
-
-    // The following condition prevents signaling to pin local participant and
-    // shared videos. The logic is:
-    // - If we have an ID, we check if the participant identified by that ID is
-    //   local or a bot/fake participant (such as with shared video).
-    // - If we don't have an ID (i.e. no participant identified by an ID), we
-    //   check for local participant. If she's currently pinned, then this
-    //   action will unpin her and that's why we won't signal here too.
-    let pin;
-
-    if (participantById) {
-        pin = !participantById.local && !participantById.isFakeParticipant;
-    } else {
-        const localParticipant = getLocalParticipant(participants);
-
-        pin = !localParticipant || !localParticipant.pinned;
-    }
-    if (pin) {
-        try {
-            conference.pinParticipant(id);
-        } catch (err) {
-            _handleParticipantError(err);
-        }
     }
 
     return next(action);


### PR DESCRIPTION
When a participant is pinned in the UI we then proceed to mark it as selected on
the JVB. This will make the participant part of the last N set and will receive
the highest (or configured highest) video quality.

Pinning a participant at the JVB level just makes sure it will be part of the
last N set.

Since only one participant can be pinned in the UI, there is no point in pinning
it at the JVB level, since selecting it already achieved the same result.