### PR TITLE
Using "Japonés" instead of "Jopones"

### DIFF
--- a/lang/languages-es.json
+++ b/lang/languages-es.json
@@ -17,7 +17,7 @@
     "hu": "Húngaro",
     "hy": "Armenio",
     "it": "Italiano",
-    "ja": "Jopones",
+    "ja": "Japonés",
     "ko": "Coreano",
     "nl": "Holandés",
     "oc": "Occitano",


### PR DESCRIPTION
Using right word to describe Japanese in Spanish