### PR TITLE
feature: android screen sharing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14887,9 +14887,8 @@
       "integrity": "sha512-l3Quzbb+qa4in2U5RSt/lT0/pHrIpEChT1NnqrVAAXNrjkXjVOsxduaaEDdDhTzNJQEm/PcAcoyrFmgvGOohxw=="
     },
     "react-native-webrtc": {
-      "version": "1.75.2",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-1.75.2.tgz",
-      "integrity": "sha512-mdEukmHNhiyVIiwdooxk4kVXWG83OOENFV9YIkC7dtGU/sOdL81vDzynqd6Af9YbGMeOr0xdpFuEGsc1OFnKZg==",
+      "version": "github:zycwind/react-native-webrtc#c7cefc2869db43073aab46504a00ddd3eace7b17",
+      "from": "github:zycwind/react-native-webrtc#c7cefc2869db43073aab46504a00ddd3eace7b17",
       "requires": {
         "base64-js": "^1.1.2",
         "event-target-shim": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-native-svg-transformer": "0.13.0",
     "react-native-swipeout": "2.3.6",
     "react-native-watch-connectivity": "0.2.0",
-    "react-native-webrtc": "1.75.2",
+    "react-native-webrtc": "github:zycwind/react-native-webrtc#c7cefc2869db43073aab46504a00ddd3eace7b17",
     "react-native-webview": "7.4.1",
     "react-redux": "7.1.0",
     "react-textarea-autosize": "7.1.0",

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -9,6 +9,7 @@ import {
     getCurrentConference
 } from '../conference';
 import JitsiMeetJS, { JitsiConnectionEvents } from '../lib-jitsi-meet';
+import { setDesktopSharingEnabled } from '../conference';
 import {
     getBackendSafeRoomName,
     parseURIString
@@ -132,6 +133,10 @@ export function connect(id: ?string, password: ?string) {
             connection.removeEventListener(
                 JitsiConnectionEvents.CONNECTION_ESTABLISHED,
                 _onConnectionEstablished);
+            // Enable desktop sharing.
+            const isDesktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled();
+            dispatch(setDesktopSharingEnabled(isDesktopSharingEnabled));
+
             dispatch(connectionEstablished(connection, Date.now()));
         }
 

--- a/react/features/base/environment/environment.js
+++ b/react/features/base/environment/environment.js
@@ -21,7 +21,7 @@ const browserNameToCheck = {
     electron: browser.isElectron.bind(browser),
     firefox: browser.isFirefox.bind(browser),
     nwjs: browser.isNWJS.bind(browser),
-    opera: browser.isOpera.bind(browser),
+    opera: (browser._isOpera || browser.isOpera).bind(browser),
     safari: browser.isSafari.bind(browser)
 };
 

--- a/react/features/base/lastn/middleware.js
+++ b/react/features/base/lastn/middleware.js
@@ -10,6 +10,8 @@ import { CONFERENCE_JOINED } from '../conference/actionTypes';
 import { getParticipantById } from '../participants/functions';
 import { MiddlewareRegistry } from '../redux';
 
+import { getLocalVideoTrack } from '../tracks';
+
 import logger from './logger';
 
 declare var APP: Object;
@@ -58,7 +60,8 @@ function _updateLastN({ getState }) {
     let lastN = defaultLastN;
 
     if (appState !== 'active') {
-        lastN = 0;
+        const localVideo = getLocalVideoTrack(state['features/base/tracks']);
+        lastN = localVideo && localVideo.videoType === 'desktop' ? 1 : 0;
     } else if (audioOnly) {
         const { screenShares, tileViewEnabled } = state['features/video-layout'];
         const largeVideoParticipantId = state['features/large-video'].participantId;

--- a/react/features/base/lib-jitsi-meet/_.native.js
+++ b/react/features/base/lib-jitsi-meet/_.native.js
@@ -22,4 +22,14 @@ import './native';
 // lib-jitsi-meet as a binary on mobile at the time of this writing. In the
 // future, implement not packaging it in the application bundle.
 import JitsiMeetJS from 'lib-jitsi-meet/lib-jitsi-meet.min';
+
+// FIXME: Hack to support getDisplayMedia.
+const { browser } = JitsiMeetJS.util;
+
+if (browser.isReactNative()) {
+    browser._isOpera = browser.isOpera.bind(browser);
+    browser.isOpera = () => true;
+    browser.isChromiumBased = () => false;
+}
+
 export { JitsiMeetJS as default };

--- a/react/features/base/lib-jitsi-meet/actions.js
+++ b/react/features/base/lib-jitsi-meet/actions.js
@@ -45,6 +45,10 @@ export function initLib() {
 
         dispatch({ type: LIB_WILL_INIT });
 
+        // FIXME: android getDisplayMedia uses isOpera:false, isChromiumBased:false, desktopSharingChromeExtId: undefined with lib-jitsi-meet
+        if (navigator.product === 'ReactNative') {
+            config.desktopSharingChromeExtId = undefined;
+        }
         try {
             JitsiMeetJS.init({
                 enableAnalyticsLogging: isAnalyticsEnabled(getState),

--- a/react/features/base/media/middleware.js
+++ b/react/features/base/media/middleware.js
@@ -24,6 +24,8 @@ import {
     _VIDEO_INITIAL_MEDIA_STATE
 } from './reducer';
 
+import { getLocalVideoTrack } from '../tracks';
+
 /**
  * Implements the entry point of the middleware of the feature base/media.
  *
@@ -66,7 +68,11 @@ MiddlewareRegistry.register(store => next => action => {
  * @private
  * @returns {Object} The value returned by {@code next(action)}.
  */
-function _appStateChanged({ dispatch }, next, action) {
+function _appStateChanged({ dispatch, getState }, next, action) {
+    const localVideo = getLocalVideoTrack(getState()['features/base/tracks']);
+    if (localVideo && localVideo.videoType === 'desktop') {
+        return next(action);
+    }
     const { appState } = action;
     const mute = appState !== 'active'; // Note that 'background' and 'inactive' are treated equal.
 

--- a/react/features/toolbox/components/native/DesktopSharingButton.js
+++ b/react/features/toolbox/components/native/DesktopSharingButton.js
@@ -1,0 +1,284 @@
+// @flow
+
+import { translate } from '../../../base/i18n';
+import { IconShareDesktop } from '../../../base/icons';
+import {
+    connect,
+    MiddlewareRegistry
+} from '../../../base/redux';
+import { AbstractButton } from '../../../base/toolbox';
+import type { AbstractButtonProps } from '../../../base/toolbox';
+
+import { getLocalTrack, getLocalVideoTrack, createLocalTracksF, replaceLocalTrack } from '../../../base/tracks';
+import { createTaskQueue } from '../../../../../modules/util/helpers';
+import {
+    TRACK_WILL_CREATE
+} from '../../../base/tracks/actionTypes';
+import { JitsiTrackErrors, JitsiTrackEvents } from '../../../base/lib-jitsi-meet';
+
+type Props = AbstractButtonProps & {
+
+    /**
+     * Whether the current conference is in audio only mode or not.
+     */
+    _audioOnly: boolean,
+
+    /**
+     * The redux {@code dispatch} function.
+     */
+    dispatch: Function
+};
+
+class DesktopSharingButton extends AbstractButton<Props, *> {
+    accessibilityLabel = 'toolbar.accessibilityLabel.shareYourScreen';
+    icon = IconShareDesktop;
+    label = 'toolbar.startScreenSharing';
+    toggledLabel = 'toolbar.stopScreenSharing';
+
+    /**
+     * Handles clicking / pressing the button, and opens the appropriate dialog.
+     *
+     * @override
+     * @protected
+     * @returns {void}
+     */
+    _handleClick() {
+        const { _audioOnly } = this.props;
+        if (_audioOnly) {
+            return;
+        }
+        this.props.dispatch({ type: 'TOGGLE_SCREEN_SHARING' });
+    }
+
+    /**
+     * Indicates whether this button is in toggled state or not.
+     *
+     * @override
+     * @protected
+     * @returns {boolean}
+     */
+    _isToggled() {
+        return this.props._sharingScreen;
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to {@link DesktopSharingButton}'s React {@code Component}
+ * props.
+ *
+ * @param {Object} state - The redux store/state.
+ * @private
+ * @returns {{}}
+ */
+function _mapStateToProps(state) {
+    const { enabled: audioOnly } = state['features/base/audio-only'];
+    const localVideo = getLocalVideoTrack(state['features/base/tracks']);
+
+    return {
+        _audioOnly: Boolean(audioOnly),
+        _sharingScreen: Boolean(localVideo && localVideo.videoType === 'desktop')
+    };
+}
+
+export default translate(connect(_mapStateToProps)(DesktopSharingButton));
+
+/**
+ * A task queue for replacement local video tracks. This separate queue exists
+ * so video replacement is not blocked by audio replacement tasks in the queue
+ * {@link _replaceLocalAudioTrackQueue}.
+ */
+const _replaceLocalVideoTrackQueue = createTaskQueue();
+
+let videoSwitchInProgress;
+
+/**
+ * Stores the "untoggle" handler which remembers whether was
+ * there any video before and whether was it muted.
+ */
+let didHaveVideo, wasVideoMuted;
+
+/**
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case 'TOGGLE_SCREEN_SHARING':
+        _toggleScreenSharing(store);
+        break;
+    }
+    return next(action);
+});
+
+/**
+ * Toggles between screen sharing and camera video if the toggle parameter
+ * is not specified and starts the procedure for obtaining new screen
+ * sharing/video track otherwise.
+ */
+function _toggleScreenSharing(store) {
+    const state = store.getState();
+    if (!videoSwitchInProgress) {
+        const tracks = state['features/base/tracks'];
+        const localVideo = getLocalVideoTrack(tracks);
+        if (localVideo && localVideo.videoType === 'desktop') {
+            _untoggleScreenSharing(store);
+            return;
+        }
+        _switchToScreenSharing(store, tracks, localVideo);
+    }
+}
+
+/**
+ * Tries to switch to the screensharing mode by disposing camera stream and
+ * replacing it with a desktop one.
+ */
+function _switchToScreenSharing(store, tracks, localVideo) {
+    videoSwitchInProgress = true;
+
+    didHaveVideo = Boolean(localVideo);
+    wasVideoMuted = !localVideo || localVideo.muted;
+    createLocalTrackF(store, tracks, 'desktop').then(desktopStream => {
+        desktopStream.on(JitsiTrackEvents.LOCAL_TRACK_STOPPED, () => _untoggleScreenSharing(store));
+        return desktopStream;
+    }).then(stream => useVideoStream(store.dispatch, localVideo, stream)).then(() => { videoSwitchInProgress = false; }).catch(() => {
+        videoSwitchInProgress = false, _untoggleScreenSharing(store);
+    })
+}
+
+/**
+ * Request to start capturing local audio and/or video. By default, the user
+ * facing camera will be selected.
+ * 
+ * @returns {Promise}
+ */
+function createLocalTrackF({ dispatch, getState }, tracks, device) {
+    // The following executes on React Native only at the time of this
+    // writing. The effort to port Web's createInitialLocalTracksAndConnect
+    // is significant and that's where the function createLocalTracksF got
+    // born. I started with the idea a porting so that we could inherit the
+    // ability to getUserMedia for audio only or video only if getUserMedia
+    // for audio and video fails. Eventually though, I realized that on
+    // mobile we do not have combined permission prompts implemented anyway
+    // (either because there are no such prompts or it does not make sense
+    // to implement them) and the right thing to do is to ask for each
+    // device separately.
+    const track = getLocalTrack(tracks, device === 'audio' ? 'audio' : 'video', /* includePending */ true);
+    if (track) {
+        if (track.mediaType == 'audio' || (device === 'video' && track.videoType !== 'desktop') || (device !== 'video' && track.videoType === 'desktop')) {
+            let err = new Error(`Local track for ${device} already exists.`);
+            err.name = 'LOCAL_TRACK_EXISTS';
+            return Promise.reject(err);
+        }
+    }
+    const gumProcess = createLocalTracksF({ devices: [ device ] }, false, { dispatch, getState }).then(localTracks => {
+        // Because GUM is called for 1 device (which is actually
+        // a media type 'audio', 'video', 'screen', etc.) we
+        // should not get more than one JitsiTrack.
+        if (localTracks.length !== 1) {
+            throw new Error(
+                `Expected exactly 1 track, but was given ${
+                    localTracks.length} tracks for device: ${
+                    device}.`);
+        }
+
+        if (gumProcess.canceled) {
+            return Promise.all(
+                localTracks.map(t =>
+                    t.dispose()
+                        .catch(err => {
+                            // Track might be already disposed so ignore such an error.
+                            // Of course, re-throw any other error(s).
+                            if (err.name !== JitsiTrackErrors.TRACK_IS_DISPOSED) {
+                                throw err;
+                            }
+                        }))).then(() => {
+                dispatch({
+                    type: TRACK_CREATE_CANCELED,
+                    trackType: device
+                });
+                throw new Error();
+            });
+        }
+        return localTracks[0];
+    }).catch(error => {
+        dispatch(gumProcess.canceled ? {
+            type: TRACK_CREATE_CANCELED,
+            trackType: device
+        } : dispatch => {
+            if (error) {
+                dispatch({
+                    type: TRACK_CREATE_ERROR,
+                    permissionDenied: error.name === 'SecurityError',
+                    trackType: device
+                });
+            }
+        })
+    });
+
+    /**
+     * Cancels the {@code getUserMedia} process represented by this
+     * {@code Promise}.
+     *
+     * @returns {Promise} This {@code Promise} i.e. {@code gumProcess}.
+     */
+    gumProcess.cancel = () => {
+        gumProcess.canceled = true;
+
+        return gumProcess;
+    };
+
+    dispatch({
+        type: TRACK_WILL_CREATE,
+        track: {
+            gumProcess,
+            local: true,
+            mediaType: device === 'desktop' ? 'video' : device
+        }
+    });
+
+    return gumProcess;
+}
+
+/**
+ * Start using provided video stream.
+ * Stops previous video stream.
+ * @param {JitsiLocalTrack} [stream] new stream to use or null
+ * @returns {Promise}
+ */
+function useVideoStream(dispatch, localVideo = { }, newStream) {
+    return new Promise((resolve, reject) => {
+        _replaceLocalVideoTrackQueue.enqueue(_onTaskComplete => {
+            dispatch(replaceLocalTrack(localVideo.jitsiTrack, newStream)).then(resolve).catch(reject).then(_onTaskComplete);
+        });
+    });
+}
+
+
+/**
+ * Turns off the screen sharing and restores
+ * the previous state described by the arguments.
+ */
+function _untoggleScreenSharing({ dispatch, getState }) {
+    videoSwitchInProgress = true;
+    const tracks = getState()['features/base/tracks'];
+    const localVideo = getLocalVideoTrack(tracks);
+    let promise;
+    if (didHaveVideo) {
+        promise = createLocalTrackF({ dispatch, getState }, tracks, 'video')
+            .then(stream => useVideoStream(dispatch, localVideo, stream)
+                .then(() => stream))
+                    .then(localVideo => {
+            if (wasVideoMuted) {
+                localVideo.mute();
+            }
+        }).catch(error => {
+            // Still fail with the original err
+            return error.name === 'LOCAL_TRACK_EXISTS' ? Promise.reject(error) : useVideoStream(dispatch, localVideo, null).then(() => {
+                throw error;
+            });
+        });
+    } else {
+        promise = useVideoStream(dispatch, localVideo, null);
+    }
+    promise.then(() => { videoSwitchInProgress = false; }).catch(error => { videoSwitchInProgress = false; });
+}

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -20,6 +20,7 @@ import AudioOnlyButton from './AudioOnlyButton';
 import HelpButton from '../HelpButton';
 import RaiseHandButton from './RaiseHandButton';
 import ToggleCameraButton from './ToggleCameraButton';
+import DesktopSharingButton from './DesktopSharingButton';
 
 /**
  * The type of the React {@code Component} props of {@link OverflowMenu}.
@@ -112,6 +113,10 @@ class OverflowMenu extends Component<Props> {
                 <RaiseHandButton { ...buttonProps } />
                 <SharedDocumentButton { ...buttonProps } />
                 <HelpButton { ...buttonProps } />
+                {
+                    this.props._desktopSharingEnabled
+                        && <DesktopSharingButton  { ...buttonProps } />
+                }
             </BottomSheet>
         );
     }
@@ -143,12 +148,22 @@ class OverflowMenu extends Component<Props> {
  * @returns {Props}
  */
 function _mapStateToProps(state) {
+    let { desktopSharingEnabled } = state['features/base/conference'];
+    if (state['features/base/config'].enableFeaturesBasedOnToken) {
+        // we enable desktop sharing if any participant already have this
+        // feature enabled
+        desktopSharingEnabled = getParticipants(state)
+            .find(({ features = {} }) =>
+                String(features['screen-sharing']) === 'true') !== undefined;
+    }
+
     return {
         _bottomSheetStyles:
             ColorSchemeRegistry.get(state, 'BottomSheet'),
         _chatEnabled: getFeatureFlag(state, CHAT_ENABLED, true),
         _isOpen: isDialogOpen(state, OverflowMenu_),
-        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED)
+        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED),
+        _desktopSharingEnabled: Boolean(desktopSharingEnabled)
     };
 }
 

--- a/react/features/toolbox/components/native/ToggleCameraButton.js
+++ b/react/features/toolbox/components/native/ToggleCameraButton.js
@@ -6,7 +6,7 @@ import { MEDIA_TYPE, toggleCameraFacingMode } from '../../../base/media';
 import { connect } from '../../../base/redux';
 import { AbstractButton } from '../../../base/toolbox';
 import type { AbstractButtonProps } from '../../../base/toolbox';
-import { isLocalTrackMuted } from '../../../base/tracks';
+import { isLocalTrackMuted, getLocalVideoTrack } from '../../../base/tracks';
 
 /**
  * The type of the React {@code Component} props of {@link ToggleCameraButton}.
@@ -74,10 +74,18 @@ class ToggleCameraButton extends AbstractButton<Props, *> {
 function _mapStateToProps(state): Object {
     const { enabled: audioOnly } = state['features/base/audio-only'];
     const tracks = state['features/base/tracks'];
+    const videoMuted = Boolean(isLocalTrackMuted(tracks, MEDIA_TYPE.VIDEO));
+    const localVideo = getLocalVideoTrack(tracks);
+
+    let visible = !videoMuted;
+    if (localVideo && localVideo.videoType === 'desktop') {
+        visible = false;
+    }
 
     return {
         _audioOnly: Boolean(audioOnly),
-        _videoMuted: isLocalTrackMuted(tracks, MEDIA_TYPE.VIDEO)
+        _videoMuted: videoMuted,
+        visible
     };
 }
 


### PR DESCRIPTION
:-) hacks to support android screen sharing.

1. implements  mediaDevices.getDisplayMedia

2. tricks lib-jitsi-meet to accept using mediaDevices.getDisplayMedia to obtain screen stream.

3. hajack WebRTCModule and its js scripts, add support to create screen stream.

4. feeds screen frames to the deliverer at a fixed framerate(interpolate frames with generated timestamp) to avoid connection problems.

5. adjust toggle camera button behaviors.(hide in screen sharing mode)

6. do not mute video stream and set lastN to 1 in android screen sharing mode when go background.

![QQ图片20200311153930](https://user-images.githubusercontent.com/16893158/76393505-a44a1800-63ae-11ea-9ae9-0e6a2e9d1dcf.jpg)

 :-) i haved tesed that feature on my android phone. one thing i figured is that hangingup in screen shareing mode and return to the welcomepage,  the backgroud is the output of screen video stream. i will optimize it later.