### PR TITLE
add feature flag to enable / disable conference timer

### DIFF
--- a/react/features/base/flags/constants.js
+++ b/react/features/base/flags/constants.js
@@ -26,6 +26,12 @@ export const CALL_INTEGRATION_ENABLED = 'call-integration.enabled';
 export const CLOSE_CAPTIONS_ENABLED = 'close-captions.enabled';
 
 /**
+ * Flag indicating if conference timer should be enabled.
+ * Default: enabled (true).
+ */
+export const CONFERENCE_TIMER_ENABLED = 'conference-timer.enabled';
+
+/**
  * Flag indicating if chat should be enabled.
  * Default: enabled (true).
  */

--- a/react/features/conference/components/native/NavigationBar.js
+++ b/react/features/conference/components/native/NavigationBar.js
@@ -5,7 +5,7 @@ import { SafeAreaView, Text, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
 import { getConferenceName } from '../../../base/conference';
-import { getFeatureFlag, MEETING_NAME_ENABLED } from '../../../base/flags';
+import { getFeatureFlag, CONFERENCE_TIMER_ENABLED, MEETING_NAME_ENABLED } from '../../../base/flags';
 import { connect } from '../../../base/redux';
 import { PictureInPictureButton } from '../../../mobile/picture-in-picture';
 import { isToolboxVisible } from '../../../toolbox';
@@ -14,6 +14,11 @@ import ConferenceTimer from '../ConferenceTimer';
 import styles, { NAVBAR_GRADIENT_COLORS } from './styles';
 
 type Props = {
+
+    /**
+     * Whether displaying the current conference timer is enabled or not.
+     */
+    _conferenceTimerEnabled: boolean,
 
     /**
      * Name of the meeting we're currently in.
@@ -73,7 +78,9 @@ class NavigationBar extends Component<Props> {
                             { this.props._meetingName }
                         </Text>
                     }
-                    <ConferenceTimer />
+                    {
+                        this.props._conferenceTimerEnabled ? <ConferenceTimer /> : null
+                    }
                 </View>
             </View>
         ];
@@ -89,6 +96,7 @@ class NavigationBar extends Component<Props> {
  */
 function _mapStateToProps(state) {
     return {
+        _conferenceTimerEnabled: getFeatureFlag(state, CONFERENCE_TIMER_ENABLED, true),
         _meetingName: getConferenceName(state),
         _meetingNameEnabled: getFeatureFlag(state, MEETING_NAME_ENABLED, true),
         _visible: isToolboxVisible(state)

--- a/react/features/conference/components/native/NavigationBar.js
+++ b/react/features/conference/components/native/NavigationBar.js
@@ -79,7 +79,7 @@ class NavigationBar extends Component<Props> {
                         </Text>
                     }
                     {
-                        this.props._conferenceTimerEnabled ? <ConferenceTimer /> : null
+                        this.props._conferenceTimerEnabled && <ConferenceTimer />
                     }
                 </View>
             </View>


### PR DESCRIPTION
This PR will add a "conference-timer.enabled" flag that will allow to show / hide the conference timer