### PR TITLE
Update lang readme to match reality

### DIFF
--- a/lang/readme.md
+++ b/lang/readme.md
@@ -6,18 +6,12 @@ i18next uses separate json files for each language.
 
 Translating Jitsi Meet
 ======================
-The translation of Jitsi Meet is integrated with Pootle. You can translate Jitsi Meet via our Pootle user interface on
-[http://translate.jitsi.org](http://translate.jitsi.org).
-
-**WARNING: Please don't create or edit manually the language files! Please use our Pootle user interface!**
+The translation of Jitsi Meet is handled editing manually the language files.
 
 Development
 ===========
-If you want to add new functionality for Jitsi Meet and you have texts that need to be translated please use our translation module.
-It is located in modules/translation. You must add key and value in main.json file in English for each translatable text.
+If you want to add new functionality for Jitsi Meet and you have texts that need to be translated you must add key and value in main.json file in English for each translatable text.
 Than you can use the key to get the translated text for the current language.
-
-**WARNING: Please don't change the other language files except main.json! They must be updated and translated via our Pootle user interface!**
 
 You can add translatable text in the HTML:
 


### PR DESCRIPTION
It looks like i18n updates are done manually editing files there. http://translate.jitsi.org is not there anymore.