### PR TITLE
Conference timer should start counting at 0

### DIFF
--- a/resources/prosody-plugins/mod_conference_duration_component.lua
+++ b/resources/prosody-plugins/mod_conference_duration_component.lua
@@ -28,7 +28,7 @@ function occupant_joined(event)
     if participant_count > 1 then
 
         if room.created_timestamp == nil then
-            room.created_timestamp = os.time(os.date("!*t")) * 1000; -- Lua provides UTC time in seconds, so convert to milliseconds
+            room.created_timestamp = os.time() * 1000; -- Lua provides UTC time in seconds, so convert to milliseconds
         end
 
         local body_json = {};


### PR DESCRIPTION
It's starting at 1 hour because os.time(os.date("!*t") returns the wrong
time depending on system timezone. os.time() already returns the number
of seconds since epoch in UTC so just use that.

Fixes #5595