### PR TITLE
feat: better room lock prompt

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -220,7 +220,7 @@
         "muteParticipantDialog": "Are you sure you want to mute this participant? You won't be able to unmute them, but they can unmute themselves at any time.",
         "muteParticipantTitle": "Mute this participant?",
         "Ok": "Ok",
-        "passwordLabel": "$t(lockRoomPasswordUppercase)",
+        "passwordLabel": "The meeting has been locked by a participant. Please enter the password to join.",
         "passwordNotSupported": "Setting a meeting $t(lockRoomPassword) is not supported.",
         "passwordNotSupportedTitle": "$t(lockRoomPasswordUppercase) not supported",
         "passwordRequired": "$t(lockRoomPasswordUppercase) required",


### PR DESCRIPTION
Changes the wording from this:

![image](https://user-images.githubusercontent.com/9974975/78262910-909f5680-7501-11ea-825f-5864c7fea7f1.png)

To this:

![image](https://user-images.githubusercontent.com/9974975/78262937-98f79180-7501-11ea-8c53-b4c7bf00cea6.png)
