### PR TITLE
fix(prejoin_page): Enable settings buttons on permission grant & CSS fixes

### DIFF
--- a/css/_audio-preview.css
+++ b/css/_audio-preview.css
@@ -13,6 +13,7 @@
         padding: 16px;
 
         &-icon {
+            color: #A4B8D1;
             display: inline-block;
         }
 
@@ -65,6 +66,10 @@
 
             .audio-preview-test-button {
                 display: inline-block;
+            }
+
+            .audio-preview-entry-text {
+                max-width: 196px;
             }
         }
 

--- a/css/_video-preview.css
+++ b/css/_video-preview.css
@@ -1,4 +1,5 @@
 .video-preview {
+    background: none;
     max-height: 290px;
     overflow: auto;
 

--- a/react/features/overlay/functions.js
+++ b/react/features/overlay/functions.js
@@ -21,3 +21,13 @@ export function getOverlayToRender(state: Object) {
 
     return undefined;
 }
+
+/**
+ * Returns the visibility of the media permissions prompt.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {boolean}
+ */
+export function getMediaPermissionPromptVisibility(state: Object) {
+    return state['features/overlay'].isMediaPermissionPromptVisible;
+}

--- a/react/features/settings/actionTypes.js
+++ b/react/features/settings/actionTypes.js
@@ -1,4 +1,6 @@
-// The type of (redux) action which sets the visibility of the audio settings popup.
+/**
+ * The type of (redux) action which sets the visibility of the audio settings popup.
+ */
 export const SET_AUDIO_SETTINGS_VISIBILITY = 'SET_AUDIO_SETTINGS_VISIBILITY';
 
 /**
@@ -12,5 +14,7 @@ export const SET_AUDIO_SETTINGS_VISIBILITY = 'SET_AUDIO_SETTINGS_VISIBILITY';
  */
 export const SET_SETTINGS_VIEW_VISIBLE = 'SET_SETTINGS_VIEW_VISIBLE';
 
-// The type of (redux) action which sets the visibility of the video settings popup.
+/**
+ * The type of (redux) action which sets the visibility of the video settings popup.
+ */
 export const SET_VIDEO_SETTINGS_VISIBILITY = 'SET_VIDEO_SETTINGS_VISIBILITY';

--- a/react/features/settings/components/web/audio/AudioSettingsHeader.js
+++ b/react/features/settings/components/web/audio/AudioSettingsHeader.js
@@ -29,7 +29,6 @@ export default function AudioSettingsHeader({ IconComponent, text }: Props) {
         <div className = 'audio-preview-header'>
             <div className = 'audio-preview-header-icon'>
                 { <Icon
-                    color = '#A4B8D1'
                     size = { 24 }
                     src = { IconComponent } />}
             </div>

--- a/react/features/settings/components/web/audio/MicrophoneEntry.js
+++ b/react/features/settings/components/web/audio/MicrophoneEntry.js
@@ -107,9 +107,7 @@ export default class MicrophoneEntry extends Component<Props, State> {
      * @returns {void}
      */
     _stopListening(jitsiTrack) {
-        jitsiTrack && jitsiTrack.off(
-            JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED,
-            this._updateLevel);
+        jitsiTrack && jitsiTrack.off(JitsiTrackEvents.TRACK_AUDIO_LEVEL_CHANGED, this._updateLevel);
         this.setState({
             level: -1
         });

--- a/react/features/toolbox/components/web/AudioSettingsButton.js
+++ b/react/features/toolbox/components/web/AudioSettingsButton.js
@@ -8,7 +8,7 @@ import { IconArrowDown } from '../../../base/icons';
 import JitsiMeetJS from '../../../base/lib-jitsi-meet/_';
 import { ToolboxButtonWithIcon } from '../../../base/toolbox';
 import { connect } from '../../../base/redux';
-
+import { getMediaPermissionPromptVisibility } from '../../../overlay';
 import { AudioSettingsPopup, toggleAudioSettings } from '../../../settings';
 
 type Props = {
@@ -17,6 +17,12 @@ type Props = {
      * Click handler for the small icon. Opens audio options.
      */
     onAudioOptionsClick: Function,
+
+    /**
+     * Whether the permission prompt is visible or not.
+     * Useful for enabling the button on permission grant.
+     */
+    permissionPromptVisibility: boolean,
 
     /**
      * If the user has audio input or audio output devices.
@@ -82,6 +88,17 @@ class AudioSettingsButton extends Component<Props, State> {
     }
 
     /**
+     * Implements React's {@link Component#componentDidUpdate}.
+     *
+     * @inheritdoc
+     */
+    componentDidUpdate(prevProps) {
+        if (this.props.permissionPromptVisibility !== prevProps.permissionPromptVisibility) {
+            this._updatePermissions();
+        }
+    }
+
+    /**
      * Implements React's {@link Component#render}.
      *
      * @inheritdoc
@@ -113,7 +130,8 @@ function mapStateToProps(state) {
     return {
         hasDevices:
             hasAvailableDevices(state, 'audioInput')
-            || hasAvailableDevices(state, 'audioOutput')
+            || hasAvailableDevices(state, 'audioOutput'),
+        permissionPromptVisibility: getMediaPermissionPromptVisibility(state)
     };
 }
 

--- a/react/features/toolbox/components/web/VideoSettingsButton.js
+++ b/react/features/toolbox/components/web/VideoSettingsButton.js
@@ -9,6 +9,7 @@ import { hasAvailableDevices } from '../../../base/devices';
 import { IconArrowDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { ToolboxButtonWithIcon } from '../../../base/toolbox';
+import { getMediaPermissionPromptVisibility } from '../../../overlay';
 
 type Props = {
 
@@ -16,6 +17,12 @@ type Props = {
      * Click handler for the small icon. Opens video options.
      */
     onVideoOptionsClick: Function,
+
+    /**
+     * Whether the permission prompt is visible or not.
+     * Useful for enabling the button on initial permission grant.
+     */
+    permissionPromptVisibility: boolean,
 
     /**
      * If the user has any video devices.
@@ -81,6 +88,17 @@ class VideoSettingsButton extends Component<Props, State> {
     }
 
     /**
+     * Implements React's {@link Component#componentDidUpdate}.
+     *
+     * @inheritdoc
+     */
+    componentDidUpdate(prevProps) {
+        if (this.props.permissionPromptVisibility !== prevProps.permissionPromptVisibility) {
+            this._updatePermissions();
+        }
+    }
+
+    /**
      * Implements React's {@link Component#render}.
      *
      * @inheritdoc
@@ -110,7 +128,8 @@ class VideoSettingsButton extends Component<Props, State> {
  */
 function mapStateToProps(state) {
     return {
-        hasDevices: hasAvailableDevices(state, 'videoInput')
+        hasDevices: hasAvailableDevices(state, 'videoInput'),
+        permissionPromptVisibility: getMediaPermissionPromptVisibility(state)
     };
 }
 


### PR DESCRIPTION
@saghul Thanks for the quick MR on removing the unneeded option. Had no clue we want to use the buttons all the time. :(

I have addressed almost all the comments from https://github.com/jitsi/jitsi-meet/pull/5481, except https://github.com/jitsi/jitsi-meet/pull/5481#discussion_r401698459.

Here is the explanation: 
* That action is needed because I'm using _object shorthand form_ (https://react-redux.js.org/using-react-redux/connect-mapdispatch#two-forms-of-mapdispatchtoprops) for actions. This way the components don't need to know about logic outside or have access to `dispatch`. They are easier to maintain and to understand. Ideally I think all react components should be as _dumb_ as possible. But if anybody has strong opinions on this we can talk.

As a side note I have a question, which may be dumb because I have no experience on how most things are handled in this project or the history of it: 
* Is there any specific reason for which we don't take advantage of `NotAllowedError` on `getUserMedia()` to handle permissions? Or is it used and part of the project needs a revamp so we can leverage it? 