### PR TITLE
Use certbot instead of certbot-auto

### DIFF
--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -10,7 +10,7 @@ DOMAIN="$(echo -e "${DOMAIN}" | tr -d '[:space:]')"
 echo "-------------------------------------------------------------------------"
 echo "This script will:"
 echo "- Need a working DNS record pointing to this machine(for domain ${DOMAIN})"
-echo "- Download certbot-auto from https://dl.eff.org to /usr/local/sbin"
+echo "- Download certbot from the debian package manager"
 echo "- Install additional dependencies in order to request Let’s Encrypt certificate"
 echo "- If running with jetty serving web content, will stop Jitsi Videobridge"
 echo "- Configure and reload nginx or apache2, whichever is used"
@@ -25,9 +25,10 @@ read EMAIL
 
 cd /usr/local/sbin
 
-if [ ! -f certbot-auto ] ; then
-  wget https://dl.eff.org/certbot-auto
-  chmod a+x ./certbot-auto
+if [ ! command -v certbot ] ; then
+    sudo add-apt-repository universe
+    sudo apt-get update
+    sudo apt-get -y install software-properties-common certbot
 fi
 
 CRON_FILE="/etc/cron.weekly/letsencrypt-renew"
@@ -51,13 +52,13 @@ if [ -f /etc/nginx/sites-enabled/$DOMAIN.conf ] ; then
         chmod u+x $TURN_HOOK
         sed -i "s/jitsi-meet.example.com/$DOMAIN/g" $TURN_HOOK
 
-        ./certbot-auto certonly --noninteractive \
+        certbot certonly --noninteractive \
         --webroot --webroot-path /usr/share/jitsi-meet \
         -d $DOMAIN \
         --agree-tos --email $EMAIL \
         --deploy-hook $TURN_HOOK
     else
-        ./certbot-auto certonly --noninteractive \
+        certbot certonly --noninteractive \
         --webroot --webroot-path /usr/share/jitsi-meet \
         -d $DOMAIN \
         --agree-tos --email $EMAIL
@@ -79,7 +80,7 @@ if [ -f /etc/nginx/sites-enabled/$DOMAIN.conf ] ; then
     service nginx reload
 elif [ -f /etc/apache2/sites-enabled/$DOMAIN.conf ] ; then
 
-    ./certbot-auto certonly --noninteractive \
+    certbot certonly --noninteractive \
     --webroot --webroot-path /usr/share/jitsi-meet \
     -d $DOMAIN \
     --agree-tos --email $EMAIL


### PR DESCRIPTION
See:
- https://github.com/jitsi/jitsi-meet/issues/6371
- https://github.com/jitsi/jitsi-meet/issues/6341
- https://github.com/jitsi/jitsi-meet/issues/6372
- https://github.com/zinc-collective/convene/pull/11

Unfortunately, certbot-auto will _not_ be updated to support Ubuntu
20.04. This is entirely reasonable, as the new certbot package appears
to provide all the functionality and can be installed from the universe
repository in 20.04-focal.

However, certbot does _not_ appear to be installable from the universe
repository in prior versions of Ubuntu server.

This is a quick spike that allowed me to get certbot working temporarily
on a fresh virtual machine, but probably should be extended to install
certbot-auto on systems which cannot install certbot via the package
manager.

Things probably worth doing before merging:

- [ ] install certbot-auto for pre-20.04 ubuntu(s)
- [ ] Dynamically dispatch the correct program (not sure how to do this
  in bash quite yet, but if y'all have suggestions, lmk!)