### PR TITLE
fix(settings): Always show mic audio levels

### DIFF
--- a/react/features/settings/functions.js
+++ b/react/features/settings/functions.js
@@ -160,27 +160,36 @@ export function createLocalVideoTracks(ids: string[]) {
 
 
 /**
- * Returns a promise which resolves with an object containing the corresponding
- * the audio jitsiTrack/error.
+ * Returns a promise which resolves with a list of objects containing
+ * the audio track and the corresponding audio device information.
  *
- * @param {string} deviceId - The deviceId for the current microphone.
- *
- * @returns {Promise<Object>}
+ * @param {Object[]} devices - A list of microphone devices.
+ * @returns {Promise<{
+ *   deviceId: string,
+ *   hasError: boolean,
+ *   jitsiTrack: Object,
+ *   label: string
+ * }[]>}
  */
-export function createLocalAudioTrack(deviceId: string) {
-    return createLocalTrack('audio', deviceId)
-                   .then(jitsiTrack => {
-                       return {
-                           hasError: false,
-                           jitsiTrack
-                       };
-                   })
-                   .catch(() => {
-                       return {
-                           hasError: true,
-                           jitsiTrack: null
-                       };
-                   });
+export function createLocalAudioTracks(devices: Object[]) {
+    return Promise.all(
+        devices.map(async ({ deviceId, label }) => {
+            let jitsiTrack = null;
+            let hasError = false;
+
+            try {
+                jitsiTrack = await createLocalTrack('audio', deviceId);
+            } catch (err) {
+                hasError = true;
+            }
+
+            return {
+                deviceId,
+                hasError,
+                jitsiTrack,
+                label
+            };
+        }));
 }
 
 /**


### PR DESCRIPTION
Right now, on the audio settings popup, only the levels for the microphone in use are shown.

This fixes the problem so the levels for all the microphones will be displayed.