### PR TITLE
config: don't enable H.264 by default on P2P

### DIFF
--- a/config.js
+++ b/config.js
@@ -364,7 +364,7 @@ var config = {
 
         // If set to true, it will prefer to use H.264 for P2P calls (if H.264
         // is supported).
-        preferH264: true
+        // preferH264: true
 
         // If set to true, disable H.264 video codec by stripping it out of the
         // SDP.

--- a/config.js
+++ b/config.js
@@ -352,7 +352,7 @@ var config = {
 
             // { urls: 'stun:jitsi-meet.example.com:4446' },
             { urls: 'stun:meet-jit-si-turnrelay.jitsi.net:443' }
-        ],
+        ]
 
         // Sets the ICE transport policy for the p2p connection. At the time
         // of this writing the list of possible values are 'all' and 'relay',


### PR DESCRIPTION
We are not actively testing it and it currently crashes Chrome 83+ when insertable streams are used.