### PR TITLE
notifications,presence-status: check if interfaceConfig is declared

### DIFF
--- a/react/features/notifications/functions.js
+++ b/react/features/notifications/functions.js
@@ -24,5 +24,5 @@ export function areThereNotifications(stateful: Object | Function) {
  * @returns {boolean}
  */
 export function joinLeaveNotificationsDisabled() {
-    return Boolean(interfaceConfig?.DISABLE_JOIN_LEAVE_NOTIFICATIONS);
+    return Boolean(typeof interfaceConfig !== 'undefined' && interfaceConfig?.DISABLE_JOIN_LEAVE_NOTIFICATIONS);
 }

--- a/react/features/presence-status/functions.js
+++ b/react/features/presence-status/functions.js
@@ -8,5 +8,5 @@ declare var interfaceConfig: Object;
  * @returns {boolean}
  */
 export function presenceStatusDisabled() {
-    return Boolean(interfaceConfig?.DISABLE_PRESENCE_STATUS);
+    return Boolean(typeof interfaceConfig !== 'undefined' && interfaceConfig?.DISABLE_PRESENCE_STATUS);
 }


### PR DESCRIPTION
Protect ourselves against interfaceConfig being undeclared. typeof
interfaceConfig will return "undefined", but that's different than having some
window.interfaceConfig = undefined, even though the valus is the same. The
former will give a ReferenceError.