### PR TITLE
Fix #312 by adding HTML5 validation pattern

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -707,6 +707,7 @@
         "connectCalendarButton": "Connect your calendar",
         "connectCalendarText": "Connect your calendar to view all your meetings in {{app}}. Plus, add {{provider}} meetings to your calendar and start them with one click.",
         "enterRoomTitle": "Start a new meeting",
+        "onlyAsciiAllowed": "Meeting name should only contain latin characters and numbers.",
         "go": "GO",
         "join": "JOIN",
         "info": "Info",

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -147,6 +147,8 @@ class WelcomePage extends AbstractWelcomePage {
                                 <input
                                     autoFocus = { true }
                                     className = 'enter-room-input'
+                                    pattern = '^[a-zA-Z0-9=\?]+$'
+                                    title = { t('welcomepage.onlyAsciiAllowed') }
                                     id = 'enter_room_field'
                                     onChange = { this._onRoomChange }
                                     placeholder


### PR DESCRIPTION
As described in #312 adding umlauts into a meeting name results in being redirected to a 404 page. The easiest way to fix this is to prevent people to submit the form while having invalid characters in the meeting name. 