### PR TITLE
include the "sendEndpointTextMessage" command name

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -272,7 +272,7 @@ api.executeCommand('avatarUrl', 'https://avatars0.githubusercontent.com/u/367164
 
 * **sendEndpointTextMessage** - Sends a text message to another participant through the datachannels.
 ```javascript
-api.executeCommand('receiverParticipantId', 'text');
+api.executeCommand('sendEndpointTextMessage', 'receiverParticipantId', 'text');
 ```
 
 You can also execute multiple commands using the `executeCommands` method:


### PR DESCRIPTION
The example code for command "sendEndpointTextMessage" was previously incomplete, as it lacked showing that the command name needed to be included as the first parameter to `api.executeCommand`