### PR TITLE
Removes i18n strings for p2p and turn.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -89,7 +89,6 @@
         "localport_plural": "Local ports:",
         "more": "Show more",
         "packetloss": "Packet loss:",
-        "peer_to_peer": " (p2p)",
         "quality": {
             "good": "Good",
             "inactive": "Inactive",
@@ -104,8 +103,7 @@
         "resolution": "Resolution:",
         "status": "Connection:",
         "transport": "Transport:",
-        "transport_plural": "Transports:",
-        "turn": " (turn)"
+        "transport_plural": "Transports:"
     },
     "dateUtils": {
         "earlier": "Earlier",

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -519,10 +519,10 @@ class ConnectionStatsTable extends Component<Props> {
 
         if (isP2P) {
             additionalData.push(
-                <span>{ t('connectionindicator.peer_to_peer') }</span>);
+                <span> (p2p)</span>);
         }
         if (isTURN) {
-            additionalData.push(<span>{ t('connectionindicator.turn') }</span>);
+            additionalData.push(<span> (turn)</span>);
         }
 
         // First show remote statistics, then local, and then transport type.


### PR DESCRIPTION
There is no point in translating this.
https://community.jitsi.org/t/translation-mistake-for-the-turn-server-label/19483