### PR TITLE
ref: disable ICE restart by default

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -356,6 +356,7 @@ class ConferenceConnector {
         }
 
         case JitsiConferenceErrors.FOCUS_LEFT:
+        case JitsiConferenceErrors.ICE_FAILED:
         case JitsiConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE:
         case JitsiConferenceErrors.OFFER_ANSWER_FAILED:
             APP.store.dispatch(conferenceWillLeave(room));

--- a/config.js
+++ b/config.js
@@ -226,6 +226,14 @@ var config = {
     // disabled, then bandwidth estimations are disabled.
     // enableRemb: false,
 
+    // Enables ICE restart logic in LJM and displays the page reload overlay on
+    // ICE failure. Current disabled by default because it's causing issues with
+    // signaling when Octo is enabled. Also when we do an "ICE restart"(which is
+    // not a real ICE restart), the client maintains the TCC sequence number
+    // counter, but the bridge resets it. The bridge sends media packets with
+    // TCC sequence numbers starting from 0.
+    // enableIceRestart: false,
+
     // Defines the minimum number of participants to start a call (the default
     // is set in Jicofo and set to 2).
     // minParticipants: 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10794,8 +10794,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#805eb938ae431cf71d67234fafaa35ae47be6308",
-      "from": "github:jitsi/lib-jitsi-meet#805eb938ae431cf71d67234fafaa35ae47be6308",
+      "version": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
+      "from": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
       "requires": {
         "@jitsi/sdp-interop": "1.0.2",
         "@jitsi/sdp-simulcast": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-utils": "github:jitsi/js-utils#cf11996bd866fdb47326c59a5d3bc24be17282d4",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#805eb938ae431cf71d67234fafaa35ae47be6308",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -101,6 +101,7 @@ export default [
     'e2eping',
     'enableDisplayNameInStats',
     'enableEmailInStats',
+    'enableIceRestart',
     'enableLayerSuspension',
     'enableLipSync',
     'enableRemb',

--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -64,6 +64,7 @@ export function isFatalJitsiConferenceError(error: Object | string) {
     return (
         error === JitsiConferenceErrors.FOCUS_DISCONNECTED
             || error === JitsiConferenceErrors.FOCUS_LEFT
+            || error === JitsiConferenceErrors.ICE_FAILED
             || error === JitsiConferenceErrors.OFFER_ANSWER_FAILED
             || error === JitsiConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE);
 }

--- a/react/features/overlay/components/AbstractPageReloadOverlay.js
+++ b/react/features/overlay/components/AbstractPageReloadOverlay.js
@@ -286,6 +286,6 @@ export function abstractMapStateToProps(state: Object) {
         details: fatalError && fatalError.details,
         isNetworkFailure:
             fatalError === configError || fatalError === connectionError,
-        reason: fatalError && fatalError.message
+        reason: fatalError && (fatalError.message || fatalError.name)
     };
 }


### PR DESCRIPTION
The reason for that it's currently causing issues with signaling when
Octo is enabled. Also when we do an "ICE restart"(which is not a real
ICE restart), the client maintains the TCC sequence number counter, but
the bridge resets it. The bridge sends media packets with TCC sequence
numbers starting from 0.

The 'enableIceRestart' config option can be used to force it, but it's
not recommended.

FIXME: update LJM before merging