### PR TITLE
Fix label text wrapping

### DIFF
--- a/css/modals/invite/_info.scss
+++ b/css/modals/invite/_info.scss
@@ -24,6 +24,7 @@
 
     .info-label {
         font-weight: bold;
+        white-space: nowrap;
     }
 
     .info-password-field {


### PR DESCRIPTION
The label text in the invite modal can wrap.
![link](https://user-images.githubusercontent.com/4980126/85145890-261ace80-b245-11ea-8b98-6689af574efa.png)
Add this css rule stops that from happening.
![fixed](https://user-images.githubusercontent.com/4980126/85145897-287d2880-b245-11ea-9f06-5714f5d2a4eb.png)
