### PR TITLE
fix: Parcel the serverURL in the Android SDK (#5504)

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetConferenceOptions.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetConferenceOptions.java
@@ -288,6 +288,7 @@ public class JitsiMeetConferenceOptions implements Parcelable {
     }
 
     private JitsiMeetConferenceOptions(Parcel in) {
+        serverURL = (URL) in.readSerializable();
         room = in.readString();
         subject = in.readString();
         token = in.readString();
@@ -376,6 +377,7 @@ public class JitsiMeetConferenceOptions implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        dest.writeSerializable(serverURL);
         dest.writeString(room);
         dest.writeString(subject);
         dest.writeString(token);


### PR DESCRIPTION
In the Android SDK, the setServerURL option is erroneously ignored. The meeting's serverURL always defaults to https://meet.jit.si because the serverURL is not parceled.

I've verified that this fixes the issue with custom serverURL values.