### PR TITLE
Enhancement for nginx config to support IPv6

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -1,7 +1,8 @@
 server_names_hash_bucket_size 64;
 
 server {
-    listen 80;
+    listen 0.0.0.0:80;
+    listen [::]:80;
     server_name jitsi-meet.example.com;
 
     location ^~ /.well-known/acme-challenge/ {
@@ -16,7 +17,8 @@ server {
     }
 }
 server {
-    listen 443 ssl;
+    listen 0.0.0.0:443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name jitsi-meet.example.com;
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
With the quick-install, the jitsi-meet.example is used as template for the nginx config and copied over (see https://github.com/jitsi/jitsi-meet/blob/master/debian/jitsi-meet-web-config.postinst). 
Unfortunately, the config does not contain the necessary settings for IPv6-enabled hosts.
With this pull request, the quick install template is adapted according to the advises given in the manual installation instructions:
https://github.com/jitsi/jitsi-meet/blob/master/doc/manual-install.md

I've tested the settings on a newly set up host today:
- setup host with Ubuntu 18.04
- install nginx
- follow the quick install guide
--> issues due to missing IPv6 config (DNS record contains AAA entry)
- change the generated nginx config file
--> everything works fine