### PR TITLE
add missing IPv6 listener to nginx jitsi module

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.conf
+++ b/doc/debian/jitsi-meet/jitsi-meet.conf
@@ -18,6 +18,7 @@ stream {
 
     server {
         listen 443;
+        listen [::]:443;
 
         # since 1.11.5
         ssl_preread on;


### PR DESCRIPTION
[PR 5216](https://github.com/jitsi/jitsi-meet/pull/5216) fixes #5209 for an installation without jitsi-meet-turnserver. However jitsi-meet-turnserver.postinst enables the doc/debian/jitsi-meet/jitsi-meet.conf nginx module, which overwrites the external nginx listening port. This PR adds the missing IPv6 listener in this nginx module.