### PR TITLE
add support url (if present) to copied dialInfo

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -321,6 +321,7 @@
         "inviteLiveStream": "Klicken Sie auf {{url}} um den Livestream dieser Konferenz zu öffnen",
         "invitePhone": "Wenn Sie stattdessen per Telefon beitreten möchten, tippen Sie hier: {{number}},,{{conferenceID}}#\n",
         "invitePhoneAlternatives": "Suche nach einer anderen Einwahlnummer?\nMeetings-Einwahlnummern sehen: {{{url}}\n\n\n\nWenn Sie sich auch über ein Raumtelefon einwählen, nehmen Sie teil, ohne sich mit dem Ton zu verbinden: {{silentUrl}}",
+        "inviteSupportMsg": "\n\nUnterstützende Informationen sind hier verfügbar: {{url}}",
         "inviteURLFirstPartGeneral": "Sie wurden zur Teilnahme an einem Meeting eingeladen.",
         "inviteURLFirstPartPersonal": "{{name}} lädt Sie zu einem Meeting ein.\n",
         "inviteURLSecondPart": "\nAm Meeting teilnehmen:\n{{url}}\n",

--- a/lang/main.json
+++ b/lang/main.json
@@ -326,6 +326,7 @@
         "inviteLiveStream": "To view the live stream of this meeting, click this link: {{url}}",
         "invitePhone": "To join by phone instead, tap this: {{number}},,{{conferenceID}}#\n",
         "invitePhoneAlternatives": "Looking for a different dial-in number?\nSee meeting dial-in numbers: {{url}}\n\n\nIf also dialing-in through a room phone, join without connecting to audio: {{silentUrl}}",
+        "inviteSupportMsg": "\n\nSupporting information is available here: {{url}}",
         "inviteURLFirstPartGeneral": "You are invited to join a meeting.",
         "inviteURLFirstPartPersonal": "{{name}} is inviting you to a meeting.\n",
         "inviteURLSecondPart": "\nJoin the meeting:\n{{url}}\n",

--- a/react/features/invite/components/info-dialog/web/InfoDialog.js
+++ b/react/features/invite/components/info-dialog/web/InfoDialog.js
@@ -24,6 +24,7 @@ import logger from '../../../logger';
 import DialInNumber from './DialInNumber';
 import PasswordForm from './PasswordForm';
 
+declare var interfaceConfig: Object;
 
 /**
  * The type of the React {@code Component} props of {@link InfoDialog}.
@@ -318,6 +319,7 @@ class InfoDialog extends Component<Props, State> {
     _getTextToCopy() {
         const { _localParticipantName, liveStreamViewURL, t } = this.props;
         const _inviteURL = _decodeRoomURI(this.props._inviteURL);
+        const supportLink = interfaceConfig.SUPPORT_URL;
 
         let invite = _localParticipantName
             ? t('info.inviteURLFirstPartPersonal', { name: _localParticipantName })
@@ -349,6 +351,14 @@ class InfoDialog extends Component<Props, State> {
             });
 
             invite = `${invite}\n${dial}\n${moreNumbers}`;
+        }
+
+        if (supportLink) {
+            const msg = t('info.inviteSupportMsg', {
+                url: supportLink
+            });
+
+            invite += msg;
         }
 
         return invite;


### PR DESCRIPTION
If defined also add the support url to the copied data of a meeting invitation.

This may give participants some upfront information about joining the meeting rather than troubleshooting when they just tried and it didn't work.