### PR TITLE
rn,conference: show lonely experience only after joining

### DIFF
--- a/react/features/conference/components/native/LonelyMeetingExperience.js
+++ b/react/features/conference/components/native/LonelyMeetingExperience.js
@@ -126,11 +126,12 @@ class LonelyMeetingExperience extends PureComponent<Props> {
  */
 function _mapStateToProps(state): $Shape<Props> {
     const { disableInviteFunctions } = state['features/base/config'];
+    const { conference } = state['features/base/conference'];
     const flag = getFeatureFlag(state, INVITE_ENABLED, true);
 
     return {
         _isInviteFunctionsDiabled: !flag || disableInviteFunctions,
-        _isLonelyMeeting: getParticipantCount(state) === 1,
+        _isLonelyMeeting: conference && getParticipantCount(state) === 1,
         _styles: ColorSchemeRegistry.get(state, 'Conference')
     };
 }


### PR DESCRIPTION
Showing the modal earlier is weird because it will be closed as soon as we
connect. Also, we don't know if we are going to be alone until we join.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
