### PR TITLE
Update main-de.json

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -771,7 +771,7 @@
         "title": "Sichere, mit umfassenden Funktionen ausgestattete und vollkommen kostenlose Videokonferenzen"
     },
     "lonelyMeetingExperience": {
-        "button": "Weitere einladen",
-        "youAreAlone": "Sie sind der Einzige in diesem Meeting"
+        "button": "Andere einladen",
+        "youAreAlone": "Nur Sie sind in diesem Meeting"
     }
 }


### PR DESCRIPTION
The word "Weitere" implied that there are already people in the meeting so I replaced it with "Andere". 
I also made line 775 gender-neutral as "der Einzige" would technically only refer to males. While using the male form to address both sexes isn't an unusual thing to do, some could consider it discriminatory against women.