### PR TITLE
feat(video quality): add maxFullResolutionParticipants

### DIFF
--- a/config.js
+++ b/config.js
@@ -123,6 +123,10 @@ var config = {
     // Sets the preferred resolution (height) for local video. Defaults to 720.
     // resolution: 720,
 
+    // How many participants while in the tile view mode, before the receiving video quality is reduced from HD to SD.
+    // Use -1 to disable.
+    // maxFullResolutionParticipants: 4
+
     // w3c spec-compliant video constraints to use for video capture. Currently
     // used by browsers that return true from lib-jitsi-meet's
     // util#browser#usesNewGumFlow. The constraints are independent from

--- a/config.js
+++ b/config.js
@@ -125,7 +125,7 @@ var config = {
 
     // How many participants while in the tile view mode, before the receiving video quality is reduced from HD to SD.
     // Use -1 to disable.
-    // maxFullResolutionParticipants: 4
+    // maxFullResolutionParticipants: 2
 
     // w3c spec-compliant video constraints to use for video capture. Currently
     // used by browsers that return true from lib-jitsi-meet's

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -122,6 +122,7 @@ export default [
     'ignoreStartMuted',
     'liveStreamingEnabled',
     'localRecording',
+    'maxFullResolutionParticipants',
     'minParticipants',
     'nick',
     'openBridgeChannel',

--- a/react/features/video-quality/middleware.js
+++ b/react/features/video-quality/middleware.js
@@ -81,7 +81,7 @@ StateListenerRegistry.register(
 
                 logger.info(`The nearest receiver video quality level for thumbnail height: ${thumbnailHeight}, `
                     + `is: ${newMaxRecvVideoQuality}, `
-                    + `override: ${overrideNearestHeight}, `
+                    + `override: ${String(overrideNearestHeight)}, `
                     + `max full res N: ${maxFullResolutionParticipants}`);
 
                 if (overrideNearestHeight) {

--- a/react/features/video-quality/middleware.js
+++ b/react/features/video-quality/middleware.js
@@ -59,11 +59,7 @@ StateListenerRegistry.register(
     /* listener */ ({ displayTileView, participantCount, reducedUI, thumbnailHeight }, { dispatch, getState }) => {
         const state = getState();
         const { maxReceiverVideoQuality } = state['features/base/conference'];
-        let { maxFullResolutionParticipants } = state['features/base/config'];
-
-        if (typeof maxFullResolutionParticipants === 'undefined') {
-            maxFullResolutionParticipants = 4;
-        }
+        const { maxFullResolutionParticipants = 2 } = state['features/base/config'];
 
         let newMaxRecvVideoQuality = VIDEO_QUALITY_LEVELS.HIGH;
 

--- a/react/features/video-quality/middleware.js
+++ b/react/features/video-quality/middleware.js
@@ -71,23 +71,25 @@ StateListenerRegistry.register(
             newMaxRecvVideoQuality = VIDEO_QUALITY_LEVELS.LOW;
         } else if (displayTileView && !Number.isNaN(thumbnailHeight)) {
             newMaxRecvVideoQuality = getNearestReceiverVideoQualityLevel(thumbnailHeight);
-        }
 
-        if (maxReceiverVideoQuality !== newMaxRecvVideoQuality) {
-            if (displayTileView && maxFullResolutionParticipants !== -1) {
-                const overrideNearestHeight
+            // Override HD level calculated for the thumbnail height when # of participants threshold is exceeded
+            if (maxReceiverVideoQuality !== newMaxRecvVideoQuality && maxFullResolutionParticipants !== -1) {
+                const override
                     = participantCount > maxFullResolutionParticipants
-                            && newMaxRecvVideoQuality > VIDEO_QUALITY_LEVELS.STANDARD;
+                        && newMaxRecvVideoQuality > VIDEO_QUALITY_LEVELS.STANDARD;
 
                 logger.info(`The nearest receiver video quality level for thumbnail height: ${thumbnailHeight}, `
                     + `is: ${newMaxRecvVideoQuality}, `
-                    + `override: ${String(overrideNearestHeight)}, `
+                    + `override: ${String(override)}, `
                     + `max full res N: ${maxFullResolutionParticipants}`);
 
-                if (overrideNearestHeight) {
+                if (override) {
                     newMaxRecvVideoQuality = VIDEO_QUALITY_LEVELS.STANDARD;
                 }
             }
+        }
+
+        if (maxReceiverVideoQuality !== newMaxRecvVideoQuality) {
             dispatch(setMaxReceiverVideoQuality(newMaxRecvVideoQuality));
         }
     }, {


### PR DESCRIPTION
Add a config option with the default value of 4, which will cap the max recv video quality to SD if there's more participants in the conference while in the tile view mode.
