### PR TITLE
step i need to do on fresh installed debian 10

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -20,7 +20,17 @@ Then add the same FQDN in the `/etc/hosts` file, associating it with the loopbac
 
 Finally on the same machine test that you can ping the FQDN with: `ping "$(hostname)"`-
 
+
+
+
 ### Add the Jitsi package repository
+
+# Ensure gpg is available for adding the apt repositorie key
+```sh
+apt-get install gnupg
+```
+
+# Downloading and adding the repositorykey
 ```sh
 echo 'deb https://download.jitsi.org stable/' >> /etc/apt/sources.list.d/jitsi-stable.list
 wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -


### PR DESCRIPTION
on a fresh installed version of debian, latest version 10, for server use (minimal task selection (on debain-installer: disable task desktop, printer; enable ssh))  gpg is not installed by default which is required to add the repository key. Also maybe add a hint how to verify the gpg key before adding it