### PR TITLE
fix(safari): Update the check for Safari

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -635,7 +635,7 @@ export class VideoContainer extends LargeContainer {
         // explicitly disabled.
         if (interfaceConfig.DISABLE_VIDEO_BACKGROUND
                 || browser.isFirefox()
-                || browser.isSafariWithWebrtc()) {
+                || browser.isSafari()) {
             return;
         }
 


### PR DESCRIPTION
In preparation for the lib-jitsi-meet PR for Safari support, isSafariWithWebrtc() will no longer be available