### PR TITLE
fix: Fixes generating self-signed certificate.

### DIFF
--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -98,7 +98,7 @@ case "$1" in
                     -reqexts SAN \
                     -extensions SAN \
                     -config <(cat /etc/ssl/openssl.cnf \
-                        <(printf '[SAN]\nsubjectAltName=DNS:localhost,DNS:$JVB_HOSTNAME,IP:$JVB_HOSTNAME'))
+                        <(printf "[SAN]\nsubjectAltName=DNS:localhost,DNS:$JVB_HOSTNAME"))
             fi
         fi
 


### PR DESCRIPTION
The wrong quotes error:
req: Error on line 354 of config file "/dev/fd/63"
Error Loading extension section SAN
140403719438784:error:0E06C069:configuration file routines:NCONF_get_section:no conf:../crypto/conf/conf_lib.c:245:

Having the ip and specifying dns:
Error Loading extension section SAN
140127168778688:error:220A4076:X509 V3 routines:a2i_GENERAL_NAME:bad ip address:../crypto/x509v3/v3_alt.c:457:value=jitsi.example.com
140127168778688:error:22098080:X509 V3 routines:X509V3_EXT_nconf:error in extension:../crypto/x509v3/v3_conf.c:47:name=subjectAltName, value=DNS:localhost,DNS:jitsi.example.com,IP:jitsi.example.com

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
