### PR TITLE
Fix tile-view sizes for the recorder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10883,8 +10883,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#47c2bc65457b0cd1620e171cf79ffe4d49d071c5",
-      "from": "github:jitsi/lib-jitsi-meet#47c2bc65457b0cd1620e171cf79ffe4d49d071c5",
+      "version": "github:jitsi/lib-jitsi-meet#b24bbdee4ecd8d42bc047743a5b13f8b14f98b23",
+      "from": "github:jitsi/lib-jitsi-meet#b24bbdee4ecd8d42bc047743a5b13f8b14f98b23",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.2",

--- a/react/features/filmstrip/subscriber.web.js
+++ b/react/features/filmstrip/subscriber.web.js
@@ -15,7 +15,7 @@ StateListenerRegistry.register(
         const state = store.getState();
 
         if (shouldDisplayTileView(state)) {
-            const gridDimensions = getTileViewGridDimensions(state['features/base/participants'].length);
+            const gridDimensions = getTileViewGridDimensions(state);
             const oldGridDimensions = state['features/filmstrip'].tileViewDimensions.gridDimensions;
             const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
 
@@ -41,7 +41,7 @@ StateListenerRegistry.register(
             const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
 
             store.dispatch(setTileViewDimensions(
-                getTileViewGridDimensions(state['features/base/participants'].length), {
+                getTileViewGridDimensions(state), {
                     clientHeight,
                     clientWidth
                 }));

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -39,13 +39,18 @@ export function getMaxColumnCount() {
  * equal count of tiles for height and width, until maxColumn is reached in
  * which rows will be added but no more columns.
  *
- * @param {number} numberOfParticipants - The number of participants including the fake participants.
+ * @param {Object} state - The redux store state.
  * @param {number} maxColumns - The maximum number of columns that can be
  * displayed.
  * @returns {Object} An object is return with the desired number of columns,
  * rows, and visible rows (the rest should overflow) for the tile view layout.
  */
-export function getTileViewGridDimensions(numberOfParticipants: number, maxColumns: number = getMaxColumnCount()) {
+export function getTileViewGridDimensions(state: Object, maxColumns: number = getMaxColumnCount()) {
+    // When in tile view mode, we must discount ourselves (the local participant) because our
+    // tile is not visible.
+    const { iAmRecorder } = state['features/base/config'];
+    const numberOfParticipants = state['features/base/participants'].length - (iAmRecorder ? 1 : 0);
+
     const columnsToMaintainASquare = Math.ceil(Math.sqrt(numberOfParticipants));
     const columns = Math.min(columnsToMaintainASquare, maxColumns);
     const rows = Math.ceil(numberOfParticipants / columns);


### PR DESCRIPTION
Yesterday I was playing a game of Magic: The Gathering with my brother and the tile-view layout is perfect for this. The recording, however, included tons of margin, which made following the game remotely bad.

Upon inspection it turns out there was an off-by-1 calculation error for the tile sizes: the loccal participant must not be accounted for in the recorder case, because it's not rendered! This fixes that.

<img width="1303" alt="Screen Shot 2020-03-06 at 13 35 22" src="https://user-images.githubusercontent.com/317464/76084136-83995100-5faf-11ea-9802-b6d86bd25c4a.png">
