### PR TITLE
in config, mention useRoomAsSharedDocumentName

### DIFF
--- a/config.js
+++ b/config.js
@@ -734,6 +734,18 @@ var config = {
     // is not persisting the local storage inside the iframe.
     // useHostPageLocalStorage: true,
 
+    // etherpad ("shared document") integration.
+    //
+
+    // If set, add a "Open shared document" link to the bottom right menu that
+    // will open an etherpad document.
+    // etherpad_base: 'https://your-etherpad-installati.on/p/',
+
+    // If etherpad_base is set, and useRoomAsSharedDocumentName is set to true,
+    // open a pad with the name of the room (lowercased) instead of a pad with a
+    // random UUID.
+    // useRoomAsSharedDocumentName: true,
+
     // List of undocumented settings used in jitsi-meet
     /**
      _immediateReloadThreshold
@@ -746,7 +758,6 @@ var config = {
      dialOutCodesUrl
      disableRemoteControl
      displayJids
-     etherpad_base
      externalConnectUrl
      firefox_fake_device
      googleApiApplicationClientID
@@ -757,7 +768,6 @@ var config = {
      peopleSearchUrl
      requireDisplayName
      tokenAuthUrl
-     useRoomAsSharedDocumentName
      */
 
     /**

--- a/config.js
+++ b/config.js
@@ -757,6 +757,7 @@ var config = {
      peopleSearchUrl
      requireDisplayName
      tokenAuthUrl
+     useRoomAsSharedDocumentName
      */
 
     /**


### PR DESCRIPTION
Found via https://github.com/jitsi/jitsi-meet/issues/1016 .

I can also craft a PR that includes the commented out setting directly after etherpad_base with a comment about its usage. Just ping me and I'll adjust.

Signed the CLA already.