### PR TITLE
TOOLBAR_BUTTONS clarifications

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -174,11 +174,15 @@ var interfaceConfig = {
     TOOLBAR_ALWAYS_VISIBLE: false,
 
     /**
-     * The name of the toolbar buttons to display in the toolbar. If present,
-     * the button will display. Exceptions are "livestreaming" and "recording"
-     * which also require being a moderator and some values in config.js to be
-     * enabled. Also, the "profile" button will not display for users with a
-     * jwt.
+     * The name of the toolbar buttons to display in the toolbar, including the
+     * "More actions" menu. If present, the button will display. Exceptions are
+     * "livestreaming" and "recording" which also require being a moderator and
+     * some values in config.js to be enabled. Also, the "profile" button will
+     * not display for users with a JWT.
+     * Notes:
+     * - it's impossible to choose which buttons go in the "More actions" menu
+     * - it's impossible to control the placement of buttons
+     * - 'desktop' controls the "Share your screen" button
      */
     TOOLBAR_BUTTONS: [
         'microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',


### PR DESCRIPTION
Documenting for per #7170, but it would be nice to either rename this option to `AVAILABLE_BUTTONS`, or create a mechanism to move some buttons out of the way into the <kbd>More actions</kbd> menu.