### PR TITLE
ios: set logger subsystem and category

### DIFF
--- a/ios/sdk/src/JitsiMeetLogger.m
+++ b/ios/sdk/src/JitsiMeetLogger.m
@@ -26,7 +26,9 @@
 */
 __attribute__((constructor))
 static void initializeLogger() {
-    [DDLog addLogger:[DDOSLogger sharedInstance]];
+    NSString *mainBundleId = [NSBundle mainBundle].bundleIdentifier;
+    DDOSLogger *osLogger = [[DDOSLogger alloc] initWithSubsystem:mainBundleId category:@"JitsiMeetSDK"];
+    [DDLog addLogger:osLogger];
 }
 
 + (void)addHandler:(JitsiMeetBaseLogHandler *)handler {


### PR DESCRIPTION
The subsystem is set to the bundle ID and the category to "JitsiMeetSDK".