### PR TITLE
Modernize interface_config.js: var -> const

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars, no-var, max-len */
 /* eslint sort-keys: ["error", "asc", {"caseSensitive": false}] */
 
-var interfaceConfig = {
+const interfaceConfig = {
     APP_NAME: 'Jitsi Meet',
     AUDIO_LEVEL_PRIMARY_COLOR: 'rgba(255,255,255,0.4)',
     AUDIO_LEVEL_SECONDARY_COLOR: 'rgba(255,255,255,0.2)',


### PR DESCRIPTION
`const` has been supported for 5+ years now.