### PR TITLE
debian/control: add missing build dependency on nodejs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: extra
 Maintainer: Jitsi Team <dev@jitsi.org>
 Uploaders: Emil Ivov <emcho@jitsi.org>, Damian Minkov <damencho@jitsi.org>
-Build-Depends: debhelper (>= 8.0.0)
+Build-Depends: debhelper (>= 8.0.0), nodejs
 Standards-Version: 3.9.6
 Homepage: https://jitsi.org/meet
 


### PR DESCRIPTION
Since `debian/rules` uses nodejs:

```
LANGUAGES := $(shell node -p "Object.keys(require('./lang/languages.json')).join(' ')")
```

* [x] CLA signed :)