### PR TITLE
Fix electron 7 memory leak

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -206,6 +206,8 @@ export class VideoContainer extends LargeContainer {
          */
         this._hideBackground = true;
 
+        this._isHidden = false;
+
         /**
          * Flag indicates whether or not the avatar is currently displayed.
          * @type {boolean}
@@ -561,6 +563,8 @@ export class VideoContainer extends LargeContainer {
                 FADE_DURATION_MS,
                 1,
                 () => {
+                    this._isHidden = false;
+                    this._updateBackground();
                     resolve();
                 }
             );
@@ -578,6 +582,8 @@ export class VideoContainer extends LargeContainer {
         return new Promise(resolve => {
             this.$wrapperParent.fadeTo(FADE_DURATION_MS, 0, () => {
                 this.$wrapperParent.css('visibility', 'hidden');
+                this._isHidden = true;
+                this._updateBackground();
                 resolve();
             });
         });
@@ -635,7 +641,7 @@ export class VideoContainer extends LargeContainer {
 
         ReactDOM.render(
             <LargeVideoBackground
-                hidden = { this._hideBackground }
+                hidden = { this._hideBackground || this._isHidden }
                 mirror = {
                     this.stream
                     && this.stream.isLocal()

--- a/react/features/large-video/components/LargeVideoBackground.web.js
+++ b/react/features/large-video/components/LargeVideoBackground.web.js
@@ -211,6 +211,19 @@ export class LargeVideoBackground extends Component<Props> {
      * @returns {void}
      */
     _updateCanvas() {
+        // On Electron 7 there is a memory leak if we try to draw into a hidden canvas that is part of the DOM tree.
+        // See: https://github.com/electron/electron/issues/22417
+        // Trying to detect all the cases when the page will be hidden because of something not in our control
+        // (for example when the page is loaded in an iframe which is hidden due to the host page styles) to solve
+        // the memory leak. Currently we are not handling the use case when the page is hidden with visibility:hidden
+        // because we don't have a good way to do it.
+        // All other cases when the canvas is not visible are handled trough the component props
+        // (hidden, _shouldDisplayTileView).
+        if (!this._canvasEl || this._canvasEl.offsetParent === null
+                || window.innerHeight === 0 || window.innerWidth === 0) {
+            return;
+        }
+
         const { videoElement } = this.props;
         const { videoWidth, videoHeight } = videoElement;
         const {

--- a/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
+++ b/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
@@ -44,9 +44,6 @@ export default class JitsiStreamPresenterEffect {
         this._canvas = document.createElement('canvas');
         this._ctx = this._canvas.getContext('2d');
 
-        if (document.body !== null) {
-            document.body.appendChild(this._canvas);
-        }
         this._desktopElement = document.createElement('video');
         this._videoElement = document.createElement('video');
         videoDiv.appendChild(this._videoElement);


### PR DESCRIPTION
It appears that if we try to draw into a hidden canvas that is attached to the DOM tree there's memory leak on electron 7.

Electron issue: https://github.com/electron/electron/issues/22417