### PR TITLE
uri: avoid using String.prototype.normalize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17595,6 +17595,12 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
+    "unorm": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "precommit-hook": "3.0.0",
     "string-replace-loader": "2.1.1",
     "style-loader": "0.19.0",
+    "unorm": "1.6.0",
     "webpack": "4.27.1",
     "webpack-bundle-analyzer": "3.4.1",
     "webpack-cli": "3.1.2",

--- a/react/features/base/util/strings.native.js
+++ b/react/features/base/util/strings.native.js
@@ -1,0 +1,14 @@
+// @flow
+
+import * as unorm from 'unorm';
+
+/**
+ * Applies NFKC normalization to the given text.
+ * NOTE: Here we use the unorm package because the JSC version in React Native for Android crashes.
+ *
+ * @param {string} text - The text that needs to be normalized.
+ * @returns {string} - The normalized text.
+ */
+export function normalizeNFKC(text: string) {
+    return unorm.nfkc(text);
+}

--- a/react/features/base/util/strings.web.js
+++ b/react/features/base/util/strings.web.js
@@ -1,0 +1,11 @@
+// @flow
+
+/**
+ * Applies NFKC normalization to the given text.
+ *
+ * @param {string} text - The text that needs to be normalized.
+ * @returns {string} - The normalized text.
+ */
+export function normalizeNFKC(text: string) {
+    return text.normalize('NFKC');
+}

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { normalizeNFKC } from './strings';
+
 /**
  * The app linking scheme.
  * TODO: This should be read from the manifest files later.
@@ -120,8 +122,8 @@ export function getBackendSafeRoomName(room: ?string): ?string {
         // But in this case we're fine goin on...
     }
 
-    // Normalize the character set
-    room = room.normalize('NFKC');
+    // Normalize the character set.
+    room = normalizeNFKC(room);
 
     // Only decoded and normalized strings can be lowercased properly.
     room = room.toLowerCase();


### PR DESCRIPTION
It crashes on Android. Well, on the JSC version React Native uses on Android.

While we could use this fallback only on Android, we have decided to use it
everywhere for consistency.