### PR TITLE
android: handle ConnectionService failures more resiliently

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ConnectionService.java
@@ -123,14 +123,17 @@ public class ConnectionService extends android.telecom.ConnectionService {
      * {@link android.telecom.Connection#STATE_ACTIVE}.
      *
      * @param callUUID the call UUID which identifies the connection.
+     * @return Whether the connection was set as active or not.
      */
-    static void setConnectionActive(String callUUID) {
+    static boolean setConnectionActive(String callUUID) {
         ConnectionImpl connection = connections.get(callUUID);
 
         if (connection != null) {
             connection.setActive();
+            return true;
         } else {
-            JitsiMeetLogger.e("%s setConnectionActive - no connection for UUID: %s", TAG, callUUID);
+            JitsiMeetLogger.w("%s setConnectionActive - no connection for UUID: %s", TAG, callUUID);
+            return false;
         }
     }
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
@@ -158,8 +158,11 @@ class RNConnectionService extends ReactContextBaseJavaModule {
     @ReactMethod
     public void reportConnectedOutgoingCall(String callUUID, Promise promise) {
         JitsiMeetLogger.d(TAG + " reportConnectedOutgoingCall " + callUUID);
-        ConnectionService.setConnectionActive(callUUID);
-        promise.resolve(null);
+        if (ConnectionService.setConnectionActive(callUUID)) {
+            promise.resolve(null);
+        } else {
+            promise.reject("CONNECTION_NOT_FOUND_ERROR", "Connection wasn't found.");
+        }
     }
 
     @Override


### PR DESCRIPTION
Some Samsung devices will fail to fully engage ConnectionService if no SIM card
was ever installed on the device. We could check for it, but it would require
the CALL_PHONE permission, which is not something we want to do, so fallback to
not using ConnectionService.