### PR TITLE
android: handle ConnectionService failures more resiliently

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/RNConnectionService.java
@@ -89,9 +89,17 @@ class RNConnectionService extends ReactContextBaseJavaModule {
         ReactApplicationContext ctx = getReactApplicationContext();
 
         Uri address = Uri.fromParts(PhoneAccount.SCHEME_SIP, handle, null);
-        PhoneAccountHandle accountHandle
-            = ConnectionService.registerPhoneAccount(
-                    getReactApplicationContext(), address, callUUID);
+        PhoneAccountHandle accountHandle;
+
+        try {
+            accountHandle
+                = ConnectionService.registerPhoneAccount(getReactApplicationContext(), address, callUUID);
+        } catch (Throwable tr) {
+            JitsiMeetLogger.e(tr, TAG + " error in startCall");
+
+            promise.reject(tr);
+            return;
+        }
 
         Bundle extras = new Bundle();
         extras.putParcelable(
@@ -110,22 +118,18 @@ class RNConnectionService extends ReactContextBaseJavaModule {
         try {
             tm = (TelecomManager) ctx.getSystemService(Context.TELECOM_SERVICE);
             tm.placeCall(address, extras);
-        } catch (Exception e) {
-            JitsiMeetLogger.e(e, TAG + " error in startCall");
+        } catch (Throwable tr) {
+            JitsiMeetLogger.e(tr, TAG + " error in startCall");
             if (tm != null) {
                 try {
                     tm.unregisterPhoneAccount(accountHandle);
-                } catch (Throwable tr) {
+                } catch (Throwable tr1) {
                     // UnsupportedOperationException: System does not support feature android.software.connectionservice
                     // was observed here. Ignore.
                 }
             }
             ConnectionService.unregisterStartCallPromise(callUUID);
-            if (e instanceof SecurityException) {
-                promise.reject("SECURITY_ERROR", "Required permissions not granted.");
-            } else {
-                promise.reject(e);
-            }
+            promise.reject(tr);
         }
     }
 

--- a/react/features/mobile/call-integration/middleware.js
+++ b/react/features/mobile/call-integration/middleware.js
@@ -194,16 +194,14 @@ function _conferenceJoined({ getState }, next, action) {
                     _updateCallIntegrationMuted(action.conference, getState());
                 }
             })
-            .catch(error => {
-                // Currently this error code is emitted only by Android.
+            .catch(() => {
+                // Currently errors here are only emitted by Android.
                 //
-                if (error.code === 'CONNECTION_NOT_FOUND_ERROR') {
-                    // Some Samsung devices will fail to fully engage ConnectionService if no SIM card
-                    // was ever installed on the device. We could check for it, but it would require
-                    // the CALL_PHONE permission, which is not something we want to do, so fallback to
-                    // not using ConnectionService.
-                    _handleConnectionServiceFailure(getState());
-                }
+                // Some Samsung devices will fail to fully engage ConnectionService if no SIM card
+                // was ever installed on the device. We could check for it, but it would require
+                // the CALL_PHONE permission, which is not something we want to do, so fallback to
+                // not using ConnectionService.
+                _handleConnectionServiceFailure(getState());
             });
     }
 
@@ -304,9 +302,11 @@ function _conferenceWillJoin({ dispatch, getState }, next, action) {
                         { text: 'OK' }
                     ],
                     { cancelable: false });
-            } else if (error.code === 'SECURITY_ERROR') {
+            } else {
                 // Some devices fail because the CALL_PHONE permission is not granted, which is
                 // nonsense, because it's not needed for self-managed connections.
+                // Some other devices fail because ConnectionService is not supported.
+                // Be that as it may, fallback to non-ConnectionService audio device handling.
 
                 _handleConnectionServiceFailure(state);
             }


### PR DESCRIPTION
Fallback to the non-ConnectionService case for any error. Also, handle errors
when registering the phone account; Pixel C devices throw UnsupportedException.