### PR TITLE
feat: Exposes the max enabled resolution in the connection stats popover.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -110,6 +110,7 @@
         "localaddress_plural": "Local addresses:",
         "localport": "Local port:",
         "localport_plural": "Local ports:",
+        "maxEnabledResolution": "send max",
         "more": "Show more",
         "packetloss": "Packet loss:",
         "quality": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#cd008d726f1f57562eb5d8e6a3cd91c7e69826a0",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#304b0a2b4e18216d792f499c74fc24bc3849303e",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.13",
     "moment": "2.19.4",

--- a/react/features/connection-indicator/components/web/ConnectionIndicator.js
+++ b/react/features/connection-indicator/components/web/ConnectionIndicator.js
@@ -345,6 +345,7 @@ class ConnectionIndicator extends AbstractConnectionIndicator<Props, State> {
             packetLoss,
             region,
             resolution,
+            maxEnabledResolution,
             serverRegion,
             transport
         } = this.state.stats;
@@ -362,6 +363,7 @@ class ConnectionIndicator extends AbstractConnectionIndicator<Props, State> {
                 packetLoss = { packetLoss }
                 region = { region }
                 resolution = { resolution }
+                maxEnabledResolution = { maxEnabledResolution }
                 serverRegion = { serverRegion }
                 shouldShowMore = { this.state.showMoreStats }
                 transport = { transport } />

--- a/react/features/connection-indicator/components/web/ConnectionIndicator.js
+++ b/react/features/connection-indicator/components/web/ConnectionIndicator.js
@@ -342,10 +342,10 @@ class ConnectionIndicator extends AbstractConnectionIndicator<Props, State> {
             bridgeCount,
             e2eRtt,
             framerate,
+            maxEnabledResolution,
             packetLoss,
             region,
             resolution,
-            maxEnabledResolution,
             serverRegion,
             transport
         } = this.state.stats;
@@ -359,11 +359,11 @@ class ConnectionIndicator extends AbstractConnectionIndicator<Props, State> {
                 e2eRtt = { e2eRtt }
                 framerate = { framerate }
                 isLocalVideo = { this.props.isLocalVideo }
+                maxEnabledResolution = { maxEnabledResolution }
                 onShowMore = { this._onToggleShowMore }
                 packetLoss = { packetLoss }
                 region = { region }
                 resolution = { resolution }
-                maxEnabledResolution = { maxEnabledResolution }
                 serverRegion = { serverRegion }
                 shouldShowMore = { this.state.showMoreStats }
                 transport = { transport } />

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -380,14 +380,18 @@ class ConnectionStatsTable extends Component<Props> {
      * @returns {ReactElement}
      */
     _renderResolution() {
-        const { resolution, t } = this.props;
-        const resolutionString = Object.keys(resolution || {})
+        const { resolution, maxEnabledResolution, t } = this.props;
+        let resolutionString = Object.keys(resolution || {})
             .map(ssrc => {
                 const { width, height } = resolution[ssrc];
 
                 return `${width}x${height}`;
             })
             .join(', ') || 'N/A';
+
+        if (maxEnabledResolution && maxEnabledResolution < 720) {
+            resolutionString += ' (' + maxEnabledResolution + 'p max enabled)';
+        }
 
         return (
             <tr>

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -397,6 +397,7 @@ class ConnectionStatsTable extends Component<Props> {
 
         if (maxEnabledResolution && maxEnabledResolution < 720) {
             const maxEnabledResolutionTitle = t('connectionindicator.maxEnabledResolution');
+
             resolutionString += ` (${maxEnabledResolutionTitle} ${maxEnabledResolution}p)`;
         }
 

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -58,6 +58,12 @@ type Props = {
     isLocalVideo: boolean,
 
     /**
+     * The send-side max enabled resolution (aka the highest layer that is not
+     * suspended on the send-side).
+     */
+    maxEnabledResolution: number,
+
+    /**
      * Callback to invoke when the show additional stats link is clicked.
      */
     onShowMore: Function,
@@ -390,7 +396,7 @@ class ConnectionStatsTable extends Component<Props> {
             .join(', ') || 'N/A';
 
         if (maxEnabledResolution && maxEnabledResolution < 720) {
-            resolutionString += ' (' + maxEnabledResolution + 'p max enabled)';
+            resolutionString += ` (send max ${maxEnabledResolution}p)`;
         }
 
         return (

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -396,7 +396,8 @@ class ConnectionStatsTable extends Component<Props> {
             .join(', ') || 'N/A';
 
         if (maxEnabledResolution && maxEnabledResolution < 720) {
-            resolutionString += ` (send max ${maxEnabledResolution}p)`;
+            const maxEnabledResolutionTitle = t('connectionindicator.maxEnabledResolution');
+            resolutionString += ` (${maxEnabledResolutionTitle} ${maxEnabledResolution}p)`;
         }
 
         return (


### PR DESCRIPTION
Adds the max enabled resolution in a parenthesis right next to the resolution stat
![Screenshot 2020-07-09 at 17 28 27](https://user-images.githubusercontent.com/642943/87059506-0eb27e00-c212-11ea-8813-91dd4bebe503.png).

I'm marking this as a draft PR because we may want to change the UI before merging this.