### PR TITLE
Added ssl options for SubjectAlternativeName (SAN) Closes #5547

### DIFF
--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -91,10 +91,14 @@ case "$1" in
                 CERT_CRT="/etc/jitsi/meet/$JVB_HOSTNAME.crt"
                 HOST="$( (hostname -s; echo localhost) | head -n 1)"
                 DOMAIN="$( (hostname -d; echo localdomain) | head -n 1)"
-                openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj \
+                openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj \
                     "/O=$DOMAIN/OU=$HOST/CN=$JVB_HOSTNAME/emailAddress=webmaster@$HOST.$DOMAIN" \
                     -keyout $CERT_KEY \
-                    -out $CERT_CRT
+                    -out $CERT_CRT \
+                    -reqexts SAN \
+                    -extensions SAN \
+                    -config <(cat /etc/ssl/openssl.cnf \
+                        <(printf '[SAN]\nsubjectAltName=DNS:localhost,DNS:$JVB_HOSTNAME,IP:$JVB_HOSTNAME')) \
             fi
         fi
 


### PR DESCRIPTION
Without this line the certificate will be rejected by all versions of Chrome since v59 (May 2017).

Also bumped up the self signed cert duration: as an intranet system admin pushing out new self signed certs as a group policy to all users every single year is simply too much.