### PR TITLE
Updates for prosody 0.11.2 (0.10+) in Buster

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -1,28 +1,21 @@
 -- Plugins path gets uncommented during jitsi-meet-tokens package install - that's where token plugin is located
 --plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }
 
--- Added for prosody 0.11.2-1 (probably 0.10+) in Buster
--- only needed when using HTTP behind a HTTPS proxy
+--
+-- Added for prosody 0.11.2-1 (0.10+) in Buster
+-- only needed when using HTTP behind a HTTPS proxy (which is the default)
 consider_bosh_secure = true
 -- The default c2s_require_encryption = true
-c2s_require_encryption = true
-
--- and reordered to get VirtualHost after Component sections
-
-Component "conference.jitmeet.example.com" "muc"
-    -- storage = "null" might need a value of "memory" instead
-    storage = "null"
-    --modules_enabled = { "token_verification" }
-    admins = { "focusUser@auth.jitmeet.example.com" }
-
-Component "jitsi-videobridge.jitmeet.example.com"
-    component_secret = "jitmeetSecret"
-
-Component "focus.jitmeet.example.com"
-    component_secret = "focusSecret"
+-- can be changed in the VirtualHost sections
+--
+-- You might want to try reorder the non-global sections 
+-- to get VirtualHost after Component sections to get rid of the error
+-- Error binding encrypted port for https: No certificate present in SSL/TLS configuration for https port 5281
+-- but this is not confirmed by more than a few people upgrading
+-- 
 
 VirtualHost "jitmeet.example.com"
-        -- enabled = false -- Remove this line to disable this host
+        -- enabled = false -- Uncomment this line to disable this host
         authentication = "anonymous"
         -- Properties below are modified by jitsi-meet-tokens package config
         -- and authentication above is switched to "token"
@@ -45,5 +38,17 @@ VirtualHost "jitmeet.example.com"
 
         c2s_require_encryption = false
 
+Component "conference.jitmeet.example.com" "muc"
+    -- storage = "null" might need a value of "memory" instead
+    storage = "null"
+    --modules_enabled = { "token_verification" }
+admins = { "focusUser@auth.jitmeet.example.com" }
+
+Component "jitsi-videobridge.jitmeet.example.com"
+    component_secret = "jitmeetSecret"
+
 VirtualHost "auth.jitmeet.example.com"
     authentication = "internal_plain"
+
+Component "focus.jitmeet.example.com"
+    component_secret = "focusSecret"

--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -1,8 +1,28 @@
 -- Plugins path gets uncommented during jitsi-meet-tokens package install - that's where token plugin is located
 --plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }
 
+-- Added for prosody 0.11.2-1 (probably 0.10+) in Buster
+-- only needed when using HTTP behind a HTTPS proxy
+consider_bosh_secure = true
+-- The default c2s_require_encryption = true
+c2s_require_encryption = true
+
+-- and reordered to get VirtualHost after Component sections
+
+Component "conference.jitmeet.example.com" "muc"
+    -- storage = "null" might need a value of "memory" instead
+    storage = "null"
+    --modules_enabled = { "token_verification" }
+    admins = { "focusUser@auth.jitmeet.example.com" }
+
+Component "jitsi-videobridge.jitmeet.example.com"
+    component_secret = "jitmeetSecret"
+
+Component "focus.jitmeet.example.com"
+    component_secret = "focusSecret"
+
 VirtualHost "jitmeet.example.com"
-        -- enabled = false -- Remove this line to enable this host
+        -- enabled = false -- Remove this line to disable this host
         authentication = "anonymous"
         -- Properties below are modified by jitsi-meet-tokens package config
         -- and authentication above is switched to "token"
@@ -25,16 +45,5 @@ VirtualHost "jitmeet.example.com"
 
         c2s_require_encryption = false
 
-Component "conference.jitmeet.example.com" "muc"
-    storage = "null"
-    --modules_enabled = { "token_verification" }
-admins = { "focusUser@auth.jitmeet.example.com" }
-
-Component "jitsi-videobridge.jitmeet.example.com"
-    component_secret = "jitmeetSecret"
-
 VirtualHost "auth.jitmeet.example.com"
     authentication = "internal_plain"
-
-Component "focus.jitmeet.example.com"
-    component_secret = "focusSecret"


### PR DESCRIPTION
The reordering with VirtualHost sections last is to avoid "Error binding encrypted port for https: No certificate present in SSL/TLS configuration for https port 5281".