### PR TITLE
Update docs with privacy error in Chrome

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -76,3 +76,7 @@ make dev
 ```
 
 The app should be running at https://localhost:8080/
+
+#### Chrome Privacy Error
+
+Newer versions of Chrome may block localhost under https and show `NET::ERR_CERT_INVALID` on the page. To solve this open `chrome://flags/#allow-insecure-localhost` and select Enable, then press Relaunch or quit and restart Chrome.

--- a/doc/development.md
+++ b/doc/development.md
@@ -79,4 +79,4 @@ The app should be running at https://localhost:8080/
 
 #### Chrome Privacy Error
 
-Newer versions of Chrome may block localhost under https and show `NET::ERR_CERT_INVALID` on the page. To solve this open `chrome://flags/#allow-insecure-localhost` and select Enable, then press Relaunch or quit and restart Chrome.
+Newer versions of Chrome may block localhost under https and show `NET::ERR_CERT_INVALID` on the page. To solve this open [chrome://flags/#allow-insecure-localhost](chrome://flags/#allow-insecure-localhost) and select Enable, then press Relaunch or quit and restart Chrome.


### PR DESCRIPTION
[Low Priority]

Adds a note to the web development docs on how to solve a security issue when running the server locally in the newest versions of Chrome.