### PR TITLE
Add avatar to poltergeist user presence

### DIFF
--- a/resources/prosody-plugins/mod_muc_poltergeist.lua
+++ b/resources/prosody-plugins/mod_muc_poltergeist.lua
@@ -221,7 +221,9 @@ function handle_create_poltergeist (event)
        creator_user = session.jitsi_meet_context_user;
        creator_group = session.jitsi_meet_context_group;
     };
-
+    if avatar ~= nil then
+        context.user.avatar = avatar
+    end
     local resources = {};
     if conversation ~= nil then
         resources["conversation"] = conversation


### PR DESCRIPTION
This PR fixes https://github.com/jitsi/jitsi-meet/issues/7250  and Add avatar to user context so it is picked by the web interface

Here a screenshot with the working version

![Capture d’écran 2020-07-08 à 10 12 58](https://user-images.githubusercontent.com/1194083/86894675-affede80-c103-11ea-8aa1-058f07222201.png)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
This is my first contribution here, I did sign the CLA