### PR TITLE
doc (quick install): Add the domain to /etc/hosts

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -14,6 +14,12 @@ b.) You only need to do this if you want to ___host your own Jitsi server___. If
 
 ## Basic Jitsi Meet install
 
+### Add the domain name to `/etc/hosts 
+
+Add the the domain used to host the Jitsi Meet instance in the `/etc/hosts` file :
+
+    127.0.0.1 meet.example.org
+
 ### Add the repository
 ```sh
 echo 'deb https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list


### PR DESCRIPTION
We ran into https://github.com/jitsi/jitsi-meet/issues/2780

Adding the domain to `/etc/hosts` as suggested by a comment in this ticket seems to solve this, and https://www.scaleway.com/en/docs/setting-up-jitsi-meet-videoconferencing-on-debian-stretch/ also suggests doing this as a first step.

As such, here is a pull request to add this step to the quick install doc :-)

Have a good day