### PR TITLE
fixed non valid json turkish language file

### DIFF
--- a/lang/main-tr.json
+++ b/lang/main-tr.json
@@ -71,9 +71,8 @@
         },
 	"privateNotice": "{{recipient}} için özel mesaj",
         "title": "Sohbet",
-        "you": "sen",
-        
-        
+        "you": "sen"
+
     },
     "connectingOverlay": {
         "joiningRoom": "Toplantıya bağlanılıyor..."


### PR DESCRIPTION
non valid turkish language file causes language change to turkish impossible, neither default language as tr works. removed comma end of json array, tested with unstable installation 