### PR TITLE
fix: Hide live stream button if user isn't a moderator

### DIFF
--- a/react/features/recording/components/LiveStream/AbstractLiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/AbstractLiveStreamButton.js
@@ -96,13 +96,15 @@ export function _mapStateToProps(state: Object, ownProps: Props) {
         // If the containing component provides the visible prop, that is one
         // above all, but if not, the button should be autonomus and decide on
         // its own to be visible or not.
+        const isModerator = isLocalParticipantModerator(state);
         const {
             enableFeaturesBasedOnToken,
             liveStreamingEnabled
         } = state['features/base/config'];
         const { features = {} } = getLocalParticipant(state);
 
-        visible = liveStreamingEnabled;
+        visible = isModerator
+            && liveStreamingEnabled;
 
         if (enableFeaturesBasedOnToken) {
             visible = visible && String(features.livestreaming) === 'true';

--- a/react/features/recording/components/LiveStream/AbstractLiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/AbstractLiveStreamButton.js
@@ -2,7 +2,10 @@
 
 import { openDialog } from '../../../base/dialog';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { getLocalParticipant } from '../../../base/participants';
+import {
+    getLocalParticipant,
+    isLocalParticipantModerator
+} from '../../../base/participants';
 import {
     AbstractButton,
     type AbstractButtonProps


### PR DESCRIPTION
Right now with Jibri installed and set up, the "Start live stream" button is visible even on users who aren't moderators:

![Start live stream button present on a normal user](https://elixi.re/i/zi4wb9oc.png)

This is not the intended behavior, and trying to start live stream as a non-moderator will result in a permissions related error.

This PR adds a moderator check logic (similar to the one the recording button has) and fixes the aforementioned issue.

---

Edit: Signed CLA.