### PR TITLE
deps: update LJM to fix Strophe.attach not handled correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10883,8 +10883,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#567ba72675b1bfd5931e7d4936a4e53ebb4ef5f2",
-      "from": "github:jitsi/lib-jitsi-meet#567ba72675b1bfd5931e7d4936a4e53ebb4ef5f2",
+      "version": "github:jitsi/lib-jitsi-meet#aadfce2283cad4de3cb58c2eed8e14d2ce62c465",
+      "from": "github:jitsi/lib-jitsi-meet#aadfce2283cad4de3cb58c2eed8e14d2ce62c465",
       "requires": {
         "@jitsi/sdp-interop": "0.1.14",
         "@jitsi/sdp-simulcast": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-utils": "github:jitsi/js-utils#8567f86ec2774ae1d1c47b22e3435928cf5d9771",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#567ba72675b1bfd5931e7d4936a4e53ebb4ef5f2",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#aadfce2283cad4de3cb58c2eed8e14d2ce62c465",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",


### PR DESCRIPTION
Updates lib-jitsi-meet to aadfce2283cad4de3cb58c2eed8e14d2ce62c465 in order to fix "not connected" error when jiconop is enabled.