### PR TITLE
Fixes showing etherpad in follow-me mode.

### DIFF
--- a/react/features/follow-me/middleware.js
+++ b/react/features/follow-me/middleware.js
@@ -139,7 +139,6 @@ function _onFollowMeCommand(attributes = {}, id, store) {
     // For now gate etherpad checks behind a web-app check to be extra safe
     // against calling a web-app global.
     if (typeof APP !== 'undefined'
-        && state['features/etherpad'].initialized
         && oldState.sharedDocumentVisible !== attributes.sharedDocumentVisible) {
         const isEtherpadVisible = attributes.sharedDocumentVisible === 'true';
         const documentManager = APP.UI.getSharedDocumentManager();


### PR DESCRIPTION
In https://github.com/jitsi/jitsi-meet/pull/4715/commits/c10657771136d03a47100883f6d8fd9552a94df1 initialized was removed from the etherpad feature state, and if it is not initialized it will be just undefined which is handled in the check for toggling on follow me.
@saghul ;)