### PR TITLE
deps(blur): Bump tfjs to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3957,25 +3957,25 @@
       "integrity": "sha512-wRoEZBv2BNORDZjNNRLu1W4Td4/LRbaqSJFVWryHeBcHr5m5xSSETwnDfFRtLLofFtVNHfi7VUZ7TFjkaktNug=="
     },
     "@tensorflow/tfjs": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.2.9.tgz",
-      "integrity": "sha512-9UAQnSp638FyM5eedYEM+j2R7VcNajiFmkeT5EXtf7YIurmMFNEm1sbajKJx7/ckz31YcYrVoUPc/iLhhDQl2A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.1.tgz",
+      "integrity": "sha512-WiE+JQ3ibr5LibGiBz6HWUqLJW8HiX6ywUSCA7ehZ67vFsw4mPuVjv0WEEUfD/l47PkXYVAmWd+RYOJiuZC7Eg==",
       "requires": {
-        "@tensorflow/tfjs-converter": "1.2.9",
-        "@tensorflow/tfjs-core": "1.2.9",
-        "@tensorflow/tfjs-data": "1.2.9",
-        "@tensorflow/tfjs-layers": "1.2.9"
+        "@tensorflow/tfjs-converter": "1.5.1",
+        "@tensorflow/tfjs-core": "1.5.1",
+        "@tensorflow/tfjs-data": "1.5.1",
+        "@tensorflow/tfjs-layers": "1.5.1"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.2.9.tgz",
-      "integrity": "sha512-OKmiuZicIgadT3Bv9BvM+oom7wRz9eC5rTglQnuv7VN9H0syFVuhf5oD1Ff70tGDhJjJgL+cPz01fZRxTXjRWA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.1.tgz",
+      "integrity": "sha512-M9tl2/ep8ntcZpmncHwKuvThsS7TaUWqJ9vJSgJmkazwTfAvlAJmZ8/p1miJ+m5sH1EJO4oTjiEmch6g8IA5IQ=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.2.9.tgz",
-      "integrity": "sha512-s0hHZSx6rGTlkkB8u8gs5n7sIPv1GXDNHmISRy+kqGzmlpkfI2kr6WXqOWQy6wFgjzopRD8cJQjBZ9USPZnYTQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.1.tgz",
+      "integrity": "sha512-N4fsi8mLsRwRs8UJN2cARB1rYFxyVXkLyZ4wOusiR976BwwZbCwQrTTSIPzPqYT3rwiexEUzm7sM6ZaDl5dpXA==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -3993,9 +3993,9 @@
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.2.9.tgz",
-      "integrity": "sha512-Ti9Cj3pte9butuEsK5OPq0Lcqdi4wVUdtQXm0o7iYOZ0umseRzfbIb6zbdqucc2MQzOMTnRoxN+FL7LZmncsHg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.1.tgz",
+      "integrity": "sha512-eu4X0tHS1Tng+cvMO9gkMhUWX/UZQ//VpiaZfQJfa3zvUgxw6s1MHJFb0JC1T1FOnEgDVriZ8G758ysJZOybog==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.1.2"
@@ -4009,9 +4009,9 @@
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.2.9.tgz",
-      "integrity": "sha512-OlXYaIb1rCk5dYmpaNsPEkO7R+T0oxfS3vQGIztNJB+YxrN8mwCu3hqgpbdKhAITiP+jxO0o+7bny8MsOCkOSQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz",
+      "integrity": "sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -4064,9 +4064,9 @@
       "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "@types/node-fetch": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
-      "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.4.tgz",
+      "integrity": "sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@react-native-community/netinfo": "4.1.5",
     "@svgr/webpack": "4.3.2",
     "@tensorflow-models/body-pix": "2.0.4",
-    "@tensorflow/tfjs": "1.2.9",
+    "@tensorflow/tfjs": "1.5.1",
     "@webcomponents/url": "0.7.1",
     "amplitude-js": "4.5.2",
     "bc-css-flags": "3.0.0",


### PR DESCRIPTION
@tensorflow-models/body-pix@2.0.4 requires tfjs version to be higher than 1.3.1

This PR fixes the below warnings seen on npm install

npm WARN @tensorflow-models/body-pix@2.0.4 requires a peer of @tensorflow/tfjs-converter@^1.3.1 but none is installed. You must install peer dependencies yourself.
npm WARN @tensorflow-models/body-pix@2.0.4 requires a peer of @tensorflow/tfjs-core@^1.3.1 but none is installed. You must install peer dependencies yourself.
