### PR TITLE
Add missing country files to make source-files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,5 +88,6 @@ source-package:
 	mkdir -p source_package/jitsi-meet/css && \
 	cp -r *.js *.html resources/*.txt connection_optimization favicon.ico fonts images libs static sounds LICENSE lang source_package/jitsi-meet && \
 	cp css/all.css source_package/jitsi-meet/css && \
+	for c in $$(ls node_modules/i18n-iso-countries/langs); do cp node_modules/i18n-iso-countries/langs/$${c} source_package/jitsi-meet/lang/countries-$${c}; done && \
 	(cd source_package ; tar cjf ../jitsi-meet.tar.bz2 jitsi-meet) && \
 	rm -rf source_package


### PR DESCRIPTION
The source packages made by `make source-files` are missing the country files.

To test for this, deploy using the produced source files (https://download.jitsi.org/jitsi-meet/src) and load the page from a browser on a non-english locale:

![image](https://user-images.githubusercontent.com/1641362/83359169-c1bccb80-a378-11ea-902d-fcbe270aaaba.png)

My change simply copies the needed files from the node_modules folder to the final source folder.

---

Related question - would it be okay to also ship the `doc` folder(160K uncompressed) in the source build?

It would ease distro packaging from the source binaries, as currently one needs to pull the source + docs from git.