### PR TITLE
    WIP - abort button for prejoin screen (issue #7004)

### DIFF
--- a/react/features/base/premeeting/components/web/PreMeetingScreen.js
+++ b/react/features/base/premeeting/components/web/PreMeetingScreen.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react';
 
-import { AudioSettingsButton, VideoSettingsButton } from '../../../../toolbox';
+import { AudioSettingsButton, VideoSettingsButton, HangupButton } from '../../../../toolbox';
 
 import CopyMeetingUrl from './CopyMeetingUrl';
 import Preview from './Preview';
@@ -63,6 +63,7 @@ export default class PreMeetingScreen extends PureComponent<Props> {
                     { this.props.children }
                     <div className = 'media-btn-container'>
                         <AudioSettingsButton visible = { true } />
+		        <HangupButton visible = { true } />
                         <VideoSettingsButton visible = { true } />
                     </div>
                     { this.props.footer }


### PR DESCRIPTION
    obviously it's not finished - don't want to waste my time if pros are planning to solve this.
    things not looked at, advice welcome: button color, non-web support, analytics, more ?

idea is to use existing interface, code, documentation by adding the quit button to the screen

Clicking on the phone disconnects successfully in the prejoin screen and when waiting for the moderator reply.
Screenshot below is code is not self-explanatory enough. The arrow under the phone is my mouse cursor and the word 'Quitter' is the bubble help (translation of 'quit' in my native language)


![quittbutton](https://user-images.githubusercontent.com/44170243/85949003-5bfe3800-b954-11ea-84c4-83b4a262a923.jpg)

I have not signed the CLA since I have no idea this PR will even deserve a reply. Will do if necessary.
