### PR TITLE
Fix the command to update jitsi-stable.list

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -22,7 +22,7 @@ Finally on the same machine test that you can ping the FQDN with: `ping "$(hostn
 
 ### Add the Jitsi package repository
 ```sh
-echo 'deb https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list
+echo 'deb https://download.jitsi.org stable/' | sudo tee -a /etc/apt/sources.list.d/jitsi-stable.list
 wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -
 ```
 

--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -22,7 +22,7 @@ Finally on the same machine test that you can ping the FQDN with: `ping "$(hostn
 
 ### Add the Jitsi package repository
 ```sh
-echo 'deb https://download.jitsi.org stable/' | sudo tee -a /etc/apt/sources.list.d/jitsi-stable.list
+echo 'deb https://download.jitsi.org stable/' | sudo tee /etc/apt/sources.list.d/jitsi-stable.list
 wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -
 ```
 


### PR DESCRIPTION
This command uses the technique recommended below that will always work. (See "Safest Solution (#3)") 

https://askubuntu.com/questions/185268/permission-denied-etc-apt-sources-list