### PR TITLE
bosh-session is a global module

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -37,8 +37,8 @@ function init_session(event)
     end
 end
 
-module:hook("bosh-session", init_session);
-module:hook("websocket-session", init_session);
+module:hook_global("bosh-session", init_session);
+module:hook_global("websocket-session", init_session);
 
 function provider.test_password(username, password)
 	return nil, "Password based auth not supported";


### PR DESCRIPTION
Needs to be hook_global or this event will never be picked up