### PR TITLE
fix(screenshot-capture): Do not switch streams at the conference level.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1426,6 +1426,9 @@ export default {
         }
 
         this._stopProxyConnection();
+        if (config.enableScreenshotCapture) {
+            APP.store.dispatch(toggleScreenshotCaptureEffect(false));
+        }
 
         // It can happen that presenter GUM is in progress while screensharing is being turned off. Here it needs to
         // wait for that GUM to be resolved in order to prevent leaking the presenter track(this.localPresenterVideo
@@ -1460,9 +1463,6 @@ export default {
                 });
         } else {
             promise = promise.then(() => this.useVideoStream(null));
-        }
-        if (config.enableScreenshotCapture) {
-            APP.store.dispatch(toggleScreenshotCaptureEffect(false));
         }
 
         return promise.then(

--- a/react/features/screenshot-capture/actions.js
+++ b/react/features/screenshot-capture/actions.js
@@ -34,17 +34,13 @@ export function toggleScreenshotCaptureEffect(enabled: boolean) {
         if (state['features/screenshot-capture'].capturesEnabled !== enabled) {
             const { jitsiTrack } = getLocalVideoTrack(state['features/base/tracks']);
 
+            // Screenshot capture effect doesn't return a modified stream. Therefore, we don't have to
+            // switch the stream at the conference level, starting/stopping the effect will suffice here.
             return createScreenshotCaptureEffect(state)
-                .then(effect =>
-                    jitsiTrack.setEffect(enabled ? effect : undefined)
-                        .then(() => {
-                            dispatch(setScreenshotCapture(enabled));
-                        })
-                        .catch(() => {
-                            dispatch(setScreenshotCapture(!enabled));
-                        })
-                )
-                .catch(() => dispatch(setScreenshotCapture(false)));
+                .then(effect => {
+                    enabled ? effect.startEffect(jitsiTrack.getOriginalStream()) : effect.stopEffect();
+                    dispatch(setScreenshotCapture(enabled));
+                });
         }
 
         return Promise.resolve();


### PR DESCRIPTION
This effect doesn't modify the media stream, so its safe to start/stop effect and not apply it on the JitsiLocalTrack. This way we can make sure that this effect is not switched out when presenter effect is applied.