### PR TITLE
Update quick-install.md - jitsi behind proxying nginx

### DIFF
--- a/doc/quick-install.md
+++ b/doc/quick-install.md
@@ -80,6 +80,9 @@ And comment the existing `org.ice4j.ice.harvest.STUN_MAPPING_HARVESTER_ADDRESSES
 See [the documentation of ice4j](https://github.com/jitsi/ice4j/blob/master/doc/configuration.md)
 for details.
 
+If the installation is behind a proxying nginx server, remove /etc/nginx/modules-enabled/60-jitsi-meet.conf . Then go to /etc/nginx/site-available/your-conf and change it to listen on 443 instead of 4444 and restart nginx.
+
+
 Default deployments on systems using systemd will have low default values for maximum processes and open files. If the used bridge will expect higher number of participants the default values need to be adjusted (the default values are good for less than 100 participants).
 To update the values edit `/etc/systemd/system.conf` and make sure you have the following values:
 ```


### PR DESCRIPTION
Howto configure jitsi behind a proxying nginx server, according to damencho at https://community.jitsi.org/t/allow-jitsi-meet-to-run-behind-waf/40391/4