### PR TITLE
Fix the WebGL memory leak for Blur effect in Chrome 77 and up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ deploy-css:
 deploy-local:
 	([ ! -x deploy-local.sh ] || ./deploy-local.sh)
 
-dev: deploy-init deploy-css deploy-lib-jitsi-meet deploy-libflac
+dev: compile deploy-init deploy-appbundle deploy-css deploy-lib-jitsi-meet deploy-libflac
 	$(WEBPACK_DEV_SERVER)
 
 source-package:

--- a/react/features/stream-effects/blur/JitsiStreamBlurEffect.js
+++ b/react/features/stream-effects/blur/JitsiStreamBlurEffect.js
@@ -100,7 +100,7 @@ export default class JitsiStreamBlurEffect {
         });
         this._maskFrameTimerWorker.postMessage({
             id: SET_INTERVAL,
-            timeMs: 200
+            timeMs: 50
         });
 
         return this._outputCanvasElement.captureStream(this._frameRate);
@@ -136,6 +136,11 @@ export default class JitsiStreamBlurEffect {
                 7, // Constant for background blur, integer values between 0-20
                 7 // Constant for edge blur, integer values between 0-20
             );
+
+            // Make sure we clear this buffer before feeding the segmentation data
+            // to drawBokehEffect for creating the blur. This fixes the memory leak
+            // that started happening in WebGL in Chrome 77 and up.
+            this._segmentationData = null;
         }
     }
 

--- a/react/features/stream-effects/blur/index.js
+++ b/react/features/stream-effects/blur/index.js
@@ -1,8 +1,10 @@
 // @flow
 
 import { load } from '@tensorflow-models/body-pix';
-
+import * as TF from '@tensorflow/tfjs';
 import JitsiStreamBlurEffect from './JitsiStreamBlurEffect';
+import { getLogger } from 'jitsi-meet-logger';
+const logger = getLogger(__filename);
 
 /**
  * This promise represents the loading of the BodyPix model that is used
@@ -20,6 +22,15 @@ export function createBlurEffect() {
     if (!MediaStreamTrack.prototype.getSettings && !MediaStreamTrack.prototype.getConstraints) {
         return Promise.reject(new Error('JitsiStreamBlurEffect not supported!'));
     }
+
+    // change the TF backend to use WebGL
+    TF.setBackend('webgl').then(() => {
+        logger.info('TensorFlow backend changed to use the WebGL');
+    })
+    .catch(error => {
+        logger.info('TensorFlow backend could not be changed to use WebGL, performance may suffer: ',
+            error);
+    });
 
     return bpModelPromise.then(bpmodel => new JitsiStreamBlurEffect(bpmodel));
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -222,7 +222,7 @@ module.exports = [
             library: [ 'JitsiMeetJS', 'app', 'effects' ],
             libraryTarget: 'window'
         }),
-        performance: getPerformanceHints(1 * 1024 * 1024)
+        performance: getPerformanceHints(2 * 1024 * 1024)
     }),
     Object.assign({}, config, {
         entry: {


### PR DESCRIPTION
- Clear the buffer used for storing the segmentation data before feeding it to the renderer.
- Configure Tensor flow to use the WebGL backend.
