### PR TITLE
Set SASL username when using anonymous mechanism with auth_token

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -95,6 +95,7 @@ local function anonymous(self, message)
 	local result, err, msg = self.profile.anonymous(self, username, self.realm);
 
 	if result == true then
+		self.username = username;
 		return "success";
 	else
 


### PR DESCRIPTION
When using SASL anonymous to create a anonymous domain while using JWT tokens to authenticate on the main domain I found that jitisi`s custom mod_auth_token defines an anonymous mechanism but fails to set the required temporary username for SASL anonymous to work. Setting the temporary username allows to configure a secure domain (https://github.com/jitsi/jicofo#secure-domain) with JWT token authentication. 