### PR TITLE
Various improvements to quick-install document

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -2,8 +2,6 @@
 
 This document describes the required steps for a quick Jitsi Meet installation on a Debian based GNU/Linux system. Debian 8 (Jessie) or later, and Ubuntu 14.04 or later are supported out-of-the-box.
 
-Debian Wheezy and other older systems may require additional things to be done. Specifically for Wheezy, [libc needs to be updated](http://lists.jitsi.org/pipermail/users/2015-September/010064.html).
-
 Also note that a recent default Ubuntu installation has only the `main` repository enabled, and Jitsi Meet needs packages from `universe`. Check your `/etc/apt/sources.list` file, and if `universe` is not present refer to [Ubuntu's documentation](https://help.ubuntu.com/community/Repositories/Ubuntu) on how to enable it. (Usually it amounts to copying the `main` lines and changing to `universe`.)
 
 N.B.:
@@ -32,37 +30,41 @@ wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | apt-key add -
 apt-get update
 ```
 
-(If you get an error:
+If you get an error:
 E: The method driver /usr/lib/apt/methods/https could not be found.
 run:
 ```sh
 apt-get install apt-transport-https
 ```
-)
 
 ### Install Jitsi Meet
 
-Note: Something to consider before installation is how you're planning to serve Jitsi Meet. The installer will check if Nginx or Apache is present (with this order) and configure a virtualhost within the web server it finds to serve Jitsi Meet. If none of the above is found it then configures itself to be served via jetty. So if for example you are planning on deploying Jitsi Meet with a web server, you have to make sure to install the server **before** installing jitsi-meet.
+Note: Something to consider before installation is how you're planning to serve Jitsi Meet. The installer will check if [Nginx](https://nginx.org/) or [Apache](https://httpd.apache.org/) is present (in that order) and configure a virtualhost within the web server it finds to serve Jitsi Meet. If none of the above is found it then configures itself to be served via [Jetty](https://www.eclipse.org/jetty/). So if for example you are planning on deploying Jitsi Meet with a web server, you have to make sure to install the server **before** installing jitsi-meet.
 
 ```sh
 apt-get -y install jitsi-meet
 ```
 
-During the installation, you will be asked to enter the hostname of the Jitsi Meet instance. If you have a FQDN hostname for the instance already set up in DNS, enter it there. If you don't have a resolvable hostname, you can enter the IP address of the machine (if it is static or doesn't change).
+During the installation, you will be asked to enter the hostname of the Jitsi Meet instance. If you have a [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) for the instance already set up in DNS, enter it there. If you don't have a resolvable hostname, you can enter the IP address of the machine (if it is static or doesn't change).
 
 This hostname (or IP address) will be used for virtualhost configuration inside the Jitsi Meet and also, you and your correspondents will be using it to access the web conferences.
 
 ### Generate a Let's Encrypt certificate
 
-Simply run the following in your shell
+In order to have encrypted communications, you need a [TLS certificate](https://en.wikipedia.org/wiki/Transport_Layer_Security). The easiest way is to use [Let's Encrypt](https://letsencrypt.org/).
+
+Simply run the following in your shell:
 
 ```sh
 /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh
 ```
 
+Note that this script uses the [HTTP-01 challenge type](https://letsencrypt.org/docs/challenge-types/) and thus your instance needs to be accessible from the public internet. If you want to use a different challenge type, don't use this script and instead choose ___I want to use my own certificate___ during jitsi-meet installation.
+
+
 #### Advanced configuration
-If installation is on a machine [behind NAT](https://github.com/jitsi/jitsi-meet/blob/master/doc/faq.md) further configuration of jitsi-videobridge is needed in order for it to be accessible.
-Provided that all required ports are routed (forwarded) to the machine that it runs on. By default these ports are (TCP/443 or TCP/4443 and UDP 10000).
+If the installation is on a machine [behind NAT](https://github.com/jitsi/jitsi-meet/blob/master/doc/faq.md) further configuration of jitsi-videobridge is needed in order for it to be accessible from outside.
+Provided that all required ports are routed (forwarded) to the machine that it runs on. By default these ports are (TCP/443 or TCP/4443 and UDP/10000).
 The following extra lines need to be added the file `/etc/jitsi/videobridge/sip-communicator.properties`:
 ```
 org.ice4j.ice.harvest.NAT_HARVESTER_LOCAL_ADDRESS=<Local.IP.Address>
@@ -86,13 +88,15 @@ By default, anyone who has access to your jitsi instance will be able to start a
 
 Launch a web browser (Chrome, Chromium or latest Opera) and enter in the URL bar the hostname (or IP address) you used in the previous step.
 
-Confirm that you trust the self-signed certificate of the newly installed Jitsi Meet.
+If you used a self-signed certificate (as opposed to using Let's Encrypt), your web browser will ask you to confirm that you trust the certificate.
 
 Enjoy!
 
 ## Adding sip-gateway to Jitsi Meet
 
 ### Install Jigasi
+
+Jigasi is a server-side application acting as a gateway to Jitsi Meet conferences. It allows regular [SIP](https://en.wikipedia.org/wiki/Session_Initiation_Protocol) clients to join meetings and provides transcription capabilities.
 
 ```sh
 apt-get -y install jigasi
@@ -125,7 +129,7 @@ Sometimes the following packages will fail to uninstall properly:
 
 When this happens, just run the uninstall command a second time and it should be ok.
 
-The reason for failure is that sometimes, the uninstall script is faster than the process that stops the daemons. The second run of the uninstall command fixes this, as by then the jigasi or jvb daemons are already stopped.
+The reason for the failure is that sometimes the uninstall script is faster than the process that stops the daemons. The second run of the uninstall command fixes this, as by then the jigasi or jitsi-videobridge daemons are already stopped.
 
 #### Systemd details
 To reload the systemd changes on a running system execute `systemctl daemon-reload` and `service jitsi-videobridge restart`.
@@ -134,4 +138,16 @@ To check the files and process part execute ```cat /proc/`cat /var/run/jitsi-vid
 ```
 Max processes             65000                65000                processes
 Max open files            65000                65000                files
+```
+
+## Debugging problems
+
+If you run into problems, one thing to try is using a different web browser. Some versions of some browsers are known to have issues with Jitsi Meet. You can also visit https://test.webrtc.org to test your browser's [WebRTC](https://en.wikipedia.org/wiki/WebRTC) support.
+
+Another place to look is the various log files:
+
+```
+/var/log/jitsi/jvb.log
+/var/log/jitsi/jicofo.log
+/var/log/prosody/prosody.log
 ```


### PR DESCRIPTION
- removed paragraph about old Debian Wheezy, the link is broken, and Wheezy doesn't even get security updates anymore, so seems unlikely anyone would do a new install with it.
- clarified that Let's Encrypt script uses only the HTTP challenge.
- added links to a few things that newbies might want to look up (nginx, apache, jetty, SIP, FQDN, Let's Encrypt, etc.
- added some basic debugging starting points, based on my experience
- some minor grammatical tweaks
- other minor tweaks