### PR TITLE
added audioPermissionRequired option

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -495,9 +495,14 @@ export default {
      */
     createInitialLocalTracks(options = {}) {
         const errors = {};
-        const initialDevices = [ 'audio' ];
-        const requestedAudio = true;
+        const initialDevices = [];
+        let requestedAudio = false;
         let requestedVideo = false;
+
+        if (options.audioPermissionRequired) {
+            initialDevices.push('audio');
+            requestedAudio = true;
+        }
 
         // Always get a handle on the audio input device so that we have statistics even if the user joins the
         // conference muted. Previous implementation would only acquire the handle when the user first unmuted,
@@ -744,6 +749,7 @@ export default {
      */
     async init({ roomName }) {
         const initialOptions = {
+            audioPermissionRequired: config.audioPermissionRequired,
             startAudioOnly: config.startAudioOnly,
             startScreenSharing: config.startScreenSharing,
             startWithAudioMuted: config.startWithAudioMuted

--- a/config.js
+++ b/config.js
@@ -96,6 +96,8 @@ var config = {
     // applied locally. FIXME: having these 2 options is confusing.
     // startWithAudioMuted: false,
 
+    audioPermissionRequired: true,
+
     // Enabling it (with #params) will disable local audio output of remote
     // participants and to enable it back a reload is needed.
     // startSilent: false


### PR DESCRIPTION
Hi, what do you think about this option ?

I'd like to introduce a configuration option to omit the audio permission call in the browser in analogy to the video permission call. This way a user can enter a Jitsi room, communicate via text and enable audio and/or video on demand. 

I've already sign the CLA

belongs to https://community.jitsi.org/t/dont-ask-for-mic-permission-in-startwithaudiomuted/48132/3