### PR TITLE
fix(large-video): center dominant speaker avatar using css

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -489,6 +489,8 @@
     height: 300px;
     margin: auto;
     position: relative;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 #mixedstream {

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -454,11 +454,6 @@ export class VideoContainer extends LargeContainer {
         const { horizontalIndent, verticalIndent }
             = this.getVideoPosition(width, height, containerWidth, containerHeight);
 
-        // update avatar position
-        const top = (containerHeight / 2) - (this.avatarHeight / 4 * 3);
-
-        this.$avatar.css('top', top);
-
         this.$wrapper.animate({
             width,
             height,


### PR DESCRIPTION
The vertical alignment was being set with javascript.
Recent changes might make the setting of alignment exit
early due to height 0 video. As position can be set
declaratively with css, use css to set position.

Steps to Reproduce bug:
1. User A start a new meeting.
2. User A video mute.
3. User B join the meeting.

Result: User B sees User A's avatar on stage but at the top of the page because top position was not set.