### PR TITLE
deps: bump lib-jitsi-meet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10884,8 +10884,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#70a3298914f3905297e4e9dcc200b95e9b7a73e9",
-      "from": "github:jitsi/lib-jitsi-meet#70a3298914f3905297e4e9dcc200b95e9b7a73e9",
+      "version": "github:jitsi/lib-jitsi-meet#c3fd3431a66556de7b2ec7632f9f6d75b64aad0a",
+      "from": "github:jitsi/lib-jitsi-meet#c3fd3431a66556de7b2ec7632f9f6d75b64aad0a",
       "requires": {
         "@jitsi/sdp-interop": "1.0.1",
         "@jitsi/sdp-simulcast": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-utils": "github:jitsi/js-utils#df68966e3c65b5c57fcd2670da1326a2c77518d1",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#70a3298914f3905297e4e9dcc200b95e9b7a73e9",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#c3fd3431a66556de7b2ec7632f9f6d75b64aad0a",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",


### PR DESCRIPTION
Changelog:
101fecbb Thu Apr 16 11:23:58 2020 +0200 Philipp Hancke: e2ee: decode static black frame for decryption errors (#1098)
c3fd3431 Thu Apr 16 13:09:18 2020 +0200 Philipp Hancke: e2ee: remove encodedFrameType workaround (#1099)

git log --no-merges --reverse --pretty="%h %ad %an: %s" 70a3298914f3905297e4e9dcc200b95e9b7a73e9..c3fd3431a66556de7b2ec7632f9f6d75b64aad0a