### PR TITLE
1. 修在语言包问题。

### DIFF
--- a/lang/languages.json
+++ b/lang/languages.json
@@ -26,6 +26,6 @@
     "sv": "Swedish",
     "tr": "Turkish",
     "vi": "Vietnamese",
-    "zhCN": "Chinese (China)",
-    "zhTW": "Chinese (Taiwan)"
+    "zh-CN": "Chinese (China)",
+    "zh-TW": "Chinese (Taiwan)"
 }

--- a/react/features/base/i18n/BuiltinLanguages.native.js
+++ b/react/features/base/i18n/BuiltinLanguages.native.js
@@ -134,13 +134,13 @@ const _LANGUAGES = {
     },
 
     // Chinese (China)
-    'zhCN': {
+    'zh': {
         languages: require('../../../../lang/languages-zhCN'),
         main: require('../../../../lang/main-zhCN')
     },
 
     // Chinese (Taiwan)
-    'zhTW': {
+    'zh-TW': {
         languages: require('../../../../lang/languages-zhTW'),
         main: require('../../../../lang/main-zhTW')
     }

--- a/react/features/base/i18n/i18next.js
+++ b/react/features/base/i18n/i18next.js
@@ -43,7 +43,7 @@ const options = {
     interpolation: {
         escapeValue: false // not needed for react as it escapes by default
     },
-    load: 'languageOnly',
+    load: 'all',
     ns: [ 'main', 'languages', 'countries' ],
     react: {
         useSuspense: false


### PR DESCRIPTION
https://github.com/jitsi/jitsi-meet/pull/4510#discussion_r311030421

web and native will return the locale string: 'zh-CN, en-US' etc, 'i18next' uses the first part of it which is called language code to determine language.

language code 'zh' is not in the white list due to 'lang/languages.json'

so i change 'zhCN' to 'zh' for looking up language code of Simplified Chinese, when locale string start with 'zh-'.

when the locale string is 'zh-TW',  we want 'i18next' use 'zh-TW' for looking up Traditional Chinese translations but not 'zh'. so i set 'i18next' init option load = 'all', e.g, 'zh-TW': languageOnly -> 'zh', currentOnly-> 'zh-TW', all-> 'zh-TW', 'zh'.

on this condition, 'i18next' sets  languages to 'zh', 'zh-TW' and will lookup translations first in Traditional Chinese,  then fallback with Simplified Chinese.

i think it is a common way to define languages like 'languageCode[-regionCode]'.

