### PR TITLE
doc(install): adds cd command to jitsi-meet installation

### DIFF
--- a/doc/manual-install.md
+++ b/doc/manual-install.md
@@ -210,6 +210,7 @@ Checkout and configure Jitsi Meet:
 cd /srv
 git clone https://github.com/jitsi/jitsi-meet.git
 mv jitsi-meet/ jitsi.example.com
+cd jitsi.example.com
 npm install
 make
 ```


### PR DESCRIPTION
Just a small change to the manual installation to make it a little more clear. Adds a cd command to go to jitsi.example.meet before running npm install and make