### PR TITLE
ref: Removes the enableLayerSuspension option from config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -130,11 +130,6 @@ var config = {
     // Enable / disable simulcast support.
     // disableSimulcast: false,
 
-    // Enable / disable layer suspension.  If enabled, endpoints whose HD
-    // layers are not in use will be suspended (no longer sent) until they
-    // are requested again.
-    // enableLayerSuspension: false,
-
     // Every participant after the Nth will start video muted.
     // startVideoMuted: 10,
 


### PR DESCRIPTION
Removes the enableLayerSuspension config option because  https://github.com/jitsi/lib-jitsi-meet/pull/1227 renders it obsolete.