### PR TITLE
Get participant specific video element

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -367,10 +367,10 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
-     * Getter for participant specific video element in Jitsi Meet
+     * Getter for participant specific video element in Jitsi Meet.
      * 
      * @param {string} participantId - Participant id
-     * or "local" for local video
+     * or "local" for local video.
      * @returns {HTMLElement|undefined} - The requested video.
      */
     _getLargeVideo(participantId) {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -370,7 +370,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * Getter for participant specific video element in Jitsi Meet.
      *
      * @param {string|undefined} participantId - Id of participant to return the video for.
-     * 
+     *
      * @returns {HTMLElement|undefined} - The requested video. Will return the local video
      * by default if participantId is undefined.
      */
@@ -387,7 +387,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             return iframe.contentWindow.document.getElementById('localVideo_container');
         }
 
-        return iframe.contentWindow.document.querySelector('#participant_${participantId} video');
+        return iframe.contentWindow.document.querySelector(`#participant_${participantId} video`);
     }
 
     /**

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -369,9 +369,10 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     /**
      * Getter for participant specific video element in Jitsi Meet.
      *
-     * @param {string} participantId - Id of participant to return the video for.
-     *
-     * @returns {HTMLElement|undefined} - The requested video.
+     * @param {string|undefined} participantId - Id of participant to return the video for.
+     * 
+     * @returns {HTMLElement|undefined} - The requested video. Will return the local video
+     * by default if participantId is undefined.
      */
     _getParticipantVideo(participantId) {
         const iframe = this.getIFrame();
@@ -382,11 +383,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             return;
         }
 
-        if (participantId === this._myUserID) {
+        if (typeof participantId === 'undefined' || participantId === this._myUserID) {
             return iframe.contentWindow.document.getElementById('localVideo_container');
         }
 
-        return iframe.contentWindow.document.querySelector('#participant_' + participantId + ' video');
+        return iframe.contentWindow.document.querySelector('#participant_${participantId} video');
     }
 
     /**

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -368,13 +368,19 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
     /**
      * Getter for participant specific video element in Jitsi Meet.
-     * 
-     * @param {string} participantId - Participant id
-     * or "local" for local video.
+     *
+     * @param {string} participantId - Participant id or "local" for local video.
+     *
      * @returns {HTMLElement|undefined} - The requested video.
      */
-    _getLargeVideo(participantId) {
+    _getParticipantVideo(participantId) {
         const iframe = this.getIFrame();
+
+        if (!iframe
+                || !iframe.contentWindow
+                || !iframe.contentWindow.document) {
+            return;
+        }
 
         if (participantId == "local") {
             return iframe.contentWindow.document.getElementById("localVideo_container");

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -367,6 +367,23 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Getter for participant specific video element in Jitsi Meet
+     * 
+     * @param {string} participantId - Participant id
+     * or "local" for local video
+     * @returns {HTMLElement|undefined} - The requested video.
+     */
+    _getLargeVideo(participantId) {
+        const iframe = this.getIFrame();
+
+        if (participantId == "local") {
+            return iframe.contentWindow.document.getElementById("localVideo_container");
+        }
+
+        return iframe.contentWindow.document.querySelector("#participant_" + participantId + " video");
+    }
+
+    /**
      * Sets the size of the iframe element.
      *
      * @param {number|string} height - The height of the iframe.

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -369,7 +369,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     /**
      * Getter for participant specific video element in Jitsi Meet.
      *
-     * @param {string} participantId - Participant id or "local" for local video.
+     * @param {string} participantId - Id of participant to return the video for.
      *
      * @returns {HTMLElement|undefined} - The requested video.
      */
@@ -382,11 +382,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             return;
         }
 
-        if (participantId == "local") {
-            return iframe.contentWindow.document.getElementById("localVideo_container");
+        if (participantId === this._myUserID) {
+            return iframe.contentWindow.document.getElementById('localVideo_container');
         }
 
-        return iframe.contentWindow.document.querySelector("#participant_" + participantId + " video");
+        return iframe.contentWindow.document.querySelector('#participant_' + participantId + ' video');
     }
 
     /**


### PR DESCRIPTION
We now have the ability to select the video element for specific participants. I'm tweaking the jitsi-meet-electron app for my use case. I need to open Always On Top windows for specific participants, so the current _getLargeVideo() wont suffice.

I made a post about this in the Developers section on the Jitsi Community Forum, but it got blocked by Akismet.