### PR TITLE
chore(deps): Update lib-jitsi-meet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10794,8 +10794,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
-      "from": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
+      "version": "github:jitsi/lib-jitsi-meet#49dd19c04a1bae25e27222a2b6dda54dc5620bf6",
+      "from": "github:jitsi/lib-jitsi-meet#49dd19c04a1bae25e27222a2b6dda54dc5620bf6",
       "requires": {
         "@jitsi/sdp-interop": "1.0.2",
         "@jitsi/sdp-simulcast": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-utils": "github:jitsi/js-utils#cf11996bd866fdb47326c59a5d3bc24be17282d4",
     "jsrsasign": "8.0.12",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#46691d8442b2db389170f9e67d8d1b84b164a493",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#49dd19c04a1bae25e27222a2b6dda54dc5620bf6",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",


### PR DESCRIPTION
fix(Firefox): Enable RTX support on Firefox
E2EE fixes/improvements
fix(screenshare): Add google conference flag only when simulcast is on
fix(video-quality): Apply pending video constraints on p2p originator