### PR TITLE
fix: no new msg notifications after opening chat modal  [NATIVE]

### DIFF
--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -32,7 +32,9 @@ class Chat extends AbstractChat<Props> {
                 headerProps = {{
                     headerLabelKey: 'chat.title'
                 }}
-                modalId = { CHAT_VIEW_MODAL_ID }>
+                modalId = { CHAT_VIEW_MODAL_ID }
+                onClose = { this.props._onToggleChat }>
+
                 <MessageContainer messages = { this.props._messages } />
                 <MessageRecipient />
                 <ChatInputBar onSend = { this.props._onSendMessage } />

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -22,7 +22,7 @@ import MessageRecipient from './MessageRecipient';
  */
 class Chat extends AbstractChat<Props> {
     /**
-     * Instantiates a new instance.
+     * Creates a new instance.
      *
      * @inheritdoc
      */

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -21,6 +21,18 @@ import MessageRecipient from './MessageRecipient';
  * the mobile client.
  */
 class Chat extends AbstractChat<Props> {
+    
+    /**
+     * Instantiates a new instance.
+     *
+     * @inheritdoc
+     */
+    constructor(props: Props) {
+        super(props);
+
+        this._onClose = this._onClose.bind(this);
+    }
+
     /**
      * Implements React's {@link Component#render()}.
      *
@@ -33,13 +45,26 @@ class Chat extends AbstractChat<Props> {
                     headerLabelKey: 'chat.title'
                 }}
                 modalId = { CHAT_VIEW_MODAL_ID }
-                onClose = { this.props._onToggleChat }>
+                onClose = { this._onClose }>
 
                 <MessageContainer messages = { this.props._messages } />
                 <MessageRecipient />
                 <ChatInputBar onSend = { this.props._onSendMessage } />
             </JitsiModal>
         );
+    }
+
+    _onClose: () => boolean
+
+    /**
+     * Closes the window.
+     *
+     * @returns {boolean}
+     */
+    _onClose() {
+        this.props._onToggleChat();
+
+        return true;
     }
 }
 

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -56,7 +56,7 @@ class Chat extends AbstractChat<Props> {
     _onClose: () => boolean
 
     /**
-     * Closes the window.
+     * Closes the modal.
      *
      * @returns {boolean}
      */

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -21,7 +21,6 @@ import MessageRecipient from './MessageRecipient';
  * the mobile client.
  */
 class Chat extends AbstractChat<Props> {
-    
     /**
      * Instantiates a new instance.
      *


### PR DESCRIPTION
create TOGGLE_CHAT action when chat modal is closed to correctly update chat isOpen state

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
