### PR TITLE
android: turn on HW video decoder

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
@@ -1,6 +1,5 @@
 /*
- * Copyright @ 2019-present 8x8, Inc.
- * Copyright @ 2017-2018 Atlassian Pty Ltd
+ * Copyright @ 2017-present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +30,13 @@ import com.facebook.react.devsupport.DevInternalSettings;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.soloader.SoLoader;
+
+import com.oney.WebRTCModule.EglUtils;
 import com.oney.WebRTCModule.RTCVideoViewManager;
 import com.oney.WebRTCModule.WebRTCModule;
 
+import org.webrtc.DefaultVideoDecoderFactory;
+import org.webrtc.EglBase;
 import org.webrtc.SoftwareVideoDecoderFactory;
 import org.webrtc.SoftwareVideoEncoderFactory;
 import org.webrtc.VideoDecoderFactory;
@@ -84,10 +87,19 @@ class ReactInstanceManagerHolder {
 
         AudioDeviceModule adm = JavaAudioDeviceModule.builder(reactContext)
             .createAudioDeviceModule();
-        VideoDecoderFactory videoDecoderFactory = new SoftwareVideoDecoderFactory();
-        VideoEncoderFactory videoEncoderFactory = new SoftwareVideoEncoderFactory();
-
         options.setAudioDeviceModule(adm);
+
+        VideoEncoderFactory videoEncoderFactory = new SoftwareVideoEncoderFactory();
+        VideoDecoderFactory videoDecoderFactory;
+        // Initialize EGL context required for HW acceleration. We are only going to use it for
+        // decoding.
+        EglBase.Context eglContext = EglUtils.getRootEglBaseContext();
+        if (eglContext == null) {
+            // Fallback to the software decoder.
+            videoDecoderFactory = new SoftwareVideoDecoderFactory();
+        } else {
+            videoDecoderFactory = new DefaultVideoDecoderFactory(eglContext);
+        }
         options.setVideoDecoderFactory(videoDecoderFactory);
         options.setVideoEncoderFactory(videoEncoderFactory);
 


### PR DESCRIPTION
In 49e3b03885bd0c00fcd9b64c2f4d6b77ad68b62a we turned on SW encoders / decoders
on account of some devices having broken HW *encoders* and also our desire for
using simulcast.

Well, the astute reader may have noticed that only *encoding* was mentioned.
Indeed, we should be able to keep using the HW decoder just fine.