### PR TITLE
Fix mod_muc_max_occupants to properly ignore whitelisted users

### DIFF
--- a/resources/prosody-plugins/mod_muc_max_occupants.lua
+++ b/resources/prosody-plugins/mod_muc_max_occupants.lua
@@ -46,6 +46,7 @@ local function check_for_max_occupants(event)
 		-- For each person in the room that's not on the whitelist, subtract one
 		-- from the count.
 		for _, occupant in room:each_occupant() do
+			user, domain, res = split_jid(occupant.bare_jid);
 			if not whitelist:contains(domain) and not whitelist:contains(user..'@'..domain) then
 				slots = slots - 1
 			end


### PR DESCRIPTION
In a typical Jitsi Meet setup, this plugin can be used to limit the number of occupants in a meeting room, while ignoring "utility" users. Such a configuration could be:

    muc_max_occupants = 2
    muc_access_whitelist = {
        "focus@auth.meet.jitsi";
    }

It would be expected that this configuration allows two users to attend the meeting room, but in practice only one is allowed, because the whitelist is not honoured.

This commit fixes it by actually updating the `user` and `domain` variables being checked. After this change, the scenario above works just fine.