### PR TITLE
ios: disable bitcode when building the SDK for a release

### DIFF
--- a/ios/scripts/release-sdk.sh
+++ b/ios/scripts/release-sdk.sh
@@ -25,7 +25,7 @@ popd
 # Build the SDK
 pushd ${PROJECT_REPO}
 rm -rf ios/sdk/JitsiMeet.framework
-xcodebuild -workspace ios/jitsi-meet.xcworkspace -scheme JitsiMeet -destination='generic/platform=iOS' -configuration Release archive
+xcodebuild -workspace ios/jitsi-meet.xcworkspace -scheme JitsiMeet -destination='generic/platform=iOS' -configuration Release ENABLE_BITCODE=NO clean archive
 if [[ $DO_GIT_TAG == 1 ]]; then
     git tag ios-sdk-${SDK_VERSION}
 fi


### PR DESCRIPTION
This makes it possible to compile the SDK with Xcode 10 and 11. The problem is
that the Google SDK (used for sign-in) is compiled with Xcode 11. This avoids
the issue.