### PR TITLE
Added details to jitsi-meet deployment

### DIFF
--- a/doc/manual-install.md
+++ b/doc/manual-install.md
@@ -225,7 +225,7 @@ npm install
 make
 ```
 
-_NOTE: When installing on older releases keep in mind that you need Node.js >= 10 and npm >= 6._
+_NOTE: When installing on older distributions keep in mind that you need Node.js >= 10 and npm >= 6._
 
 Edit host names in `/srv/jitsi-meet/config.js` (see also the example config file):
 ```

--- a/doc/manual-install.md
+++ b/doc/manual-install.md
@@ -225,6 +225,8 @@ npm install
 make
 ```
 
+_NOTE: When installing on older releases keep in mind that you need Node.js >= 10 and npm >= 6._
+
 Edit host names in `/srv/jitsi-meet/config.js` (see also the example config file):
 ```
 var config = {


### PR DESCRIPTION
Added clarifications that user needs updated npm and node versions on some versions of Linux: e.g Ubuntu 18.04 has node v8.10 and npm v3.5