### PR TITLE
Move the coturn udp port to 4446 and add script for deploying coturn certificates with certbot

### DIFF
--- a/config.js
+++ b/config.js
@@ -342,7 +342,7 @@ var config = {
         // The STUN servers that will be used in the peer to peer connections
         stunServers: [
 
-            // { urls: 'stun:jitsi-meet.example.com:443' },
+            // { urls: 'stun:jitsi-meet.example.com:4446' },
             { urls: 'stun:meet-jit-si-turnrelay.jitsi.net:443' }
         ],
 

--- a/debian/jitsi-meet-turnserver.install
+++ b/debian/jitsi-meet-turnserver.install
@@ -1,2 +1,3 @@
-doc/debian/jitsi-meet-turn/turnserver.conf  /usr/share/jitsi-meet-turnserver/
-doc/debian/jitsi-meet/jitsi-meet.conf       /usr/share/jitsi-meet-turnserver/
+doc/debian/jitsi-meet-turn/turnserver.conf          /usr/share/jitsi-meet-turnserver/
+doc/debian/jitsi-meet/jitsi-meet.conf               /usr/share/jitsi-meet-turnserver/
+doc/debian/jitsi-meet-turn/coturn-certbot-deploy.sh /usr/share/jitsi-meet-turnserver/

--- a/debian/jitsi-meet-turnserver.postinst
+++ b/debian/jitsi-meet-turnserver.postinst
@@ -112,13 +112,6 @@ case "$1" in
         sed -i "s/__turnSecret__/$TURN_SECRET/g" $TURN_CONFIG
         sed -i "s/__external_ip_address__/$JVB_HOSTNAME/g" $TURN_CONFIG
 
-        # Hack Debian Buster coturn to be able to bind privileged port 443
-        COTURN_UNIT_FILE="/lib/systemd/system/coturn.service"
-        if [[ -f $COTURN_UNIT_FILE ]] && ! grep -q "CAP_NET_BIND_SERVICE" "$COTURN_UNIT_FILE" ; then
-            sed -i "s/\[Service\]/\[Service\]\nAmbientCapabilities=CAP_NET_BIND_SERVICE/g" $COTURN_UNIT_FILE
-            systemctl daemon-reload
-        fi
-
         # SSL for nginx
         db_get jitsi-meet/cert-choice
         CERT_CHOICE="$RET"

--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -6,8 +6,8 @@ muc_mapper_domain_base = "jitmeet.example.com";
 turncredentials_secret = "__turnSecret__";
 
 turncredentials = {
-  { type = "stun", host = "jitmeet.example.com", port = "443" },
-  { type = "turn", host = "jitmeet.example.com", port = "443", transport = "udp" },
+  { type = "stun", host = "jitmeet.example.com", port = "4446" },
+  { type = "turn", host = "jitmeet.example.com", port = "4446", transport = "udp" },
   { type = "turns", host = "jitmeet.example.com", port = "443", transport = "tcp" }
 };
 

--- a/doc/debian/jitsi-meet-turn/coturn-certbot-deploy.sh
+++ b/doc/debian/jitsi-meet-turn/coturn-certbot-deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+COTURN_CERT_DIR="/etc/coturn/certs"
+
+# create a directory to store certs if it does not exists
+if [ ! -d "$COTURN_CERT_DIR" ]; then
+	mkdir -p /etc/coturn/certs
+	chown -R turnserver:turnserver /etc/coturn/
+	chmod -R 700 /etc/coturn/
+fi
+
+for domain in $RENEWED_DOMAINS; do
+        case $domain in
+        jitsi-meet.example.com)
+                # Make sure the certificate and private key files are
+                # never world readable, even just for an instant while
+                # we're copying them into daemon_cert_root.
+                umask 077
+
+                cp "$RENEWED_LINEAGE/fullchain.pem" "$COTURN_CERT_DIR/$domain.fullchain.pem"
+                cp "$RENEWED_LINEAGE/privkey.pem" "$COTURN_CERT_DIR/$domain.privkey.pem"
+
+                # Apply the proper file ownership and permissions for
+                # the daemon to read its certificate and key.
+                chown turnserver "$COTURN_CERT_DIR/$domain.fullchain.pem" \
+                        "$COTURN_CERT_DIR/$domain.privkey.pem"
+                chmod 400 "$COTURN_CERT_DIR/$domain.fullchain.pem" \
+                        "$COTURN_CERT_DIR/$domain.privkey.pem"
+
+                ;;
+        esac
+done
+

--- a/doc/debian/jitsi-meet-turn/turnserver.conf
+++ b/doc/debian/jitsi-meet-turn/turnserver.conf
@@ -8,7 +8,7 @@ cert=/etc/jitsi/meet/jitsi-meet.example.com.crt
 pkey=/etc/jitsi/meet/jitsi-meet.example.com.key
 
 no-tcp
-listening-port=443
+listening-port=4446
 tls-listening-port=4445
 external-ip=__external_ip_address__
 


### PR DESCRIPTION
This PR should fix issue noticed in https://github.com/jitsi/jitsi-meet/issues/5529

This PR:

* move the udp port of coturn to 4446 ;
* add script to deploy letsencrypt certificates.

## Move udp's coturn port to 4446

As coturn is started as non-root user, the port 443 is not available.

The UDP port is moved to 4446.

## Add script for deploying letsencrypt certificates

As coturn is runned as non-root user, coturn could not load and start using letsencrypt certificates.

This PR add a letsencrypt hook to copy certificates into `/etc/coturn/certs`, and change the owner to the `turnserver` user, and chmod them to `0400`.

The hook will be executed on each deploy.