### PR TITLE
Add is supported to CXProvider

### DIFF
--- a/ios/sdk/src/callkit/JMCallKitProxy.swift
+++ b/ios/sdk/src/callkit/JMCallKitProxy.swift
@@ -53,7 +53,7 @@ import Foundation
     @objc public static var enabled: Bool = true {
         didSet {
             provider.invalidate()
-            if enabled {
+            if enabled && provider.isSupported {
                 guard isProviderConfigured() else  { return; }
                 provider = CXProvider(configuration: providerConfiguration!)
                 provider.setDelegate(emitter, queue: nil)

--- a/ios/sdk/src/callkit/JMCallKitProxy.swift
+++ b/ios/sdk/src/callkit/JMCallKitProxy.swift
@@ -52,8 +52,9 @@ import Foundation
     /// Defaults to enabled, set to false when you don't want to use CallKit.
     @objc public static var enabled: Bool = true {
         didSet {
+            let regionCode = Locale.current.regionCode as String?
             provider.invalidate()
-            if enabled && provider.isSupported {
+            if enabled && !regionCode!.contains("CN") && !regionCode!.contains("CHN") {
                 guard isProviderConfigured() else  { return; }
                 provider = CXProvider(configuration: providerConfiguration!)
                 provider.setDelegate(emitter, queue: nil)


### PR DESCRIPTION
We can use [it](https://stackoverflow.com/a/51319158/9503097) to enable provider only if region not is China [CN-CHN], because these regions [CallKit is not supported](https://github.com/jitsi/jitsi-meet/issues/3152).
