### PR TITLE
Update main-de.json

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -613,7 +613,7 @@
             "show": "Im Vordergrund anzeigen",
             "speakerStats": "Sprecherstatistik ein-/ausblenden",
             "tileView": "Kachelansicht ein-/ausschalten",
-            "toggleCamera": "Kamera ein-/ausschalten",
+            "toggleCamera": "Kamera wechseln",
             "videomute": "„Video stummschalten“ ein-/ausschalten",
             "videoblur": "Video-Unschärfe ein-/ausschalten"
         },


### PR DESCRIPTION
Changed inaccurate translation of "toggleCamera".

Current translation is "Kamera ein-/ausschalten" ("switch camera on / off"). But what it does instead is switch from front to rear camera ("Kamera wechseln").