### PR TITLE
Fixed using deeplinks using external API

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -131,8 +131,8 @@ class DeepLinkingMobilePage extends Component<Props> {
                     </p>
                     <a
                         { ...onOpenLinkProperties }
-                        target= "_top"
                         href = { this._generateDownloadURL() }
+                        target = '_top'
                         onClick = { this._onDownloadApp }>
                         <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
@@ -141,8 +141,8 @@ class DeepLinkingMobilePage extends Component<Props> {
                     <a
                         { ...onOpenLinkProperties }
                         className = { `${_SNS}__href` }
-                        target= "_top"
                         href = { generateDeepLinkingURL() }
+                        target = '_top'
                         onClick = { this._onOpenApp }>
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -131,6 +131,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                     </p>
                     <a
                         { ...onOpenLinkProperties }
+                        target= "_top"
                         href = { this._generateDownloadURL() }
                         onClick = { this._onDownloadApp }>
                         <button className = { downloadButtonClassName }>
@@ -140,6 +141,7 @@ class DeepLinkingMobilePage extends Component<Props> {
                     <a
                         { ...onOpenLinkProperties }
                         className = { `${_SNS}__href` }
+                        target= "_top"
                         href = { generateDeepLinkingURL() }
                         onClick = { this._onOpenApp }>
                         {/* <button className = { `${_SNS}__button` }> */}

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -132,21 +132,21 @@ class DeepLinkingMobilePage extends Component<Props> {
                     <a
                         { ...onOpenLinkProperties }
                         href = { this._generateDownloadURL() }
-                        target = '_top'
                         onClick = { this._onDownloadApp }>
                         <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
+                        target = '_top'
                     </a>
                     <a
                         { ...onOpenLinkProperties }
                         className = { `${_SNS}__href` }
                         href = { generateDeepLinkingURL() }
-                        target = '_top'
                         onClick = { this._onOpenApp }>
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }
                         {/* </button> */}
+                        target = '_top'
                     </a>
                     { renderPromotionalFooter() }
                     <DialInSummary


### PR DESCRIPTION
This update opens links in the full body of the window so deeplinks will work on iOS Safari when using the external API in an iFrame.