### PR TITLE
quick-install.md: add a section about server firewalls.

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -46,6 +46,23 @@ During the installation, you will be asked to enter the hostname of the Jitsi Me
 
 This hostname (or IP address) will be used for virtualhost configuration inside the Jitsi Meet and also, you and your correspondents will be using it to access the web conferences.
 
+### Check your firewall rules
+
+Jitsi needs the ports `443/tcp` and `10000/udp` to be open for
+incoming connexions.
+
+#### With `ufw`
+
+If you are using `ufw` this can be checked with:
+```
+sudo ufw status verbose
+```
+If these ports are not open, issue:
+```
+sudo ufw allow in 443/tcp
+sudo ufw allow in 10000/udp
+```
+
 ### Generate a Let's Encrypt certificate (optional, recommended)
 
 In order to have encrypted communications, you need a [TLS certificate](https://en.wikipedia.org/wiki/Transport_Layer_Security). The easiest way is to use [Let's Encrypt](https://letsencrypt.org/).


### PR DESCRIPTION
This commit entices people to check their firewall settings after install and provides specific instructions for the `ufw` firewall.

When I installed jisti on an existing machine, people could join rooms but no video/audio was available -- except if participants were no more than two and on the same subnet. It seems this was due to port `10000/udp` being blocked on the server.

Thanks for the software.