### PR TITLE
ref(constants): use 720 for the high quality level

### DIFF
--- a/react/features/base/conference/constants.js
+++ b/react/features/base/conference/constants.js
@@ -42,7 +42,7 @@ export const JITSI_CONFERENCE_URL_KEY = Symbol('url');
  * @type {object}
  */
 export const VIDEO_QUALITY_LEVELS = {
-    HIGH: 1080,
+    HIGH: 720,
     STANDARD: 360,
     LOW: 180
 };


### PR DESCRIPTION
720 is requested by default for the local video stream
and when using the quality slider the resolution would
be increased to 1080.

Note that this will limit the receive quality to 720 as well,
because both send and receive constraints are changed at
the same time when the quality slider is used.