### PR TITLE
Fix bug external iframe is blocked by third party cookie

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -316,7 +316,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._frame.style.border = 0;
         this._frame.setAttribute('data-cookiescript', 'accepted');
         this._frame.setAttribute('data-cookiecategory', 'functionality');
-        this._frame.alt = "Please accept cookie policy first";
+        this._frame.alt = 'Please accept cookie policy first';
 
         if (onload) {
             // waits for iframe resources to load

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -308,12 +308,15 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
         this._frame = document.createElement('iframe');
         this._frame.allow = 'camera; microphone; display-capture';
-        this._frame.src = this._url;
+        this._frame.setAttribute("data-src", this._url);
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);
         this._frame.setAttribute('allowFullScreen', 'true');
         this._frame.style.border = 0;
+        this._frame.setAttribute('data-cookiescript', 'accepted');
+        this._frame.setAttribute('data-cookiecategory', 'functionality');
+        this._frame.alt = "Please accept cookie policy first";
 
         if (onload) {
             // waits for iframe resources to load

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -308,7 +308,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
         this._frame = document.createElement('iframe');
         this._frame.allow = 'camera; microphone; display-capture';
-        this._frame.setAttribute("data-src", this._url);
+        this._frame.setAttribute('data-src', this._url);
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);


### PR DESCRIPTION
I read this [cookie-script page](https://mail.cookie-script.com/how-to-block-third-party-cookies.html) about third party cookie and maybe this would be to help asking for permissions before the iframe fails.