### PR TITLE
Removes resolveAppName postprocess we do not need.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -113,7 +113,6 @@
     },
     "deepLinking": {
         "appNotInstalled": "You need the {{app}} mobile app to join this meeting on your phone.",
-        "description": "Nothing happened? We tried launching your meeting in the {{app}} desktop app. Try again or launch it in the {{app}} web app.",
         "descriptionWithoutWeb": "Nothing happened? We tried launching your meeting in the {{app}} desktop app.",
         "downloadApp": "Download the app",
         "launchWebButton": "Launch in web",

--- a/react/features/base/i18n/i18next.js
+++ b/react/features/base/i18n/i18next.js
@@ -9,8 +9,6 @@ import MAIN_RESOURCES from '../../../../lang/main.json';
 
 import languageDetector from './languageDetector';
 
-declare var interfaceConfig: Object;
-
 /**
  * The available/supported languages.
  *
@@ -37,9 +35,6 @@ export const DEFAULT_LANGUAGE = LANGUAGES[0];
  * @type {Object}
  */
 const options = {
-    app:
-        (typeof interfaceConfig !== 'undefined' && interfaceConfig.APP_NAME)
-            || 'Jitsi Meet',
     backend: {
         loadPath: 'lang/{{ns}}-{{lng}}.json'
     },
@@ -64,11 +59,6 @@ const options = {
 i18next
     .use(navigator.product === 'ReactNative' ? {} : I18nextXHRBackend)
     .use(languageDetector)
-    .use({
-        name: 'resolveAppName',
-        process: (res, key) => i18next.t(key, { app: options.app }),
-        type: 'postProcessor'
-    })
     .init(options);
 
 // Add default language which is preloaded from the source code.

--- a/react/features/overlay/components/web/UserMediaPermissionsFilmstripOnlyOverlay.js
+++ b/react/features/overlay/components/web/UserMediaPermissionsFilmstripOnlyOverlay.js
@@ -9,6 +9,8 @@ import AbstractUserMediaPermissionsOverlay, { abstractMapStateToProps }
     from './AbstractUserMediaPermissionsOverlay';
 import FilmstripOnlyOverlayFrame from './FilmstripOnlyOverlayFrame';
 
+declare var interfaceConfig: Object;
+
 /**
  * Implements a React Component for overlay with guidance how to proceed with
  * gUM prompt. This component will be displayed only for filmstrip only mode.
@@ -34,7 +36,7 @@ class UserMediaPermissionsFilmstripOnlyOverlay
                     <div className = 'inlay-filmstrip-only__title'>
                         {
                             t('startupoverlay.title',
-                                { postProcess: 'resolveAppName' })
+                                { app: interfaceConfig.APP_NAME })
                         }
                     </div>
                     <div className = 'inlay-filmstrip-only__text'>

--- a/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
+++ b/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
@@ -33,7 +33,7 @@ class UserMediaPermissionsOverlay extends AbstractUserMediaPermissionsOverlay {
                     <h3 className = 'inlay__title'>
                         {
                             t('startupoverlay.title',
-                                { postProcess: 'resolveAppName' })
+                                { app: interfaceConfig.APP_NAME })
                         }
                     </h3>
                     <span className = 'inlay__text'>


### PR DESCRIPTION
i18next.options are initialized before interfaceConfig overwrites are processed which leads to wrong translations.