### PR TITLE
fix(features/welcome): Make input field accessible

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -175,7 +175,7 @@ body.welcome-page {
         text-align: center;
         vertical-align: middle;
         line-height: $welcomePageButtonLineHeight;
-        cursor: pointer;
+        border: none;
     }
 
     .welcome-page-settings {

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -193,37 +193,37 @@ class WelcomePage extends AbstractWelcomePage {
                                 { app: APP_NAME }) }
                         </p>
                     </div>
-                    <div id = 'enter_room'>
-                        <div className = 'enter-room-input-container'>
+                    <form
+                        id = 'enter_room'
+                        onSubmit = { this._onFormSubmit } >
+                        <label className = 'enter-room-input-container'>
                             <div className = 'enter-room-title'>
                                 { t('welcomepage.enterRoomTitle') }
                             </div>
-                            <form onSubmit = { this._onFormSubmit }>
-                                <input
-                                    autoFocus = { true }
-                                    className = 'enter-room-input'
-                                    id = 'enter_room_field'
-                                    onChange = { this._onRoomChange }
-                                    pattern = { ROOM_NAME_VALIDATE_PATTERN_STR }
-                                    placeholder = { this.state.roomPlaceholder }
-                                    ref = { this._setRoomInputRef }
-                                    title = { t('welcomepage.roomNameAllowedChars') }
-                                    type = 'text'
-                                    value = { this.state.room } />
-                                { this._renderInsecureRoomNameWarning() }
-                            </form>
-                        </div>
-                        <div
+                            <input
+                                autoFocus = { true }
+                                className = 'enter-room-input'
+                                id = 'enter_room_field'
+                                onChange = { this._onRoomChange }
+                                pattern = { ROOM_NAME_VALIDATE_PATTERN_STR }
+                                placeholder = { this.state.roomPlaceholder }
+                                ref = { this._setRoomInputRef }
+                                title = { t('welcomepage.roomNameAllowedChars') }
+                                type = 'text'
+                                value = { this.state.room } />
+                            { this._renderInsecureRoomNameWarning() }
+                        </label>
+                        <button
                             className = 'welcome-page-button'
                             id = 'enter_room_button'
-                            onClick = { this._onFormSubmit }>
+                            type = 'submit'>
                             {
                                 showResponsiveText
                                     ? t('welcomepage.goSmall')
                                     : t('welcomepage.go')
                             }
-                        </div>
-                    </div>
+                        </button>
+                    </form>
                     { this._renderTabs() }
                 </div>
                 { showAdditionalContent


### PR DESCRIPTION
Input fields need to have labels (see https://dequeuniversity.com/rules/axe/3.5/label-title-only for more details).

This patch does the following changes:
 - associates the input field with the on-screen label, to fix the accessibility violation
 - converts the "Go" button from a div to a submit button, thus making it focusable using the keyboard
 - moves the `<form>` element such that it encompasses the submit button, which doesn't need a click handler anymore since it will trigger the form submit event
 - adjusts the style of the button (overwrites the default browser style)

No visual changes are introduced.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
