### PR TITLE
fix: Avoid overwriting the max resolution requested by the tile-view.

### DIFF
--- a/react/features/conference/middleware.js
+++ b/react/features/conference/middleware.js
@@ -6,7 +6,7 @@ import {
     VIDEO_QUALITY_LEVELS,
     conferenceLeft,
     getCurrentConference,
-    setMaxReceiverVideoQuality
+    setPreferredVideoQuality
 } from '../base/conference';
 import { hideDialog, isDialogOpen } from '../base/dialog';
 import { setActiveModalId } from '../base/modal';
@@ -33,7 +33,7 @@ MiddlewareRegistry.register(store => next => action => {
         dispatch(setFilmstripEnabled(!reducedUI));
 
         dispatch(
-            setMaxReceiverVideoQuality(
+            setPreferredVideoQuality(
                 reducedUI
                     ? VIDEO_QUALITY_LEVELS.LOW
                     : VIDEO_QUALITY_LEVELS.HIGH));


### PR DESCRIPTION
Part of [1] replaces a `setPreferredVideoQuality` call with a
`setMaxReceiverVideoQuality` call. The change was part of a bigger
changeset that adds logic that tries to adjust the max based on reduced
ui turned on or off and allow to set prefered through the config.

However, by calling `setMaxReceiverVideoQuality` instead of
`setPreferredVideoQuality`, the new feature overrides the lower
resolution requested by tile-view earlier in some occasions.

This PR reverts back to using `setPreferredVideoQuality` instead of
`setMaxReceiverVideoQuality` as this achieves the same result without
overwriting the max set by the tile-view.

[1]: https://github.com/jitsi/jitsi-meet/commit/7d513738d2179b68a8b21233d2bc9e93d3da05ab

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
