### PR TITLE
feat: improve default HTTPS security (#5768)

### DIFF
--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -153,6 +153,23 @@ case "$1" in
             db_set jitsi-meet/jvb-serve "false"
         fi
 
+        # securing HTTPS with DH parameters
+        if [[ ( "$FORCE_NGINX" = "true" || "$FORCE_APACHE" = "true" ) && ( -z "$JVB_HOSTNAME_OLD" || "$RECONFIGURING" = "true" ) ]] ; then
+            HTTPS_SECURE="true"
+            if [ ! -f /etc/ssl/private/dhparams.pem ] ; then
+                echo ""
+                echo "------------------------------------------------"
+                echo ""
+                echo "Generating random DH parameters for secure HTTPS webserver config."
+                echo ""
+                echo "Stay patient this might take some minutes to gain entropy ..."
+                echo ""
+                echo "------------------------------------------------"
+                echo ""
+                openssl dhparam -out /etc/ssl/private/dhparams.pem 4096
+            fi
+        fi
+
         if [[ "$FORCE_NGINX" = "true" && ( -z "$JVB_HOSTNAME_OLD" || "$RECONFIGURING" = "true" ) ]] ; then
 
             # this is a reconfigure, lets just delete old links
@@ -179,6 +196,12 @@ case "$1" in
                 CERT_CRT_ESC=$(echo $CERT_CRT | sed 's/\./\\\./g')
                 CERT_CRT_ESC=$(echo $CERT_CRT_ESC | sed 's/\//\\\//g')
                 sed -i "s/ssl_certificate\ \/etc\/jitsi\/meet\/.*crt/ssl_certificate\ $CERT_CRT_ESC/g" \
+                    /etc/nginx/sites-available/$JVB_HOSTNAME.conf
+            fi
+
+            if [ "$HTTPS_SECURE" = "true" ] ; then
+                # activated commented ssl_dhparam line for present file
+                sed -i "s/#ssl_dhparam\ \/etc\/ssl\/private\/dhparams.pem;/ssl_dhparam\ \/etc\/ssl\/private\/dhparams.pem;/g" \
                     /etc/nginx/sites-available/$JVB_HOSTNAME.conf
             fi
 
@@ -209,6 +232,12 @@ case "$1" in
                 CERT_CRT_ESC=$(echo $CERT_CRT | sed 's/\./\\\./g')
                 CERT_CRT_ESC=$(echo $CERT_CRT_ESC | sed 's/\//\\\//g')
                 sed -i "s/SSLCertificateFile\ \/etc\/jitsi\/meet\/.*crt/SSLCertificateFile\ $CERT_CRT_ESC/g" \
+                    /etc/apache2/sites-available/$JVB_HOSTNAME.conf
+            fi
+
+            if [ "$HTTPS_SECURE" = "true" ] ; then
+                # activated commented ssl_dhparam line for present file
+                sed -i "s/#SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem/SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem;/g" \
                     /etc/apache2/sites-available/$JVB_HOSTNAME.conf
             fi
 

--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -237,7 +237,7 @@ case "$1" in
 
             if [ "$HTTPS_SECURE" = "true" ] ; then
                 # activated commented ssl_dhparam line for present file
-                sed -i "s/#SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem/SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem;/g" \
+                sed -i "s/#SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem/SSLOpenSSLConfCmd\ DHParameters\ \/etc\/ssl\/private\/dhparams.pem/g" \
                     /etc/apache2/sites-available/$JVB_HOSTNAME.conf
             fi
 

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -25,8 +25,8 @@ server {
     ssl_prefer_server_ciphers on;
     # weaker AES256+EECDH for older iOS/Android
     ssl_ciphers EECDH+AESGCM:EDH+AESGCM:AES256+EECDH;
-    # requires pregenerated with 'openssl dhparam -out /etc/nginx/dhparam.pem 4096'
-    #ssl_dhparam /etc/nginx/dhparam.pem;
+    # requires pregenerated with 'openssl dhparam -out /etc/ssl/private/dhparams.pem 4096'
+    #ssl_dhparam /etc/ssl/private/dhparams.pem;
     ssl_ecdh_curve secp384r1;
     ssl_session_timeout 10m;
     ssl_session_cache shared:SSL:10m;

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -21,9 +21,16 @@ server {
     listen [::]:443 ssl;
     server_name jitsi-meet.example.com;
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_prefer_server_ciphers on;
-    ssl_ciphers "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED";
+    # weaker AES256+EECDH for older iOS/Android
+    ssl_ciphers EECDH+AESGCM:EDH+AESGCM:AES256+EECDH;
+    # requires pregenerated with 'openssl dhparam -out /etc/nginx/dhparam.pem 4096'
+    #ssl_dhparam /etc/nginx/dhparam.pem;
+    ssl_ecdh_curve secp384r1;
+    ssl_session_timeout 10m;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
 
     add_header Strict-Transport-Security "max-age=31536000";
 

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -11,13 +11,18 @@
 
   ServerName jitsi-meet.example.com
 
-  SSLProtocol TLSv1 TLSv1.1 TLSv1.2
+  SSLProtocol TLSv1.2
   SSLEngine on
   SSLProxyEngine on
   SSLCertificateFile /etc/jitsi/meet/jitsi-meet.example.com.crt
   SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
-  SSLCipherSuite "EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA256:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EDH+aRSA+AESGCM:EDH+aRSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!MEDIUM:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!RC4:!SEED"
+  # weaker AES256+EECDH for older iOS/Android
+  SSLCipherSuite "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH"
   SSLHonorCipherOrder on
+  # requires pregenerated with 'openssl dhparam -out /etc/nginx/dhparam.pem 4096'
+  #SSLOpenSSLConfCmd DHParameters "/etc/ssl/private/dhparams.pem"
+  SSLCompression off
+  SSLSessionTickets Off
   Header set Strict-Transport-Security "max-age=31536000"
 
   DocumentRoot "/usr/share/jitsi-meet"

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -19,7 +19,7 @@
   # weaker AES256+EECDH for older iOS/Android
   SSLCipherSuite "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH"
   SSLHonorCipherOrder on
-  # requires pregenerated with 'openssl dhparam -out /etc/nginx/dhparam.pem 4096'
+  # requires pregenerated with 'openssl dhparam -out /etc/ssl/private/dhparams.pem 4096'
   #SSLOpenSSLConfCmd DHParameters "/etc/ssl/private/dhparams.pem"
   SSLCompression off
   SSLSessionTickets Off


### PR DESCRIPTION
Gave it a quick down sampling from Ansible to BASH.
This should get ofc some testing for older legacy clients.
Otherwise aims we don't those kind of security reviews:
https://citizenlab.ca/2020/04/move-fast-roll-your-own-crypto-a-quick-look-at-the-confidentiality-of-zoom-meetings/