### PR TITLE
Fix audio device selection

### DIFF
--- a/css/_audio-preview.css
+++ b/css/_audio-preview.css
@@ -1,5 +1,6 @@
 .audio-preview {
     &-content {
+        background: #2A3A4B;
         font-size: 15px;
         line-height: 24px;
         max-height: 456px;
@@ -32,7 +33,7 @@
         margin-left: 48px;
 
         &--selected {
-            background: rgba(28,32,37,0.5);
+            background: #1C2025;
             cursor: initial;
             margin-left: 0;
             padding-left: 21px;
@@ -55,7 +56,7 @@
 
         &:hover {
             .audio-preview-entry {
-                background: rgba(255,255,255, 0.2);
+                background: #3F4E5E;
                 margin-left: 0;
                 padding-left: 48px;
 
@@ -80,8 +81,23 @@
 
     &-microphone {
         position: relative;
-    }
 
+        &:hover {
+            .audio-preview-entry {
+                background: #3F4E5E;
+                margin-left: 0;
+                padding-left: 48px;
+
+                &--selected {
+                    padding-left: 21px;
+                }
+            }
+        }
+
+        .audio-preview-entry-text {
+            max-width: 196px;
+        }
+    }
 
     &-icon {
         border-radius: 50%;

--- a/react/features/base/devices/actions.js
+++ b/react/features/base/devices/actions.js
@@ -243,8 +243,10 @@ export function setAudioInputDeviceAndUpdateSettings(deviceId) {
  * @returns {Function}
  */
 export function setAudioOutputDevice(deviceId) {
-    return function(dispatch) {
-        return setAudioOutputDeviceId(deviceId, dispatch);
+    return function(dispatch, getState) {
+        const deviceLabel = getDeviceLabelById(getState(), deviceId, 'audioOutput');
+
+        return setAudioOutputDeviceId(deviceId, dispatch, true, deviceLabel);
     };
 }
 

--- a/react/features/base/devices/functions.js
+++ b/react/features/base/devices/functions.js
@@ -8,6 +8,12 @@ import logger from './logger';
 
 declare var APP: Object;
 
+const webrtcKindToJitsiKindTranslator = {
+    audioinput: 'audioInput',
+    audiooutput: 'audioOutput',
+    videoinput: 'videoInput'
+};
+
 /**
  * Detects the use case when the labels are not available if the A/V permissions
  * are not yet granted.
@@ -42,6 +48,29 @@ export function getAudioOutputDeviceId() {
 }
 
 /**
+ * Finds the real device id of the default device of the given type.
+ *
+ * @param {Object} state - The redux state.
+ * @param {*} kind - The type of the device. One of "audioInput",
+ * "audioOutput", and "videoInput". Also supported is all lowercase versions
+ * of the preceding types.
+ * @returns {string|undefined}
+ */
+export function getDefaultDeviceId(state: Object, kind: string) {
+    const kindToSearch = webrtcKindToJitsiKindTranslator[kind] || kind;
+    const defaultDevice = (state['features/base/devices'].availableDevices[kindToSearch] || [])
+        .find(d => d.deviceId === 'default');
+
+    // Find the device with a matching group id.
+    const matchingDevice = (state['features/base/devices'].availableDevices[kindToSearch] || [])
+        .find(d => d.deviceId !== 'default' && d.groupId === defaultDevice.groupId);
+
+    if (matchingDevice) {
+        return matchingDevice.deviceId;
+    }
+}
+
+/**
  * Finds a device with a label that matches the passed label and returns its id.
  *
  * @param {Object} state - The redux state.
@@ -52,12 +81,6 @@ export function getAudioOutputDeviceId() {
  * @returns {string|undefined}
  */
 export function getDeviceIdByLabel(state: Object, label: string, kind: string) {
-    const webrtcKindToJitsiKindTranslator = {
-        audioinput: 'audioInput',
-        audiooutput: 'audioOutput',
-        videoinput: 'videoInput'
-    };
-
     const kindToSearch = webrtcKindToJitsiKindTranslator[kind] || kind;
 
     const device
@@ -80,12 +103,6 @@ export function getDeviceIdByLabel(state: Object, label: string, kind: string) {
  * @returns {string|undefined}
  */
 export function getDeviceLabelById(state: Object, id: string, kind: string) {
-    const webrtcKindToJitsiKindTranslator = {
-        audioinput: 'audioInput',
-        audiooutput: 'audioOutput',
-        videoinput: 'videoInput'
-    };
-
     const kindToSearch = webrtcKindToJitsiKindTranslator[kind] || kind;
 
     const device

--- a/react/features/toolbox/components/web/AudioSettingsButton.js
+++ b/react/features/toolbox/components/web/AudioSettingsButton.js
@@ -117,7 +117,9 @@ class AudioSettingsButton extends Component<Props, State> {
      */
     render() {
         const { isDisabled, onAudioOptionsClick, visible } = this.props;
-        const settingsDisabled = !this.state.hasPermissions || isDisabled;
+        const settingsDisabled = !this.state.hasPermissions
+            || isDisabled
+            || !JitsiMeetJS.mediaDevices.isMultipleAudioInputSupported();
 
         return visible ? (
             <AudioSettingsPopup>


### PR DESCRIPTION
Pass the real deviceId to gUM instead of 'default' for Chrome to return the correct media stream.
Update userSelectedAudioOutputDeviceId and userSelectedAudioOutputDeviceLabel when a new speaker is selected from the audio settings popup menu.
Disable audio settings pop-up on Firefox as changing mics isn't currently supported.