### PR TITLE
Fix typo executeCommand on API documentation

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -273,7 +273,7 @@ api.executeCommand('avatarUrl', 'https://avatars0.githubusercontent.com/u/367164
 
 * **sendEndpointTextMessage** - Sends a text message to another participant through the datachannels.
 ```javascript
-api.executeCommand('receiverParticipantId', 'text');
+api.executeCommand('sendEndpointTextMessage', 'text');
 ```
 
 You can also execute multiple commands using the `executeCommands` method:


### PR DESCRIPTION
 its sendEndpointTextMessage  instead of receiverParticipantId.