### PR TITLE
nginx, add a map for ssl_preread_protocol, too, similiar to alpn

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.conf
+++ b/doc/debian/jitsi-meet/jitsi-meet.conf
@@ -15,6 +15,11 @@ stream {
         ~\bhttp/1\.     web;
         default         turn;
     }
+    map $ssl_preread_protocol $upstream {
+    "TLSv1.2" web;
+    "TLSv1.3" web;
+    default turn;
+    }
 
     server {
         listen 443;


### PR DESCRIPTION
SSL/TLS does not work: 
openssl s_client -connect mymeet.server.com:443

ALPN with HTTP/2 or HTTP/1.1 works: 
openssl s_client -connect mymeet.server.com:443 -alpn h2

after this change, both seem to work fine. 

also https://www.ssllabs.com/ssltest/analyze.html was not working against my Jitsi Meet setup ->"no supported protocols" and with this change it works again, too.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
