### PR TITLE
fix(large-video): bring back workaround for selecting on conference join

### DIFF
--- a/react/features/large-video/middleware.js
+++ b/react/features/large-video/middleware.js
@@ -38,13 +38,19 @@ MiddlewareRegistry.register(store => next => action => {
 
         break;
     }
-    case CONFERENCE_JOINED:
     case PARTICIPANT_JOINED:
     case PARTICIPANT_LEFT:
     case PIN_PARTICIPANT:
     case TRACK_ADDED:
     case TRACK_REMOVED:
         store.dispatch(selectParticipantInLargeVideo());
+        break;
+
+    case CONFERENCE_JOINED:
+        // Ensure a participant is selected on conference join. This addresses
+        // the case where video tracks were received before CONFERENCE_JOINED
+        // fired; without the conference selection may not happen.
+        store.dispatch(selectParticipant());
         break;
 
     case TRACK_UPDATED:


### PR DESCRIPTION
Bring back the workaround introduced in afd2aea7
but removed in 21dcc41d. On conference join,
several other actions have already been fired
that try to set the large video participant
and select the participant on the bridge.
The problem is there is no conference during
these actions so the select participant
never fires. Then subsequent actions do not
fire select participant because the large
video participant has not changed.