### PR TITLE
Correct bad translation

### DIFF
--- a/lang/main-fr.json
+++ b/lang/main-fr.json
@@ -601,7 +601,7 @@
             "show": "Afficher en premier plan",
             "speakerStats": "Afficher/cacher les statistiques de parole",
             "tileView": "Activer/désactiver la vue mosaïque",
-            "toggleCamera": "Activer/désactiver la caméra",
+            "toggleCamera": "Changer de caméra",
             "videomute": "Activer/désactiver la vidéo",
             "videoblur": "Activer/désactiver le flou de la vidéo"
         },


### PR DESCRIPTION
"toggle camera" is to switch front to rear or rear to front.
The french translation said "on/off camera", it's not exactly that