### PR TITLE
Retry "external_api: fixed using deeplinks"

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -125,7 +125,8 @@ class DeepLinkingMobilePage extends Component<Props> {
                     <a
                         { ...onOpenLinkProperties }
                         href = { this._generateDownloadURL() }
-                        onClick = { this._onDownloadApp }>
+                        onClick = { this._onDownloadApp }
+                        target = '_top'>
                         <button className = { downloadButtonClassName }>
                             { t(`${_TNS}.downloadApp`) }
                         </button>
@@ -134,7 +135,8 @@ class DeepLinkingMobilePage extends Component<Props> {
                         { ...onOpenLinkProperties }
                         className = { `${_SNS}__href` }
                         href = { generateDeepLinkingURL() }
-                        onClick = { this._onOpenApp }>
+                        onClick = { this._onOpenApp }
+                        target = '_top'>
                         {/* <button className = { `${_SNS}__button` }> */}
                         { t(`${_TNS}.openApp`) }
                         {/* </button> */}


### PR DESCRIPTION
Set `target='_top'` inside anchor.

Courtesy of #6700 by @msalmasi
Follow-up to: #6784

1. Open https://localhost:8080/test
2. Make sure `target='_top'` is applied to the button and the link
3. Make sure `target='_top'` is not appended as a plain text

![Clipboard01](https://user-images.githubusercontent.com/3362943/82413308-a098d880-9a64-11ea-84f4-9c7db4211206.png)
