### PR TITLE
Increase the width of the welcomescreen's "GO" button

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -212,7 +212,7 @@ $welcomePageTabContentDisplay: inherit;
 $welcomePageTabButtonsDisplay: flex;
 $welcomePageTabDisplay: block;
 
-$welcomePageButtonWidth: 51px;
+$welcomePageButtonWidth: 75px;
 $welcomePageButtonMinWidth: inherit;
 $welcomePageButtonFontSize: 14px;
 $welcomePageButtonHeight: 35px;


### PR DESCRIPTION
Non english languages have longer captions for this action and don't fit into the button. An example of that is the translation of "Go" in catalan: "Som-hi".  It does not fit and the hyphen breaks the word into two lines.

Disclaimer: this is my first contibution. Please be kind :)

![before](https://user-images.githubusercontent.com/10705635/81506395-45454880-92f6-11ea-8afb-8859f4e04607.gif)

![after](https://user-images.githubusercontent.com/10705635/81506396-45dddf00-92f6-11ea-9f32-a39e0b74a58e.gif)

