### PR TITLE
Improved JitsiMeetExternalAPI documentation

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -273,7 +273,7 @@ api.executeCommand('avatarUrl', 'https://avatars0.githubusercontent.com/u/367164
 
 * **sendEndpointTextMessage** - Sends a text message to another participant through the datachannels.
 ```javascript
-api.executeCommand('receiverParticipantId', 'text');
+api.executeCommand('sendEndpointTextMessage', 'receiverParticipantId', 'text');
 ```
 
 You can also execute multiple commands using the `executeCommands` method:

--- a/doc/api.md
+++ b/doc/api.md
@@ -61,12 +61,13 @@ const options = {
 const api = new JitsiMeetExternalAPI(domain, options);
 ```
 
-You can overwrite options set in [config.js] and [interface_config.js].
-For example, to enable the filmstrip-only interface mode, you can use:
+You can overwrite options set in [config.js] and [interface_config.js] via **configOverwrite** and **interfaceConfigOverwrite** respectively.
+For example, to start with audio muted, and enable the filmstrip-only interface mode, you can use:
 
 ```javascript
 const options = {
     ...
+    configOverwrite: { startWithAudioMuted: true },
     interfaceConfigOverwrite: { filmStripOnly: true },
     ...
 };

--- a/doc/api.md
+++ b/doc/api.md
@@ -294,6 +294,10 @@ You can add event listeners to the embedded Jitsi Meet using the `addEventListen
 ```javascript
 api.addEventListener(event, listener);
 ```
+or, via the more modern method:
+```javascript
+api.addListener(event, listener);
+```
 
 The `event` parameter is a String object with the name of the event.
 The `listener` parameter is a Function object with one argument that will be notified when the event occurs with data related to the event.
@@ -537,6 +541,10 @@ If you want to remove a listener you can use `removeEventListener` method with a
 **NOTE: This method still exists but it is deprecated. JitsiMeetExternalAPI class extends [EventEmitter]. Use [EventEmitter] methods( `removeListener`).**
 ```javascript
 api.removeEventListener('incomingMessage');
+```
+or, via the more modern method:
+```javascript
+api.removeAllListeners('incomingMessage')
 ```
 
 If you want to remove more than one event you can use `removeEventListeners` method with an Array with the names of the events as an argument.


### PR DESCRIPTION
This PR makes three small improvements to the JitsiMeetExternalAPI documentation:
- Fixed missing `sendEndpointTextMessage` command name.
- Clarified that `configOverwrite` and `interfaceConfigOverwrite` are two separate dictionaries.
- Show modern EventEmitter-style `addListener` example next to the deprecation warning about the old-style `addEventListener` example.

I have, just a moment ago, signed the CLA.
