### PR TITLE
fix: don't let robots index jitsi installations

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -26,6 +26,7 @@ server {
     ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED";
 
     add_header Strict-Transport-Security "max-age=31536000";
+    add_header X-Robots-Tag "noindex";
 
     ssl_certificate /etc/jitsi/meet/jitsi-meet.example.com.crt;
     ssl_certificate_key /etc/jitsi/meet/jitsi-meet.example.com.key;

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -19,6 +19,7 @@
   SSLCipherSuite "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED"
   SSLHonorCipherOrder on
   Header set Strict-Transport-Security "max-age=31536000"
+  Header set X-Robots-Tag "noindex"
 
   DocumentRoot "/usr/share/jitsi-meet"
   <Directory "/usr/share/jitsi-meet">

--- a/head.html
+++ b/head.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />


### PR DESCRIPTION
Currently, [Google](https://www.google.com/webhp?q=site:meet.jit.si) (and other engines) will index everything.

This PR avoids that.