### PR TITLE
fix dev server backend default in development doc

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -69,7 +69,7 @@ Use it at the CLI, type
 make dev
 ```
 
-By default the backend deployment used is `beta.meet.jit.si`. You can point the Jitsi-Meet app at a different backend by using a proxy server. To do this, set the WEBPACK_DEV_SERVER_PROXY_TARGET variable:
+By default the backend deployment used is `alpha.jitsi.net`. You can point the Jitsi-Meet app at a different backend by using a proxy server. To do this, set the WEBPACK_DEV_SERVER_PROXY_TARGET variable:
 ```
 export WEBPACK_DEV_SERVER_PROXY_TARGET=https://your-example-server.com
 make dev


### PR DESCRIPTION
The development doc mentions `beta.meet.jit.si` as the default dev backend however the webpack config default to the alpha intead:
```
const devServerProxyTarget
    = process.env.WEBPACK_DEV_SERVER_PROXY_TARGET || 'https://alpha.jitsi.net';
```