### PR TITLE
Add gzip and expires to nginx server config.

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -41,12 +41,7 @@ server {
 
     gzip on;
     gzip_types text/plain text/css application/javascript application/json;
-
-    location ~* \.(js|css|png|ico)$ {
-       expires 30d;
-       add_header Cache-Control "public";
-       etag on;
-    }
+    gzip_vary on;
 
     location = /config.js {
         alias /etc/jitsi/meet/jitsi-meet.example.com-config.js;

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -39,6 +39,15 @@ server {
     index index.html index.htm;
     error_page 404 /static/404.html;
 
+    gzip on;
+    gzip_types text/plain text/css application/javascript;
+
+    location ~* \.(js|css|png|ico)$ {
+       expires 30d;
+       add_header Cache-Control "public";
+       etag on;
+    }
+
     location = /config.js {
         alias /etc/jitsi/meet/jitsi-meet.example.com-config.js;
     }

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -40,7 +40,7 @@ server {
     error_page 404 /static/404.html;
 
     gzip on;
-    gzip_types text/plain text/css application/javascript;
+    gzip_types text/plain text/css application/javascript application/json;
 
     location ~* \.(js|css|png|ico)$ {
        expires 30d;


### PR DESCRIPTION
The provided nginx configs do not enable gzip by default, nor do they enable caching of the content.  This pull request enables both gzip and content caching, via the expires header.

As the content has a version string appended, it should be safe to cache the content for longer periods of time, though the etag field should cover content changes as well.  I'm flexible on the content caching part of this, if people have strong opinions there.

However, the gzip option changes the main page load from 4.6MB of content to 2.0MB of content - which makes a difference on low bandwidth connections, for minimal server CPU.  The compression applies for meeting resources as well, and I see no downsides for enabling compression in the default configuration.

I've not added Apache config changes, as experimentally Apache has gzip enabled by default (but no expires headers - though mod_expires isn't enabled by default, so enabling caching headers would require playing with the enabled modules).  As Apache is a second choice for servers, I don't think the change to enable mod_expires and then enable caching is worth the effort, although I could be convinced.

I've signed the contribution agreement document, you should be able to find that under my email address.