### PR TITLE
fix(prejoin_page): Always show 'join without audio' & add disabled button

### DIFF
--- a/css/_prejoin.scss
+++ b/css/_prejoin.scss
@@ -55,6 +55,23 @@
             margin: 0;
             padding: 0;
         }
+
+        &--disabled {
+            background: #5E6D7A;
+            border: 1px solid #5E6D7A;
+            color: #AFB6BC;
+            cursor: initial;
+
+            .prejoin-btn-icon {
+                & > svg {
+                    fill: #AFB6BC;
+                }
+            }
+
+            .prejoin-btn-options {
+                border-left: 1px solid #AFB6BC;
+            }
+        }
     }
 
     &-btn-options {
@@ -149,6 +166,11 @@
             &:-ms-input-placeholder {
                 @include name-placeholder;
             }
+        }
+
+        &--text {
+            margin: 16px 0;
+            outline: none;
         }
     }
 

--- a/react/features/prejoin/components/Prejoin.js
+++ b/react/features/prejoin/components/Prejoin.js
@@ -15,7 +15,7 @@ import { connect } from '../../base/redux';
 import { getDisplayName, updateSettings } from '../../base/settings';
 import ActionButton from './buttons/ActionButton';
 import {
-    areJoinByPhoneButtonsVisible,
+    isJoinByPhoneButtonVisible,
     isDeviceStatusVisible,
     isJoinByPhoneDialogVisible
 } from '../functions';
@@ -34,6 +34,11 @@ type Props = {
      * Flag signaling if the device status is visible or not.
      */
     deviceStatusVisible: boolean,
+
+    /**
+     * If join by phone button should be visible.
+     */
+    hasJoinByPhoneButton: boolean,
 
     /**
      * Flag signaling if a user is logged in or not.
@@ -79,11 +84,6 @@ type Props = {
      * If 'JoinByPhoneDialog' is visible or not.
      */
     showDialog: boolean,
-
-    /**
-     * If join by phone buttons should be visible.
-     */
-    hasJoinByPhoneButtons: boolean,
 
     /**
      * Used for translation.
@@ -210,11 +210,11 @@ class Prejoin extends Component<Props, State> {
     render() {
         const {
             deviceStatusVisible,
+            hasJoinByPhoneButton,
             isAnonymousUser,
             joinConference,
             joinConferenceWithoutAudio,
             name,
-            hasJoinByPhoneButtons,
             showDialog,
             t
         } = this.props;
@@ -251,7 +251,7 @@ class Prejoin extends Component<Props, State> {
                                             src = { IconVolumeOff } />
                                         { t('prejoin.joinWithoutAudio') }
                                     </div>
-                                    <div
+                                    {hasJoinByPhoneButton && <div
                                         className = 'prejoin-preview-dropdown-btn'
                                         onClick = { _showDialog }>
                                         <Icon
@@ -259,12 +259,13 @@ class Prejoin extends Component<Props, State> {
                                             size = { 24 }
                                             src = { IconPhone } />
                                         { t('prejoin.joinAudioByPhone') }
-                                    </div>
+                                    </div>}
                                 </div> }
                                 isOpen = { showJoinByPhoneButtons }
                                 onClose = { _onDropdownClose }>
                                 <ActionButton
-                                    hasOptions = { hasJoinByPhoneButtons }
+                                    disabled = { !name }
+                                    hasOptions = { true }
                                     onClick = { joinConference }
                                     onOptionsClick = { _onOptionsClick }
                                     type = 'primary'>
@@ -312,7 +313,7 @@ function mapStateToProps(state): Object {
         name: getDisplayName(state),
         roomName: getRoomName(state),
         showDialog: isJoinByPhoneDialogVisible(state),
-        hasJoinByPhoneButtons: areJoinByPhoneButtonsVisible(state)
+        hasJoinByPhoneButton: isJoinByPhoneButtonVisible(state)
     };
 }
 

--- a/react/features/prejoin/components/buttons/ActionButton.js
+++ b/react/features/prejoin/components/buttons/ActionButton.js
@@ -22,6 +22,11 @@ type Props = {
     className?: string,
 
     /**
+     * If the button is disabled or not.
+     */
+    disabled?: boolean,
+
+    /**
      * If the button has options.
      */
     hasOptions?: boolean,
@@ -47,18 +52,28 @@ type Props = {
  *
  * @returns {ReactElement}
  */
-function ActionButton({ children, className, hasOptions, type, onClick, onOptionsClick }: Props) {
-    const ownClassName = `prejoin-btn ${classNameByType[type]}`;
+function ActionButton({ children, className, disabled, hasOptions, type, onClick, onOptionsClick }: Props) {
+    let ownClassName = 'prejoin-btn';
+    let clickHandler = onClick;
+    let optionsClickHandler = onOptionsClick;
+
+    if (disabled) {
+        clickHandler = null;
+        optionsClickHandler = null;
+        ownClassName = `${ownClassName} prejoin-btn--disabled`;
+    } else {
+        ownClassName = `${ownClassName} ${classNameByType[type]}`;
+    }
     const cls = className ? `${className} ${ownClassName}` : ownClassName;
 
     return (
         <div
             className = { cls }
-            onClick = { onClick }>
+            onClick = { clickHandler }>
             {children}
             {hasOptions && <div
                 className = 'prejoin-btn-options'
-                onClick = { onOptionsClick }>
+                onClick = { optionsClickHandler }>
                 <Icon
                     className = 'prejoin-btn-icon'
                     size = { 14 }

--- a/react/features/prejoin/components/preview/ParticipantName.js
+++ b/react/features/prejoin/components/preview/ParticipantName.js
@@ -96,7 +96,7 @@ class ParticipantName extends Component<Props> {
                 value = { value } />
         )
             : <div
-                className = 'prejoin-preview-name'
+                className = 'prejoin-preview-name prejoin-preview-name--text'
                 onKeyDown = { _onKeyDown }
                 tabIndex = '0' >
                 {value}

--- a/react/features/prejoin/functions.js
+++ b/react/features/prejoin/functions.js
@@ -23,12 +23,12 @@ function applyMuteOptionsToTrack(track, shouldMute) {
 }
 
 /**
- * Selector for the visibility of the 'join by phone' buttons.
+ * Selector for the visibility of the 'join by phone' button.
  *
  * @param {Object} state - The state of the app.
  * @returns {boolean}
  */
-export function areJoinByPhoneButtonsVisible(state: Object): boolean {
+export function isJoinByPhoneButtonVisible(state: Object): boolean {
     return Boolean(getDialOutUrl(state) && getDialOutStatusUrl(state));
 }
 


### PR DESCRIPTION
* The prejoin page always displays the 'join without audio' option.
* The join button will be disabled if there is no input.
* Fix some CSS for the case when the user is not anonymous.