### PR TITLE
fix(chat): preserve intentional linebreaks in message display

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -205,6 +205,10 @@
         border-radius: 6px 0px 6px 6px;
     }
 
+    .usermessage {
+        white-space: pre-wrap;
+    }
+
     &.error {
         border-radius: 0px;
 


### PR DESCRIPTION
before
<img width="350" alt="Screen Shot 2019-11-19 at 9 24 39 AM" src="https://user-images.githubusercontent.com/1243084/69170478-fd640800-0aae-11ea-9207-f55c2a5ad758.png">

after
<img width="355" alt="Screen Shot 2019-11-19 at 9 24 33 AM" src="https://user-images.githubusercontent.com/1243084/69170461-f6d59080-0aae-11ea-8354-94311bce0e00.png">
