### PR TITLE
fix: Fixes setting subject from url.

### DIFF
--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -16,6 +16,7 @@ import {
     getLocalParticipant,
     getParticipantById,
     getPinnedParticipant,
+    PARTICIPANT_ROLE,
     PARTICIPANT_UPDATED,
     PIN_PARTICIPANT
 } from '../participants';
@@ -602,13 +603,26 @@ function _trackAddedOrRemoved(store, next, action) {
  * @private
  * @returns {Object} The value returned by {@code next(action)}.
  */
-function _updateLocalParticipantInConference({ getState }, next, action) {
+function _updateLocalParticipantInConference({ dispatch, getState }, next, action) {
     const { conference } = getState()['features/base/conference'];
     const { participant } = action;
     const result = next(action);
 
-    if (conference && participant.local && 'name' in participant) {
-        conference.setDisplayName(participant.name);
+    const localParticipant = getLocalParticipant(getState);
+
+    if (conference && participant.id === localParticipant.id) {
+        if ('name' in participant) {
+            conference.setDisplayName(participant.name);
+        }
+
+        const { pendingSubjectChange, subject } = getState()['features/base/conference'];
+        const isModerator = participant.role === PARTICIPANT_ROLE.MODERATOR;
+
+        // when local user role is updated to moderator and we have a pending subject change
+        // which was not reflected we need to set it (the first time we tried was before becoming moderator)
+        if (isModerator && pendingSubjectChange !== subject) {
+            dispatch(setSubject(pendingSubjectChange));
+        }
     }
 
     return result;


### PR DESCRIPTION
There are occasions when role to moderator can change a little bit after joining the room, and initial try to set subject will silently be ignored if not moderator.