### PR TITLE
android: make reportConnectedOutgoingCall return a Promise

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
@@ -144,9 +144,10 @@ class RNConnectionService
      * @param callUUID - the call's UUID.
      */
     @ReactMethod
-    public void reportConnectedOutgoingCall(String callUUID) {
+    public void reportConnectedOutgoingCall(String callUUID, Promise promise) {
         JitsiMeetLogger.d(TAG + " reportConnectedOutgoingCall " + callUUID);
         ConnectionService.setConnectionActive(callUUID);
+        promise.resolve(null);
     }
 
     @Override


### PR DESCRIPTION
The call-integration middleware relies on it returning it, as iOS does.