### PR TITLE
feat: safe decodeURIComponent

### DIFF
--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -11,6 +11,7 @@ import {
     participantLeft
 } from '../participants';
 import { toState } from '../redux';
+import { safeDecodeURIComponent } from '../util';
 
 import {
     AVATAR_ID_COMMAND,
@@ -163,7 +164,7 @@ export function getConferenceName(stateful: Function | Object): string {
         || subject
         || callDisplayName
         || (callee && callee.name)
-        || _.startCase(decodeURIComponent(room));
+        || _.startCase(safeDecodeURIComponent(room));
 }
 
 /**

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -374,6 +374,23 @@ function _standardURIToString(thiz: ?Object) {
 }
 
 /**
+ * Sometimes we receive strings that we don't know if already percent-encoded, or not, due to the
+ * various sources we get URLs or room names. This function encapsulates the decoding in a safe way.
+ *
+ * @param {string} text - The text to decode.
+ * @returns {string}
+ */
+export function safeDecodeURIComponent(text: string) {
+    try {
+        return decodeURIComponent(text);
+    } catch (e) {
+        // The text wasn't encoded.
+    }
+
+    return text;
+}
+
+/**
  * Attempts to return a {@code String} representation of a specific
  * {@code Object} which is supposed to represent a URL. Obviously, if a
  * {@code String} is specified, it is returned. If a {@code URL} is specified,

--- a/react/features/recent-list/functions.native.js
+++ b/react/features/recent-list/functions.native.js
@@ -3,7 +3,7 @@ import {
     getLocalizedDurationFormatter
 } from '../base/i18n';
 import { NavigateSectionList } from '../base/react';
-import { parseURIString } from '../base/util';
+import { parseURIString, safeDecodeURIComponent } from '../base/util';
 
 /**
  * Creates a displayable list item of a recent list entry.
@@ -31,7 +31,7 @@ function toDisplayableItem(item, defaultServerURL, t) {
             _toDurationString(item.duration),
             serverName
         ],
-        title: decodeURIComponent(location.room),
+        title: safeDecodeURIComponent(location.room),
         url: item.conference
     };
 }


### PR DESCRIPTION
Handles both encoded and non encoded room names

![image](https://user-images.githubusercontent.com/9974975/68945924-e02ef100-07b1-11ea-88e9-18021e9453af.png)
