### PR TITLE
fix(prejoin_page): Fix camera light being open while video disabled

### DIFF
--- a/react/features/base/media/functions.js
+++ b/react/features/base/media/functions.js
@@ -5,6 +5,17 @@ import { toState } from '../redux';
 import { VIDEO_MUTISM_AUTHORITY } from './constants';
 
 /**
+ * Determines whether audio is currently muted.
+ *
+ * @param {Function|Object} stateful - The redux store, state, or
+ * {@code getState} function.
+ * @returns {boolean}
+ */
+export function isAudioMuted(stateful: Function | Object) {
+    return Boolean(toState(stateful)['features/base/media'].audio.muted);
+}
+
+/**
  * Determines whether video is currently muted by the audio-only authority.
  *
  * @param {Function|Object} stateful - The redux store, state, or

--- a/react/features/prejoin/components/preview/Preview.js
+++ b/react/features/prejoin/components/preview/Preview.js
@@ -3,9 +3,9 @@
 import React from 'react';
 
 import { Avatar } from '../../../base/avatar';
-import { Video } from '../../../base/media';
+import { isVideoMutedByUser, Video } from '../../../base/media';
 import { connect } from '../../../base/redux';
-import { getActiveVideoTrack, isPrejoinVideoMuted } from '../../functions';
+import { getActiveVideoTrack } from '../../functions';
 
 export type Props = {
 
@@ -69,7 +69,7 @@ function Preview(props: Props) {
 function mapStateToProps(state) {
     return {
         videoTrack: getActiveVideoTrack(state),
-        showCameraPreview: !isPrejoinVideoMuted(state)
+        showCameraPreview: !isVideoMutedByUser(state)
     };
 }
 

--- a/react/features/prejoin/functions.js
+++ b/react/features/prejoin/functions.js
@@ -2,6 +2,7 @@
 
 import { getRoomName } from '../base/conference';
 import { getDialOutStatusUrl, getDialOutUrl } from '../base/config/functions';
+import { isAudioMuted, isVideoMutedByUser } from '../base/media';
 
 /**
  * Mutes or unmutes a track.
@@ -40,7 +41,7 @@ export function isJoinByPhoneButtonVisible(state: Object): boolean {
  */
 export function isDeviceStatusVisible(state: Object): boolean {
     return !((isAudioDisabled(state) && isPrejoinVideoDisabled(state))
-        || (isPrejoinAudioMuted(state) && isPrejoinVideoMuted(state)));
+        || (isAudioMuted(state) && isVideoMutedByUser(state)));
 }
 
 /**
@@ -75,13 +76,12 @@ export async function getAllPrejoinConfiguredTracks(state: Object): Promise<Obje
     if (csTrack) {
         tracks.push(csTrack);
     } else if (videoTrack) {
-        await applyMuteOptionsToTrack(videoTrack, isPrejoinVideoMuted(state));
+        await applyMuteOptionsToTrack(videoTrack, isVideoMutedByUser(state));
         tracks.push(videoTrack);
     }
 
     if (audioTrack) {
-        await applyMuteOptionsToTrack(audioTrack, isPrejoinAudioMuted(state));
-        isPrejoinAudioMuted(state) && audioTrack.mute();
+        await applyMuteOptionsToTrack(audioTrack, isAudioMuted(state));
         tracks.push(audioTrack);
     }
 
@@ -189,26 +189,6 @@ export function getFullDialOutNumber(state: Object): string {
  */
 export function getVideoTrack(state: Object): Object {
     return state['features/prejoin']?.videoTrack;
-}
-
-/**
- * Selector for getting the mute status of the prejoin audio.
- *
- * @param {Object} state - The state of the app.
- * @returns {boolean}
- */
-export function isPrejoinAudioMuted(state: Object): boolean {
-    return state['features/prejoin']?.audioMuted;
-}
-
-/**
- * Selector for getting the mute status of the prejoin video.
- *
- * @param {Object} state - The state of the app.
- * @returns {boolean}
- */
-export function isPrejoinVideoMuted(state: Object): boolean {
-    return state['features/prejoin']?.videoMuted;
 }
 
 /**

--- a/react/features/prejoin/middleware.js
+++ b/react/features/prejoin/middleware.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../base/media';
+import { SET_VIDEO_MUTED } from '../base/media';
 import { MiddlewareRegistry } from '../base/redux';
 import { updateSettings } from '../base/settings';
 
@@ -9,8 +9,8 @@ import {
     ADD_PREJOIN_VIDEO_TRACK,
     PREJOIN_START_CONFERENCE
 } from './actionTypes';
-import { setPrejoinAudioMuted, setPrejoinVideoMuted } from './actions';
-import { getAllPrejoinConfiguredTracks } from './functions';
+import { mutePrejoinVideo } from './actions';
+import { getAllPrejoinConfiguredTracks, isPrejoinPageVisible } from './functions';
 
 declare var APP: Object;
 
@@ -22,6 +22,7 @@ declare var APP: Object;
  */
 MiddlewareRegistry.register(store => next => async action => {
     switch (action.type) {
+
     case ADD_PREJOIN_AUDIO_TRACK: {
         const { value: audioTrack } = action;
 
@@ -67,13 +68,12 @@ MiddlewareRegistry.register(store => next => async action => {
         break;
     }
 
-    case SET_AUDIO_MUTED: {
-        store.dispatch(setPrejoinAudioMuted(Boolean(action.muted)));
-        break;
-    }
-
     case SET_VIDEO_MUTED: {
-        store.dispatch(setPrejoinVideoMuted(Boolean(action.muted)));
+        // Don't forward mute video action if not on prejoin page
+        if (isPrejoinPageVisible(store.getState())) {
+            store.dispatch(mutePrejoinVideo());
+        }
+
         break;
     }
 

--- a/react/features/prejoin/reducer.js
+++ b/react/features/prejoin/reducer.js
@@ -14,13 +14,11 @@ import {
     SET_PREJOIN_AUDIO_MUTED,
     SET_PREJOIN_DEVICE_ERRORS,
     SET_PREJOIN_PAGE_VISIBILITY,
-    SET_PREJOIN_VIDEO_DISABLED,
-    SET_PREJOIN_VIDEO_MUTED
+    SET_PREJOIN_VIDEO_DISABLED
 } from './actionTypes';
 
 const DEFAULT_STATE = {
     audioDisabled: false,
-    audioMuted: false,
     audioTrack: null,
     contentSharingTrack: null,
     country: '',
@@ -38,9 +36,8 @@ const DEFAULT_STATE = {
     showPrejoin: true,
     showJoinByPhoneDialog: false,
     userSelectedSkipPrejoin: false,
-    videoTrack: null,
-    videoDisabled: false,
-    videoMuted: false
+    videoTrack: undefined,
+    videoDisabled: false
 };
 
 /**
@@ -64,9 +61,11 @@ ReducerRegistry.register(
         }
 
         case ADD_PREJOIN_VIDEO_TRACK: {
+            const videoTrack = action.value;
+
             return {
                 ...state,
-                videoTrack: action.value
+                videoTrack
             };
         }
 
@@ -89,12 +88,6 @@ ReducerRegistry.register(
                 videoDisabled: action.value
             };
         }
-
-        case SET_PREJOIN_VIDEO_MUTED:
-            return {
-                ...state,
-                videoMuted: action.value
-            };
 
         case SET_PREJOIN_AUDIO_MUTED:
             return {

--- a/react/features/toolbox/components/AudioMuteButton.js
+++ b/react/features/toolbox/components/AudioMuteButton.js
@@ -7,16 +7,12 @@ import {
     sendAnalytics
 } from '../../analytics';
 import { translate } from '../../base/i18n';
-import { MEDIA_TYPE } from '../../base/media';
+import { isAudioMuted, MEDIA_TYPE } from '../../base/media';
 import { connect } from '../../base/redux';
 import { AbstractAudioMuteButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { isLocalTrackMuted } from '../../base/tracks';
-import {
-    isPrejoinAudioMuted,
-    isAudioDisabled,
-    isPrejoinPageVisible
-} from '../../prejoin/functions';
+import { isAudioDisabled, isPrejoinPageVisible } from '../../prejoin/functions';
 import { muteLocal } from '../../remote-video-menu/actions';
 
 declare var APP: Object;
@@ -158,7 +154,7 @@ function _mapStateToProps(state): Object {
     let _disabled;
 
     if (isPrejoinPageVisible(state)) {
-        _audioMuted = isPrejoinAudioMuted(state);
+        _audioMuted = isAudioMuted(state);
         _disabled = state['features/base/config'].startSilent;
     } else {
         const tracks = state['features/base/tracks'];

--- a/react/features/toolbox/components/VideoMuteButton.js
+++ b/react/features/toolbox/components/VideoMuteButton.js
@@ -12,17 +12,14 @@ import { setAudioOnly } from '../../base/audio-only';
 import { translate } from '../../base/i18n';
 import {
     VIDEO_MUTISM_AUTHORITY,
+    isVideoMutedByUser,
     setVideoMuted
 } from '../../base/media';
 import { connect } from '../../base/redux';
 import { AbstractVideoMuteButton } from '../../base/toolbox';
 import type { AbstractButtonProps } from '../../base/toolbox';
 import { getLocalVideoType, isLocalVideoTrackMuted } from '../../base/tracks';
-import {
-    isPrejoinPageVisible,
-    isPrejoinVideoDisabled,
-    isPrejoinVideoMuted
-} from '../../prejoin/functions';
+import { isPrejoinPageVisible, isPrejoinVideoDisabled } from '../../prejoin/functions';
 
 declare var APP: Object;
 
@@ -195,7 +192,7 @@ function _mapStateToProps(state): Object {
     let _videoDisabled = false;
 
     if (isPrejoinPageVisible(state)) {
-        _videoMuted = isPrejoinVideoMuted(state);
+        _videoMuted = isVideoMutedByUser(state);
         _videoDisabled = isPrejoinVideoDisabled(state);
     }
 


### PR DESCRIPTION
As @zbettenbuk noticed while on prejoin page the option of disabling video does not turn off the camera light. 

This MR fixes the problem by creating/destroying the video track according to the mute/unmute video option. 