### PR TITLE
show non-encoded room name in auth dialog

### DIFF
--- a/modules/UI/authentication/AuthHandler.js
+++ b/modules/UI/authentication/AuthHandler.js
@@ -7,6 +7,9 @@ import {
 } from '../../../react/features/base/lib-jitsi-meet';
 import UIUtil from '../util/UIUtil';
 
+import { safeDecodeURIComponent } from '../../../react/features/base/util';
+import { safeStartCase } from '../../../react/features/base/conference/functions';
+
 import LoginDialog from './LoginDialog';
 
 const logger = require('jitsi-meet-logger').getLogger(__filename);
@@ -241,7 +244,8 @@ function requireAuth(room, lockPassword) {
     }
 
     authRequiredDialog = LoginDialog.showAuthRequiredDialog(
-        room.getName(), authenticate.bind(null, room, lockPassword)
+        safeStartCase(safeDecodeURIComponent(room.getName())),
+        authenticate.bind(null, room, lockPassword)
     );
 }
 

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -383,7 +383,7 @@ export function sendLocalParticipant(
  * @param {string} s - The string to do start case on.
  * @returns {string}
  */
-function safeStartCase(s = '') {
+export function safeStartCase(s = '') {
     return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
         (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
         , '');

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -383,8 +383,8 @@ export function sendLocalParticipant(
  * @param {string} s - The string to do start case on.
  * @returns {string}
  */
-export function safeStartCase(s = '') {
-    return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
+export function safeStartCase(s: string) {
+    return _.words(`${s || ''}`.replace(/['\u2019]/g, '')).reduce(
         (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
         , '');
 }


### PR DESCRIPTION
Fixes the [authentication dialog](https://github.com/jitsi/jicofo#secure-domain) showing room names in url-encoded form (which is unreadable unless it's ASCII).

I exported `safeStartCase` from `react/features/base/conference/functions.js` to re-use it, but maybe it should be added to `react/features/base/util` somewhere instead?

* [x] CLA signed