### PR TITLE
fix(deep-linking): do not accept native app name as raw html

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { connect } from '../../base/redux';
 
 import { createDeepLinkingPageEvent, sendAnalytics } from '../../analytics';
-import { translate, translateToHTML } from '../../base/i18n';
+import { translate } from '../../base/i18n';
 import { Platform } from '../../base/react';
 import { DialInSummary } from '../../invite';
 
@@ -109,12 +109,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                             : null
                     }
                     <p className = { `${_SNS}__text` }>
-                        {
-                            translateToHTML(
-                                t,
-                                `${_TNS}.appNotInstalled`,
-                                { app: NATIVE_APP_NAME })
-                        }
+                        { t(`${_TNS}.appNotInstalled`, { app: NATIVE_APP_NAME }) }
                     </p>
                     <a
                         href = { this._generateDownloadURL() }


### PR DESCRIPTION
There is no need to display the native app name as
raw html.