### PR TITLE
Fixup subject update

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -763,12 +763,12 @@ export function setStartMutedPolicy(
  * @param {string} subject - The new subject.
  * @returns {void}
  */
-export function setSubject(subject: string = '') {
+export function setSubject(subject: string) {
     return (dispatch: Dispatch<any>, getState: Function) => {
         const { conference } = getState()['features/base/conference'];
 
         if (conference) {
-            conference.setSubject(subject);
+            conference.setSubject(subject || '');
         } else {
             dispatch({
                 type: SET_PENDING_SUBJECT_CHANGE,

--- a/react/features/base/conference/middleware.js
+++ b/react/features/base/conference/middleware.js
@@ -615,13 +615,14 @@ function _updateLocalParticipantInConference({ dispatch, getState }, next, actio
             conference.setDisplayName(participant.name);
         }
 
-        const { pendingSubjectChange, subject } = getState()['features/base/conference'];
-        const isModerator = participant.role === PARTICIPANT_ROLE.MODERATOR;
+        if ('role' in participant && participant.role === PARTICIPANT_ROLE.MODERATOR) {
+            const { pendingSubjectChange, subject } = getState()['features/base/conference'];
 
-        // when local user role is updated to moderator and we have a pending subject change
-        // which was not reflected we need to set it (the first time we tried was before becoming moderator)
-        if (isModerator && pendingSubjectChange !== subject) {
-            dispatch(setSubject(pendingSubjectChange));
+            // When the local user role is updated to moderator and we have a pending subject change
+            // which was not reflected we need to set it (the first time we tried was before becoming moderator).
+            if (pendingSubjectChange !== subject) {
+                dispatch(setSubject(pendingSubjectChange));
+            }
         }
     }
 


### PR DESCRIPTION
After https://github.com/jitsi/jitsi-meet/commit/929622b27c3a407b42cf18fdc9ac9713bc076010 we observed a regression in an 8x8 backend service. Upon closer examination, I noticed than an extra unneeded update was being sent when no subject is specified, this should fix that.
