### PR TITLE
jitsi-meet.example-apache: allow spaces in meeting names

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -47,7 +47,7 @@
   ProxyPassReverse /http-bind http://localhost:5280/http-bind/
 
   RewriteEngine on
-  RewriteRule ^/([a-zA-Z0-9]+)$ /index.html
+  RewriteRule ^/([a-zA-Z0-9\s]+)$ /index.html
 </VirtualHost>
 
 # Mozilla Guideline v5.4, Apache 2.4.41, OpenSSL 1.1.1d, intermediate configuration, no OCSP


### PR DESCRIPTION
The apache example configuration doesn't allow for special characters in meeting room names at the moment (as opposed to the nginx example). Here's a quick fix for at least spaces.
Also, there exists no ProxyPass for /xmpp-websocket in the apache config. Is this on purpose?