### PR TITLE
fix: Workaround on FF for getting the resolution of the desktop track

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1641,7 +1641,7 @@ export default {
 
             // Workaround for Firefox since it doesn't return the correct width/height of the desktop stream
             // that is being currently shared.
-            if (!height || height === 0) {
+            if (!height) {
                 const desktopResizeConstraints = {
                     width: 1280,
                     height: 720,

--- a/conference.js
+++ b/conference.js
@@ -1637,9 +1637,27 @@ export default {
 
         if (!this.localPresenterVideo && !mute) {
             // create a new presenter track and apply the presenter effect.
-            const { height } = this.localVideo.track.getSettings();
-            const defaultCamera
-                = getUserSelectedCameraDeviceId(APP.store.getState());
+            let { height } = this.localVideo.track.getSettings();
+
+            // Workaround for Firefox since it doesn't return the correct width/height of the desktop stream
+            // that is being currently shared.
+            if (!height || height === 0) {
+                const desktopResizeConstraints = {
+                    width: 1280,
+                    height: 720,
+                    resizeMode: 'crop-and-scale'
+                };
+
+                try {
+                    await this.localVideo.track.applyConstraints(desktopResizeConstraints);
+                } catch (err) {
+                    logger.error('Failed to apply constraints on the desktop stream for presenter mode', err);
+
+                    return;
+                }
+                height = desktopResizeConstraints.height;
+            }
+            const defaultCamera = getUserSelectedCameraDeviceId(APP.store.getState());
             let effect;
 
             try {


### PR DESCRIPTION
Firefox doesn't return the width/height of the desktop stream that is returned by getDisplayMedia.
The canvas for presenter mode cannot be created if the application window size cannot be determined. Therefore, add a workaround by applying constraints on the existing MediaStreamTrack.