### PR TITLE
rn,connection: fix autogenerated BOSH address

### DIFF
--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -299,12 +299,12 @@ function _constructOptions(state) {
             // Handle relative URLs, which won't work on mobile.
             const {
                 protocol,
-                hostname,
+                host,
                 contextRoot
             } = parseURIString(locationURL.href);
 
             // eslint-disable-next-line max-len
-            bosh = `${protocol}//${hostname}${contextRoot || '/'}${bosh.substr(1)}`;
+            bosh = `${protocol}//${host}${contextRoot || '/'}${bosh.substr(1)}`;
         }
 
         // Append room to the URL's search.


### PR DESCRIPTION
When the location URL contains a nonstandard port, it won't be included in
URL.hostname, but it will in URL.host.