### PR TITLE
Fix keyboard accessibility on welcome page

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -161,6 +161,7 @@ body.welcome-page {
         vertical-align: middle;
         line-height: $welcomePageButtonLineHeight;
         cursor: pointer;
+        border: none;
     }
 
     .welcome-page-settings {

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -211,7 +211,7 @@ class WelcomePage extends AbstractWelcomePage {
                                     value = { this.state.room } />
                             </form>
                         </div>
-                        <div
+                        <button
                             className = 'welcome-page-button'
                             id = 'enter_room_button'
                             onClick = { this._onFormSubmit }>
@@ -220,7 +220,7 @@ class WelcomePage extends AbstractWelcomePage {
                                     ? t('welcomepage.goSmall')
                                     : t('welcomepage.go')
                             }
-                        </div>
+                        </button>
                     </div>
                     { this._renderTabs() }
                 </div>


### PR DESCRIPTION
Replace `<div>` with `<button>`

Closes #5992.

The button should be same:
![Clipboard01](https://user-images.githubusercontent.com/3362943/82124171-d1d78700-978c-11ea-9aba-c9f9585cc6a1.png)