### PR TITLE
change cjson to cjson.safe and catch error from decode function

### DIFF
--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -7,7 +7,7 @@ local hex = require "util.hex";
 local jwt = require "luajwtjitsi";
 local http = require "net.http";
 local jid = require "util.jid";
-local json = require "cjson";
+local json_safe = require "cjson.safe";
 local path = require "util.paths";
 local sha256 = require "util.hashes".sha256;
 local timer = require "util.timer";
@@ -255,7 +255,10 @@ function Util:process_and_verify_token(session)
     if self.asapKeyServer and session.auth_token ~= nil then
         local dotFirst = session.auth_token:find("%.");
         if not dotFirst then return nil, "Invalid token" end
-        local header = json.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
+        local header, err = json_safe.decode(basexx.from_url64(session.auth_token:sub(1,dotFirst-1)));
+        if err then
+            return false, "not-allowed", "bad token format";
+        end
         local kid = header["kid"];
         if kid == nil then
             return false, "not-allowed", "'kid' claim is missing";


### PR DESCRIPTION
When using jitsi-meet with jwt, and jwt in invalid format, 
I get an error **/jitsi-meet/resources/prosody-plugins/token/util.lib.lua:258: Expected value but found invalid token at character 1**. So the purpose of this minor fix is ​​to catch the error, and return early without causing the frontend to hang.