### PR TITLE
Enable IFrame API to identify when a participant track has been muted or not

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2130,6 +2130,11 @@ export default {
             if (participantThatMutedUs) {
                 APP.store.dispatch(participantMutedUs(participantThatMutedUs));
             }
+            APP.API.notifyParticipantMuteStatusChanged(
+                track.getParticipantId(),
+                track.type,
+                track.isMuted()
+            );
         });
 
         room.on(JitsiConferenceEvents.SUBJECT_CHANGED,

--- a/conference.js
+++ b/conference.js
@@ -2098,6 +2098,14 @@ export default {
             }
 
             APP.store.dispatch(trackAdded(track));
+
+            APP.API.notifyTrackAdded(
+                track.getParticipantId(),
+                {
+                    type: track.type,
+                    muted: track.muted
+                }
+            );
         });
 
         room.on(JitsiConferenceEvents.TRACK_REMOVED, track => {
@@ -2106,6 +2114,14 @@ export default {
             }
 
             APP.store.dispatch(trackRemoved(track));
+
+            APP.API.notifyTrackRemoved(
+                track.getParticipantId(),
+                {
+                    type: track.type,
+                    muted: track.muted
+                }
+            );
         });
 
         room.on(JitsiConferenceEvents.TRACK_AUDIO_LEVEL_CHANGED, (id, lvl) => {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -588,6 +588,38 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that the user has
+     * added a track.
+     *
+     * @param {string} id - User id.
+     * @param {Object} track - The track type and muted state.
+     * @returns {void}
+     */
+    notifyTrackAdded(id: string, track: Object) {
+        this._sendEvent({
+            name: 'track-added',
+            id,
+            track
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that the user has
+     * removed a track.
+     *
+     * @param {string} id - User id.
+     * @param {Object} track - The track type and muted state.
+     * @returns {void}
+     */
+    notifyTrackRemoved(id: string, track: Object) {
+        this._sendEvent({
+            name: 'track-removed',
+            id,
+            track
+        });
+    }
+
+    /**
      * Notify external application (if API is enabled) that user changed their
      * avatar.
      *

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -723,6 +723,25 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that user changed mute
+     * status for a track.
+     *
+     * @param {string} id  - User id.
+     * @param {string} type - 'audio' or 'video' (track type).
+     * @param {boolean} muted - Muted state.
+     * @returns {void}
+     */
+    notifyParticipantMuteStatusChanged(id: string, type: string, muted: boolean) {
+        logger.log('participant-mute-status-changed', id, type, muted);
+        this._sendEvent({
+            name: 'participant-mute-status-changed',
+            id,
+            type,
+            muted
+        });
+    }
+
+    /**
      * Notify external application (if API is enabled) for audio muted status
      * changed.
      *

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -75,6 +75,8 @@ const events = {
     'participant-role-changed': 'participantRoleChanged',
     'password-required': 'passwordRequired',
     'proxy-connection-event': 'proxyConnectionEvent',
+    'track-added': 'trackAdded',
+    'track-removed': 'trackRemoved',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -71,6 +71,7 @@ const events = {
     'participant-joined': 'participantJoined',
     'participant-kicked-out': 'participantKickedOut',
     'participant-left': 'participantLeft',
+    'participant-mute-status-changed': 'participantMuteStatusChanged',
     'participant-role-changed': 'participantRoleChanged',
     'password-required': 'passwordRequired',
     'proxy-connection-event': 'proxyConnectionEvent',


### PR DESCRIPTION
This PR allows the IFrame API to identify when a participant track has been muted or not by using the events 'participant-mute-status-changed', 'track-added' and 'track-removed'.
