### PR TITLE
Move STUN/TURN to IANA-assigned ports - 3478 and 5349 (TLS)

### DIFF
--- a/config.js
+++ b/config.js
@@ -339,7 +339,7 @@ var config = {
         // The STUN servers that will be used in the peer to peer connections
         stunServers: [
 
-            // { urls: 'stun:jitsi-meet.example.com:4446' },
+            // { urls: 'stun:jitsi-meet.example.com:3478' },
             { urls: 'stun:meet-jit-si-turnrelay.jitsi.net:443' }
         ],
 

--- a/debian/jitsi-meet-turnserver.postinst
+++ b/debian/jitsi-meet-turnserver.postinst
@@ -49,7 +49,7 @@ case "$1" in
                 # nothing to do
                 echo "------------------------------------------------"
                 echo ""
-                echo "turnserver is listening on tcp 4445 as other nginx sites use port 443"
+                echo "turnserver is listening on tcp 5349 as other nginx sites use port 443"
                 echo ""
                 echo "------------------------------------------------"
                 NGINX_MULTIPLEXING="false"
@@ -152,7 +152,7 @@ case "$1" in
             PROSODY_HOST_CONFIG="/etc/prosody/conf.avail/$JVB_HOSTNAME.cfg.lua"
             if [ -f $PROSODY_HOST_CONFIG ] ; then
                 # If we are not multiplexing we need to change the port in prosody config
-                sed -i 's/"443"/"4445"/g' $PROSODY_HOST_CONFIG
+                sed -i 's/"443"/"5349"/g' $PROSODY_HOST_CONFIG
                 invoke-rc.d prosody restart || true
             fi
         fi

--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -6,9 +6,9 @@ muc_mapper_domain_base = "jitmeet.example.com";
 turncredentials_secret = "__turnSecret__";
 
 turncredentials = {
-  { type = "stun", host = "jitmeet.example.com", port = "4446" },
-  { type = "turn", host = "jitmeet.example.com", port = "4446", transport = "udp" },
-  { type = "turns", host = "jitmeet.example.com", port = "443", transport = "tcp" }
+  { type = "stun", host = "jitmeet.example.com", port = "3478" },
+  { type = "turn", host = "jitmeet.example.com", port = "3478", transport = "udp" },
+  { type = "turns", host = "jitmeet.example.com", port = "5349", transport = "tcp" }
 };
 
 cross_domain_bosh = false;

--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -8,7 +8,7 @@ turncredentials_secret = "__turnSecret__";
 turncredentials = {
   { type = "stun", host = "jitmeet.example.com", port = "3478" },
   { type = "turn", host = "jitmeet.example.com", port = "3478", transport = "udp" },
-  { type = "turns", host = "jitmeet.example.com", port = "5349", transport = "tcp" }
+  { type = "turns", host = "jitmeet.example.com", port = "443", transport = "tcp" }
 };
 
 cross_domain_bosh = false;

--- a/doc/debian/jitsi-meet-turn/turnserver.conf
+++ b/doc/debian/jitsi-meet-turn/turnserver.conf
@@ -7,8 +7,8 @@ cert=/etc/jitsi/meet/jitsi-meet.example.com.crt
 pkey=/etc/jitsi/meet/jitsi-meet.example.com.key
 
 no-tcp
-listening-port=4446
-tls-listening-port=4445
+listening-port=3478
+tls-listening-port=5349
 external-ip=__external_ip_address__
 
 syslog

--- a/doc/debian/jitsi-meet/jitsi-meet.conf
+++ b/doc/debian/jitsi-meet/jitsi-meet.conf
@@ -7,7 +7,7 @@ stream {
         server 127.0.0.1:4444;
     }
     upstream turn {
-        server 127.0.0.1:4445;
+        server 127.0.0.1:5349;
     }
     # since 1.13.10
     map $ssl_preread_alpn_protocols $upstream {


### PR DESCRIPTION
See https://github.com/jitsi/jitsi-meet/pull/5714#issuecomment-615491997

This change moves STUN/TURN to the IANA-assigned ports, 3478 and 5349 (TLS)