### PR TITLE
Add participantRoleChanged event to external API

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2091,7 +2091,7 @@ export default {
         room.on(JitsiConferenceEvents.USER_ROLE_CHANGED, (id, role) => {
             if (this.isLocalId(id)) {
                 logger.info(`My role changed, new role: ${role}`);
-                
+
                 APP.store.dispatch(localParticipantRoleChanged(role));
                 APP.API.notifyUserRoleChanged(id, role);
             } else {

--- a/conference.js
+++ b/conference.js
@@ -2091,8 +2091,9 @@ export default {
         room.on(JitsiConferenceEvents.USER_ROLE_CHANGED, (id, role) => {
             if (this.isLocalId(id)) {
                 logger.info(`My role changed, new role: ${role}`);
-
+                
                 APP.store.dispatch(localParticipantRoleChanged(role));
+                APP.API.notifyUserRoleChanged(id, role);
             } else {
                 APP.store.dispatch(participantRoleChanged(id, role));
             }

--- a/doc/api.md
+++ b/doc/api.md
@@ -465,6 +465,14 @@ changes. The listener will receive an object with the following structure:
 }
 ```
 
+* **participantRoleChanged** - event notification fired when the role of the local user has changed (none, moderator, participant). The listener will receive an object with the following structure:
+```javascript
+{
+    id: string // the id of the participant
+    role: string // the new role of the participant
+}
+```
+
 * **passwordRequired** - event notifications fired when failing to join a room because it has a password.
 
 * **videoConferenceJoined** - event notifications fired when the local user has joined the video conference. The listener will receive an object with the following structure:

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -444,7 +444,7 @@ class API {
      * changed.
      *
      * @param {string} id - User id.
-     * @param (string) role - user's new role.
+     * @param (string) role - User's new role.
      * @returns {void}
      */
     notifyUserRoleChanged(id: string, role: string) {
@@ -454,7 +454,7 @@ class API {
             role
         });
     }
-    
+
     /**
      * Notify external application (if API is enabled) that user changed their
      * avatar.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -444,7 +444,7 @@ class API {
      * has changed.
      *
      * @param {string} id - User id.
-     * @param (string) role - The new user role.
+     * @param {string} role - The new user role.
      * @returns {void}
      */
     notifyUserRoleChanged(id: string, role: string) {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -440,11 +440,11 @@ class API {
     }
 
     /**
-     * Notify external application (if API is enabled) that user role has
-     * changed.
+     * Notify external application (if API is enabled) that the user role
+     * has changed.
      *
      * @param {string} id - User id.
-     * @param (string) role - User's new role.
+     * @param (string) role - The new user role.
      * @returns {void}
      */
     notifyUserRoleChanged(id: string, role: string) {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -440,6 +440,22 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that user role has
+     * changed.
+     *
+     * @param {string} id - User id.
+     * @param (string) role - user's new role.
+     * @returns {void}
+     */
+    notifyUserRoleChanged(id: string, role: string) {
+        this._sendEvent({
+            name: 'participant-role-changed',
+            id,
+            role
+        });
+    }
+    
+    /**
      * Notify external application (if API is enabled) that user changed their
      * avatar.
      *

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -67,6 +67,7 @@ const events = {
     'participant-joined': 'participantJoined',
     'participant-kicked-out': 'participantKickedOut',
     'participant-left': 'participantLeft',
+    'participant-role-changed': 'participantRoleChanged',
     'password-required': 'passwordRequired',
     'proxy-connection-event': 'proxyConnectionEvent',
     'video-ready-to-close': 'readyToClose',

--- a/react/features/base/participants/actionTypes.js
+++ b/react/features/base/participants/actionTypes.js
@@ -58,6 +58,19 @@ export const PARTICIPANT_DISPLAY_NAME_CHANGED
 export const PARTICIPANT_ID_CHANGED = 'PARTICIPANT_ID_CHANGED';
 
 /**
+ * Action to signal that participant role has changed. e.
+ *
+ * {
+ *     type: PARTICIPANT_ROLE_CHANGED,
+ *     participant: {
+ *         id: string
+ *     }
+ *     role: string
+ * }
+ */
+export const PARTICIPANT_ROLE_CHANGED = 'PARTICIPANT_ROLE_CHANGED';
+
+/**
  * Action to signal that a participant has joined.
  *
  * {

--- a/react/features/external-api/middleware.js
+++ b/react/features/external-api/middleware.js
@@ -12,6 +12,7 @@ import {
     PARTICIPANT_KICKED,
     PARTICIPANT_LEFT,
     PARTICIPANT_JOINED,
+    PARTICIPANT_ROLE_CHANGED,
     SET_LOADABLE_AVATAR_URL,
     getLocalParticipant,
     getParticipantById
@@ -156,6 +157,10 @@ MiddlewareRegistry.register(store => next => action => {
 
         break;
     }
+    
+    case PARTICIPANT_ROLE_CHANGED:
+        APP.API.notifyUserRoleChanged(action.participant.id, action.participant.role);
+        break;
 
     case SET_FILMSTRIP_VISIBLE:
         APP.API.notifyFilmstripDisplayChanged(action.visible);

--- a/react/features/external-api/middleware.js
+++ b/react/features/external-api/middleware.js
@@ -157,7 +157,7 @@ MiddlewareRegistry.register(store => next => action => {
 
         break;
     }
-    
+
     case PARTICIPANT_ROLE_CHANGED:
         APP.API.notifyUserRoleChanged(action.participant.id, action.participant.role);
         break;


### PR DESCRIPTION
Added participantRoleChanged event to the external API.
The event is fired when the conference participant role changes. This was done to facilitate the use of the password command - which can only be invoked if the participant is the moderator.