### PR TITLE
fix(mobile-landing): do not attempt opening download link in new window

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -114,9 +114,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                     </p>
                     <a
                         href = { this._generateDownloadURL() }
-                        onClick = { this._onDownloadApp }
-                        rel = 'noopener noreferrer'
-                        target = '_blank'>
+                        onClick = { this._onDownloadApp }>
                         <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
@@ -124,9 +122,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                     <a
                         className = { `${_SNS}__href` }
                         href = { generateDeepLinkingURL() }
-                        onClick = { this._onOpenApp }
-                        rel = 'noopener noreferrer'
-                        target = '_blank'>
+                        onClick = { this._onOpenApp }>
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }
                         {/* </button> */}

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -93,6 +93,12 @@ class DeepLinkingMobilePage extends Component<Props> {
         const { NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
         const downloadButtonClassName
             = `${_SNS}__button ${_SNS}__button_primary`;
+        const onOpenLinkProperties = _URLS[Platform.OS]
+            ? {}
+            : {
+                target: '_blank',
+                rel: 'noopener noreferrer'
+            };
 
         return (
             <div className = { _SNS }>
@@ -113,6 +119,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                         { t(`${_TNS}.appNotInstalled`, { app: NATIVE_APP_NAME }) }
                     </p>
                     <a
+                        { ...onOpenLinkProperties }
                         href = { this._generateDownloadURL() }
                         onClick = { this._onDownloadApp }>
                         <button className = { downloadButtonClassName }>
@@ -120,6 +127,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                         </button>
                     </a>
                     <a
+                        { ...onOpenLinkProperties }
                         className = { `${_SNS}__href` }
                         href = { generateDeepLinkingURL() }
                         onClick = { this._onOpenApp }>

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -93,9 +93,20 @@ class DeepLinkingMobilePage extends Component<Props> {
         const { NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
         const downloadButtonClassName
             = `${_SNS}__button ${_SNS}__button_primary`;
+
+
         const onOpenLinkProperties = _URLS[Platform.OS]
-            ? {}
+            ? {
+                // When opening a link to the download page, we want to let the
+                // OS itself handle intercepting and opening the appropriate
+                // app store. This avoids potential issues with browsers, such
+                // as iOS Chrome, not opening the store properly.
+            }
             : {
+                // When falling back to another URL (Firebase) let the page be
+                // opened in a new window. This helps prevent the user getting
+                // trapped in an app-open-cycle where going back to the mobile
+                // browser re-triggers the app-open behavior.
                 target: '_blank',
                 rel: 'noopener noreferrer'
             };


### PR DESCRIPTION
Instead let the mobile OS take care of opening the URL
in the appropriate application. Without target _blank,
iOS 13.2.2 on Chrome will open about:blank and immediately
close the tab instead of opening the store.