### PR TITLE
Make the raisehand indicator more noticeable

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -363,8 +363,18 @@
     }
 }
 
+@keyframes raisehandanimation {
+  from {background: $raiseHandBg;}
+  to {background-color: red;}
+  to {background-color: red; transform: scale(1.1);}
+}
+
 .raisehandindicator {
-  background: $raiseHandBg;
+  animation-name: raisehandanimation;
+  animation-duration: 2s;
+  animation-direction: alternate;
+  animation-delay: 5s;
+  animation-iteration-count: infinite;
 }
 
 .connection-indicator {


### PR DESCRIPTION
I got feedback from my users that a busy moderator might need some more "help" to become perceived.

This patch make the raised hand icon become changing the color and slightly pulsating after a some seconds.

It is already approved and tested within https://github.com/igniterealtime/openfire-pade-plugin/commit/48c9afcb7d5634f2d2728939b86e9dbcc1d95a71 and should be pushed upstream herewith.