### PR TITLE
React Native accessibility fixes

### DIFF
--- a/react/features/base/dialog/components/native/BottomSheet.js
+++ b/react/features/base/dialog/components/native/BottomSheet.js
@@ -84,6 +84,8 @@ class BottomSheet extends PureComponent<Props> {
 
         return (
             <SlidingView
+                accessibleRole = 'menu'
+                accessibilityViewIsModal = { true }
                 onHide = { this.props.onCancel }
                 position = 'bottom'
                 show = { true }>

--- a/react/features/base/dialog/components/native/BottomSheet.js
+++ b/react/features/base/dialog/components/native/BottomSheet.js
@@ -84,7 +84,7 @@ class BottomSheet extends PureComponent<Props> {
 
         return (
             <SlidingView
-                accessibleRole = 'menu'
+                accessibilityRole = 'menu'
                 accessibilityViewIsModal = { true }
                 onHide = { this.props.onCancel }
                 position = 'bottom'

--- a/react/features/base/toolbox/components/ToolboxItem.native.js
+++ b/react/features/base/toolbox/components/ToolboxItem.native.js
@@ -41,7 +41,8 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             elementAfter,
             onClick,
             showLabel,
-            styles
+            styles,
+            toggled
         } = this.props;
 
         let children = this._renderIcon();
@@ -73,7 +74,7 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             <TouchableHighlight
                 accessibilityLabel = { this.accessibilityLabel }
                 accessibilityRole = 'button'
-                accessibilityState = { {'selected': this.toggled} }
+                accessibilityState = {{ 'selected': toggled }}
                 disabled = { disabled }
                 onPress = { onClick }
                 style = { style }

--- a/react/features/base/toolbox/components/ToolboxItem.native.js
+++ b/react/features/base/toolbox/components/ToolboxItem.native.js
@@ -73,6 +73,7 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             <TouchableHighlight
                 accessibilityLabel = { this.accessibilityLabel }
                 accessibilityRole = 'button'
+                accessibilityState = {'selected': this.toggled}
                 disabled = { disabled }
                 onPress = { onClick }
                 style = { style }

--- a/react/features/base/toolbox/components/ToolboxItem.native.js
+++ b/react/features/base/toolbox/components/ToolboxItem.native.js
@@ -73,7 +73,7 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             <TouchableHighlight
                 accessibilityLabel = { this.accessibilityLabel }
                 accessibilityRole = 'button'
-                accessibilityState = {{'selected': this.toggled}}
+                accessibilityState = { {'selected': this.toggled} }
                 disabled = { disabled }
                 onPress = { onClick }
                 style = { style }

--- a/react/features/base/toolbox/components/ToolboxItem.native.js
+++ b/react/features/base/toolbox/components/ToolboxItem.native.js
@@ -72,6 +72,7 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
         return (
             <TouchableHighlight
                 accessibilityLabel = { this.accessibilityLabel }
+                accessibilityRole = 'button'
                 disabled = { disabled }
                 onPress = { onClick }
                 style = { style }

--- a/react/features/base/toolbox/components/ToolboxItem.native.js
+++ b/react/features/base/toolbox/components/ToolboxItem.native.js
@@ -73,7 +73,7 @@ export default class ToolboxItem extends AbstractToolboxItem<Props> {
             <TouchableHighlight
                 accessibilityLabel = { this.accessibilityLabel }
                 accessibilityRole = 'button'
-                accessibilityState = {'selected': this.toggled}
+                accessibilityState = {{'selected': this.toggled}}
                 disabled = { disabled }
                 onPress = { onClick }
                 style = { style }

--- a/react/features/toolbox/components/native/Toolbox.js
+++ b/react/features/toolbox/components/native/Toolbox.js
@@ -110,6 +110,7 @@ class Toolbox extends PureComponent<Props> {
 
         return (
             <View
+                accessibilityRole = 'toolbar'
                 pointerEvents = 'box-none'
                 style = { styles.toolbar }>
                 {


### PR DESCRIPTION
This pull request adds various commits to fix issues mentioned in #5817 .

* The buttons are buttons.
* Toggled on buttons are selected.
* The toolbox is a tool bar.
* The bottom sheet is a menu.

Things still unsolved:
* Hints are not yet assigned. Looks like they are the same as the visible label when not toggled in most cases, so don't actually add any value for screen reader users. I might drop this.
* The thing that is the area where one clicks to close is not yet a button and has no label. I haven't found that particular component yet.
* Same goes for the unlabeled area before the video element in the swiping order.

These changes are untested, since I cannot actually build for react native or test on a device at the moment. I am leaving this open for edits by maintainers so you can augment to these proposed changes and make corrections.