### PR TITLE
Toggle lobby via IFrame API command

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -21,6 +21,7 @@ import {
 import { isEnabled as isDropboxEnabled } from '../../react/features/dropbox';
 import { setE2EEKey } from '../../react/features/e2ee';
 import { invite } from '../../react/features/invite';
+import { toggleLobbyMode } from '../../react/features/lobby/actions.web';
 import { RECORDING_TYPES } from '../../react/features/recording/constants';
 import { getActiveSession } from '../../react/features/recording/functions';
 import { muteAllParticipants } from '../../react/features/remote-video-menu/actions';
@@ -89,10 +90,8 @@ function initCommands() {
 
             APP.store.dispatch(muteAllParticipants(localIds));
         },
-        'enable-lobby': () => {
-            const { conference } = APP.store.getState()['features/base/conference'];
-
-            conference.enableLobby();
+        'toggle-lobby': isLobbyEnabled => {
+            APP.store.dispatch(toggleLobbyMode(isLobbyEnabled));
         },
         'password': password => {
             const { conference, passwordRequired }

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -89,6 +89,11 @@ function initCommands() {
 
             APP.store.dispatch(muteAllParticipants(localIds));
         },
+        'enable-lobby': () => {
+            const { conference } = APP.store.getState()['features/base/conference'];
+
+            conference.enableLobby();
+        },
         'password': password => {
             const { conference, passwordRequired }
                 = APP.store.getState()['features/base/conference'];

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -31,7 +31,7 @@ const commands = {
     displayName: 'display-name',
     e2eeKey: 'e2ee-key',
     email: 'email',
-    enableLobby: 'enable-lobby',
+    toggleLobby: 'toggle-lobby',
     hangup: 'video-hangup',
     muteEveryone: 'mute-everyone',
     password: 'password',

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -31,6 +31,7 @@ const commands = {
     displayName: 'display-name',
     e2eeKey: 'e2ee-key',
     email: 'email',
+    enableLobby: 'enable-lobby',
     hangup: 'video-hangup',
     muteEveryone: 'mute-everyone',
     password: 'password',


### PR DESCRIPTION
Adds `enableLobby` command to the IFrame API that enables lobby for the conference when executed.

Example execution:
`api.executeCommand('toggleLobby', true);`