### PR TITLE
prosody muc_size plugin, room get info error fix

### DIFF
--- a/resources/prosody-plugins/mod_muc_size.lua
+++ b/resources/prosody-plugins/mod_muc_size.lua
@@ -137,7 +137,7 @@ function handle_get_room (event)
     local room_address
         = jid.join(room_name, muc_domain_prefix.."."..domain_name);
 
-    if subdomain ~= "" then
+    if subdomain and subdomain ~= "" then
         room_address = "["..subdomain.."]"..room_address;
     end
 


### PR DESCRIPTION
When you are using mod_muc_size plugin, and trying to get room info (/root api url) you get the following error, when didn't add subdomain to the GET parameters:

http.server                                                         error       Traceback[httpserver]: /usr/lib/prosody/util/async.lua:137: /prosody-plugins/mod_muc_size.lua:141: attempt to concatenate local 'subdomain' (a nil value)


Similar to the room_size handler, add the subdomain existence condition.