### PR TITLE
ref(base/connection/actions.native): JitsiConnection.connect returns void

### DIFF
--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -104,7 +104,7 @@ export function connect(id: ?string, password: ?string) {
             JitsiConnectionEvents.CONNECTION_FAILED,
             _onConnectionFailed);
 
-        return connection.connect({
+        connection.connect({
             id,
             password
         });


### PR DESCRIPTION
Do not return anything from JitsiConnection.connect, because it's not a promise and returns void. Doing so is confusing to the reader.