### PR TITLE
ref(feedback): emit api feedback submitted on completion

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -372,6 +372,13 @@ changes. The listener will receive an object with the following structure:
     email: string // the new email
 }
 ```
+* **feedbackSubmitted** - event notifications about conference feedback submission
+```javascript
+{
+    error: string // The error which occurred during submission, if any.
+}
+```
+
 * **filmstripDisplayChanged** - event notifications about the visibility of the filmstrip being updated.
 ```javascript
 {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -627,10 +627,14 @@ class API {
      * has been submitted. Intended to be used in conjunction with the
      * submit-feedback command to get notified if feedback was submitted.
      *
+     * @param {string} error - A failure message, if any.
      * @returns {void}
      */
-    notifyFeedbackSubmitted() {
-        this._sendEvent({ name: 'feedback-submitted' });
+    notifyFeedbackSubmitted(error: string) {
+        this._sendEvent({
+            name: 'feedback-submitted',
+            error
+        });
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9073,8 +9073,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#502ba82e1e4e4cdf8fe768566b6414f5c100491a",
-      "from": "github:jitsi/lib-jitsi-meet#502ba82e1e4e4cdf8fe768566b6414f5c100491a",
+      "version": "github:jitsi/lib-jitsi-meet#97475026de59442f9b8a50d5abed6131a0b1c544",
+      "from": "github:jitsi/lib-jitsi-meet#97475026de59442f9b8a50d5abed6131a0b1c544",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "js-utils": "github:jitsi/js-utils#192b1c996e8c05530eb1f19e82a31069c3021e31",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#502ba82e1e4e4cdf8fe768566b6414f5c100491a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#97475026de59442f9b8a50d5abed6131a0b1c544",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.11",
     "moment": "2.19.4",

--- a/react/features/external-api/middleware.js
+++ b/react/features/external-api/middleware.js
@@ -18,7 +18,7 @@ import {
 import { MiddlewareRegistry } from '../base/redux';
 import { getBaseUrl } from '../base/util';
 import { appendSuffix } from '../display-name';
-import { SUBMIT_FEEDBACK } from '../feedback';
+import { SUBMIT_FEEDBACK_ERROR, SUBMIT_FEEDBACK_SUCCESS } from '../feedback';
 import { SET_FILMSTRIP_VISIBLE } from '../filmstrip';
 
 declare var APP: Object;
@@ -156,7 +156,11 @@ MiddlewareRegistry.register(store => next => action => {
         APP.API.notifyFilmstripDisplayChanged(action.visible);
         break;
 
-    case SUBMIT_FEEDBACK:
+    case SUBMIT_FEEDBACK_ERROR:
+        APP.API.notifyFeedbackSubmitted(action.error || 'Unknown error');
+        break;
+
+    case SUBMIT_FEEDBACK_SUCCESS:
         APP.API.notifyFeedbackSubmitted();
         break;
     }

--- a/react/features/feedback/actionTypes.js
+++ b/react/features/feedback/actionTypes.js
@@ -10,12 +10,20 @@
 export const CANCEL_FEEDBACK = 'CANCEL_FEEDBACK';
 
 /**
- * The type of the action which signals feedback was submitted for recording.
+ * The type of the action which signals feedback failed to be recorded.
  *
  * {
- *     type: SUBMIT_FEEDBACK,
- *     message: string,
- *     score: number
+ *     type: SUBMIT_FEEDBACK_ERROR
+ *     error: string
  * }
  */
-export const SUBMIT_FEEDBACK = 'SUBMIT_FEEDBACK';
+export const SUBMIT_FEEDBACK_ERROR = 'SUBMIT_FEEDBACK_ERROR';
+
+/**
+ * The type of the action which signals feedback has been recorded.
+ *
+ * {
+ *     type: SUBMIT_FEEDBACK_SUCCESS,
+ * }
+ */
+export const SUBMIT_FEEDBACK_SUCCESS = 'SUBMIT_FEEDBACK_SUCCESS';

--- a/react/features/feedback/actions.js
+++ b/react/features/feedback/actions.js
@@ -5,7 +5,11 @@ import type { Dispatch } from 'redux';
 import { openDialog } from '../base/dialog';
 import { FEEDBACK_REQUEST_IN_PROGRESS } from '../../../modules/UI/UIErrors';
 
-import { CANCEL_FEEDBACK, SUBMIT_FEEDBACK } from './actionTypes';
+import {
+    CANCEL_FEEDBACK,
+    SUBMIT_FEEDBACK_ERROR,
+    SUBMIT_FEEDBACK_SUCCESS
+} from './actionTypes';
 import { FeedbackDialog } from './components';
 
 declare var config: Object;
@@ -114,17 +118,22 @@ export function openFeedbackDialog(conference: Object, onClose: ?Function) {
  * rating.
  * @param {JitsiConference} conference - The JitsiConference for which the
  * feedback is being left.
- * @returns {{
- *     type: SUBMIT_FEEDBACK
- * }}
+ * @returns {Function}
  */
 export function submitFeedback(
         score: number,
         message: string,
         conference: Object) {
-    conference.sendFeedback(score, message);
+    return (dispatch: Dispatch<any>) => conference.sendFeedback(score, message)
+        .then(
+            () => dispatch({ type: SUBMIT_FEEDBACK_SUCCESS }),
+            error => {
+                dispatch({
+                    type: SUBMIT_FEEDBACK_ERROR,
+                    error
+                });
 
-    return {
-        type: SUBMIT_FEEDBACK
-    };
+                return Promise.reject(error);
+            }
+        );
 }

--- a/react/features/feedback/reducer.js
+++ b/react/features/feedback/reducer.js
@@ -4,7 +4,8 @@ import {
 
 import {
     CANCEL_FEEDBACK,
-    SUBMIT_FEEDBACK
+    SUBMIT_FEEDBACK_ERROR,
+    SUBMIT_FEEDBACK_SUCCESS
 } from './actionTypes';
 
 const DEFAULT_STATE = {
@@ -31,7 +32,8 @@ ReducerRegistry.register(
             };
         }
 
-        case SUBMIT_FEEDBACK: {
+        case SUBMIT_FEEDBACK_ERROR:
+        case SUBMIT_FEEDBACK_SUCCESS: {
             return {
                 ...state,
                 message: '',


### PR DESCRIPTION
Compared to firing the event on submission because
the submission ajax will not be completed at that
time..

Relies on https://github.com/jitsi/lib-jitsi-meet/pull/952 being merged first.