### PR TITLE
rn: fixup room lock prompt messsage

### DIFF
--- a/react/features/room-lock/components/RoomLockPrompt.native.js
+++ b/react/features/room-lock/components/RoomLockPrompt.native.js
@@ -77,7 +77,7 @@ class RoomLockPrompt extends Component<Props> {
 
         return (
             <InputDialog
-                contentKey = 'dialog.passwordLabel'
+                contentKey = 'security.about'
                 onCancel = { this._onCancel }
                 onSubmit = { this._onSubmit }
                 textInputProps = { textInputProps }

--- a/react/features/room-lock/components/RoomLockPrompt.native.js
+++ b/react/features/room-lock/components/RoomLockPrompt.native.js
@@ -129,10 +129,7 @@ class RoomLockPrompt extends Component<Props> {
     _validateInput(value: string) {
 
         // we want only digits, but both number-pad and numeric add ',' and '.' as symbols
-        if (this.props.passwordNumberOfDigits
-            && value.length > 0
-            && !/^\d+$/.test(value)) {
-
+        if (this.props.passwordNumberOfDigits && value.length > 0 && !/^\d+$/.test(value)) {
             return false;
         }
 


### PR DESCRIPTION
Prompt when trying to join a locked meeting.

<img width="545" alt="Screen Shot 2020-05-27 at 15 51 33" src="https://user-images.githubusercontent.com/317464/83029053-7e89f200-a032-11ea-8696-79c2e1c0fb56.png">

Prompt when adding a password to a meeting without one.

<img width="545" alt="Screen Shot 2020-05-27 at 15 52 02" src="https://user-images.githubusercontent.com/317464/83029079-89448700-a032-11ea-822d-3348e6e50801.png">

The latter used to be the same as the former, which is incorrect.