### PR TITLE
Adding Spanish translation of "Hebrew" literal

### DIFF
--- a/lang/languages-es.json
+++ b/lang/languages-es.json
@@ -13,6 +13,7 @@
     "fi": "Finlandés",
     "fr": "Francés",
     "frCA": "Franco (Canadiense)",
+    "he": "Hebreo",
     "hr": "Croata",
     "hu": "Húngaro",
     "hy": "Armenio",

--- a/lang/languages-esUS.json
+++ b/lang/languages-esUS.json
@@ -13,6 +13,7 @@
     "fi": "Finlandés",
     "fr": "Francés",
     "frCA": "Francés (Canadiense)",
+    "he": "Hebreo",
     "hr": "Croata",
     "hu": "Húngaro",
     "hy": "Armenio",


### PR DESCRIPTION
Adding Spanish translations of Hebrew literal for **_es_** (Spanish) and **_esUS_** (Spanish (Latin America)) that have not been translated yet.

https://www.rae.es/drae2001/hebreo

![Captura de pantalla 2020-04-11 a las 13 15 54](https://user-images.githubusercontent.com/1285260/79042916-f2477b00-7bfb-11ea-87aa-81e167f18ad9.png)
