### PR TITLE
ref: Tweak logging logic for thumbnail display mode and tile view.

### DIFF
--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -617,7 +617,7 @@ SmallVideo.prototype.updateView = function() {
     }
 
     if (this.displayMode !== oldDisplayMode) {
-        logger.debug(`Displaying ${displayModeString} for ${this.id}, reason: [${JSON.stringify(displayModeInput)}]`);
+        logger.debug(`Displaying ${displayModeString} for ${this.id}, data: [${JSON.stringify(displayModeInput)}]`);
     }
 };
 

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -511,7 +511,7 @@ SmallVideo.prototype.isCurrentlyOnLargeVideo = function() {
  * or <tt>false</tt> otherwise.
  */
 SmallVideo.prototype.isVideoPlayable = function() {
-    return this.videoStream && !this.isVideoMuted && !this.videoStream.isMuted();
+    return this.videoStream && !this.isVideoMuted && !APP.conference.isAudioOnly();
 };
 
 /**


### PR DESCRIPTION
This PR slightly refactors the display mode logging logic. While debugging a broken call I've noticed this state being printed in the JS console logs:

```json
{
  "isAudioOnly": false,
  "tileViewEnabled": true,
  "isVideoPlayable": false,
  "hasVideo": true,
  "connectionStatus": "active",
  "mutedWhileDisconnected": false,
  "wasVideoPlayed": false,
  "videoStream": true,
  "isVideoMuted": false,
  "videoStreamMuted": false
}
```

Looking at how the `isVideoPlayable` flag is computed in SmallVideo.js the above state is impossible: `isVideoPlayable` is computed as `videoStream && !isVideoMuted && !videoStreamMuted`, so, in this particular case, it owed to be `true`; yet, it is computed as `false`.

In this PR I'm not attempting to fix the issue because I don't know how it's possible to end-up in this particular situation. In this PR I am modifying the code in an effort to help me understand what could be the problem: I compute the state once, store it in a variable and use that particular state variable to compute the display mode and print the diagnostic message, instead of computing the display mode and then re-building the state object to print it.