### PR TITLE
Make app movable to SD card

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.jitsi.meet">
+    package="org.jitsi.meet"
+    android:installLocation="auto">
   <application
       android:allowBackup="true"
       android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Rationale
Over 25% of the world's Android devices still run Android 6.0 or older [[1]](https://www.androidauthority.com/android-version-distribution-748439/). This version of Android still has native support for moving applications to SD cards — this is crucial when dealing with low-storage devices. Many more recent OEM OSes also support moving applications to SD cards. This means making applications movable to the SD card is IMHO a rational choice.

## Solution
Add `android:installLocation="auto"` flag to AndroidMainfest.xml. The default for Android is, curiously, not `"auto"` but `"internalOnly"`

https://developer.android.com/guide/topics/data/install-location

Signed-off-by: Atrate <Atrate@protonmail.com>