### PR TITLE
s/Low bandwidth/Audio only/

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -25,7 +25,7 @@
         "none": "No audio devices available"
     },
     "audioOnly": {
-        "audioOnly": "Low bandwidth"
+        "audioOnly": "Audio only"
     },
     "calendarSync": {
         "addMeetingURL": "Add a meeting link",


### PR DESCRIPTION
When Jitsi starts up in English, the text for the lowest quality should indicate that this means "Audio only" in order not to puzzle users.