### PR TITLE
fix(native-ui): reorder overflow menu options to be more accessible (issue #6552)

### DIFF
--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -125,14 +125,14 @@ class OverflowMenu extends PureComponent<Props, State> {
                 onCancel = { this._onCancel }
                 onSwipe = { this._onSwipe }
                 renderHeader = { this._renderMenuExpandToggle }>
-                <AudioRouteButton { ...buttonProps } />
-                <InviteButton { ...buttonProps } />
-                <AudioOnlyButton { ...buttonProps } />
                 <RaiseHandButton { ...buttonProps } />
+                <TileViewButton { ...buttonProps } />
+                <ToggleCameraButton { ...buttonProps } />
+                <InviteButton { ...buttonProps } />
                 <MoreOptionsButton { ...moreOptionsButtonProps } />
                 <Collapsible collapsed = { !showMore }>
-                    <ToggleCameraButton { ...buttonProps } />
-                    <TileViewButton { ...buttonProps } />
+                    <AudioOnlyButton { ...buttonProps } />
+                    <AudioRouteButton { ...buttonProps } />
                     <RecordButton { ...buttonProps } />
                     <LiveStreamButton { ...buttonProps } />
                     <RoomLockButton { ...buttonProps } />
@@ -159,7 +159,7 @@ class OverflowMenu extends PureComponent<Props, State> {
                     styles.expandMenuContainer
                 ] }>
                 <TouchableOpacity onPress = { this._onToggleMenu }>
-                    { /* $FlowFixMeProps */ }
+                    { /* $FlowFixMeProps */}
                     <IconDragHandle style = { this.props._bottomSheetStyles.expandIcon } />
                 </TouchableOpacity>
             </View>


### PR DESCRIPTION
Feel free to just close and ignore if you UI redesign is very immanent anyways. However, if not, please consider pulling this one in in the meantime making the more common choices easier accessible for new users at least.

#### before:
![before_short](https://user-images.githubusercontent.com/5106/80984790-a10f5d80-8e2e-11ea-8248-a1a9a829e953.png)
![before_full](https://user-images.githubusercontent.com/5106/80984786-9f459a00-8e2e-11ea-8814-343fd623a805.png)

#### after:
![after_short](https://user-images.githubusercontent.com/5106/80984796-a2d92100-8e2e-11ea-9952-3990933b3622.png)
![after_full](https://user-images.githubusercontent.com/5106/80984791-a1a7f400-8e2e-11ea-9cf7-e9e41691a7fa.png)
