### PR TITLE
Show/Hide Invite People button

### DIFF
--- a/react/features/conference/components/native/LonelyMeetingExperience.js
+++ b/react/features/conference/components/native/LonelyMeetingExperience.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-
+import { INVITE_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
@@ -41,7 +41,13 @@ type Props = {
     /**
      * Function to be used to translate i18n labels.
      */
-    t: Function
+    t: Function,
+
+    /**
+     * Whether the invite people button is visible.
+     * Default: Visible (true)
+     */
+    _inviteEnabled: boolean,
 };
 
 /**
@@ -65,7 +71,13 @@ class LonelyMeetingExperience extends PureComponent<Props> {
      * @inheritdoc
      */
     render() {
-        const { _isInviteFunctionsDiabled, _isLonelyMeeting, _styles, t } = this.props;
+        const {
+            _isInviteFunctionsDiabled,
+            _isLonelyMeeting,
+            _styles,
+            t,
+            _inviteEnabled
+        } = this.props;
 
         if (!_isLonelyMeeting) {
             return null;
@@ -80,7 +92,7 @@ class LonelyMeetingExperience extends PureComponent<Props> {
                     ] }>
                     { t('lonelyMeetingExperience.youAreAlone') }
                 </Text>
-                { !_isInviteFunctionsDiabled && (
+                { !_isInviteFunctionsDiabled && _inviteEnabled && (
                     <TouchableOpacity
                         onPress = { this._onPress }
                         style = { [
@@ -129,7 +141,8 @@ function _mapStateToProps(state): $Shape<Props> {
     return {
         _isInviteFunctionsDiabled: disableInviteFunctions,
         _isLonelyMeeting: getParticipantCount(state) === 1,
-        _styles: ColorSchemeRegistry.get(state, 'Conference')
+        _styles: ColorSchemeRegistry.get(state, 'Conference'),
+        _inviteEnabled: getFeatureFlag(state, INVITE_ENABLED, true)
     };
 }
 

--- a/react/features/conference/components/native/LonelyMeetingExperience.js
+++ b/react/features/conference/components/native/LonelyMeetingExperience.js
@@ -85,13 +85,13 @@ class LonelyMeetingExperience extends PureComponent<Props> {
 
         return (
             <View style = { styles.lonelyMeetingContainer }>
-                <Text
+                { _inviteEnabled && (<Text
                     style = { [
                         styles.lonelyMessage,
                         _styles.lonelyMessage
                     ] }>
                     { t('lonelyMeetingExperience.youAreAlone') }
-                </Text>
+                </Text>) }
                 { !_isInviteFunctionsDiabled && _inviteEnabled && (
                     <TouchableOpacity
                         onPress = { this._onPress }

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -6,7 +6,7 @@ import Collapsible from 'react-native-collapsible';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { BottomSheet, hideDialog, isDialogOpen } from '../../../base/dialog';
-import { IOS_RECORDING_ENABLED, getFeatureFlag, INVITE_ENABLED } from '../../../base/flags';
+import { IOS_RECORDING_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { IconDragHandle } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
@@ -49,13 +49,7 @@ type Props = {
     /**
      * Used for hiding the dialog when the selection was completed.
      */
-    dispatch: Function,
-
-    /**
-     * Whether the invite people button is visible.
-     * Default: Visible (true)
-     */
-    _inviteEnabled: boolean,
+    dispatch: Function
 };
 
 type State = {
@@ -133,10 +127,7 @@ class OverflowMenu extends PureComponent<Props, State> {
                 onSwipe = { this._onSwipe }
                 renderHeader = { this._renderMenuExpandToggle }>
                 <AudioRouteButton { ...buttonProps } />
-                {
-                    this.props._inviteEnabled
-                    && <InviteButton { ...buttonProps } />
-                }
+                <InviteButton { ...buttonProps } />
                 <AudioOnlyButton { ...buttonProps } />
                 <RaiseHandButton { ...buttonProps } />
                 <MoreOptionsButton { ...moreOptionsButtonProps } />
@@ -250,8 +241,7 @@ function _mapStateToProps(state) {
     return {
         _bottomSheetStyles: ColorSchemeRegistry.get(state, 'BottomSheet'),
         _isOpen: isDialogOpen(state, OverflowMenu_),
-        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED),
-        _inviteEnabled: getFeatureFlag(state, INVITE_ENABLED, true)
+        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED)
     };
 }
 

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -6,7 +6,7 @@ import Collapsible from 'react-native-collapsible';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { BottomSheet, hideDialog, isDialogOpen } from '../../../base/dialog';
-import { IOS_RECORDING_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { IOS_RECORDING_ENABLED, getFeatureFlag, INVITE_ENABLED } from '../../../base/flags';
 import { IconDragHandle } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
@@ -49,7 +49,13 @@ type Props = {
     /**
      * Used for hiding the dialog when the selection was completed.
      */
-    dispatch: Function
+    dispatch: Function,
+
+    /**
+     * Whether the invite people button is visible.
+     * Default: Visible (true)
+     */
+    _inviteEnabled: boolean,
 };
 
 type State = {
@@ -127,7 +133,10 @@ class OverflowMenu extends PureComponent<Props, State> {
                 onSwipe = { this._onSwipe }
                 renderHeader = { this._renderMenuExpandToggle }>
                 <AudioRouteButton { ...buttonProps } />
-                <InviteButton { ...buttonProps } />
+                {
+                    this.props._inviteEnabled
+                    && <InviteButton { ...buttonProps } />
+                }
                 <AudioOnlyButton { ...buttonProps } />
                 <RaiseHandButton { ...buttonProps } />
                 <MoreOptionsButton { ...moreOptionsButtonProps } />
@@ -241,7 +250,8 @@ function _mapStateToProps(state) {
     return {
         _bottomSheetStyles: ColorSchemeRegistry.get(state, 'BottomSheet'),
         _isOpen: isDialogOpen(state, OverflowMenu_),
-        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED)
+        _recordingEnabled: Platform.OS !== 'ios' || getFeatureFlag(state, IOS_RECORDING_ENABLED),
+        _inviteEnabled: getFeatureFlag(state, INVITE_ENABLED, true)
     };
 }
 


### PR DESCRIPTION
Allows the user to show/hide "Invite people" button and "You are along" text on the conference page
Use key 'invite.enabled' as true or false to hide or show invite people button