### PR TITLE
Allow underscore and dash in room names with Apache2

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -46,5 +46,6 @@
   ProxyPassReverse /http-bind http://localhost:5280/http-bind/
 
   RewriteEngine on
-  RewriteRule ^/([a-zA-Z0-9]+)$ /index.html
+  RewriteCond %{REQUEST_URI} !^/http-bind$
+  RewriteRule ^/([a-zA-Z0-9_-]+)$ /index.html
 </VirtualHost>


### PR DESCRIPTION
See #6536 

Tested with
* apache2/stable,stable,now 2.4.38-3+deb10u3
* jitsi-meet/stable,now 2.0.4548-1