### PR TITLE
config: remove aspect ratio constraint from config example

### DIFF
--- a/config.js
+++ b/config.js
@@ -111,11 +111,10 @@ var config = {
     // w3c spec-compliant video constraints to use for video capture. Currently
     // used by browsers that return true from lib-jitsi-meet's
     // util#browser#usesNewGumFlow. The constraints are independent from
-    // this config's resolution value. Defaults to requesting an ideal aspect
-    // ratio of 16:9 with an ideal resolution of 720.
+    // this config's resolution value. Defaults to requesting an ideal
+    // resolution of 720p.
     // constraints: {
     //     video: {
-    //         aspectRatio: 16 / 9,
     //         height: {
     //             ideal: 720,
     //             max: 720,


### PR DESCRIPTION
Some cameras may not be able to satisfy it and gUM will fail.

Refs: https://github.com/jitsi/lib-jitsi-meet/pull/1066