### PR TITLE
feat(config.js): add 'websocket' config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -30,6 +30,9 @@ var config = {
     // BOSH URL. FIXME: use XEP-0156 to discover it.
     bosh: '//jitsi-meet.example.com/http-bind',
 
+    // Websocket URL
+    // websocket: 'wss://jitsi-meet.example.com/xmpp-websocket',
+
     // The name of client node advertised in XEP-0115 'c' stanza
     clientNode: 'http://jitsi.org/jitsimeet',
 

--- a/connection.js
+++ b/connection.js
@@ -75,7 +75,15 @@ function connect(id, password, roomName) {
     const connectionConfig = Object.assign({}, config);
     const { issuer, jwt } = APP.store.getState()['features/base/jwt'];
 
-    connectionConfig.bosh += `?room=${roomName}`;
+    // Use Websocket URL for the web app if configured. Note that there is no 'isWeb' check, because there's assumption
+    // that this code executes only on web browsers/electron. This needs to be changed when mobile and web are unified.
+    let serviceUrl = connectionConfig.websocket || connectionConfig.bosh;
+
+    serviceUrl += `?room=${roomName}`;
+
+    // FIXME Remove deprecated 'bosh' option assignment at some point(LJM will be accepting only 'serviceUrl' option
+    //  in future). It's included for the time being for Jitsi Meet and lib-jitsi-meet versions interoperability.
+    connectionConfig.serviceUrl = connectionConfig.bosh = serviceUrl;
 
     const connection
         = new JitsiMeetJS.JitsiConnection(

--- a/connection_optimization/do_external_connect.js
+++ b/connection_optimization/do_external_connect.js
@@ -17,10 +17,11 @@ import parseURLParams from '../react/features/base/config/parseURLParams';
 
 if (typeof createConnectionExternally === 'function') {
     // URL params have higher priority than config params.
+    // Do not use external connect if websocket is enabled.
     let url
         = parseURLParams(window.location, true, 'hash')[
                 'config.externalConnectUrl']
-            || config.externalConnectUrl;
+            || config.websocket ? undefined : config.externalConnectUrl;
     const isRecorder
         = parseURLParams(window.location, true, 'hash')['config.iAmRecorder'];
 

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -59,6 +59,16 @@ server {
         proxy_set_header Host $http_host;
     }
 
+    # xmpp websockets
+    location = /xmpp-websocket {
+        proxy_pass http://127.0.0.1:5280/xmpp-websocket?prefix=$prefix&$args;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $http_host;
+        tcp_nodelay on;
+    }
+
     location ~ ^/([^/?&:'"]+)$ {
         try_files $uri @root_path;
     }
@@ -89,5 +99,14 @@ server {
         set $prefix "$1";
 
         rewrite ^/(.*)$ /http-bind;
+    }
+
+    # websockets for subdomains
+    location ~ ^/([^/?&:'"]+)/xmpp-websocket {
+        set $subdomain "$1.";
+        set $subdir "$1/";
+        set $prefix "$1";
+
+        rewrite ^/(.*)$ /xmpp-websocket;
     }
 }

--- a/doc/example-config-files/multidomain/config.js.multidomain.example
+++ b/doc/example-config-files/multidomain/config.js.multidomain.example
@@ -10,5 +10,6 @@ var config = {
         focus: 'focus.jitsi.example.com',
     },
     useNicks: false,
-    bosh: '//jitsi.example.com/http-bind' // FIXME: use xep-0156 for that
+    bosh: '//jitsi.example.com/http-bind', // FIXME: use xep-0156 for that
+    websocket: 'wss://jitsi.example.com/xmpp-websocket'
 };

--- a/doc/example-config-files/multidomain/jitsi.example.com.multidomain.example
+++ b/doc/example-config-files/multidomain/jitsi.example.com.multidomain.example
@@ -60,4 +60,12 @@ server {
         rewrite ^/(.*)$ /http-bind;
     }
 
+    # websockets for subdomains
+    location ~ ^/([^/?&:'"]+)/xmpp-websocket {
+        set $subdomain "$1.";
+        set $subdir "$1/";
+        set $prefix "$1";
+
+        rewrite ^/(.*)$ /xmpp-websocket;
+    }
 }

--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -95,6 +95,9 @@ export function initAnalytics({ getState }: { getState: Function }) {
                 permanentProperties.group = group;
             }
 
+            //  Report if user is using websocket
+            permanentProperties.websocket = navigator.product !== 'ReactNative' && typeof config.websocket === 'string';
+
             // Optionally, include local deployment information based on the
             // contents of window.config.deploymentInfo.
             if (deploymentInfo) {

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -312,7 +312,8 @@ function _constructOptions(state) {
 
         room && (bosh += `?room=${getBackendSafeRoomName(room)}`);
 
-        options.bosh = bosh;
+        // FIXME Remove deprecated 'bosh' option assignment at some point.
+        options.serviceUrl = options.bosh = bosh;
     }
 
     return options;


### PR DESCRIPTION
Config.js will allow to specify both BOSH and Websocket URLs(even at the same time). In such case the web app will prefer Websocket over BOSH. The reason is that it appears to be more stable and a bit faster on web, while on mobile Websocket is dropped too quickly(killed by the OS) on network changes.