### PR TITLE
Fixing wrong text at key "done" in main-es.json

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -170,7 +170,7 @@
         "copy": "Copiar",
         "dismiss": "Descartar",
         "displayNameRequired": "¡Hola! ¿Cuál es tu nombre?",
-        "done": "Por favor ingresa tu nombre aquí",
+        "done": "Listo",
         "enterDisplayName": "Por favor ingresa tu nombre aquí",
         "error": "Error",
         "externalInstallationMsg": "Necesita instalar nuestra extensión para compartir escritorio.",


### PR DESCRIPTION
The literal of the button in "Manage Call Quality" in Spanish says "Insert your name here" instead of "done" (probably due to a C&P).

![Captura de pantalla 2020-04-11 a las 17 46 42](https://user-images.githubusercontent.com/1285260/79048301-7c074080-7c1c-11ea-9a10-ea29a4ee3723.png)

This change uses the same literal that was proposed in [Spanish (Latin American)](https://github.com/jitsi/jitsi-meet/blob/5c39a2f6a6e59b2c4f9c40715ee31d2791915f9d/lang/main-esUS.json#L177): "Listo". 

It sounds fine in both variants of Spanish language.