### PR TITLE
fix(remote-status-message): position

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -429,6 +429,8 @@ export class VideoContainer extends LargeContainer {
             return;
         }
 
+        this.positionRemoteStatusMessages();
+
         const [ width, height ] = this._getVideoSize(containerWidth, containerHeight);
 
         if (width === 0 || height === 0) {
@@ -456,8 +458,6 @@ export class VideoContainer extends LargeContainer {
         const top = (containerHeight / 2) - (this.avatarHeight / 4 * 3);
 
         this.$avatar.css('top', top);
-
-        this.positionRemoteStatusMessages();
 
         this.$wrapper.animate({
             width,


### PR DESCRIPTION
In addition to the issue with the avatar position described in https://github.com/jitsi/jitsi-meet/pull/4862, the same issue applies for the position of the status message and remote connection status message.