### PR TITLE
Prosody: add plugin to set the focus user as owner on any room

### DIFF
--- a/resources/prosody-plugins/mod_muc_setowner.lua
+++ b/resources/prosody-plugins/mod_muc_setowner.lua
@@ -1,0 +1,27 @@
+-- Automatically set some users as owner in MUC rooms.
+--
+-- In Jitsi Meet this makes it possible to not set jicofo as an admin.
+--
+-- Sample usage:
+--
+-- Component "muc.meet.jitsi" "muc"
+--    modules_enabled = { "muc_setowner" };
+--    muc_owner_list = { "focus@auth.meet.jitsi" }
+
+local split_jid = require "util.jid".split;
+local muc_service = module:depends("muc");
+local room_mt = muc_service.room_mt;
+
+local owner_list = module:get_option_set("muc_owner_list", {});
+
+local original_get_affiliation = room_mt.get_affiliation;
+
+room_mt.get_affiliation = function (room, jid)
+    local user, domain, res = split_jid(jid);
+
+    if owner_list:contains(user..'@'..domain) then
+        return "owner"
+    end
+
+    return original_get_affiliation(room, jid);
+end


### PR DESCRIPTION
According to [its README file](https://github.com/jitsi/jicofo#manual-prosody-configuration), jicofo needs to be admin for the sole purpose of setting itself owner to the rooms it creates or joins. But this prevents us from being able to restrict its rights.

This commit introduces a new plugin that sets the focus user as owner, so we can disable the admin rights for jicofo, in order to be able to constraint its behaviour (e.g. make it honour the `restrict_room_creation` setting).

We've been using it for quite some time and jicofo does not seem hindered by this plugin at all, even if it doesn't handle errors very well.