### PR TITLE
Leaves room only when it is already joined.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2544,7 +2544,11 @@ export default {
     leaveRoomAndDisconnect() {
         APP.store.dispatch(conferenceWillLeave(room));
 
-        return room.leave().then(disconnect, disconnect);
+        if (room.isJoined()) {
+            return room.leave().then(disconnect, disconnect);
+        }
+
+        return disconnect();
     },
 
     /**


### PR DESCRIPTION
In case of hitting errors like max participant limit reached and when clicking hangup, the attempt to leave room second time results error and reload screen.