### PR TITLE
fix(native-ios): Provide a good place to specify BundleIdentifier and TeamID for more convenient onboarding (Issue #6554)

### DIFF
--- a/doc/mobile.md
+++ b/doc/mobile.md
@@ -69,10 +69,7 @@ supported for building the Android app and Windows **is not supported at alll**.
 
 3. Other remarks
 
-    It's likely you'll need to change the bundle ID for deploying to a device.
-    This can be changed in the "General" tab.  Under "Identity" set
-    "Bundle Identifier" to a different value, and adjust the "Team" in the
-    "Signing" section to match your own.
+	Adjust the `ios/xcconfig/Identity.xcconfig` file in your favorite editor to provide your TeamID and change the bundle Identifier base to be able to build on devices.
 
 
 ## Android

--- a/ios/app/app.xcodeproj/project.pbxproj
+++ b/ios/app/app.xcodeproj/project.pbxproj
@@ -121,6 +121,10 @@
 		DE4C456021DE1E4E00EA0709 /* FIRUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FIRUtilities.h; sourceTree = "<group>"; };
 		E58801132278944E008B0561 /* JitsiMeetContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JitsiMeetContext.swift; sourceTree = "<group>"; };
 		E5C97B62227A1EB400199214 /* JitsiMeetCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JitsiMeetCommands.swift; sourceTree = "<group>"; };
+		F2BABB5F246061E6008C0F26 /* Identity.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Identity.xcconfig; sourceTree = "<group>"; };
+		F2BABB60246061E6008C0F26 /* jitsi-meet.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "jitsi-meet.release.xcconfig"; sourceTree = "<group>"; };
+		F2BABB61246061E6008C0F26 /* jitsi-meet.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "jitsi-meet.debug.xcconfig"; sourceTree = "<group>"; };
+		F2BABB62246061E6008C0F26 /* default.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = default.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,6 +229,7 @@
 				83CBBA001A601CBA00E9B192 /* Products */,
 				13B07FAE1A68108700A75B9A /* src */,
 				5E96ADD5E49F3B3822EF9A52 /* Pods */,
+				F2BABB5E246061E6008C0F26 /* xcconfig */,
 				0BEA5C261F7B8F73000D0AB4 /* Watch app */,
 				0BEA5C351F7B8F73000D0AB4 /* WatchKit extension */,
 			);
@@ -240,6 +245,18 @@
 				0BEA5C311F7B8F73000D0AB4 /* JitsiMeetCompanion Extension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		F2BABB5E246061E6008C0F26 /* xcconfig */ = {
+			isa = PBXGroup;
+			children = (
+				F2BABB5F246061E6008C0F26 /* Identity.xcconfig */,
+				F2BABB60246061E6008C0F26 /* jitsi-meet.release.xcconfig */,
+				F2BABB61246061E6008C0F26 /* jitsi-meet.debug.xcconfig */,
+				F2BABB62246061E6008C0F26 /* default.xcconfig */,
+			);
+			name = xcconfig;
+			path = ../xcconfig;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -593,6 +610,7 @@
 /* Begin XCBuildConfiguration section */
 		0BEA5C421F7B8F73000D0AB4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -607,13 +625,13 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = JitsiMeetCompanion_Extension;
 				INFOPLIST_FILE = watchos/app/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet.watchkit;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet.watchkit";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -627,6 +645,7 @@
 		};
 		0BEA5C431F7B8F73000D0AB4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -641,14 +660,14 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				IBSC_MODULE = JitsiMeetCompanion_Extension;
 				INFOPLIST_FILE = watchos/app/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet.watchkit;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet.watchkit";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -661,6 +680,7 @@
 		};
 		0BEA5C441F7B8F73000D0AB4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -674,13 +694,13 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = watchos/extension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet.watchkit.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet.watchkit.extension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -694,6 +714,7 @@
 		};
 		0BEA5C451F7B8F73000D0AB4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -707,14 +728,14 @@
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = watchos/extension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet.watchkit.extension;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet.watchkit.extension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -732,11 +753,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDebug;
 				CODE_SIGN_ENTITLEMENTS = app.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -754,9 +774,8 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet";
 				PRODUCT_NAME = "jitsi-meet";
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -767,10 +786,9 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconRelease;
 				CODE_SIGN_ENTITLEMENTS = app.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = FC967L3QRG;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -788,14 +806,14 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.jitsi.meet;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLEIDENTIFIER_BASE).meet";
 				PRODUCT_NAME = "jitsi-meet";
-				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
 		83CBBA201A601CBA00E9B192 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -856,6 +874,7 @@
 		};
 		83CBBA211A601CBA00E9B192 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F2BABB62246061E6008C0F26 /* default.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;

--- a/ios/app/watchos/app/Info.plist
+++ b/ios/app/watchos/app/Info.plist
@@ -26,7 +26,7 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>org.jitsi.meet</string>
+	<string>$(APP_BUNDLEIDENTIFIER_BASE).meet</string>
 	<key>WKWatchKitApp</key>
 	<true/>
 </dict>

--- a/ios/app/watchos/extension/Info.plist
+++ b/ios/app/watchos/extension/Info.plist
@@ -33,7 +33,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>WKAppBundleIdentifier</key>
-			<string>org.jitsi.meet.watchkit</string>
+			<string>$(APP_BUNDLEIDENTIFIER_BASE).meet.watchkit</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>

--- a/ios/xcconfig/Identity.xcconfig
+++ b/ios/xcconfig/Identity.xcconfig
@@ -1,0 +1,8 @@
+// Change to yours (you find the id by 'security find-identity -v' it is the one inside the brackets, )
+// and then make git ignore it by
+// git update-index --skip-worktree BuildConfig/Identity.xcconfig
+DEVELOPMENT_TEAM = FC967L3QRG
+CODE_SIGN_IDENTITY = Apple Development
+
+// Also change this (e.g. prepend your org) to build on your account
+APP_BUNDLEIDENTIFIER_BASE = org.jitsi

--- a/ios/xcconfig/default.xcconfig
+++ b/ios/xcconfig/default.xcconfig
@@ -1,0 +1,1 @@
+#include "Identity.xcconfig"

--- a/ios/xcconfig/jitsi-meet.debug.xcconfig
+++ b/ios/xcconfig/jitsi-meet.debug.xcconfig
@@ -1,0 +1,2 @@
+#include "Identity.xcconfig"
+#include "../Pods/Target Support Files/Pods-jitsi-meet/Pods-jitsi-meet.debug.xcconfig"

--- a/ios/xcconfig/jitsi-meet.release.xcconfig
+++ b/ios/xcconfig/jitsi-meet.release.xcconfig
@@ -1,0 +1,2 @@
+#include "Identity.xcconfig"
+#include "../Pods/Target Support Files/Pods-jitsi-meet/Pods-jitsi-meet.debug.xcconfig"


### PR DESCRIPTION
Provided an `Identity.xcconfig` file that can be used for this purpose.

Also provided config files that include the pod config files to work. See [Stack-Overflow]( https://stackoverflow.com/questions/24236596/edit-xcode-xcconfig-file-and-cocoapods) for confirmation this works.

The rational is to get people quicker to have a working setup to contribute. (Manually changing Team and Identifier in the targets leads to annoying overhead and difficult to separate file changes, also there are 2 places where the bundle identifier is in plists that need to be adjusted)