### PR TITLE
fix(suboptimal-browser): remove inserting of app name in notification

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -429,7 +429,7 @@
         "somebody": "Somebody",
         "startSilentTitle": "You joined with no audio output!",
         "startSilentDescription": "Rejoin the meeting to enable audio",
-        "suboptimalExperienceDescription": "Eer... we are afraid your experience with {{appName}} isn't going to be that great here. We are looking for ways to improve this but, until then, please try using one of the <a href='static/recommendedBrowsers.html' target='_blank'>fully supported browsers</a>.",
+        "suboptimalBrowserWarning": "We are afraid your meeting experience isn't going to be that great here. We are looking for ways to improve this, but until then please try using one of the <a href='static/recommendedBrowsers.html' target='_blank'>fully supported browsers</a>.",
         "suboptimalExperienceTitle": "Browser Warning",
         "unmute": "Unmute",
         "newDeviceCameraTitle": "New camera detected",

--- a/react/features/conference/functions.js
+++ b/react/features/conference/functions.js
@@ -2,7 +2,6 @@ import { translateToHTML } from '../base/i18n';
 import { isSuboptimalBrowser } from '../base/environment';
 import { toState } from '../base/redux';
 
-import { getName } from '../app';
 import {
     areThereNotifications,
     showWarningNotification
@@ -24,10 +23,8 @@ export function maybeShowSuboptimalExperienceNotification(dispatch, t) {
                     titleKey: 'notify.suboptimalExperienceTitle',
                     description: translateToHTML(
                         t,
-                        'notify.suboptimalExperienceDescription',
-                        {
-                            appName: getName()
-                        })
+                        'notify.suboptimalBrowserWarning'
+                    )
                 }
             )
         );


### PR DESCRIPTION
This prevents inserting any user overridden APP_NAME
values into html. A new translation key is being used
to immediately stop non-english languages from using the
problematic string.

Also tweaked the copy to remove the "eer" and fix
some grammar.

<img width="1267" alt="Screen Shot 2019-08-04 at 8 50 01 AM" src="https://user-images.githubusercontent.com/1243084/62426106-7886e700-b695-11e9-9b02-faca63f2f83e.png">
