### PR TITLE
fix: Fixed browser language detect (close #5987)

### DIFF
--- a/react/features/base/i18n/customNavigatorDetector.js
+++ b/react/features/base/i18n/customNavigatorDetector.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+declare var navigator: Object;
+
+/**
+ * Custom language detection, just returns the config property if any.
+ */
+export default {
+    /**
+     * Does not support caching.
+     *
+     * @returns {void}
+     */
+    cacheUserLanguage: Function.prototype,
+
+    /**
+     * Looks the language up in the config.
+     *
+     * @returns {string} The default language if any.
+     */
+    lookup() {
+        let found = [];
+
+        if (typeof navigator !== 'undefined') {
+            if (navigator.languages) {
+                // chrome only; not an array, so can't use .push.apply instead of iterating
+                for (let i = 0; i < navigator.languages.length; i++) {
+                    found.push(navigator.languages[i]);
+                }
+            }
+            if (navigator.userLanguage) {
+                found.push(navigator.userLanguage);
+            }
+            if (navigator.language) {
+                found.push(navigator.language);
+            }
+        }
+
+        // Fix language format (en-US => enUS)
+        found = found.map<string>(f => f.replace(/[-_]+/g, ''));
+
+        return found.length > 0 ? found : undefined;
+    },
+
+    /**
+     * Name of the language detector.
+     */
+    name: 'customNavigatorDetector'
+};

--- a/react/features/base/i18n/languageDetector.web.js
+++ b/react/features/base/i18n/languageDetector.web.js
@@ -3,6 +3,8 @@
 import BrowserLanguageDetector from 'i18next-browser-languagedetector';
 
 import configLanguageDetector from './configLanguageDetector';
+import customNavigatorDetector from './customNavigatorDetector';
+
 
 declare var interfaceConfig: Object;
 
@@ -14,13 +16,15 @@ declare var interfaceConfig: Object;
  */
 const order = [
     'querystring',
-    'localStorage',
-    configLanguageDetector.name
+    'localStorage'
 ];
 
 // Allow i18next to detect the system language reported by the Web browser
 // itself.
-interfaceConfig.LANG_DETECTION && order.push('navigator');
+interfaceConfig.LANG_DETECTION && order.push(customNavigatorDetector.name);
+
+// Default use configured language
+order.push(configLanguageDetector.name);
 
 /**
  * The singleton language detector for Web.
@@ -37,6 +41,7 @@ const languageDetector
 
 // Add the language detector which looks the language up in the config. Its
 // order has already been established above.
+languageDetector.addDetector(customNavigatorDetector);
 languageDetector.addDetector(configLanguageDetector);
 
 export default languageDetector;


### PR DESCRIPTION
* Fix detection order, use browser language before config language.
* Use a custom navigator detector to return names in the format "enUS" instead of "en-US".

I've already sign the CLA