### PR TITLE
full-screen: fix not re-entering full-screen after dialog is shown

### DIFF
--- a/react/features/base/dialog/functions.js
+++ b/react/features/base/dialog/functions.js
@@ -4,6 +4,17 @@ import { ColorSchemeRegistry } from '../color-scheme';
 import { toState } from '../redux';
 
 /**
+ * Checks if any {@code Dialog} is currently open.
+ *
+ * @param {Function|Object} stateful - The redux store, the redux
+ * {@code getState} function, or the redux state itself.
+ * @returns {boolean}
+ */
+export function isAnyDialogOpen(stateful: Function) {
+    return Boolean(toState(stateful)['features/base/dialog'].component);
+}
+
+/**
  * Checks if a {@code Dialog} with a specific {@code component} is currently
  * open.
  *

--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -4,6 +4,7 @@ import { Immersive } from 'react-native-immersive';
 
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../../base/app';
 import { getCurrentConference } from '../../base/conference';
+import { isAnyDialogOpen } from '../../base/dialog/functions';
 import { Platform } from '../../base/react';
 import { MiddlewareRegistry, StateListenerRegistry } from '../../base/redux';
 
@@ -48,8 +49,9 @@ StateListenerRegistry.register(
     /* selector */ state => {
         const { enabled: audioOnly } = state['features/base/audio-only'];
         const conference = getCurrentConference(state);
+        const dialogOpen = isAnyDialogOpen(state);
 
-        return conference ? !audioOnly : false;
+        return conference ? !audioOnly && !dialogOpen : false;
     },
     /* listener */ fullScreen => _setFullScreen(fullScreen)
 );
@@ -70,7 +72,8 @@ function _onImmersiveChange({ getState }) {
     if (appState === 'active') {
         const { enabled: audioOnly } = state['features/base/audio-only'];
         const conference = getCurrentConference(state);
-        const fullScreen = conference ? !audioOnly : false;
+        const dialogOpen = isAnyDialogOpen(state);
+        const fullScreen = conference ? !audioOnly && !dialogOpen : false;
 
         _setFullScreen(fullScreen);
     }


### PR DESCRIPTION
This has the side effect of showing the bottom navbar when the toolbox is open,
which is a nice thing since back is accessible.