### PR TITLE
ref(log): debug device list and selected devices

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2274,7 +2274,7 @@ export default {
                 })
                 .then(stream => this.useAudioStream(stream))
                 .then(() => {
-                    logger.log('switched local audio device');
+                    logger.log(`switched local audio device: ${this.localAudio?.getDeviceId()}`);
 
                     this._updateAudioDeviceId();
                 })
@@ -2651,12 +2651,6 @@ export default {
         // audio devices detected or if the local audio stream already exists.
         const available = audioDeviceCount > 0 || Boolean(this.localAudio);
 
-        logger.debug(
-            `Microphone button enabled: ${available}`,
-            `local audio: ${this.localAudio}`,
-            `audio devices: ${audioMediaDevices}`,
-            `device count: ${audioDeviceCount}`);
-
         APP.store.dispatch(setAudioAvailable(available));
         APP.API.notifyAudioAvailabilityChanged(available);
     },
@@ -2676,12 +2670,6 @@ export default {
         // created before the permissions were rejected (through browser
         // config).
         const available = videoDeviceCount > 0 || Boolean(this.localVideo);
-
-        logger.debug(
-            `Camera button enabled: ${available}`,
-            `local video: ${this.localVideo}`,
-            `video devices: ${videoMediaDevices}`,
-            `device count: ${videoDeviceCount}`);
 
         APP.store.dispatch(setVideoAvailable(available));
         APP.API.notifyVideoAvailabilityChanged(available);

--- a/react/features/base/devices/functions.js
+++ b/react/features/base/devices/functions.js
@@ -4,6 +4,8 @@ import { parseURLParams } from '../config';
 import JitsiMeetJS from '../lib-jitsi-meet';
 import { updateSettings } from '../settings';
 
+import logger from './logger';
+
 declare var APP: Object;
 
 /**
@@ -187,6 +189,9 @@ export function setAudioOutputDeviceId(
         dispatch: Function,
         userSelection: boolean = false,
         newLabel: ?string): Promise<*> {
+
+    logger.debug(`setAudioOutputDevice: ${String(newLabel)}[${newId}]`);
+
     return JitsiMeetJS.mediaDevices.setAudioOutputDevice(newId)
         .then(() => {
             const newSettings = {

--- a/react/features/base/devices/reducer.js
+++ b/react/features/base/devices/reducer.js
@@ -9,6 +9,8 @@ import { groupDevicesByKind } from './functions';
 
 import { ReducerRegistry } from '../redux';
 
+import logger from './logger';
+
 const DEFAULT_STATE = {
     availableDevices: {
         audioInput: [],
@@ -17,6 +19,24 @@ const DEFAULT_STATE = {
     },
     pendingRequests: []
 };
+
+/**
+ * Logs the current device list.
+ *
+ * @param {Object} deviceList - Whatever is returned by {@link groupDevicesByKind}.
+ * @returns {string}
+ */
+function logDeviceList(deviceList) {
+    const devicesToStr = list => list.map(device => `\t\t${device.label}[${device.deviceId}]`).join('\n');
+    const audioInputs = devicesToStr(deviceList.audioInput);
+    const audioOutputs = devicesToStr(deviceList.audioOutput);
+    const videoInputs = devicesToStr(deviceList.videoInput);
+
+    logger.debug('Device list updated:\n'
+        + `audioInput:\n${audioInputs}\n`
+        + `audioOutput:\n${audioOutputs}\n`
+        + `videoInput:\n${videoInputs}`);
+}
 
 /**
  * Listen for actions which changes the state of known and used devices.
@@ -34,6 +54,8 @@ ReducerRegistry.register(
         switch (action.type) {
         case UPDATE_DEVICE_LIST: {
             const deviceList = groupDevicesByKind(action.devices);
+
+            logDeviceList(deviceList);
 
             return {
                 ...state,
@@ -56,11 +78,17 @@ ReducerRegistry.register(
                 pendingRequests: [ ]
             };
 
-        // TODO: Changing of current audio and video device id is currently
-        // handled outside of react/redux. Fall through to default logic for
-        // now.
-        case SET_AUDIO_INPUT_DEVICE:
-        case SET_VIDEO_INPUT_DEVICE:
+        // TODO: Changing of current audio and video device id is currently handled outside of react/redux.
+        case SET_AUDIO_INPUT_DEVICE: {
+            logger.debug(`set audio input device: ${action.deviceId}`);
+
+            return state;
+        }
+        case SET_VIDEO_INPUT_DEVICE: {
+            logger.debug(`set video input device: ${action.deviceId}`);
+
+            return state;
+        }
         default:
             return state;
         }


### PR DESCRIPTION
Logs the device list when is updated in the reducer and removes
"button enabled" logging which used to dump the device list, but
in a useless way(Object[Object]).

Makes an attempt to log currently selected device, but because of
multiple possible paths it's impossible to find one reliable spot to log
selected device. One has to rely on device list and the GUM call logged
to figure things out.