### PR TITLE
fix(chat): wrap long text

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -226,6 +226,8 @@
 
     .messagecontent {
         margin: 5px 10px;
+        max-width: 100%;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
without changes
<img width="384" alt="Screen Shot 2019-11-18 at 9 13 01 AM" src="https://user-images.githubusercontent.com/1243084/69074186-bd841e80-09e3-11ea-9ae2-9451a360f84a.png">

with changes
<img width="372" alt="Screen Shot 2019-11-18 at 9 12 55 AM" src="https://user-images.githubusercontent.com/1243084/69074214-cc6ad100-09e3-11ea-947d-c57121b7050c.png">

