### PR TITLE
ssperakerstats: prevent access of nil object

### DIFF
--- a/resources/prosody-plugins/mod_speakerstats_component.lua
+++ b/resources/prosody-plugins/mod_speakerstats_component.lua
@@ -53,7 +53,10 @@ function on_message(event)
         local oldDominantSpeakerId = roomSpeakerStats['dominantSpeakerId'];
 
         if oldDominantSpeakerId then
-            roomSpeakerStats[oldDominantSpeakerId]:setDominantSpeaker(false);
+            local oldDominantSpeaker = roomSpeakerStats[oldDominantSpeakerId];
+            if oldDominantSpeaker then
+                oldDominantSpeaker:setDominantSpeaker(false);
+            end
         end
 
         if newDominantSpeaker then


### PR DESCRIPTION
If the dominant speaker leaves their object will be gone from the mapping.