### PR TITLE
webpack-server-dev: don't proxy /lang/

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -281,6 +281,7 @@ module.exports = [
 function devServerProxyBypass({ path }) {
     if (path.startsWith('/css/') || path.startsWith('/doc/')
             || path.startsWith('/fonts/') || path.startsWith('/images/')
+            || path.startsWith('/lang/')
             || path.startsWith('/sounds/')
             || path.startsWith('/static/')
             || path.endsWith('.wasm')) {


### PR DESCRIPTION
I was testing some translations but `make dev` kept serving me outdated files.