### PR TITLE
config: Add option to set preferred audio bitrate.

### DIFF
--- a/config.js
+++ b/config.js
@@ -107,6 +107,11 @@ var config = {
     // participants and to enable it back a reload is needed.
     // startSilent: false
 
+    // Sets the preferred target bitrate for the Opus audio codec by setting its
+    // 'maxaveragebitrate' parameter. Currently not available in p2p mode.
+    // Valid values are in the range 6000 to 510000
+    // opusMaxAvgBitrate: 20000,
+
     // Video
 
     // Sets the preferred resolution (height) for local video. Defaults to 720.

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -130,6 +130,7 @@ export default [
     'minParticipants',
     'nick',
     'openBridgeChannel',
+    'opusMaxAvgBitrate',
     'p2p',
     'pcStatsInterval',
     'preferH264',


### PR DESCRIPTION
The maxaveragebitrate parameter to be used by Opus can be configured
through the new opusMaxAvgBitrate config option. Values are restricted
by Opus to integers between 6000 to 510000. Works for non-p2p only.

Depends on https://github.com/jitsi/jicofo/pull/551 and https://github.com/jitsi/lib-jitsi-meet/pull/1219