### PR TITLE
Smaller thumbnail size for participants who are not streaming/sharing screen.

### DIFF
--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -92,6 +92,11 @@
         video {
             object-fit: contain;
         }
+
+        #videosDelimiter {
+            order: 10;
+            width: 100%;
+        }
     }
 
     .has-overflow#filmstripRemoteVideosContainer {

--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -39,29 +39,50 @@ const Filmstrip = {
         const thumbs = this._getThumbs(!forceUpdate);
         const avatarSize = height / 2;
 
-        if (thumbs.localThumb) {
-            thumbs.localThumb.css({
-                'padding-top': '',
-                height: `${height}px`,
-                'min-height': `${height}px`,
-                'min-width': `${width}px`,
-                width: `${width}px`
-            });
-        }
+        const bigVideoCSS = {
+            'padding-top': '',
+            height: `${height}px`,
+            'min-height': `${height}px`,
+            'min-width': `${width}px`,
+            width: `${width}px`
+        };
 
-        if (thumbs.remoteThumbs) {
-            thumbs.remoteThumbs.css({
-                'padding-top': '',
-                height: `${height}px`,
-                'min-height': `${height}px`,
-                'min-width': `${width}px`,
-                width: `${width}px`
-            });
+        if (thumbs.localThumb) {
+            thumbs.localThumb.css(bigVideoCSS);
         }
 
         $('.avatar-container').css({
             height: `${avatarSize}px`,
             width: `${avatarSize}px`
+        });
+
+        Array.from(thumbs.remoteThumbs).forEach(videoThumb => {
+            const $thumb = $(videoThumb);
+
+            // Smaller video
+            if ($thumb.hasClass('without-camera')) {
+                const ratio = width / height;
+
+                // Everything is relative to vw ; width is 15%
+                const smallVideoWidthPercent = 15;
+                const smallVideoHeight = smallVideoWidthPercent / ratio;
+                const smallVideoAvatar = smallVideoHeight / 2.5;
+
+                $thumb.css({
+                    'padding-top': '',
+                    height: `${smallVideoHeight}vw`,
+                    'min-height': `${smallVideoHeight}vw`,
+                    'min-width': `${smallVideoWidthPercent}vw`,
+                    width: `${smallVideoWidthPercent}vw`
+                });
+                $thumb.find('.avatar-container')
+                    .css({
+                        height: `${smallVideoAvatar}vw`,
+                        width: `${smallVideoAvatar}vw`
+                    });
+            } else { // Normal video
+                $thumb.css(bigVideoCSS);
+            }
         });
     },
 

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -28,6 +28,7 @@ import {
     setTileView,
     shouldDisplayTileView
 } from '../../../react/features/video-layout';
+import { CLIENT_RESIZED } from '../../../react/features/base/responsive-ui';
 /* eslint-enable no-unused-vars */
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -556,8 +557,37 @@ export default class SmallVideo {
         }
 
         if (this.displayMode !== oldDisplayMode) {
+            this.reArrangeVideos();
             logger.debug(`Displaying ${displayModeString} for ${this.id}, data: [${JSON.stringify(displayModeInput)}]`);
         }
+    }
+
+    /**
+     * Change the order of the element, based on displayMode
+     * If is sharing screen/streaming order should be < 10
+     * Else order > 10
+     * Also adds special className 'without-camera' to apply
+     * different styles (smaller width and height)
+     */
+    reArrangeVideos() {
+        if (!this.isLocal
+            && (this.displayMode === DISPLAY_VIDEO || this.displayMode === DISPLAY_VIDEO_WITH_NAME)) {
+            this.container.style.order = 1;
+            this.$container.removeClass('without-camera');
+        } else if (!this.isLocal
+            && (this.displayMode === DISPLAY_AVATAR_WITH_NAME || this.displayMode === DISPLAY_AVATAR)) {
+            this.container.style.order = 11;
+            this.$container.addClass('without-camera');
+        }
+
+        // Force rerender for filmstrip
+        const { clientHeight, clientWidth } = APP.store.getState()['features/base/responsive-ui'];
+
+        APP.store.dispatch({
+            type: CLIENT_RESIZED,
+            clientWidth,
+            clientHeight
+        });
     }
 
     /**

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -242,6 +242,8 @@ class Filmstrip extends Component <Props> {
                             onMouseOver = { this._onMouseOver }
                             style = { filmstripRemoteVideosContainerStyle }>
                             <div id = 'localVideoTileViewContainer' />
+                            {/* Empty line between smaller and bigger videos */}
+                            <div id = 'videosDelimiter' />
                         </div>
                     </div>
                 </div>

--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -46,10 +46,11 @@ export function getMaxColumnCount() {
  * rows, and visible rows (the rest should overflow) for the tile view layout.
  */
 export function getTileViewGridDimensions(state: Object, maxColumns: number = getMaxColumnCount()) {
-    // When in tile view mode, we must discount ourselves (the local participant) because our
-    // tile is not visible.
-    const { iAmRecorder } = state['features/base/config'];
-    const numberOfParticipants = state['features/base/participants'].length - (iAmRecorder ? 1 : 0);
+
+    // This is needed to calculate the size of large videos, therefore, numberOfParticipants
+    // should be only the number of people who are streaming
+    const streamingParticipantsSelector = 'span.videocontainer:not(.without-camera)';
+    const numberOfParticipants = document.querySelectorAll(streamingParticipantsSelector).length || 1;
 
     const columnsToMaintainASquare = Math.ceil(Math.sqrt(numberOfParticipants));
     const columns = Math.min(columnsToMaintainASquare, maxColumns);


### PR DESCRIPTION
The width and height of thumbnails are calculated based on the number of particiapnts(columns), trying to maintain a square.
* Changed columns to be calculated only based on streaming participants, to keep the previous calculations of big videos.
* Added different style to thumbnails of participants who are not streaming, which is 15% of the client's viewport, and height calculated based on the other video's ratio.
