### PR TITLE
Improve accessibility of Buttons in Webapp

### DIFF
--- a/react/features/base/toolbox/components/AbstractButton.js
+++ b/react/features/base/toolbox/components/AbstractButton.js
@@ -230,13 +230,14 @@ export default class AbstractButton<P: Props, S: *> extends Component<P, S> {
 
     /**
      * Helper function to be implemented by subclasses, which must return a
-     * {@code boolean} value indicating if this button is toggled or not.
+     * {@code boolean} value indicating if this button is toggled or not or
+     * undefined if the button is not toggleable.
      *
      * @protected
-     * @returns {boolean}
+     * @returns {?boolean}
      */
     _isToggled() {
-        return false;
+        return undefined;
     }
 
     _onClick: (*) => void;

--- a/react/features/base/toolbox/components/ToolboxItem.web.js
+++ b/react/features/base/toolbox/components/ToolboxItem.web.js
@@ -13,6 +13,66 @@ import type { Props } from './AbstractToolboxItem';
  */
 export default class ToolboxItem extends AbstractToolboxItem<Props> {
     /**
+     * Initializes a new {@code ToolboxItem} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._onKeyDown = this._onKeyDown.bind(this);
+        this._onKeyUp = this._onKeyUp.bind(this);
+    }
+
+    /**
+     * Handles 'Enter' key on the button to trigger onClick for accessibility.
+     *
+     * @param {Object} event - The key event.
+     * @private
+     * @returns {void}
+     */
+    _onKeyDown(event) {
+        // If the event coming to the dialog has been subject to preventDefault
+        // we don't handle it here.
+        if (event.defaultPrevented) {
+            return;
+        }
+
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.props.onClick();
+        } else if (event.key === ' ') {
+            // Space triggers button onKeyUp but we need to prevent PTT here
+            event.preventDefault();
+            event.stopPropagation();
+        }
+    }
+
+    /**
+     * Handles ' ' (Space) key on the button to trigger onClick for
+     * accessibility.
+     *
+     * @param {Object} event - The key event.
+     * @private
+     * @returns {void}
+     */
+    _onKeyUp(event) {
+        // If the event coming to the dialog has been subject to preventDefault
+        // we don't handle it here.
+        if (event.defaultPrevented) {
+            return;
+        }
+
+        if (event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.props.onClick();
+        }
+    }
+
+    /**
      * Handles rendering of the actual item. If the label is being shown, which
      * is controlled with the `showLabel` prop, the item is rendered for its
      * display in an overflow menu, otherwise it will only have an icon, which
@@ -37,6 +97,8 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             'aria-label': this.accessibilityLabel,
             className: className + (disabled ? ' disabled' : ''),
             onClick: disabled ? undefined : onClick,
+            onKeyDown: this._onKeyDown,
+            onKeyUp: this._onKeyUp,
             tabIndex: 0,
             role: 'button'
         };

--- a/react/features/base/toolbox/components/ToolboxItem.web.js
+++ b/react/features/base/toolbox/components/ToolboxItem.web.js
@@ -27,14 +27,20 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             elementAfter,
             onClick,
             showLabel,
-            tooltipPosition
+            tooltipPosition,
+            toggled
         } = this.props;
         const className = showLabel ? 'overflow-menu-item' : 'toolbox-button';
         const props = {
+            'aria-pressed': toggled,
+            'aria-disabled': disabled,
             'aria-label': this.accessibilityLabel,
             className: className + (disabled ? ' disabled' : ''),
-            onClick: disabled ? undefined : onClick
+            onClick: disabled ? undefined : onClick,
+            tabIndex: 0,
+            role: 'button'
         };
+
         const elementType = showLabel ? 'li' : 'div';
         const useTooltip = this.tooltip && this.tooltip.length > 0;
         let children = (

--- a/react/features/base/toolbox/components/ToolboxItem.web.js
+++ b/react/features/base/toolbox/components/ToolboxItem.web.js
@@ -15,15 +15,16 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
     /**
      * Initializes a new {@code ToolboxItem} instance.
      *
-     * @param {Object} props - The read-only properties with which the new
-     * instance is to be initialized.
+     * @inheritdoc
      */
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
 
         this._onKeyDown = this._onKeyDown.bind(this);
         this._onKeyUp = this._onKeyUp.bind(this);
     }
+
+    _onKeyDown: (Object) => void;
 
     /**
      * Handles 'Enter' key on the button to trigger onClick for accessibility.
@@ -49,6 +50,8 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             event.stopPropagation();
         }
     }
+
+    _onKeyUp: (Object) => void;
 
     /**
      * Handles ' ' (Space) key on the button to trigger onClick for

--- a/react/features/toolbox/components/web/ToolbarButton.js
+++ b/react/features/toolbox/components/web/ToolbarButton.js
@@ -114,8 +114,8 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
     _renderButton(children) {
         return (
             <div
-                aria-checked = { this.props.toggled }
                 aria-label = { this.props.accessibilityLabel }
+                aria-pressed = { this.props.toggled }
                 className = 'toolbox-button'
                 onClick = { this.props.onClick }
                 onKeyDown = { this._onKeyDown }

--- a/react/features/toolbox/components/web/ToolbarButton.js
+++ b/react/features/toolbox/components/web/ToolbarButton.js
@@ -52,9 +52,12 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
     _renderButton(children) {
         return (
             <div
+                aria-checked = { this.props.toggled }
                 aria-label = { this.props.accessibilityLabel }
                 className = 'toolbox-button'
-                onClick = { this.props.onClick }>
+                onClick = { this.props.onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 { this.props.tooltip
                     ? <Tooltip
                         content = { this.props.tooltip }

--- a/react/features/toolbox/components/web/ToolbarButton.js
+++ b/react/features/toolbox/components/web/ToolbarButton.js
@@ -44,15 +44,16 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
     /**
      * Initializes a new {@code ToolbarButton} instance.
      *
-     * @param {Object} props - The read-only properties with which the new
-     * instance is to be initialized.
+     * @inheritdoc
      */
-    constructor(props) {
+    constructor(props: Props) {
         super(props);
 
         this._onKeyDown = this._onKeyDown.bind(this);
         this._onKeyUp = this._onKeyUp.bind(this);
     }
+
+    _onKeyDown: (Object) => void;
 
     /**
      * Handles 'Enter' key on the button to trigger onClick for accessibility.
@@ -77,6 +78,8 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
             event.preventDefault();
         }
     }
+
+    _onKeyUp: (Object) => void;
 
     /**
      * Handles ' '(Space) key on the button to trigger onClick for

--- a/react/features/toolbox/components/web/ToolbarButton.js
+++ b/react/features/toolbox/components/web/ToolbarButton.js
@@ -42,6 +42,65 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
     };
 
     /**
+     * Initializes a new {@code ToolbarButton} instance.
+     *
+     * @param {Object} props - The read-only properties with which the new
+     * instance is to be initialized.
+     */
+    constructor(props) {
+        super(props);
+
+        this._onKeyDown = this._onKeyDown.bind(this);
+        this._onKeyUp = this._onKeyUp.bind(this);
+    }
+
+    /**
+     * Handles 'Enter' key on the button to trigger onClick for accessibility.
+     *
+     * @param {Object} event - The key event.
+     * @private
+     * @returns {void}
+     */
+    _onKeyDown(event) {
+        // If the event coming to the dialog has been subject to preventDefault
+        // we don't handle it here.
+        if (event.defaultPrevented) {
+            return;
+        }
+
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.props.onClick();
+        } else if (event.key === ' ') {
+            // Space triggers button onKeyUp but we need to prevent default here
+            event.preventDefault();
+        }
+    }
+
+    /**
+     * Handles ' '(Space) key on the button to trigger onClick for
+     * accessibility.
+     *
+     * @param {Object} event - The key event.
+     * @private
+     * @returns {void}
+     */
+    _onKeyUp(event) {
+        // If the event coming to the dialog has been subject to preventDefault
+        // we don't handle it here.
+        if (event.defaultPrevented) {
+            return;
+        }
+
+        if (event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+            this.props.onClick();
+        }
+    }
+
+    /**
      * Renders the button of this {@code ToolbarButton}.
      *
      * @param {Object} children - The children, if any, to be rendered inside
@@ -56,6 +115,8 @@ class ToolbarButton extends AbstractToolbarButton<Props> {
                 aria-label = { this.props.accessibilityLabel }
                 className = 'toolbox-button'
                 onClick = { this.props.onClick }
+                onKeyDown = { this._onKeyDown }
+                onKeyUp = { this._onKeyUp }
                 role = 'button'
                 tabIndex = { 0 }>
                 { this.props.tooltip


### PR DESCRIPTION
Fixes https://github.com/jitsi/jitsi-meet/issues/4541

This focuses on the buttons/toggles along the bottom of the app.

Uses the ARIA authoring practices as a base, marks the buttons as
`role=button`
`tabIndex=0` (to make them reachable via TAB)
`aria-pressed` (to mark it as a toggle and expose its state)

more info: https://www.w3.org/TR/wai-aria-practices-1.1/examples/button/button.html

Handles onKeyDown to trigger on ENTER (like a <button> does)
Handles onKeyUp to trigger on SPACE (like a <button> does)
The latter here means ignoring PTT whilst the user has an interactive button focused. PTT remains to work when anything else is focused.