### PR TITLE
Allow DOMAIN to override default domain.

### DIFF
--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -3,7 +3,8 @@
 set -e
 
 DEB_CONF_RESULT=`debconf-show jitsi-meet-web-config | grep jvb-hostname`
-DOMAIN="${DEB_CONF_RESULT##*:}"
+# Allow overriding the domain by setting the DOMAIN environment variable.
+DOMAIN="${DOMAIN-${DEB_CONF_RESULT##*:}}"
 # remove whitespace
 DOMAIN="$(echo -e "${DOMAIN}" | tr -d '[:space:]')"
 


### PR DESCRIPTION
Now I can run: `DOMAIN=guest.jitsi.example.com install-letsencrypt-cert.sh`