### PR TITLE
fix: Reuse the existing JitsiLocalTrack on presenter unmute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10931,8 +10931,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#4a87f342858963c36bb64a8a0e89d8d7e6e06060",
-      "from": "github:jitsi/lib-jitsi-meet#4a87f342858963c36bb64a8a0e89d8d7e6e06060",
+      "version": "github:jitsi/lib-jitsi-meet#ea2114ca92b80bf27a04c9e3c124f80eb91c924f",
+      "from": "github:jitsi/lib-jitsi-meet#ea2114ca92b80bf27a04c9e3c124f80eb91c924f",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "js-utils": "github:jitsi/js-utils#192b1c996e8c05530eb1f19e82a31069c3021e31",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#4a87f342858963c36bb64a8a0e89d8d7e6e06060",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ea2114ca92b80bf27a04c9e3c124f80eb91c924f",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -35,7 +35,7 @@ export async function createLocalPresenterTrack(options, desktopHeight) {
         video: {
             aspectRatio: 4 / 3,
             height: {
-                exact: result
+                ideal: result
             }
         }
     };

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -135,7 +135,12 @@ MiddlewareRegistry.register(store => next => action => {
             const isVideoTrack = jitsiTrack.type !== MEDIA_TYPE.AUDIO;
 
             if (isVideoTrack) {
-                if (jitsiTrack.isLocal()) {
+                if (jitsiTrack.type === MEDIA_TYPE.PRESENTER) {
+                    APP.conference.mutePresenter(muted);
+                }
+
+                // Make sure we change the video mute state only for camera tracks.
+                if (jitsiTrack.isLocal() && jitsiTrack.videoType !== 'desktop') {
                     APP.conference.setVideoMuteStatus(muted);
                 } else {
                     APP.UI.setVideoMuted(participantID, muted);


### PR DESCRIPTION
- Reuse the existing JitsiLocalTrack for the presenter video on presenter unmute.
- Dispatch a new UIEvent PRESENTER_MUTED when the JitsiLocalTrack mute handler emits a TRACK_MUTE_CHANGED event after muting/unmuting the presenter track.
- handle device selection changes properly when screenshare is in progress.
- dispatch setVideoMuted only for camera/presenter track and not for desktop tracks.