### PR TITLE
ref(NAT64AddrInfoModule): use 'ipv4only.arpa' well known host

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfoModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfoModule.java
@@ -43,7 +43,7 @@ public class NAT64AddrInfoModule
      * The host for which the module wil try to resolve both IPv4 and IPv6
      * addresses in order to figure out the NAT64 prefix.
      */
-    private final static String HOST = "nat64.jitsi.net";
+    private final static String HOST = "ipv4only.arpa";
 
     /**
      * How long is the {@link NAT64AddrInfo} instance valid.


### PR DESCRIPTION
Use 'ipv4only.arpa' well known host defined in RFC7050 instead of 'nat64.jitsi.net' as suggested by Jonathan Lennox.