### PR TITLE
fix(icons): scope white svgs to Icon components

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -33,7 +33,7 @@ body {
     }
 }
 
-svg {
+.jitsi-icon svg {
     fill: white;
 }
 

--- a/react/features/base/icons/components/Icon.js
+++ b/react/features/base/icons/components/Icon.js
@@ -11,7 +11,7 @@ type Props = {
     /**
      * Class name for the web platform, if any.
      */
-    className?: string,
+    className: string,
 
     /**
      * Color of the icon (if not provided by the style object).
@@ -68,7 +68,7 @@ export default function Icon(props: Props) {
 
     return (
         <Container
-            className = { className }
+            className = { `jitsi-icon ${className}` }
             style = { restStyle }>
             <IconComponent
                 fill = { calculatedColor }
@@ -79,3 +79,6 @@ export default function Icon(props: Props) {
     );
 }
 
+Icon.defaultProps = {
+    className: ''
+};


### PR DESCRIPTION
Attempts to fix the issue where third party svgs might not expect css setting color. For example, and the only case I know about, atlaskit checkbox hides its checkmark svg using color.

<img width="244" alt="Screen Shot 2019-09-17 at 10 28 21 AM" src="https://user-images.githubusercontent.com/1243084/65066416-280fd400-d939-11e9-8256-1a8116544b87.png">
