### PR TITLE
android: disable PiP on Android Go devices

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -1,6 +1,5 @@
 /*
- * Copyright @ 2018-present 8x8, Inc.
- * Copyright @ 2017-2018 Atlassian Pty Ltd
+ * Copyright @ 2017-present 8x8, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,7 +125,7 @@ public class JitsiMeetView extends BaseReactView<JitsiMeetViewListener>
             = ReactInstanceManagerHolder.getNativeModule(
                 PictureInPictureModule.class);
         if (pipModule != null
-                && PictureInPictureModule.isPictureInPictureSupported()
+                && pipModule.isPictureInPictureSupported()
                 && !JitsiMeetActivityDelegate.arePermissionsBeingRequested()
                 && this.url != null) {
             try {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Platform } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 import { PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
@@ -66,9 +66,8 @@ function _mapStateToProps(state): Object {
     const flag = Boolean(getFeatureFlag(state, PIP_ENABLED));
     let enabled = flag;
 
-    // Override flag for Android < 26, PiP was introduced in Oreo.
-    // https://developer.android.com/guide/topics/ui/picture-in-picture
-    if (Platform.OS === 'android' && Platform.Version < 26) {
+    // Override flag for Android, since it might be unsupported.
+    if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {
         enabled = false;
     }
 


### PR DESCRIPTION
Despite running Android 8.1, they don't support Picture-in-Picture.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
