### PR TITLE
fix(optimise): cope with URL interface config overrides

### DIFF
--- a/react/features/filmstrip/components/web/Toolbar.js
+++ b/react/features/filmstrip/components/web/Toolbar.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import { connect } from '../../../base/redux';
+import { connect, equals } from '../../../base/redux';
 import { SettingsButton } from '../../../settings';
 import {
     AudioMuteButton,
@@ -88,9 +88,13 @@ class Toolbar extends Component<Props> {
 function _mapStateToProps(state): Object { // eslint-disable-line no-unused-vars
     // XXX: We are not currently using state here, but in the future, when
     // interfaceConfig is part of redux we will.
+    //
+    // NB: We compute the buttons again here because if URL parameters were used to
+    // override them we'd miss it.
+    const buttons = new Set(interfaceConfig.TOOLBAR_BUTTONS);
 
     return {
-        _visibleButtons: visibleButtons
+        _visibleButtons: equals(visibleButtons, buttons) ? visibleButtons : buttons
     };
 }
 

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -28,7 +28,7 @@ import {
     getParticipants,
     participantUpdated
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
+import { connect, equals } from '../../../base/redux';
 import { OverflowMenuItem } from '../../../base/toolbox';
 import { getLocalVideoTrack, toggleScreensharing } from '../../../base/tracks';
 import { VideoBlurButton } from '../../../blur';
@@ -1330,6 +1330,10 @@ function _mapStateToProps(state) {
         }
     }
 
+    // NB: We compute the buttons again here because if URL parameters were used to
+    // override them we'd miss it.
+    const buttons = new Set(interfaceConfig.TOOLBAR_BUTTONS);
+
     return {
         _chatOpen: state['features/chat'].isOpen,
         _conference: conference,
@@ -1351,7 +1355,7 @@ function _mapStateToProps(state) {
             || sharedVideoStatus === 'start'
             || sharedVideoStatus === 'pause',
         _visible: isToolboxVisible(state),
-        _visibleButtons: visibleButtons
+        _visibleButtons: equals(visibleButtons, buttons) ? visibleButtons : buttons
     };
 }
 


### PR DESCRIPTION
Regresssion from bd8a7edbd2f9e3058b67d39fdc1c78156902f995.

When the toolbar buttons are overridden with URL parameters, our computed set of
buttons will be wrong. Thus, compute it every time and check for the
differences.