### PR TITLE
jitsi-meet-turn: fix getting an external ip in IPv6 enabled networks

### DIFF
--- a/debian/jitsi-meet-turnserver.postinst
+++ b/debian/jitsi-meet-turnserver.postinst
@@ -106,10 +106,9 @@ case "$1" in
         TURN_SECRET="$RET"
 
         # no turn config exists, lt's copy template and fill it in
-        PUBLIC_IPv4=$(dig -4 +short myip.opendns.com a @resolver1.opendns.com) || true
-        PUBLIC_IPv6=$(dig -6 +short myip.opendns.com aaaa @resolver1.opendns.com) || true
-        if [ -z "$PUBLIC_IPv4" -a -z "$PUBLIC_IPv6" ] ; then
-            PUBLIC_IPv4="127.0.0.1"
+        PUBLIC_IP=$(dig -4 +short myip.opendns.com a @resolver1.opendns.com) || true
+        if [ -z "$PUBLIC_IP" ] ; then
+            PUBLIC_IP="127.0.0.1"
             echo "------------------------------------------------"
             echo "Warning! Could not resolve your external ip address! Error:^"
             echo "Your turn server will not work till you edit your $TURN_CONFIG config file."
@@ -119,16 +118,7 @@ case "$1" in
         cp /usr/share/jitsi-meet-turnserver/turnserver.conf $TURN_CONFIG
         sed -i "s/jitsi-meet.example.com/$JVB_HOSTNAME/g" $TURN_CONFIG
         sed -i "s/__turnSecret__/$TURN_SECRET/g" $TURN_CONFIG
-        if [ ! -z "$PUBLIC_IPv4" ] ; then
-            sed -i "s/__external_ipv4_address__/$PUBLIC_IPv4/g" $TURN_CONFIG
-        else
-            sed -i "/__external_ipv4_address__/d" $TURN_CONFIG
-        fi
-        if [ ! -z "$PUBLIC_IPv6" ] ; then
-            sed -i "s/__external_ipv6_address__/$PUBLIC_IPv6/g" $TURN_CONFIG
-        else
-            sed -i "/__external_ipv6_address__/d" $TURN_CONFIG
-        fi
+        sed -i "s/__external_ip_address__/$PUBLIC_IP/g" $TURN_CONFIG
 
         # SSL for nginx
         db_get jitsi-meet/cert-choice

--- a/debian/jitsi-meet-turnserver.postinst
+++ b/debian/jitsi-meet-turnserver.postinst
@@ -106,9 +106,10 @@ case "$1" in
         TURN_SECRET="$RET"
 
         # no turn config exists, lt's copy template and fill it in
-        PUBLIC_IP=$(dig +short myip.opendns.com @resolver1.opendns.com) || true
-        if [ -z "$PUBLIC_IP" ] ; then
-            PUBLIC_IP="127.0.0.1"
+        PUBLIC_IPv4=$(dig -4 +short myip.opendns.com a @resolver1.opendns.com) || true
+        PUBLIC_IPv6=$(dig -6 +short myip.opendns.com aaaa @resolver1.opendns.com) || true
+        if [ -z "$PUBLIC_IPv4" -a -z "$PUBLIC_IPv6" ] ; then
+            PUBLIC_IPv4="127.0.0.1"
             echo "------------------------------------------------"
             echo "Warning! Could not resolve your external ip address! Error:^"
             echo "Your turn server will not work till you edit your $TURN_CONFIG config file."
@@ -118,7 +119,16 @@ case "$1" in
         cp /usr/share/jitsi-meet-turnserver/turnserver.conf $TURN_CONFIG
         sed -i "s/jitsi-meet.example.com/$JVB_HOSTNAME/g" $TURN_CONFIG
         sed -i "s/__turnSecret__/$TURN_SECRET/g" $TURN_CONFIG
-        sed -i "s/__external_ip_address__/$PUBLIC_IP/g" $TURN_CONFIG
+        if [ ! -z "$PUBLIC_IPv4" ] ; then
+            sed -i "s/__external_ipv4_address__/$PUBLIC_IPv4/g" $TURN_CONFIG
+        else
+            sed -i "/__external_ipv4_address__/d" $TURN_CONFIG
+        fi
+        if [ ! -z "$PUBLIC_IPv6" ] ; then
+            sed -i "s/__external_ipv6_address__/$PUBLIC_IPv6/g" $TURN_CONFIG
+        else
+            sed -i "/__external_ipv6_address__/d" $TURN_CONFIG
+        fi
 
         # SSL for nginx
         db_get jitsi-meet/cert-choice

--- a/doc/debian/jitsi-meet-turn/turnserver.conf
+++ b/doc/debian/jitsi-meet-turn/turnserver.conf
@@ -9,6 +9,7 @@ pkey=/etc/jitsi/meet/jitsi-meet.example.com.key
 no-tcp
 listening-port=4446
 tls-listening-port=4445
-external-ip=__external_ip_address__
+external-ip=__external_ipv4_address__
+external-ip=__external_ipv6_address__
 
 syslog

--- a/doc/debian/jitsi-meet-turn/turnserver.conf
+++ b/doc/debian/jitsi-meet-turn/turnserver.conf
@@ -9,7 +9,6 @@ pkey=/etc/jitsi/meet/jitsi-meet.example.com.key
 no-tcp
 listening-port=4446
 tls-listening-port=4445
-external-ip=__external_ipv4_address__
-external-ip=__external_ipv6_address__
+external-ip=__external_ip_address__
 
 syslog


### PR DESCRIPTION
- adds the resolved ipv6 and ipv4 to external-ip if found

fixes #6165