### PR TITLE
fix(presenter): go back to using standard resolutions for presenter

### DIFF
--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -27,8 +27,8 @@ export async function createLocalPresenterTrack(options, desktopHeight) {
 
     // compute the constraints of the camera track based on the resolution
     // of the desktop screen that is being shared.
-    const cameraHeights = [ 120, 180, 240, 360, 480, 600, 720 ];
-    const proportion = 4;
+    const cameraHeights = [ 180, 270, 360, 540, 720 ];
+    const proportion = 5;
     const result = cameraHeights.find(
             height => (desktopHeight / proportion) < height);
     const constraints = {


### PR DESCRIPTION
Trying to start USB camera (especially Logitech Brio) with non-standard 4:3 resolutions like 320x240, 800x600, etc. doesn't seem to be working. The getUserMedia is successful but the stream returned by the browser is distorted.