### PR TITLE
fix locale detect error on mobile apps (android and ios)

### DIFF
--- a/react/features/base/i18n/languageDetector.native.js
+++ b/react/features/base/i18n/languageDetector.native.js
@@ -17,7 +17,7 @@ export default {
     detect() {
         const { LocaleDetector } = NativeModules;
 
-        return LocaleDetector.locale.replace(/_/, '-');
+        return LocaleDetector.locale.replace(/[_-]/, '');
     },
 
     init: Function.prototype,


### PR DESCRIPTION
The Android app fail to detect locale for some languages with country code like pt_BR or zh_TW. The application expects the language to be without underscore (ptBR or zhTW).