### PR TITLE
Fix wrong boolean value on _desktopSharingEnabled

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -907,7 +907,7 @@ class Toolbox extends Component<Props, State> {
                 <OverflowMenuItem
                     accessibilityLabel
                         = { t('toolbar.accessibilityLabel.shareYourScreen') }
-                    disabled = { _desktopSharingEnabled }
+                    disabled = { !_desktopSharingEnabled }
                     icon = { IconShareDesktop }
                     iconId = 'share-desktop'
                     key = 'desktop'


### PR DESCRIPTION
I've noticed that "start screen sharing" was always disabled on low res (on the OverflowMenuItem).
There is a small issue on the disabled property condition.

<img width="242" alt="Screenshot 2020-04-22 at 15 35 50" src="https://user-images.githubusercontent.com/1850538/79988475-fbafcd80-84ae-11ea-8fcd-62ad5c6593a1.png">
