### PR TITLE
fix(RemoteVideo): .oncanplay -> addEventListener

### DIFF
--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -456,14 +456,16 @@ export default class RemoteVideo extends SmallVideo {
             return;
         }
 
-        streamElement.oncanplay = () => {
+        const listener = () => {
             this._canPlayEventReceived = true;
             this.VideoLayout.remoteVideoActive(streamElement, this.id);
-            streamElement.oncanplay = undefined;
+            streamElement.removeEventListener('canplay', listener);
 
             // Refresh to show the video
             this.updateView();
         };
+
+        streamElement.addEventListener('canplay', listener);
     }
 
     /**


### PR DESCRIPTION

Replaces the .oncanplay listener with addEventListener('canplay', ...).
This is needed because third party libraries (for example callstats)
are brutally overriding the .oncanplay property and replacing our
listener.