### PR TITLE
chore(deps): update lib to 47c2bc6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10883,8 +10883,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#463f741cb6c76bb41490c0bc50728e4767f648ba",
-      "from": "github:jitsi/lib-jitsi-meet#463f741cb6c76bb41490c0bc50728e4767f648ba",
+      "version": "github:jitsi/lib-jitsi-meet#47c2bc65457b0cd1620e171cf79ffe4d49d071c5",
+      "from": "github:jitsi/lib-jitsi-meet#47c2bc65457b0cd1620e171cf79ffe4d49d071c5",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-utils": "github:jitsi/js-utils#8567f86ec2774ae1d1c47b22e3435928cf5d9771",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#463f741cb6c76bb41490c0bc50728e4767f648ba",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#47c2bc65457b0cd1620e171cf79ffe4d49d071c5",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",


### PR DESCRIPTION
To get a workaround in for wired desktop
screensharing in spot in electron 8. With
the change, no "exact" is used in gum
constraints while attempting to get the
wired screensharing device, as that
triggers overconstrainederror.