### PR TITLE
fix(presenter): resize desktop track to 720p when presenter starts

### DIFF
--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -27,7 +27,7 @@ export async function createLocalPresenterTrack(options, desktopHeight) {
 
     // compute the constraints of the camera track based on the resolution
     // of the desktop screen that is being shared.
-    const cameraHeights = [ 180, 270, 360, 540, 720 ];
+    const cameraHeights = [ 120, 180, 240, 360, 480, 600, 720 ];
     const proportion = 4;
     const result = cameraHeights.find(
             height => (desktopHeight / proportion) < height);


### PR DESCRIPTION
Resize the desktop MediaStreamTrack to 720p using applyConstraints for the following cases
- When the track height cannot be determined (firefox doesn't seem to return the track settings.
- Determine if the window is in portrait/landscape mode and resize only the dimension which is bigger than 1280/720. The other side resizes to preserve the aspect ratio.
- Add more 4:3 resolutions to pick from when the camera stream is obtained.
When the presenter is turned on, we start sending full 30 fps which can be very cpu intensive if the shared desktop window is very big. 