### PR TITLE
auth: implement extension point to allow for branding to dictate redi…

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -198,6 +198,14 @@ var interfaceConfig = {
     DISABLE_PRESENCE_STATUS: false,
 
     /**
+     * If window.waitForRedirect exists, is a Promise and resolves
+     * successfully, this is the URL that the page will be redirected to,
+     * effectively shortcircuiting the conference - useful in cases where
+     * the meeting join needs to be delegated to another context / deployment
+     */
+    PREJOIN_REDIRECT_URL: undefined,
+
+    /**
      * If true, notifications regarding joining/leaving are no longer displayed.
      */
     DISABLE_JOIN_LEAVE_NOTIFICATIONS: false,


### PR DESCRIPTION
…rection in case of existing authentication

So, the intent here is to be able to redirect right before joining a meeting, if you already have credentials. This seemed like a non-intrusive approach where:
- _jitsi-meet_ looks for an existing global promise and uses it for timing in case it's there
- code in branding will put the global there and takes care of determining if the user has credentials or not

WDYT?