### PR TITLE
Hide tabs if nothing to show

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.js
+++ b/react/features/welcome/components/AbstractWelcomePage.js
@@ -7,6 +7,7 @@ import type { Dispatch } from 'redux';
 import { createWelcomePageEvent, sendAnalytics } from '../../analytics';
 import { appNavigate } from '../../app';
 import { isCalendarEnabled } from '../../calendar-sync';
+import { isRecentListEnabled } from '../../recent-list/functions';
 
 /**
  * {@code AbstractWelcomePage}'s React {@code Component} prop types.
@@ -17,6 +18,11 @@ type Props = {
      * Whether the calendar functionality is enabled or not.
      */
     _calendarEnabled: boolean,
+
+    /**
+     * Whether the recent list is enabled
+     */
+    _recentListEnabled: Boolean,
 
     /**
      * Room name to join to.
@@ -239,6 +245,7 @@ export class AbstractWelcomePage extends Component<Props, *> {
 export function _mapStateToProps(state: Object) {
     return {
         _calendarEnabled: isCalendarEnabled(state),
+        _recentListEnabled: isRecentListEnabled(),
         _room: state['features/base/conference'].room,
         _settings: state['features/base/settings']
     };

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -285,7 +285,7 @@ class WelcomePage extends AbstractWelcomePage {
             return null;
         }
 
-        const { _calendarEnabled, t } = this.props;
+        const { _calendarEnabled, _recentListEnabled, t } = this.props;
 
         const tabs = [];
 
@@ -296,10 +296,16 @@ class WelcomePage extends AbstractWelcomePage {
             });
         }
 
-        tabs.push({
-            label: t('welcomepage.recentList'),
-            content: <RecentList />
-        });
+        if (_recentListEnabled) {
+            tabs.push({
+                label: t('welcomepage.recentList'),
+                content: <RecentList />
+            });
+        }
+
+        if (tabs.length === 0) {
+            return null;
+        }
 
         return (
             <Tabs


### PR DESCRIPTION
Fix for #5447 

Tested in Chrome with calendar not configured and RECENT_LIST_ENABLED: false