### PR TITLE
Allow to configure more than 5 colums in tile view

### DIFF
--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -31,7 +31,7 @@ export function getCurrentLayout(state: Object) {
 export function getMaxColumnCount() {
     const configuredMax = interfaceConfig.TILE_VIEW_MAX_COLUMNS || 5;
 
-    return Math.min(Math.max(configuredMax, 1), 5);
+    return Math.max(configuredMax, 1);
 }
 
 /**


### PR DESCRIPTION
For sessions with a bigger audience I would like to use more than 5 columns in the grid layout. We know, the automatic layout will choose the appropriate grid NxN size in the range [1..5] and then a 5xN layout with a vertical scrollbar. But for the moderator or speakers of a bigger conference, it's hard to recognize "raised hands" or get noticed of "comming-and-going" if he is forced to scroll around all the times. Maybe -- as a long-term feature -- every user may adjust the actually used maximum column value for it's on on client GUI.

The value for the column maximum `TILE_VIEW_MAX_COLUMNS` is already configurable via the `interface_config.js`. But this lines of code no just implement the default of '5' (which may be also refactored to a constant); the returned value is also clamped not to exceed this value. 

If there's no other technical reason, I suggest to **remove this limit** to allow any value of users choice. Of course, it's appropriate to clamp the value to be greater than zero because this is out-of-model and will prevent an impending div-by-zero upstream.