### PR TITLE
fix: layout of the insecure room name warning icon

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -95,8 +95,12 @@ body.welcome-page {
                     flex-direction: row;
                     margin-top: 5px;
 
-                    svg {
-                        fill: $defaultWarningColor
+                    .jitsi-icon {
+                        margin-right: 15px;
+
+                        svg {
+                            fill: $defaultWarningColor
+                        }
                     }
                 }
 


### PR DESCRIPTION
From this
![image](https://user-images.githubusercontent.com/9974975/85740054-98862580-b701-11ea-9cf6-29e43260fbfd.png)

To this
![image](https://user-images.githubusercontent.com/9974975/85740097-a176f700-b701-11ea-8ef9-a0f769b9e5b3.png)
