### PR TITLE
fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14340,7 +14340,7 @@
       }
     },
     "react-emoji-render": {
-      "version": "1.0.0",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/react-emoji-render/-/react-emoji-render-1.2.4.tgz",
       "integrity": "sha512-AqktVXV38uDpgf02BoCXrzLYFsHAsxfdWwjrLexSJ22l1JgB01y1KejjxW/zTuCzod6O7BZfiMS866LEEfMHmA==",
       "requires": {


### PR DESCRIPTION
The commit from #6674 was missing the updated `version` field for `react-emoji-render` in `package-lock.json`, making it inconsistent (though working just fine for now). Sorry.

Thanks for spotting that, @netaskd!