### PR TITLE
Skip global shortcut handling when meta key is pressed

### DIFF
--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -43,6 +43,11 @@ const KeyboardShortcut = {
             if (!enabled) {
                 return;
             }
+
+            if (e.metaKey) {
+                return;
+            }
+
             const key = this._getKeyboardKey(e).toUpperCase();
             const num = parseInt(key, 10);
 
@@ -62,6 +67,11 @@ const KeyboardShortcut = {
             if (!enabled) {
                 return;
             }
+
+            if (e.metaKey) {
+                return;
+            }
+
             if (!($(':focus').is('input[type=text]')
                 || $(':focus').is('input[type=password]')
                 || $(':focus').is('textarea'))) {


### PR DESCRIPTION
I keep triggering all kinds of unwanted things when controlling my window manager while Jitsi Meet is focussed. For example, to split windows, I press Windows key + D. Now when a Jitsi Meet window is in focus at the same time, the screen share dialog pops up, disrupting my call.

This patch should skip shortcut actions when the Windows key is held (Windows key = `metaKey` in web browsers, apparently). Note that I didn't actually test it, yet, because I didn't find the time to figure out how to build and run the project from source. However, I feel pretty confident that it is correct, so before I end up never submitting it, I just went ahead without testing. Hope you still find it useful.

Feel free to extend this to other modifier keys, of course - I just went with the least invasive possible patch to scratch my specific itch ;-)