### PR TITLE
lang: enable support for romanian lang

### DIFF
--- a/react/features/base/i18n/BuiltinLanguages.native.js
+++ b/react/features/base/i18n/BuiltinLanguages.native.js
@@ -145,6 +145,12 @@ const _LANGUAGES = {
         main: require('../../../../lang/main-sc')
     },
 
+    // Romanian
+    'ro': {
+        languages: require('../../../../lang/languages-ro'),
+        main: require('../../../../lang/main-ro')
+    },
+
     // Russian
     'ru': {
         languages: require('../../../../lang/languages-ru'),


### PR DESCRIPTION
Translations were already added in a previous commit, but we still need to change BuiltinLanguages.native.js so that mobile apps have the lang available.