### PR TITLE
fix(blur): update to bodyPix 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3944,9 +3944,9 @@
       }
     },
     "@tensorflow-models/body-pix": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tensorflow-models/body-pix/-/body-pix-1.1.2.tgz",
-      "integrity": "sha512-moCCTlP77v20HMg1e/Hs1LehCDLAKS32e6OUeI1MA/4HrRRO1Dq9engVCLFZUMO2+mJXdQeBdzexcFg0WQox7w=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@tensorflow-models/body-pix/-/body-pix-2.0.4.tgz",
+      "integrity": "sha512-wRoEZBv2BNORDZjNNRLu1W4Td4/LRbaqSJFVWryHeBcHr5m5xSSETwnDfFRtLLofFtVNHfi7VUZ7TFjkaktNug=="
     },
     "@tensorflow/tfjs": {
       "version": "1.2.9",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@react-native-community/google-signin": "3.0.1",
     "@react-native-community/netinfo": "4.1.5",
     "@svgr/webpack": "4.3.2",
-    "@tensorflow-models/body-pix": "1.1.2",
+    "@tensorflow-models/body-pix": "2.0.4",
     "@tensorflow/tfjs": "1.2.9",
     "@webcomponents/url": "0.7.1",
     "amplitude-js": "4.5.2",


### PR DESCRIPTION
- Update to bodyPix 2.0
- Change settings for personSegmentation to improve performance.
- Earlier multiple instances were running in parallel because it was taking longer than the default 50 ms on some of the slower machines making it completely unusable.
- We are now waiting for the person segmentation to be complete before calling it again when the TimerWorker handler is invoked.
- By doing this, the cpu and memory consumption when blur feature is turned on have come down drastically.