### PR TITLE
Update TileView.js

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -577,6 +577,7 @@
         "showAdvanced": "Erweiterte Einstellungen anzeigen",
         "startWithAudioMuted": "Stumm beitreten",
         "startWithVideoMuted": "Ohne Video beitreten",
+        "useWidescreen": "Video in Breitbild anzeigen",
         "version": "Version"
     },
     "share": {

--- a/lang/main.json
+++ b/lang/main.json
@@ -635,6 +635,7 @@
         "showAdvanced": "Show advanced settings",
         "startWithAudioMuted": "Start with audio muted",
         "startWithVideoMuted": "Start with video muted",
+        "useWidescreen": "Show video in widescreen mode",
         "version": "Version"
     },
     "share": {

--- a/react/features/base/settings/reducer.js
+++ b/react/features/base/settings/reducer.js
@@ -33,6 +33,7 @@ const DEFAULT_STATE = {
     startAudioOnly: false,
     startWithAudioMuted: false,
     startWithVideoMuted: false,
+    useWidescreen: false,
     userSelectedAudioOutputDeviceId: undefined,
     userSelectedCameraDeviceId: undefined,
     userSelectedMicDeviceId: undefined,

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -14,6 +14,7 @@ import {
 } from '../../../base/conference';
 import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
+import { getPropertyValue } from '../../../base/settings';
 
 import Thumbnail from './Thumbnail';
 import styles from './styles';
@@ -51,7 +52,12 @@ type Props = {
     /**
      * Callback to invoke when tile view is tapped.
      */
-    onClick: Function
+    onClick: Function,
+
+    /**
+     * Indicate whether the tile view should be in widescreen mode
+     */
+    _useWideScreen: boolean
 };
 
 /**
@@ -64,12 +70,12 @@ type Props = {
 const MARGIN = 10;
 
 /**
- * The aspect ratio the tiles should display in.
+ * The standard aspect ratio the tiles should display in.
  *
  * @private
  * @type {number}
  */
-const TILE_ASPECT_RATIO = 16 / 9;
+const STANDARD_TILE_ASPECT_RATIO = 1;
 
 /**
  * Implements a React {@link Component} which displays thumbnails in a two
@@ -174,6 +180,10 @@ class TileView extends Component<Props> {
         return participants;
     }
 
+    _getTileAspectRatio() {
+        return this.props._useWideScreen ? 16 / 9 : STANDARD_TILE_ASPECT_RATIO;
+    }
+
     /**
      * Calculate the height and width for the tiles.
      *
@@ -197,7 +207,7 @@ class TileView extends Component<Props> {
         }
 
         return {
-            height: tileWidth / TILE_ASPECT_RATIO,
+            height: tileWidth / this._getTileAspectRatio(),
             width: tileWidth
         };
     }
@@ -241,7 +251,7 @@ class TileView extends Component<Props> {
      */
     _renderThumbnails() {
         const styleOverrides = {
-            aspectRatio: TILE_ASPECT_RATIO,
+            aspectRatio: this._getTileAspectRatio(),
             flex: 0,
             height: this._getTileDimensions().height,
             width: null
@@ -287,7 +297,8 @@ function _mapStateToProps(state) {
         _aspectRatio: responsiveUi.aspectRatio,
         _height: responsiveUi.clientHeight,
         _participants: state['features/base/participants'],
-        _width: responsiveUi.clientWidth
+        _width: responsiveUi.clientWidth,
+        _useWideScreen: state['features/base/settings'].useWidescreen
     };
 }
 

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -14,7 +14,6 @@ import {
 } from '../../../base/conference';
 import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
-import { getPropertyValue } from '../../../base/settings';
 
 import Thumbnail from './Thumbnail';
 import styles from './styles';
@@ -180,6 +179,13 @@ class TileView extends Component<Props> {
         return participants;
     }
 
+    /**
+     * Return the aspect ratio of the tile view to use with respect to the
+     * widescreen setting.
+     *
+     * @private
+     * @returns {number}
+     */
     _getTileAspectRatio() {
         return this.props._useWideScreen ? 16 / 9 : STANDARD_TILE_ASPECT_RATIO;
     }

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -69,7 +69,7 @@ const MARGIN = 10;
  * @private
  * @type {number}
  */
-const TILE_ASPECT_RATIO = 1;
+const TILE_ASPECT_RATIO = 16 / 9;
 
 /**
  * Implements a React {@link Component} which displays thumbnails in a two

--- a/react/features/settings/components/native/SettingsView.js
+++ b/react/features/settings/components/native/SettingsView.js
@@ -55,6 +55,11 @@ type State = {
     serverURL: string,
 
     /**
+     * Whether to show video tiles in widecsreen or not.
+     */
+    useWidescreen: boolean,
+
+    /**
      * Whether to show advanced settings or not.
      */
     showAdvanced: boolean,
@@ -92,6 +97,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
             displayName,
             email,
             serverURL,
+            useWidescreen,
             startWithAudioMuted,
             startWithVideoMuted
         } = props._settings || {};
@@ -103,6 +109,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
             displayName,
             email,
             serverURL,
+            useWidescreen,
             showAdvanced: false,
             startWithAudioMuted,
             startWithVideoMuted
@@ -117,6 +124,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
         this._onShowAdvanced = this._onShowAdvanced.bind(this);
         this._setURLFieldReference = this._setURLFieldReference.bind(this);
         this._showURLAlert = this._showURLAlert.bind(this);
+        this._onUseWidescreen = this._onUseWidescreen.bind(this);
     }
 
     /**
@@ -334,6 +342,23 @@ class SettingsView extends AbstractSettingsView<Props, State> {
         this.setState({ showAdvanced: !this.state.showAdvanced });
     }
 
+    _onUseWidescreen: (boolean) => void;
+
+    /**
+     * Callback to update the use widescreen value.
+     *
+     * @param {boolean} useWidescreen - The new value to set.
+     * @returns {void}
+     */
+    _onUseWidescreen(useWidescreen) {
+        this._updateSettings({
+            useWidescreen
+        });
+        this.setState({
+            useWidescreen
+        });
+    }
+
     /**
      * Callback to update the start with audio muted value.
      *
@@ -391,7 +416,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
      * @returns {React$Element}
      */
     _renderAdvancedSettings() {
-        const { disableCallIntegration, disableP2P, disableCrashReporting, showAdvanced } = this.state;
+        const { disableCallIntegration, disableP2P, disableCrashReporting, showAdvanced, useWidescreen } = this.state;
 
         if (!showAdvanced) {
             return (
@@ -407,6 +432,13 @@ class SettingsView extends AbstractSettingsView<Props, State> {
 
         return (
             <>
+                <FormRow
+                    fieldSeparator = { true }
+                    label = 'settingsView.useWidescreen'>
+                    <Switch
+                        onValueChange = { this._onUseWidescreen }
+                        value = { useWidescreen } />
+                </FormRow>
                 <FormRow
                     fieldSeparator = { true }
                     label = 'settingsView.disableCallIntegration'>


### PR DESCRIPTION
set video tile aspect ratio in app to 16:9 like it's standard in browser

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
