### PR TITLE
feat: make display name prompt platform independent

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2198,12 +2198,6 @@ export default {
 
         APP.keyboardshortcut.init();
 
-        if (config.requireDisplayName
-                && !APP.conference.getLocalDisplayName()
-                && !room.isHidden()) {
-            APP.UI.promptDisplayName();
-        }
-
         APP.store.dispatch(conferenceJoined(room));
 
         const displayName

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -15,7 +15,6 @@ import Filmstrip from './videolayout/Filmstrip';
 
 import { getLocalParticipant } from '../../react/features/base/participants';
 import { toggleChat } from '../../react/features/chat';
-import { openDisplayNamePrompt } from '../../react/features/display-name';
 import { setEtherpadHasInitialzied } from '../../react/features/etherpad';
 import { setFilmstripVisible } from '../../react/features/filmstrip';
 import { setNotificationsEnabled } from '../../react/features/notifications';
@@ -547,13 +546,6 @@ UI.notifyInitiallyMuted = function() {
 
 UI.handleLastNEndpoints = function(leavingIds, enteringIds) {
     VideoLayout.onLastNEndpointsChanged(leavingIds, enteringIds);
-};
-
-/**
- * Prompt user for nickname.
- */
-UI.promptDisplayName = () => {
-    APP.store.dispatch(openDisplayNamePrompt(undefined));
 };
 
 /**

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -1,6 +1,8 @@
 // @flow
 
 import { reloadNow } from '../../app';
+import { openDisplayNamePrompt } from '../../display-name';
+
 import {
     ACTION_PINNED,
     ACTION_UNPINNED,
@@ -12,6 +14,7 @@ import {
 import { CONNECTION_ESTABLISHED, CONNECTION_FAILED } from '../connection';
 import { JitsiConferenceErrors } from '../lib-jitsi-meet';
 import {
+    getLocalParticipant,
     getParticipantById,
     getPinnedParticipant,
     PARTICIPANT_UPDATED,
@@ -186,6 +189,7 @@ function _conferenceJoined({ dispatch, getState }, next, action) {
     const result = next(action);
     const { conference } = action;
     const { pendingSubjectChange } = getState()['features/base/conference'];
+    const { requireDisplayName } = getState()['features/base/config'];
 
     pendingSubjectChange && dispatch(setSubject(pendingSubjectChange));
 
@@ -198,6 +202,12 @@ function _conferenceJoined({ dispatch, getState }, next, action) {
         dispatch(conferenceWillLeave(conference));
     };
     window.addEventListener('beforeunload', beforeUnloadHandler);
+
+    if (requireDisplayName
+        && !getLocalParticipant(getState)?.name
+        && !conference.isHidden()) {
+        dispatch(openDisplayNamePrompt(undefined));
+    }
 
     return result;
 }


### PR DESCRIPTION
This change lets the display name prompt open on mobile too for the predefined circumstances