### PR TITLE
ref: remove VIDEOBRIDGE_NOT_AVAILABLE

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -357,7 +357,6 @@ class ConferenceConnector {
 
         case JitsiConferenceErrors.FOCUS_LEFT:
         case JitsiConferenceErrors.ICE_FAILED:
-        case JitsiConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE:
         case JitsiConferenceErrors.OFFER_ANSWER_FAILED:
             APP.store.dispatch(conferenceWillLeave(room));
 

--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -65,8 +65,7 @@ export function isFatalJitsiConferenceError(error: Object | string) {
         error === JitsiConferenceErrors.FOCUS_DISCONNECTED
             || error === JitsiConferenceErrors.FOCUS_LEFT
             || error === JitsiConferenceErrors.ICE_FAILED
-            || error === JitsiConferenceErrors.OFFER_ANSWER_FAILED
-            || error === JitsiConferenceErrors.VIDEOBRIDGE_NOT_AVAILABLE);
+            || error === JitsiConferenceErrors.OFFER_ANSWER_FAILED);
 }
 
 /**


### PR DESCRIPTION
The event will not longer by emitted by lib-jitsi-meet. Jicofo is capable of starting the session as soon as a bridge becomes available, so there's no need to reload the page.