### PR TITLE
Fixes nginx match rule, containing wrong chars.

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -45,7 +45,7 @@ server {
         proxy_set_header Host $http_host;
     }
 
-    location ~ ^/([^?&:’“]+)$ {
+    location ~ ^/([^/?&:'"]+)$ {
         try_files $uri @root_path;
     }
 


### PR DESCRIPTION
Also adds a missing '/'.