### PR TITLE
Add config to hide logo-deep-linking on deeplinking page

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -102,6 +102,11 @@ var interfaceConfig = {
     GENERATE_ROOMNAMES_ON_WELCOME_PAGE: true,
 
     /**
+     * Hide the logo on the deep linking pages.
+     */
+    HIDE_DEEP_LINKING_LOGO: false,
+
+    /**
      * Hide the invite prompt in the header when alone in the meeting.
      */
     HIDE_INVITE_MORE_HEADER: false,

--- a/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingDesktopPage.web.js
@@ -72,7 +72,7 @@ class DeepLinkingDesktopPage<P : Props> extends Component<P> {
      */
     render() {
         const { t } = this.props;
-        const { NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
+        const { HIDE_DEEP_LINKING_LOGO, NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
         const rightColumnStyle
             = SHOW_DEEP_LINKING_IMAGE ? null : { width: '100%' };
 
@@ -82,9 +82,13 @@ class DeepLinkingDesktopPage<P : Props> extends Component<P> {
             <AtlasKitThemeProvider mode = 'light'>
                 <div className = 'deep-linking-desktop'>
                     <div className = 'header'>
-                        <img
-                            className = 'logo'
-                            src = 'images/logo-deep-linking.png' />
+                        {
+                            HIDE_DEEP_LINKING_LOGO
+                                ? null
+                                : <img
+                                    className = 'logo'
+                                    src = 'images/logo-deep-linking.png' />
+                        }
                     </div>
                     <div className = 'content'>
                         {

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.js
@@ -91,7 +91,7 @@ class DeepLinkingMobilePage extends Component<Props> {
      */
     render() {
         const { _downloadUrl, _room, t } = this.props;
-        const { NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
+        const { HIDE_DEEP_LINKING_LOGO, NATIVE_APP_NAME, SHOW_DEEP_LINKING_IMAGE } = interfaceConfig;
         const downloadButtonClassName
             = `${_SNS}__button ${_SNS}__button_primary`;
 
@@ -115,9 +115,13 @@ class DeepLinkingMobilePage extends Component<Props> {
         return (
             <div className = { _SNS }>
                 <div className = 'header'>
-                    <img
-                        className = 'logo'
-                        src = 'images/logo-deep-linking.png' />
+                    {
+                        HIDE_DEEP_LINKING_LOGO
+                            ? null
+                            : <img
+                                className = 'logo'
+                                src = 'images/logo-deep-linking.png' />
+                    }
                 </div>
                 <div className = { `${_SNS}__body` }>
                     {


### PR DESCRIPTION
This adds the ability to configure hiding the logo on the deep linking page.
HIDE_DEEP_LINKING_LOGO defaults to false in the config.
The implementation also defaults to showing the logo if HIDE_DEEP_LINKING_LOGO is missing from the config.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
