### PR TITLE
config: fix opusMaxAverageBitrate option name

### DIFF
--- a/config.js
+++ b/config.js
@@ -116,7 +116,7 @@ var config = {
     // Sets the preferred target bitrate for the Opus audio codec by setting its
     // 'maxaveragebitrate' parameter. Currently not available in p2p mode.
     // Valid values are in the range 6000 to 510000
-    // opusMaxAvgBitrate: 20000,
+    // opusMaxAverageBitrate: 20000,
 
     // Video
 

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -125,7 +125,7 @@ export default [
     'minParticipants',
     'nick',
     'openBridgeChannel',
-    'opusMaxAvgBitrate',
+    'opusMaxAverageBitrate',
     'p2p',
     'pcStatsInterval',
     'preferH264',


### PR DESCRIPTION
Must match the lib-jitsi-meet counterpart.

Fixes: https://github.com/jitsi/jitsi-meet/issues/7384

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
