### PR TITLE
Fix issue #6179 (do not create handlers if analytics are disabled)

### DIFF
--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -39,7 +39,7 @@ export function createLocalTrack(type: string, deviceId: string) {
 export function isAnalyticsEnabled(stateful: Function | Object) {
     const { disableThirdPartyRequests, analytics = {} } = toState(stateful)['features/base/config'];
 
-    return !(disableThirdPartyRequests || analytics.disabled);
+    return !(disableThirdPartyRequests || !analytics.googleAnalyticsTrackingId);
 }
 
 /**


### PR DESCRIPTION
In `react/features/base/lib-jitsi-meet/functions.any.js`, fixed function `isAnalyticsEnabled` to check for `analytics.googleAnalyticsTrackingId` and not `analytics.disabled` (that does not work) so that when analytics are disabled in the config file, the function returns the correct value (false).

```javascript
export function isAnalyticsEnabled(stateful: Function | Object) {
    const { disableThirdPartyRequests, analytics = {} } = toState(stateful)['features/base/config'];

    return !(disableThirdPartyRequests || !analytics.googleAnalyticsTrackingId);
}
```

This solves issue #6179, beacause in this way function `createHandlers` in `react/features/analytics/functions.js` returns an empty array and do not try to create handlers (that would lead to an error):

```javascript
export function createHandlers({ getState }: { getState: Function }) {
    getJitsiMeetGlobalNS().analyticsHandlers = [];
    window.analyticsHandlers = []; // Legacy support.

    if (!isAnalyticsEnabled(getState)) {
        return Promise.resolve([]);
    }

    const state = getState();
[...]
```