### PR TITLE
deps: react-native-sound@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14810,9 +14810,8 @@
       "integrity": "sha512-HDwEaXcQIuXXCV70O+bK1rizFong3wj+5Q/jSyifKFLg0VWF95xh8XQgfzXwtq0NggL9vNjPKXa016KuFu+VFg=="
     },
     "react-native-sound": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/react-native-sound/-/react-native-sound-0.11.0.tgz",
-      "integrity": "sha512-4bGAZfni6E2L695NQjOZwNLBQGXgBGYC4Sy+h99K5h0HqNZjCqR0+aLel+ezASxEJDpaH83gylNObXpiqJgdwg=="
+      "version": "github:jitsi/react-native-sound#3fe5480fce935e888d5089d94a191c7c7e3aa190",
+      "from": "github:jitsi/react-native-sound#3fe5480fce935e888d5089d94a191c7c7e3aa190"
     },
     "react-native-svg": {
       "version": "9.7.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react-native-immersive": "2.0.0",
     "react-native-keep-awake": "4.0.0",
     "react-native-linear-gradient": "2.5.6",
-    "react-native-sound": "0.11.0",
+    "react-native-sound": "github:jitsi/react-native-sound#3fe5480fce935e888d5089d94a191c7c7e3aa190",
     "react-native-svg": "9.7.1",
     "react-native-svg-transformer": "0.13.0",
     "react-native-swipeout": "2.3.6",


### PR DESCRIPTION
Fixes an issue with not loading sounds on iOS when the bundle name contains
spaces.

See:
https://github.com/jitsi/react-native-sound/commit/3fe5480fce935e888d5089d94a191c7c7e3aa190