### PR TITLE
participants: fix accessing the local participant ID

### DIFF
--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -231,7 +231,7 @@ StateListenerRegistry.register(
 
                 });
         } else {
-            const localParticipantId = getLocalParticipant(store.getState).getId();
+            const localParticipantId = getLocalParticipant(store.getState).id;
 
             // We left the conference, the local participant must be updated.
             _e2eeUpdated(store, conference, localParticipantId, false);


### PR DESCRIPTION
getLocalParticipant returns a participant object stored in Redux, not a
JitsiParticipant object.