### PR TITLE
fix(prejoin): Replace the stored audio/video tracks when device list changes

### DIFF
--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -211,6 +211,18 @@ export function getLocalJitsiVideoTrack(state) {
 }
 
 /**
+ * Returns the stored local audio track.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Object}
+ */
+export function getLocalJitsiAudioTrack(state) {
+    const track = getLocalAudioTrack(state['features/base/tracks']);
+
+    return track?.jitsiTrack;
+}
+
+/**
  * Returns track of specified media type for specified participant id.
  *
  * @param {Track[]} tracks - List of all tracks.


### PR DESCRIPTION
When on prejoin screen, if the device list changes (devices are added or removed),
the newly created tracks do not properly replace the old ones, resulting in
errors after joining the meeting and trying to change the devices.
This change fixes the problem.
