### PR TITLE
fix: label tooltips are not visible in tile view

### DIFF
--- a/css/_labels.scss
+++ b/css/_labels.scss
@@ -4,7 +4,7 @@
     top: 30px;
     right: 30px;
     transition: right 0.5s;
-    z-index: $zindex3;
+    z-index: $filmstripVideosZ + 1;
 
     .circular-label {
         align-items: center;

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -200,8 +200,8 @@ class Conference extends AbstractConference<Props, *> {
                 <div id = 'videospace'>
                     <LargeVideo />
                     <KnockingParticipantList />
-                    { hideLabels || <Labels /> }
                     <Filmstrip filmstripOnly = { filmstripOnly } />
+                    { hideLabels || <Labels /> }
                 </div>
 
                 { filmstripOnly || _showPrejoin || <Toolbox /> }


### PR DESCRIPTION
The tooltip of the CircularLabel components were not visible in tile view because filmstrip was rendered on top of them, so the hover event didn't kick in