### PR TITLE
Feature: Presenter mode

### DIFF
--- a/react/features/analytics/middleware.js
+++ b/react/features/analytics/middleware.js
@@ -147,9 +147,10 @@ MiddlewareRegistry.register(store => next => action => {
         const state = getState();
         const { localTracksDuration } = state['features/analytics'];
 
-        if (localTracksDuration.conference.startedTime === -1) {
+        if (localTracksDuration.conference.startedTime === -1 || action.mediaType === 'presenter') {
             // We don't want to track the media duration if the conference is not joined yet because otherwise we won't
             // be able to compare them with the conference duration (from conference join to conference will leave).
+            // Also, do not track media duration for presenter tracks.
             break;
         }
         dispatch({

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -46,6 +46,7 @@ import {
     getCurrentConference
 } from './functions';
 import logger from './logger';
+import { MEDIA_TYPE } from '../media';
 
 declare var APP: Object;
 
@@ -589,7 +590,10 @@ function _syncReceiveVideoQuality({ getState }, next, action) {
 function _trackAddedOrRemoved(store, next, action) {
     const track = action.track;
 
-    if (track && track.local) {
+    // TODO All track swapping should happen here instead of conference.js.
+    // Since we swap the tracks for the web client in conference.js, ignore
+    // presenter tracks here and do not add/remove them to/from the conference.
+    if (track && track.local && track.mediaType !== MEDIA_TYPE.PRESENTER) {
         return (
             _syncConferenceLocalTracksWithState(store, action)
                 .then(() => next(action)));

--- a/react/features/base/media/actions.js
+++ b/react/features/base/media/actions.js
@@ -11,7 +11,11 @@ import {
     STORE_VIDEO_TRANSFORM,
     TOGGLE_CAMERA_FACING_MODE
 } from './actionTypes';
-import { CAMERA_FACING_MODE, VIDEO_MUTISM_AUTHORITY } from './constants';
+import {
+    CAMERA_FACING_MODE,
+    MEDIA_TYPE,
+    VIDEO_MUTISM_AUTHORITY
+} from './constants';
 
 /**
  * Action to adjust the availability of the local audio.
@@ -89,6 +93,7 @@ export function setVideoAvailable(available: boolean) {
  *
  * @param {boolean} muted - True if the local video is to be muted or false if
  * the local video is to be unmuted.
+ * @param {MEDIA_TYPE} mediaType - The type of media.
  * @param {number} authority - The {@link VIDEO_MUTISM_AUTHORITY} which is
  * muting/unmuting the local video.
  * @param {boolean} ensureTrack - True if we want to ensure that a new track is
@@ -97,6 +102,7 @@ export function setVideoAvailable(available: boolean) {
  */
 export function setVideoMuted(
         muted: boolean,
+        mediaType: MEDIA_TYPE = MEDIA_TYPE.VIDEO,
         authority: number = VIDEO_MUTISM_AUTHORITY.USER,
         ensureTrack: boolean = false) {
     return (dispatch: Dispatch<any>, getState: Function) => {
@@ -107,6 +113,8 @@ export function setVideoMuted(
 
         return dispatch({
             type: SET_VIDEO_MUTED,
+            authority,
+            mediaType,
             ensureTrack,
             muted: newValue
         });

--- a/react/features/base/media/constants.js
+++ b/react/features/base/media/constants.js
@@ -15,6 +15,7 @@ export const CAMERA_FACING_MODE = {
  */
 export const MEDIA_TYPE = {
     AUDIO: 'audio',
+    PRESENTER: 'presenter',
     VIDEO: 'video'
 };
 

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -11,6 +11,47 @@ import {
 import logger from './logger';
 
 /**
+ * Creates a local video track for presenter. The constraints are computed based
+ * on the height of the desktop that is being shared.
+ *
+ * @param {Object} options - The options with which the local presenter track
+ * is to be created.
+ * @param {string|null} [options.cameraDeviceId] - Camera device id or
+ * {@code undefined} to use app's settings.
+ * @param {number} desktopHeight - The height of the desktop that is being
+ * shared.
+ * @returns {Promise<JitsiLocalTrack>}
+ */
+export async function createLocalPresenterTrack(options, desktopHeight) {
+    const { cameraDeviceId } = options;
+
+    // compute the constraints of the camera track based on the resolution
+    // of the desktop screen that is being shared.
+    const cameraHeights = [ 180, 270, 360, 540, 720 ];
+    const proportion = 4;
+    const result = cameraHeights.find(
+            height => (desktopHeight / proportion) < height);
+    const constraints = {
+        video: {
+            aspectRatio: 4 / 3,
+            height: {
+                exact: result
+            }
+        }
+    };
+    const [ videoTrack ] = await JitsiMeetJS.createLocalTracks(
+        {
+            cameraDeviceId,
+            constraints,
+            devices: [ 'video' ]
+        });
+
+    videoTrack.type = MEDIA_TYPE.PRESENTER;
+
+    return videoTrack;
+}
+
+/**
  * Create local tracks of specific types.
  *
  * @param {Object} options - The options with which the local tracks are to be
@@ -53,11 +94,15 @@ export function createLocalTracksF(
 
     const state = store.getState();
     const {
-        constraints,
         desktopSharingFrameRate,
         firefox_fake_device, // eslint-disable-line camelcase
         resolution
     } = state['features/base/config'];
+    const constraints = options.constraints
+        ?? state['features/base/config'].constraints;
+
+    // Do not load blur effect if option for ignoring effects is present.
+    // This is needed when we are creating a video track for presenter mode.
     const loadEffectsPromise = state['features/blur'].blurEnabled
         ? getBlurEffect()
             .then(blurEffect => [ blurEffect ])
@@ -158,6 +203,18 @@ export function getLocalVideoTrack(tracks) {
 }
 
 /**
+ * Returns the media type of the local video, presenter or video.
+ *
+ * @param {Track[]} tracks - List of all tracks.
+ * @returns {MEDIA_TYPE}
+ */
+export function getLocalVideoType(tracks) {
+    const presenterTrack = getLocalTrack(tracks, MEDIA_TYPE.PRESENTER);
+
+    return presenterTrack ? MEDIA_TYPE.PRESENTER : MEDIA_TYPE.VIDEO;
+}
+
+/**
  * Returns track of specified media type for specified participant id.
  *
  * @param {Track[]} tracks - List of all tracks.
@@ -195,6 +252,29 @@ export function getTrackByJitsiTrack(tracks, jitsiTrack) {
  */
 export function getTracksByMediaType(tracks, mediaType) {
     return tracks.filter(t => t.mediaType === mediaType);
+}
+
+/**
+ * Checks if the local video track in the given set of tracks is muted.
+ *
+ * @param {Track[]} tracks - List of all tracks.
+ * @returns {Track[]}
+ */
+export function isLocalVideoTrackMuted(tracks) {
+    const presenterTrack = getLocalTrack(tracks, MEDIA_TYPE.PRESENTER);
+    const videoTrack = getLocalTrack(tracks, MEDIA_TYPE.VIDEO);
+
+    // Make sure we check the mute status of only camera tracks, i.e.,
+    // presenter track when it exists, camera track when the presenter
+    // track doesn't exist.
+    if (presenterTrack) {
+        return isLocalTrackMuted(tracks, MEDIA_TYPE.PRESENTER);
+    } else if (videoTrack) {
+        return videoTrack.videoType === 'camera'
+            ? isLocalTrackMuted(tracks, MEDIA_TYPE.VIDEO) : true;
+    }
+
+    return true;
 }
 
 /**

--- a/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
+++ b/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
@@ -1,0 +1,161 @@
+// @flow
+
+import {
+    CLEAR_INTERVAL,
+    INTERVAL_TIMEOUT,
+    SET_INTERVAL,
+    timerWorkerScript
+} from './TimeWorker';
+
+/**
+ * Represents a modified MediaStream that adds video as pip on a desktop stream.
+ * <tt>JitsiStreamPresenterEffect</tt> does the processing of the original
+ * desktop stream.
+ */
+export default class JitsiStreamPresenterEffect {
+    _canvas: HTMLCanvasElement;
+    _ctx: CanvasRenderingContext2D;
+    _desktopElement: HTMLVideoElement;
+    _desktopStream: MediaStream;
+    _frameRate: number;
+    _onVideoFrameTimer: Function;
+    _onVideoFrameTimerWorker: Function;
+    _renderVideo: Function;
+    _videoFrameTimerWorker: Worker;
+    _videoElement: HTMLVideoElement;
+    isEnabled: Function;
+    startEffect: Function;
+    stopEffect: Function;
+
+    /**
+     * Represents a modified MediaStream that adds a camera track at the
+     * bottom right corner of the desktop track using a HTML canvas.
+     * <tt>JitsiStreamPresenterEffect</tt> does the processing of the original
+     * video stream.
+     *
+     * @param {MediaStream} videoStream - The video stream which is user for
+     * creating the canvas.
+     */
+    constructor(videoStream: MediaStream) {
+        const videoDiv = document.createElement('div');
+        const firstVideoTrack = videoStream.getVideoTracks()[0];
+        const { height, width, frameRate } = firstVideoTrack.getSettings() ?? firstVideoTrack.getConstraints();
+
+        this._canvas = document.createElement('canvas');
+        this._ctx = this._canvas.getContext('2d');
+
+        if (document.body !== null) {
+            document.body.appendChild(this._canvas);
+        }
+        this._desktopElement = document.createElement('video');
+        this._videoElement = document.createElement('video');
+        videoDiv.appendChild(this._videoElement);
+        videoDiv.appendChild(this._desktopElement);
+        if (document.body !== null) {
+            document.body.appendChild(videoDiv);
+        }
+
+        // Set the video element properties
+        this._frameRate = parseInt(frameRate, 10);
+        this._videoElement.width = parseInt(width, 10);
+        this._videoElement.height = parseInt(height, 10);
+        this._videoElement.autoplay = true;
+        this._videoElement.srcObject = videoStream;
+
+        // set the style attribute of the div to make it invisible
+        videoDiv.style.display = 'none';
+
+        // Bind event handler so it is only bound once for every instance.
+        this._onVideoFrameTimer = this._onVideoFrameTimer.bind(this);
+        this._videoFrameTimerWorker = new Worker(timerWorkerScript);
+        this._videoFrameTimerWorker.onmessage = this._onVideoFrameTimer;
+    }
+
+    /**
+     * EventHandler onmessage for the videoFrameTimerWorker WebWorker.
+     *
+     * @private
+     * @param {EventHandler} response - The onmessage EventHandler parameter.
+     * @returns {void}
+     */
+    _onVideoFrameTimer(response) {
+        if (response.data.id === INTERVAL_TIMEOUT) {
+            this._renderVideo();
+        }
+    }
+
+    /**
+     * Loop function to render the video frame input and draw presenter effect.
+     *
+     * @private
+     * @returns {void}
+     */
+    _renderVideo() {
+        // adjust the canvas width/height on every frame incase the window has been resized.
+        const [ track ] = this._desktopStream.getVideoTracks();
+        const { height, width } = track.getSettings() ?? track.getConstraints();
+
+        this._canvas.width = parseInt(width, 10);
+        this._canvas.height = parseInt(height, 10);
+        this._ctx.drawImage(this._desktopElement, 0, 0, this._canvas.width, this._canvas.height);
+        this._ctx.drawImage(this._videoElement, this._canvas.width - this._videoElement.width, this._canvas.height
+            - this._videoElement.height, this._videoElement.width, this._videoElement.height);
+
+        // draw a border around the video element.
+        this._ctx.beginPath();
+        this._ctx.lineWidth = 2;
+        this._ctx.strokeStyle = '#A9A9A9'; // dark grey
+        this._ctx.rect(this._canvas.width - this._videoElement.width, this._canvas.height - this._videoElement.height,
+            this._videoElement.width, this._videoElement.height);
+        this._ctx.stroke();
+    }
+
+    /**
+     * Checks if the local track supports this effect.
+     *
+     * @param {JitsiLocalTrack} jitsiLocalTrack - Track to apply effect.
+     * @returns {boolean} - Returns true if this effect can run on the
+     * specified track, false otherwise.
+     */
+    isEnabled(jitsiLocalTrack: Object) {
+        return jitsiLocalTrack.isVideoTrack() && jitsiLocalTrack.videoType === 'desktop';
+    }
+
+    /**
+     * Starts loop to capture video frame and render presenter effect.
+     *
+     * @param {MediaStream} desktopStream - Stream to be used for processing.
+     * @returns {MediaStream} - The stream with the applied effect.
+     */
+    startEffect(desktopStream: MediaStream) {
+        const firstVideoTrack = desktopStream.getVideoTracks()[0];
+        const { height, width } = firstVideoTrack.getSettings() ?? firstVideoTrack.getConstraints();
+
+        // set the desktop element properties.
+        this._desktopStream = desktopStream;
+        this._desktopElement.width = parseInt(width, 10);
+        this._desktopElement.height = parseInt(height, 10);
+        this._desktopElement.autoplay = true;
+        this._desktopElement.srcObject = desktopStream;
+        this._canvas.width = parseInt(width, 10);
+        this._canvas.height = parseInt(height, 10);
+        this._videoFrameTimerWorker.postMessage({
+            id: SET_INTERVAL,
+            timeMs: 1000 / this._frameRate
+        });
+
+        return this._canvas.captureStream(this._frameRate);
+    }
+
+    /**
+     * Stops the capture and render loop.
+     *
+     * @returns {void}
+     */
+    stopEffect() {
+        this._videoFrameTimerWorker.postMessage({
+            id: CLEAR_INTERVAL
+        });
+    }
+
+}

--- a/react/features/stream-effects/presenter/TimeWorker.js
+++ b/react/features/stream-effects/presenter/TimeWorker.js
@@ -1,0 +1,62 @@
+// @flow
+
+/**
+ * SET_INTERVAL constant is used to set interval and it is set in
+ * the id property of the request.data property. timeMs property must
+ * also be set. request.data example:
+ *
+ * {
+ *      id: SET_INTERVAL,
+ *      timeMs: 33
+ * }
+ */
+export const SET_INTERVAL = 1;
+
+/**
+ * CLEAR_INTERVAL constant is used to clear the interval and it is set in
+ * the id property of the request.data property.
+ *
+ * {
+ *      id: CLEAR_INTERVAL
+ * }
+ */
+export const CLEAR_INTERVAL = 2;
+
+/**
+ * INTERVAL_TIMEOUT constant is used as response and it is set in the id
+ * property.
+ *
+ * {
+ *      id: INTERVAL_TIMEOUT
+ * }
+ */
+export const INTERVAL_TIMEOUT = 3;
+
+/**
+ * The following code is needed as string to create a URL from a Blob.
+ * The URL is then passed to a WebWorker. Reason for this is to enable
+ * use of setInterval that is not throttled when tab is inactive.
+ */
+const code = `
+    var timer;
+
+    onmessage = function(request) {
+        switch (request.data.id) {
+        case ${SET_INTERVAL}: {
+            timer = setInterval(() => {
+                postMessage({ id: ${INTERVAL_TIMEOUT} });
+            }, request.data.timeMs);
+            break;
+        }
+        case ${CLEAR_INTERVAL}: {
+            if (timer) {
+                clearInterval(timer);
+            }
+            break;
+        }
+        }
+    };
+`;
+
+export const timerWorkerScript
+    = URL.createObjectURL(new Blob([ code ], { type: 'application/javascript' }));

--- a/react/features/stream-effects/presenter/index.js
+++ b/react/features/stream-effects/presenter/index.js
@@ -1,0 +1,19 @@
+// @flow
+
+import JitsiStreamPresenterEffect from './JitsiStreamPresenterEffect';
+
+/**
+ * Creates a new instance of JitsiStreamPresenterEffect.
+ *
+ * @param {MediaStream} stream - The video stream which will be used for
+ * creating the presenter effect.
+ * @returns {Promise<JitsiStreamPresenterEffect>}
+ */
+export function createPresenterEffect(stream: MediaStream) {
+    if (!MediaStreamTrack.prototype.getSettings
+        && !MediaStreamTrack.prototype.getConstraints) {
+        return Promise.reject(new Error('JitsiStreamPresenterEffect not supported!'));
+    }
+
+    return Promise.resolve(new JitsiStreamPresenterEffect(stream));
+}

--- a/react/features/toolbox/components/VideoMuteButton.js
+++ b/react/features/toolbox/components/VideoMuteButton.js
@@ -10,14 +10,13 @@ import {
 import { setAudioOnly } from '../../base/audio-only';
 import { translate } from '../../base/i18n';
 import {
-    MEDIA_TYPE,
     VIDEO_MUTISM_AUTHORITY,
     setVideoMuted
 } from '../../base/media';
 import { connect } from '../../base/redux';
 import { AbstractVideoMuteButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
-import { isLocalTrackMuted } from '../../base/tracks';
+import { getLocalVideoType, isLocalVideoTrackMuted } from '../../base/tracks';
 import UIEvents from '../../../../service/UI/UIEvents';
 
 declare var APP: Object;
@@ -31,6 +30,11 @@ type Props = AbstractButtonProps & {
      * Whether the current conference is in audio only mode or not.
      */
     _audioOnly: boolean,
+
+    /**
+     * MEDIA_TYPE of the local video.
+     */
+    _videoMediaType: string,
 
     /**
      * Whether video is currently muted or not.
@@ -136,10 +140,12 @@ class VideoMuteButton extends AbstractVideoMuteButton<Props, *> {
             this.props.dispatch(
                 setAudioOnly(false, /* ensureTrack */ true));
         }
+        const mediaType = this.props._videoMediaType;
 
         this.props.dispatch(
             setVideoMuted(
                 videoMuted,
+                mediaType,
                 VIDEO_MUTISM_AUTHORITY.USER,
                 /* ensureTrack */ true));
 
@@ -167,7 +173,8 @@ function _mapStateToProps(state): Object {
 
     return {
         _audioOnly: Boolean(audioOnly),
-        _videoMuted: isLocalTrackMuted(tracks, MEDIA_TYPE.VIDEO)
+        _videoMediaType: getLocalVideoType(tracks),
+        _videoMuted: isLocalVideoTrackMuted(tracks)
     };
 }
 


### PR DESCRIPTION
- Adds the ability to share video as a Pip when screenshare is in progress.
- Local video is controlled only by the camera button when screenshare is in progress.
- The resolution for the presenter camera is calculated based on the resolution of the desktop share that is in progress.
- A new media type "presenter" has been added and the newly created video track is added to the redux store. No new presenter APIs have been added.
- This PR has changes only for the presenter mode, the crop effect and renaming of the tensor flow related bundle changes will be in separate PR