### PR TITLE
ios: fix not activating Audio Unit in some corner cases

### DIFF
--- a/ios/sdk/src/callkit/JMCallKitEmitter.swift
+++ b/ios/sdk/src/callkit/JMCallKitEmitter.swift
@@ -71,6 +71,15 @@ internal final class JMCallKitEmitter: NSObject, CXProviderDelegate {
         action.fulfill()
     }
 
+    func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
+        listeners.forEach {
+            let listener = $0 as! JMCallKitListener
+            listener.performSetHeldCall?(UUID: action.callUUID, isOnHold: action.isOnHold)
+        }
+
+        action.fulfill()
+    }
+
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
         let uuid = pendingMuteActions.remove(action.uuid)
 

--- a/ios/sdk/src/callkit/JMCallKitListener.swift
+++ b/ios/sdk/src/callkit/JMCallKitListener.swift
@@ -26,6 +26,8 @@ import Foundation
 
     @objc optional func performEndCall(UUID: UUID)
 
+    @objc optional func performSetHeldCall(UUID: UUID, isOnHold: Bool)
+
     @objc optional func performSetMutedCall(UUID: UUID, isMuted: Bool)
 
     @objc optional func performStartCall(UUID: UUID, isVideo: Bool)

--- a/react/features/mobile/call-integration/CallKit.js
+++ b/react/features/mobile/call-integration/CallKit.js
@@ -47,6 +47,10 @@ if (CallKit) {
                     delegate._onPerformEndCallAction,
                     context),
                 CallKit.addListener(
+                    'performSetHeldCallAction',
+                    delegate._onPerformSetHeldCallAction,
+                    context),
+                CallKit.addListener(
                     'performSetMutedCallAction',
                     delegate._onPerformSetMutedCallAction,
                     context),

--- a/react/features/mobile/call-integration/middleware.js
+++ b/react/features/mobile/call-integration/middleware.js
@@ -113,6 +113,7 @@ function _appWillMount({ dispatch, getState }, next, action) {
     };
 
     const delegate = {
+        _onPerformSetHeldCallAction,
         _onPerformSetMutedCallAction,
         _onPerformEndCallAction
     };
@@ -360,6 +361,24 @@ function _onPerformEndCallAction({ callUUID }) {
         // Accept".
         delete conference.callUUID;
         dispatch(appNavigate(undefined));
+    }
+}
+
+/**
+ * Handles CallKit's event {@code performSetHeldCallAction}.
+ *
+ * @param {Object} event - The details of the CallKit event
+ * {@code performSetHeldCallAction}.
+ * @returns {void}
+ */
+function _onPerformSetHeldCallAction({ callUUID, onHold }) {
+    const { getState } = this; // eslint-disable-line no-invalid-this
+    const conference = getCurrentConference(getState);
+
+    if (conference && conference.callUUID === callUUID) {
+        if (AudioMode.setAudioEnabled) {
+            AudioMode.setAudioEnabled(!onHold);
+        }
     }
 }
 


### PR DESCRIPTION
When a user was in a conference, and then goes bacck to being alone the Audio
Unit may not work properly if this state lasted for too long (around the 10
minute mark).

The solution this commit implements is based on the use of manual audio, that
is, WebRTC will no longer activate / deactivate the audio unit by itself, we
have to. Thus the Audio Unit will not be enabled until there are at least 2
participants in the meeting.

This is not enough, however, since CallKit will put the AVAudioSession in a
weird state (setActive will jusst fail) after about 10 minutes, so we have to
add another workaround: "hold" the call in CallKit while we are alone in a
meeting.