### PR TITLE
Make header text on welcome page selectable

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -43,6 +43,10 @@ body.welcome-page {
             line-height: $welcomePageHeaderTextTitleLineHeight;
             margin-bottom: $welcomePageHeaderTextTitleMarginBottom;
             opacity: $welcomePageHeaderTextTitleOpacity;
+
+            // Fix #4814: refer _base.scss
+            -webkit-user-select: text;
+            user-select: text;
         }
 
         .header-text-description {
@@ -53,6 +57,10 @@ body.welcome-page {
             line-height: $welcomePageHeaderTextDescriptionLineHeight;
             margin-bottom: $welcomePageHeaderTextDescriptionMarginBottom;
             align-self: $welcomePageHeaderTextDescriptionAlignSelf;
+
+            // Fix #4814: refer _base.scss
+            -webkit-user-select: text;
+            user-select: text;
         }
 
         #enter_room {


### PR DESCRIPTION
This is a partial fix for #4814.

On https://meet.jit.si, elements inside `<template id =
"welcome-page-additional-content-template"></template>` need to be styled additionally. Until then #4814 should not be closed.