### PR TITLE
add mention of UDP ports to open on the proxy.

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -62,7 +62,7 @@ Simply run the following in your shell
 
 #### Advanced configuration
 If installation is on a machine [behind NAT](https://github.com/jitsi/jitsi-meet/blob/master/doc/faq.md) further configuration of jitsi-videobridge is needed in order for it to be accessible.
-Provided that all required ports are routed (forwarded) to the machine that it runs on. By default these ports are (TCP/443 or TCP/4443 and UDP 10000).
+Provided that all required ports are routed (forwarded) to the machine that it runs on. By default these ports are (TCP/443 or TCP/4443 and UDP/10000). It is also necessary to forward ports UDP/16384 to UDP/32768.
 The following extra lines need to be added the file `/etc/jitsi/videobridge/sip-communicator.properties`:
 ```
 org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=<Local.IP.Address>


### PR DESCRIPTION
Dear jitsi team,

Thanks for your great tool! I have been using it for a week to teach. It worked pretty well.

Just one small note regarding the installation process, that I followed to install my own instance.

I am behind a NAT. I had to open the range of UDP ports 16384 to 32768 to have jitsi fully working.

This PR updates the quick-install documentation with that information.

Keep up the good work!