### PR TITLE
Pass upper case country codes to i18n-iso-countries

### DIFF
--- a/react/features/invite/components/dial-in-summary/web/NumbersList.js
+++ b/react/features/invite/components/dial-in-summary/web/NumbersList.js
@@ -63,8 +63,10 @@ class NumbersList extends Component<Props> {
             hasFlags = true;
             numbers = numbersMapping.reduce(
                 (resultNumbers, number) => {
+                    // The i18n-iso-countries package insists on upper case.
+                    const countryCode = number.countryCode.toUpperCase();
                     const countryName
-                        = t(`countries:countries.${number.countryCode}`);
+                        = t(`countries:countries.${countryCode}`);
 
                     if (resultNumbers[countryName]) {
                         resultNumbers[countryName].push(number);


### PR DESCRIPTION
Related to #5697.

I know that converting to upper case fixes the issue in #5697. But I haven't tested if PR builds and/or does not error, or if the linter passes. (How to run the linter?) I tried to build this but `make` does not work for me because the `libs` dir is created too late. (And I assume for now it's my mistake and not a broken Makefile).
```
./node_modules/.bin/webpack -p
rm -fr libs
cp \
	build/app.bundle.min.js \
	build/app.bundle.min.map \
	build/do_external_connect.min.js \
	build/do_external_connect.min.map \
	build/external_api.min.js \
	build/external_api.min.map \
	build/flacEncodeWorker.min.js \
	build/flacEncodeWorker.min.map \
	build/device_selection_popup_bundle.min.js \
	build/device_selection_popup_bundle.min.map \
	build/dial_in_info_bundle.min.js \
	build/dial_in_info_bundle.min.map \
	build/alwaysontop.min.js \
	build/alwaysontop.min.map \
	./analytics-ga.js \
	build/analytics-ga.min.js \
	build/analytics-ga.min.map \
	build/video-blur-effect.min.js \
	build/video-blur-effect.min.map \
	build/rnnoise-processor.min.js \
	build/rnnoise-processor.min.map \
	libs
cp \
	node_modules/rnnoise-wasm/dist//rnnoise.wasm \
	libs
cp: target 'libs' is not a directory
mkdir -p libs
make: *** [Makefile:31: deploy-appbundle] Error 1
make: *** Waiting for unfinished jobs....
mkdir: cannot create directory ‘libs’: File exists
make: *** [Makefile:28: deploy-init] Error 1
```