### PR TITLE
allow more characters in meeting name when reverse proxied

### DIFF
--- a/doc/example-config-files/jitsi.example.com.example
+++ b/doc/example-config-files/jitsi.example.com.example
@@ -6,7 +6,7 @@ server {
     root /srv/jitsi.example.com;
     index index.html;
 
-    location ~ ^/([a-zA-Z0-9=\?]+)$ {
+    location ~ ^/(?!(http-bind|external_api\.|xmpp-websocket))([a-zA-Z0-9=_äÄöÖüÜß\?\-]+)$ {
         rewrite ^/(.*)$ / break;
         }
 


### PR DESCRIPTION
excluding special locations (bosh, xmpp, legacy lib).
addresses #3811