### PR TITLE
Update browser links to HTTPS

### DIFF
--- a/react/features/unsupported-browser/components/browserLinks.js
+++ b/react/features/unsupported-browser/components/browserLinks.js
@@ -5,14 +5,14 @@
  *
  * @type {string}
  */
-export const CHROME = 'http://google.com/chrome';
+export const CHROME = 'https://www.google.com/chrome/';
 
 /**
  * The URL at which Chromium is available for download.
  *
  * @type {string}
  */
-export const CHROMIUM = 'http://www.chromium.org/';
+export const CHROMIUM = 'https://www.chromium.org/';
 
 /**
  * The URL at which Microsoft Edge is available for download.
@@ -27,7 +27,7 @@ export const EDGE
  *
  * @type {string}
  */
-export const FIREFOX = 'http://www.getfirefox.com/';
+export const FIREFOX = 'https://www.getfirefox.com/';
 
 /**
  * The URL at which Safari is available for download.

--- a/static/recommendedBrowsers.html
+++ b/static/recommendedBrowsers.html
@@ -13,10 +13,10 @@
             We recommend to try with the latest version of&nbsp;
             <a
                 className = 'unsupported-desktop-browser__link'
-                href = 'http://google.com/chrome' >Chrome</a>&nbsp;or&nbsp;
+                href = 'https://www.google.com/chrome/' >Chrome</a>&nbsp;or&nbsp;
             <a
                 class = 'unsupported-desktop-browser__link'
-                href = 'http://www.chromium.org/'>Chromium</a>
+                href = 'https://www.chromium.org/'>Chromium</a>
         </p>
     </div>
 </body>


### PR DESCRIPTION
This should be self-explaining: I noted the browser links in jitsi meet are http. Obviously these days all upstream URLs for browsers support or default to HTTPS.