### PR TITLE
Fixes conference duration config to use valid IDNA.

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -30,7 +30,7 @@ VirtualHost "jitmeet.example.com"
                 certificate = "/etc/prosody/certs/jitmeet.example.com.crt";
         }
         speakerstats_component = "speakerstats.jitmeet.example.com"
-        conference_duration_component = "conference_duration.jitmeet.example.com"
+        conference_duration_component = "conferenceduration.jitmeet.example.com"
         -- we need bosh
         modules_enabled = {
             "bosh";
@@ -68,5 +68,5 @@ Component "focus.jitmeet.example.com"
 Component "speakerstats.jitmeet.example.com" "speakerstats_component"
     muc_component = "conference.jitmeet.example.com"
 
-Component "conference_duration.jitmeet.example.com" "conference_duration_component"
+Component "conferenceduration.jitmeet.example.com" "conference_duration_component"
     muc_component = "conference.jitmeet.example.com"

--- a/resources/prosody-plugins/mod_conference_duration.lua
+++ b/resources/prosody-plugins/mod_conference_duration.lua
@@ -1,5 +1,5 @@
 local conference_duration_component
     = module:get_option_string(
-        "conference_duration_component", "conference_duration"..module.host);
+        "conference_duration_component", "conferenceduration"..module.host);
 
 module:add_identity("component", "conference_duration", conference_duration_component);


### PR DESCRIPTION
Using underscore in the address results:
```
lua5.1: /usr/lib/prosody/util/openssl.lua:109: attempt to concatenate a nil value
stack traceback:
	/usr/lib/prosody/util/openssl.lua:109: in function 'add_sRVName'
	/usr/lib/prosody/util/openssl.lua:133: in function 'from_prosody'
	/usr/bin/prosodyctl:739: in function 'config'
	/usr/bin/prosodyctl:836: in function </usr/bin/prosodyctl:829>
	(tail call): ?
	/usr/bin/prosodyctl:1523: in main chunk
	[C]: ?
```
when installing jitsi-meet-prosody package and breaks jitsi-meet new installations.
The error was that `idna_to_ascii` return nil in the code:`ia5string("_" .. service .. "." .. idna_to_ascii(host))`.