### PR TITLE
ref: reduce device popup bundle size

### DIFF
--- a/react/features/base/dialog/components/web/AbstractDialogTab.js
+++ b/react/features/base/dialog/components/web/AbstractDialogTab.js
@@ -29,14 +29,14 @@ export type Props = {
  *
  * @extends Component
  */
-class AbstractDialogTab extends Component<Props> {
+class AbstractDialogTab<P: Props, S: *> extends Component<P, S> {
     /**
      * Initializes a new {@code AbstractDialogTab} instance.
      *
-     * @param {Object} props - The read-only properties with which the new
+     * @param {P} props - The read-only properties with which the new
      * instance is to be initialized.
      */
-    constructor(props: Props) {
+    constructor(props: P) {
         super(props);
 
         // Bind event handler so it is only bound once for every instance.

--- a/react/features/base/dialog/components/web/DialogWithTabs.js
+++ b/react/features/base/dialog/components/web/DialogWithTabs.js
@@ -3,10 +3,11 @@
 import Tabs from '@atlaskit/tabs';
 import React, { Component } from 'react';
 
-import { StatelessDialog } from '../../../dialog';
-import { translate } from '../../../i18n';
+import { translate } from '../../../i18n/functions';
 
 import logger from '../../logger';
+
+import StatelessDialog from './StatelessDialog';
 
 /**
  * The type of the React {@code Component} props of {@link DialogWithTabs}.

--- a/react/features/base/dialog/components/web/StatelessDialog.js
+++ b/react/features/base/dialog/components/web/StatelessDialog.js
@@ -5,7 +5,7 @@ import Modal, { ModalFooter } from '@atlaskit/modal-dialog';
 import _ from 'lodash';
 import React, { Component } from 'react';
 
-import { translate } from '../../../i18n';
+import { translate } from '../../../i18n/functions';
 
 import type { DialogProps } from '../../constants';
 

--- a/react/features/base/logging/functions.js
+++ b/react/features/base/logging/functions.js
@@ -33,7 +33,7 @@ export const _initLogging = _.once(() => {
     }
 
     // Lazy load it to avoid cycles in early web bootstrap code.
-    const { default: JitsiMeetJS } = require('../lib-jitsi-meet');
+    const { default: JitsiMeetJS } = require('../lib-jitsi-meet/_');
 
     Logger.setGlobalOptions(DEFAULT_RN_OPTS);
     JitsiMeetJS.setGlobalLogOptions(DEFAULT_RN_OPTS);

--- a/react/features/base/media/components/AbstractAudio.js
+++ b/react/features/base/media/components/AbstractAudio.js
@@ -36,7 +36,7 @@ type Props = {
      * @type {Object | string}
      */
     src: Object | string,
-    stream: Object,
+    stream?: Object,
     loop?: ?boolean
 }
 

--- a/react/features/base/media/components/Audio.native.js
+++ b/react/features/base/media/components/Audio.native.js
@@ -1,0 +1,5 @@
+// @flow
+
+import Audio from './native/Audio';
+
+export default Audio;

--- a/react/features/base/media/components/Audio.web.js
+++ b/react/features/base/media/components/Audio.web.js
@@ -1,0 +1,5 @@
+// @flow
+
+import Audio from './web/Audio';
+
+export default Audio;

--- a/react/features/base/media/components/Video.native.js
+++ b/react/features/base/media/components/Video.native.js
@@ -1,0 +1,5 @@
+// @flow
+
+import Video from './native/Video';
+
+export default Video;

--- a/react/features/base/media/components/Video.web.js
+++ b/react/features/base/media/components/Video.web.js
@@ -1,0 +1,5 @@
+// @flow
+
+import Video from './web/Video';
+
+export default Video;

--- a/react/features/base/media/components/web/Video.js
+++ b/react/features/base/media/components/web/Video.js
@@ -21,7 +21,7 @@ type Props = {
     /**
      * Optional callback to invoke once the video starts playing.
      */
-    onVideoPlaying: Function,
+    onVideoPlaying?: Function,
 
     /**
      * The JitsiLocalTrack to display.

--- a/react/features/device-selection/components/AudioInputPreview.js
+++ b/react/features/device-selection/components/AudioInputPreview.js
@@ -2,7 +2,9 @@
 
 import React, { Component } from 'react';
 
-import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
+import JitsiMeetJS from '../../base/lib-jitsi-meet/_';
+
+const JitsiTrackEvents = JitsiMeetJS.events.track;
 
 /**
  * The type of the React {@code Component} props of {@link AudioInputPreview}.

--- a/react/features/device-selection/components/AudioOutputPreview.js
+++ b/react/features/device-selection/components/AudioOutputPreview.js
@@ -2,8 +2,8 @@
 
 import React, { Component } from 'react';
 
-import { translate } from '../../base/i18n';
-import { Audio } from '../../base/media';
+import { translate } from '../../base/i18n/functions';
+import Audio from '../../base/media/components/Audio';
 
 const TEST_SOUND_PATH = 'sounds/ring.wav';
 

--- a/react/features/device-selection/components/DeviceSelection.js
+++ b/react/features/device-selection/components/DeviceSelection.js
@@ -2,10 +2,12 @@
 
 import React from 'react';
 
-import { AbstractDialogTab } from '../../base/dialog';
-import type { Props as AbstractDialogTabProps } from '../../base/dialog';
-import { translate } from '../../base/i18n';
-import JitsiMeetJS, { createLocalTrack } from '../../base/lib-jitsi-meet';
+import AbstractDialogTab, {
+    type Props as AbstractDialogTabProps
+} from '../../base/dialog/components/web/AbstractDialogTab';
+import { translate } from '../../base/i18n/functions';
+import JitsiMeetJS from '../../base/lib-jitsi-meet/_';
+import { createLocalTrack } from '../../base/lib-jitsi-meet/functions';
 
 import logger from '../logger';
 

--- a/react/features/device-selection/components/DeviceSelector.web.js
+++ b/react/features/device-selection/components/DeviceSelector.web.js
@@ -4,7 +4,7 @@ import AKDropdownMenu from '@atlaskit/dropdown-menu';
 import ChevronDownIcon from '@atlaskit/icon/glyph/chevron-down';
 import React, { Component } from 'react';
 
-import { translate } from '../../base/i18n';
+import { translate } from '../../base/i18n/functions';
 
 /**
  * The type of the React {@code Component} props of {@link DeviceSelector}.

--- a/react/features/device-selection/components/VideoInputPreview.js
+++ b/react/features/device-selection/components/VideoInputPreview.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import { Video } from '../../base/media';
+import Video from '../../base/media/components/Video';
 
 const VIDEO_ERROR_CLASS = 'video-preview-has-error';
 
@@ -15,7 +15,7 @@ type Props = {
      * An error message to display instead of a preview. Displaying an error
      * will take priority over displaying a video preview.
      */
-    error: string,
+    error: ?string,
 
     /**
      * The JitsiLocalTrack to display.

--- a/react/features/settings/components/web/DeviceSelectionPopup.js
+++ b/react/features/settings/components/web/DeviceSelectionPopup.js
@@ -20,9 +20,9 @@ import {
     setVideoInputDevice
 } from '../../../../../modules/API/external/functions';
 
-import { parseURLParams } from '../../../base/config';
-import { DialogWithTabs } from '../../../base/dialog';
-import { DeviceSelection } from '../../../device-selection';
+import parseURLParams from '../../../base/config/parseURLParams';
+import DialogWithTabs from '../../../base/dialog/components/web/DialogWithTabs';
+import DeviceSelection from '../../../device-selection/components/DeviceSelection';
 
 /**
  * Implements a class that renders the React components for the device selection

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -182,7 +182,7 @@ module.exports = [
         entry: {
             'device_selection_popup_bundle': './react/features/settings/popup.js'
         },
-        performance: getPerformanceHints(2.5 * 1024 * 1024)
+        performance: getPerformanceHints(700 * 1024)
     }),
     Object.assign({}, config, {
         entry: {


### PR DESCRIPTION
Due to some broad imports the ```device_selection_popup_bundle.min.js``` bundle basically contained the entire application (2.4Mb). With this change it goes down to ~650k.

**Before:**
336K - alwaysontop.min.js
5.8K - analytics-ga.js
3.1K - analytics-ga.min.js
2.7M - app.bundle.min.js
**2.4M - device_selection_popup_bundle.min.js**
464K - dial_in_info_bundle.min.js
2.3K - do_external_connect.min.js
26K - external_api.min.js
2.7K - external_connect.js
3.9K - flacEncodeWorker.min.js
661K - lib-jitsi-meet.min.js
356K - libflac4-1.3.2.min.js
883K - video-blur-effect.min.js

**After:**
336K - alwaysontop.min.js
5.8K - analytics-ga.js
3.1K - analytics-ga.min.js
2.6M - app.bundle.min.js
**647K - device_selection_popup_bundle.min.js**
464K - dial_in_info_bundle.min.js
2.3K - do_external_connect.min.js
 26K - external_api.min.js
2.7K - external_connect.js
3.9K - flacEncodeWorker.min.js
661K - lib-jitsi-meet.min.js
356K - libflac4-1.3.2.min.js
883K - video-blur-effect.min.js