### PR TITLE
Limit trust of Jitsi signing key

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -22,8 +22,8 @@ Finally on the same machine test that you can ping the FQDN with: `ping "$(hostn
 
 ### Add the Jitsi package repository
 ```sh
-echo 'deb https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list
-wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -
+curl https://download.jitsi.org/jitsi-key.gpg.key | gpg --dearmor > /usr/share/keyrings/jitsi-keyring.gpg
+echo 'deb [signed-by=/usr/share/keyrings/jitsi-keyring.gpg] https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list
 ```
 ### Open ports in your firewall
 


### PR DESCRIPTION
This change sets the Jitsi signing key in the sources.list entry using the signed-by option. This avoids adding the Jitsi signing key to the global SecureApt trust anchor in /etc/apt/trusted.gpg.d, which would cause the system to accept signatures from Jitsi's key on all other repositories configured on the system that don't have a signed-by option (including the official Debian repositories). (See https://wiki.debian.org/DebianRepository/UseThirdParty)