### PR TITLE
rn,welcome: fix accessing local participant

### DIFF
--- a/react/features/welcome/components/WelcomePageSideBar.native.js
+++ b/react/features/welcome/components/WelcomePageSideBar.native.js
@@ -44,12 +44,12 @@ type Props = {
     /**
      * Display name of the local participant.
      */
-    _displayName: string,
+    _displayName: ?string,
 
     /**
      * ID of the local participant.
      */
-    _localParticipantId: string,
+    _localParticipantId: ?string,
 
     /**
      * Sets the side bar visible or hidden.
@@ -157,10 +157,12 @@ class WelcomePageSideBar extends Component<Props> {
  */
 function _mapStateToProps(state: Object) {
     const _localParticipant = getLocalParticipant(state);
+    const _localParticipantId = _localParticipant?.id;
+    const _displayName = _localParticipant && getParticipantDisplayName(state, _localParticipantId);
 
     return {
-        _displayName: getParticipantDisplayName(state, _localParticipant.id),
-        _localParticipantId: _localParticipant.id,
+        _displayName,
+        _localParticipantId,
         _visible: state['features/welcome'].sideBarVisible
     };
 }


### PR DESCRIPTION
It need not always exist, since it's created asynchronousluy on app
initiualization. Make sure we are ready for it.

I've seen backtraces because of this.