### PR TITLE
fix(livestreaming): window.open params

### DIFF
--- a/react/features/recording/components/LiveStream/web/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyForm.js
@@ -85,7 +85,7 @@ class StreamKeyForm extends AbstractStreamKeyForm<Props> {
      * @returns {void}
      */
     _onOpenHelp() {
-        window.open(this.helpURL, 'noopener');
+        window.open(this.helpURL, '_blank', 'noopener');
     }
 }
 


### PR DESCRIPTION

The target parameter from window.open was missing which was causing
reload in electron.