### PR TITLE
[UI] Jitsi prefers the WebRTC implementation of Chromium

### DIFF
--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react';
 import { isBrowsersOptimal } from '../../base/environment';
 import { translate } from '../../base/i18n';
 
-import { CHROME, FIREFOX } from './browserLinks';
+import { CHROMIUM, FIREFOX } from './browserLinks';
 
 /**
  * The namespace of the CSS styles of UnsupportedDesktopBrowser.

--- a/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/UnsupportedDesktopBrowser.js
@@ -45,10 +45,10 @@ class UnsupportedDesktopBrowser extends Component<Props> {
                     It looks like you're using a browser we don't support.
                 </h2>
                 <p className = { `${_SNS}__description` }>
-                    Please try again with the latest version of&nbsp;
+                    Please try again with the latest version of a browser based on&nbsp;
                     <a
                         className = { `${_SNS}__link` }
-                        href = { CHROME } >Chrome</a>&nbsp;
+                        href = { CHROMIUM } >Chromium</a>&nbsp;
                     {
                         this._showFirefox() && <>and <a
                             className = { `${_SNS}__link` }


### PR DESCRIPTION
Jitsi actually prefers the WebRTC implementation of Chromium, which means e.g. Chrome, but also Opera and such, why not be that clear. In addition FOSS should link to FOSS, I think. :) Plus: Google Chrome can easily be found on the linked chromium site, so no loss here. New wording works with FF too. ;) Thanks a lot