### PR TITLE
1. 修正语言检测 zh-CN，修正 bosh 端口问题。

### DIFF
--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -298,11 +298,12 @@ function _constructOptions(state) {
             const {
                 protocol,
                 hostname,
+                port,
                 contextRoot
             } = parseURIString(locationURL.href);
 
             // eslint-disable-next-line max-len
-            bosh = `${protocol}//${hostname}${contextRoot || '/'}${bosh.substr(1)}`;
+            bosh = `${protocol}//${hostname}:${port || '80'}${contextRoot || '/'}${bosh.substr(1)}`;
         }
 
         // Append room to the URL's search.

--- a/react/features/base/i18n/languageDetector.native.js
+++ b/react/features/base/i18n/languageDetector.native.js
@@ -17,7 +17,7 @@ export default {
     detect() {
         const { LocaleDetector } = NativeModules;
 
-        return LocaleDetector.locale.replace(/_/, '-');
+        return LocaleDetector.locale.replace(/[_-]/, '');
     },
 
     init: Function.prototype,


### PR DESCRIPTION
1. languageDetector.native.js cannot set language properly when localDetector.java returned 'zh-CN'/'zh_CN'.

2. when creating bosh connection with configs from config.js, e.g. serverURL: 'http://localhost:8080' bosh: '/http-bind', we got boshUrl without port info (http://localhost/http-bind), which seems that 'http://localhost:8080/http-bind' is correct. we can also change nginx configs to solve this.
