### PR TITLE
Add minimized mode for the meeting

### DIFF
--- a/css/_minimized.scss
+++ b/css/_minimized.scss
@@ -1,0 +1,18 @@
+.minimized-mode {
+    .filmstrip {
+        display: none;
+    }
+    .settings-button-small-icon {
+        display: none;
+    }
+    .new-toolbox .toolbox-content .button-group-center .toolbox-button .toolbox-icon,
+    .new-toolbox .toolbox-content .button-group-right .toolbox-button .toolbox-icon,
+    .new-toolbox .toolbox-content .button-group-left .toolbox-button .toolbox-icon {
+        width: 16px;
+        height: 16px;
+        svg {
+            width: 14px;
+            height: 14px;
+        }
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -96,5 +96,6 @@ $flagsImagePath: "../images/";
 @import 'country-picker';
 @import 'modals/invite/invite_more';
 @import 'modals/security/security';
+@import 'minimized';
 
 /* Modules END */

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -136,6 +136,10 @@ function initCommands() {
             sendAnalytics(createApiEvent('film.strip.toggled'));
             APP.UI.toggleFilmstrip();
         },
+        'toggle-minimized': () => {
+            sendAnalytics(createApiEvent('minimized.toggled'));
+            APP.UI.toggleMinimized();
+        },
         'toggle-chat': () => {
             sendAnalytics(createApiEvent('chat.toggled'));
             APP.UI.toggleChat();

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -39,6 +39,7 @@ const commands = {
     setVideoQuality: 'set-video-quality',
     subject: 'subject',
     submitFeedback: 'submit-feedback',
+    toggleMinimized: 'toggle-minimized',
     toggleAudio: 'toggle-audio',
     toggleChat: 'toggle-chat',
     toggleFilmStrip: 'toggle-film-strip',

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -10,6 +10,7 @@ import { getLocalParticipant } from '../../react/features/base/participants';
 import { toggleChat } from '../../react/features/chat';
 import { setDocumentUrl } from '../../react/features/etherpad';
 import { setFilmstripVisible } from '../../react/features/filmstrip';
+import { setMinimizedEnabled } from '../../react/features/minimized';
 import { joinLeaveNotificationsDisabled, setNotificationsEnabled } from '../../react/features/notifications';
 import {
     dockToolbox,
@@ -309,6 +310,15 @@ UI.toggleFilmstrip = function() {
     const { visible } = APP.store.getState()['features/filmstrip'];
 
     APP.store.dispatch(setFilmstripVisible(!visible));
+};
+
+/**
+ * Toggles minimized.
+ */
+UI.toggleMinimized = function() {
+    const { enabled } = APP.store.getState()['features/minimized'];
+
+    APP.store.dispatch(setMinimizedEnabled(!enabled));
 };
 
 /**

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -68,6 +68,11 @@ const LAYOUT_CLASSNAMES = {
 type Props = AbstractProps & {
 
     /**
+     * Whether the local participant is in minimized mode
+     */
+    _isMinimized: boolean,
+
+    /**
      * Whether the local participant is recording the conference.
      */
     _iAmRecorder: boolean,
@@ -181,21 +186,27 @@ class Conference extends AbstractConference<Props, *> {
             filmStripOnly: filmstripOnly
         } = interfaceConfig;
         const {
+            _isMinimized,
             _iAmRecorder,
             _layoutClassName,
             _showPrejoin
         } = this.props;
-        const hideLabels = filmstripOnly || _iAmRecorder;
+        const hideLabels = filmstripOnly || _iAmRecorder || _isMinimized;
+        let _minimizedClassName = '';
+        if (_isMinimized) {
+            _minimizedClassName = ' minimized-mode';
+        }
+
 
         return (
             <div
-                className = { _layoutClassName }
+                className = { _layoutClassName + _minimizedClassName }
                 id = 'videoconference_page'
                 onMouseMove = { this._onShowToolbar }>
 
                 <Notice />
                 <Subject />
-                <InviteMore />
+                { _isMinimized || <InviteMore />}
                 <div id = 'videospace'>
                     <LargeVideo />
                     { hideLabels
@@ -204,7 +215,7 @@ class Conference extends AbstractConference<Props, *> {
                 </div>
 
                 { filmstripOnly || _showPrejoin || <Toolbox /> }
-                { filmstripOnly || <Chat /> }
+                { _isMinimized || filmstripOnly || <Chat /> }
 
                 { this.renderNotificationsContainer() }
 
@@ -274,6 +285,7 @@ class Conference extends AbstractConference<Props, *> {
 function _mapStateToProps(state) {
     return {
         ...abstractMapStateToProps(state),
+        _isMinimized: state['features/minimized'].enabled,
         _iAmRecorder: state['features/base/config'].iAmRecorder,
         _layoutClassName: LAYOUT_CLASSNAMES[getCurrentLayout(state)],
         _roomName: getConferenceNameForTitle(state),

--- a/react/features/minimized/actionTypes.js
+++ b/react/features/minimized/actionTypes.js
@@ -1,0 +1,9 @@
+/**
+ * The type of (redux) action which sets whether the filmstrip is enabled.
+ *
+ * {
+ *     type: SET_MINIMIZED_ENABLED,
+ *     enabled: boolean
+ * }
+ */
+export const SET_MINIMIZED_ENABLED = 'SET_MINIMIZED_ENABLED';

--- a/react/features/minimized/actions.js
+++ b/react/features/minimized/actions.js
@@ -1,0 +1,21 @@
+// @flow
+
+import {
+    SET_MINIMIZED_ENABLED
+} from './actionTypes';
+
+/**
+ * Sets whether the minimized is enabled.
+ *
+ * @param {boolean} enabled - Whether the minimized is enabled.
+ * @returns {{
+ *     type: SET_MINIMIZED_ENABLED,
+ *     enabled: boolean
+ * }}
+ */
+export function setMinimizedEnabled(enabled: boolean) {
+    return {
+        type: SET_MINIMIZED_ENABLED,
+        enabled
+    };
+}

--- a/react/features/minimized/index.js
+++ b/react/features/minimized/index.js
@@ -1,0 +1,4 @@
+export * from './actions';
+export * from './actionTypes';
+
+import './reducer';

--- a/react/features/minimized/reducer.js
+++ b/react/features/minimized/reducer.js
@@ -1,0 +1,31 @@
+// @flow
+
+import { ReducerRegistry } from '../base/redux';
+
+import {
+    SET_MINIMIZED_ENABLED
+} from './actionTypes';
+
+const DEFAULT_STATE = {
+    /**
+     * The indicator which determines whether the minimized mode is enabled.
+     *
+     * @public
+     * @type {boolean}
+     */
+    enabled: true
+};
+
+ReducerRegistry.register(
+    'features/minimized',
+    (state = DEFAULT_STATE, action) => {
+        switch (action.type) {
+        case SET_MINIMIZED_ENABLED:
+            return {
+                ...state,
+                enabled: action.enabled
+            };
+        }
+
+        return state;
+    });


### PR DESCRIPTION
This is a proof of concept of the idea of support "minimized" mode for the
Jitsi embeded iframe.

For easy the process of taking a look of the idea, I had set it on as default,
but of course it should be off by default, and enabled/disabled through the
external api.

I don't know how much I'm interfering in other part.

ToDo:
  - Modify the styles of the notifications to be shown as somethi more sensible
    in this context (probably a full with box at the top of the minimized
    screen). Maybe other option is to not show the notification and send the
    notifications to the external app and give them the responsability of
    inform the user.
  - Disable the shortcuts that makes no sense in this environment (for example,
    toggle chat, filmstrip and things like that).
  - The interface is really restricted, but in theory you should be able to
    maximize the app again and use, for example the dropdowns to select the
    camera or whatever you want.
  - Ensure the tileView is always disable in the minimized mode (not storing
    the tileView as disable, the tileView is going to keep its own state, but
    is going to be shown as no-tiled view when is minimized)

Of course this is for open the discussion and see if it makes sense and do you
like to have this feature, I'm more than happy on keep working on it and move
it forward to an stable/acceptable state.

#### Sample Screenshot
![image](https://user-images.githubusercontent.com/290303/83434368-a4e8cc80-a43a-11ea-9694-8fe1722e0caa.png)
