### PR TITLE
Change language detection to "true"

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -31,7 +31,7 @@ var interfaceConfig = {
     APP_NAME: 'Jitsi Meet',
     NATIVE_APP_NAME: 'Jitsi Meet',
     PROVIDER_NAME: 'Jitsi',
-    LANG_DETECTION: false, // Allow i18n to detect the system language
+    LANG_DETECTION: true, // Allow i18n to detect the system language
     INVITATION_POWERED_BY: true,
 
     /**


### PR DESCRIPTION
Worldwide users will profit from the change to auto-detect the browser language and to startup the interface with their language.