### PR TITLE
allow setting the feedback percentage

### DIFF
--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -103,6 +103,7 @@ export default [
     'enableTcc',
     'etherpad_base',
     'failICE',
+    'feedbackPercentage',
     'fileRecordingsEnabled',
     'firefox_fake_device',
     'forceJVB121Ratio',

--- a/react/features/feedback/actions.js
+++ b/react/features/feedback/actions.js
@@ -54,6 +54,7 @@ export function maybeOpenFeedbackDialog(conference: Object) {
 
     return (dispatch: Dispatch<any>, getState: Function): Promise<R> => {
         const state = getState();
+        const { feedbackPercentage = 100 } = state['features/base/config'];
 
         if (interfaceConfig.filmStripOnly || config.iAmRecorder) {
             // Intentionally fall through the if chain to prevent further action
@@ -69,7 +70,7 @@ export function maybeOpenFeedbackDialog(conference: Object) {
                 feedbackSubmitted: true,
                 showThankYou: true
             });
-        } else if (conference.isCallstatsEnabled()) {
+        } else if (conference.isCallstatsEnabled() && feedbackPercentage > Math.random() * 100) {
             return new Promise(resolve => {
                 dispatch(openFeedbackDialog(conference, () => {
                     const { submitted } = getState()['features/feedback'];


### PR DESCRIPTION
This PR adds a config.js value to let the deployment decide how often we want the app to ask the user for feedback (defaults to 100, 100 = always, 0 = feedback disabled)