### PR TITLE
fix(webpack.config.js): specify Host header in the  webpack  proxy pass

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,10 @@ const config = {
             '/': {
                 bypass: devServerProxyBypass,
                 secure: false,
-                target: devServerProxyTarget
+                target: devServerProxyTarget,
+                headers: {
+                    'Host': new URL(devServerProxyTarget).host
+                }
             }
         }
     },


### PR DESCRIPTION
Without changing the 'Host' header, a standalone instance we use for
jitsi dev work will generate:

config.websocket = 'wss://localhost:8080/xmpp-websocket'

This was fine with BOSH, but a Websocket will not connect.

With this change it will be(based on the default devServerProxyTarget):

config.websocket = 'wss://alpha.jitsi.net/xmpp-websocket'