### PR TITLE
Fix grammar on unsupported browser message

### DIFF
--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -50,7 +50,7 @@ class UnsupportedDesktopBrowser extends Component<Props> {
                         className = { `${_SNS}__link` }
                         href = { CHROME } >Chrome</a>&nbsp;
                     {
-                        this._showFirefox() && <>and <a
+                        this._showFirefox() && <>or <a
                             className = { `${_SNS}__link` }
                             href = { FIREFOX }>Firefox</a></>
                     }


### PR DESCRIPTION
It should read "Chrome or Firefox" not "Chrome and Firefox", as you only need to use a single browser, not both.