### PR TITLE
i18n: german, fix translation key.

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -452,7 +452,7 @@
         "somebody": "Jemand",
         "startSilentTitle": "Sie sind ohne Audioausgabe beigetreten!",
         "startSilentDescription": "Treten Sie dem Meeting noch einmal bei, um Ihr Audio zu aktivieren",
-        "suboptimalExperienceDescription": "Tut uns leid, aber die Konferenz wird mit {{appName}} kein großartiges Erlebnis. Wir versuchen immer die Situation zu verbessern, bis dahin empfehlen wir aber die Verwendung einer der <a href=\"static/recommendedBrowsers.html\" target=\"_blank\">vollständig unterstützen Browser</a>.",
+        "suboptimalBrowserWarning": "Tut uns leid, aber die Konferenz wird mit {{appName}} kein großartiges Erlebnis. Wir versuchen immer die Situation zu verbessern, bis dahin empfehlen wir aber die Verwendung einer der <a href=\"static/recommendedBrowsers.html\" target=\"_blank\">vollständig unterstützen Browser</a>.",
         "suboptimalExperienceTitle": "Browserwarnung",
         "unmute": "Stummschaltung aufheben",
         "newDeviceCameraTitle": "Neue Kamera erkannt",


### PR DESCRIPTION
Fix key for german translation. But apparently, this is off in many other translation files, too (sorry, sparse time).

CLA already signed.

```bash
$rgrep suboptimalExperienceDescription lang -l                                             git:(de_i18n|) 
lang/main-kab.json
lang/main-it.json
lang/main-tr.json
lang/main-af.json
lang/main-enGB.json
lang/main-km.json
lang/main-az.json
lang/main-nb.json
lang/main-ja.json
lang/main-nl.json
lang/main-cs.json
lang/main-et.json
lang/main-fi.json
lang/main-sv.json
lang/main-vi.json
lang/main-hr.json
lang/main-da.json
lang/main-eo.json
lang/main-hy.json
lang/main-sl.json
```