### PR TITLE
travis: wait 10 seconds after script to catch the error logged

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ osx_image: xcode10.2
 language: objective-c
 script:
 - "./ios/travis-ci/build-ipa.sh"
+after_script:
+  - sleep 10


### PR DESCRIPTION
Adds wait time suggested by Travis support in order to see the last error logged.