### PR TITLE
feat(close3): Move readyToClose flow to the close page

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2858,7 +2858,14 @@ export default {
             this._room = undefined;
             room = undefined;
 
-            APP.API.notifyReadyToClose();
+            /**
+             * Don't call {@code notifyReadyToClose} if the promotional page flag is set
+             * and let the page take care of sending the message, since there will be
+             * a redirect to the page regardlessly.
+             */
+            if (!interfaceConfig.SHOW_PROMOTIONAL_CLOSE_PAGE) {
+                APP.API.notifyReadyToClose();
+            }
             APP.store.dispatch(maybeRedirectToWelcomePage(values[0]));
         });
     },

--- a/react/features/app/actions.js
+++ b/react/features/app/actions.js
@@ -2,6 +2,7 @@
 
 import type { Dispatch } from 'redux';
 
+import { API_ID } from '../../../modules/API/constants';
 import { setRoom } from '../base/conference';
 import {
     configWillLoad,
@@ -168,9 +169,11 @@ export function redirectWithStoredParams(pathname: string) {
  * window.location.pathname. If the specified pathname is relative, the context
  * root of the Web app will be prepended to the specified pathname before
  * assigning it to window.location.pathname.
+ * @param {string} hashParam - Optional hash param to assign to
+ * window.location.hash.
  * @returns {Function}
  */
-export function redirectToStaticPage(pathname: string) {
+export function redirectToStaticPage(pathname: string, hashParam: ?string) {
     return () => {
         const windowLocation = window.location;
         let newPathname = pathname;
@@ -182,6 +185,10 @@ export function redirectToStaticPage(pathname: string) {
             newPathname.startsWith('./')
                 && (newPathname = newPathname.substring(2));
             newPathname = getLocationContextRoot(windowLocation) + newPathname;
+        }
+
+        if (hashParam) {
+            windowLocation.hash = hashParam;
         }
 
         windowLocation.pathname = newPathname;
@@ -285,6 +292,7 @@ export function maybeRedirectToWelcomePage(options: Object = {}) {
         // if close page is enabled redirect to it, without further action
         if (enableClosePage) {
             const { isGuest, jwt } = getState()['features/base/jwt'];
+            let hashParam;
 
             // save whether current user is guest or not, and pass auth token,
             // before navigating to close page
@@ -294,12 +302,15 @@ export function maybeRedirectToWelcomePage(options: Object = {}) {
             let path = 'close.html';
 
             if (interfaceConfig.SHOW_PROMOTIONAL_CLOSE_PAGE) {
+                if (Number(API_ID) === API_ID) {
+                    hashParam = `#jitsi_meet_external_api_id=${API_ID}`;
+                }
                 path = 'close3.html';
             } else if (!options.feedbackSubmitted) {
                 path = 'close2.html';
             }
 
-            dispatch(redirectToStaticPage(`static/${path}`));
+            dispatch(redirectToStaticPage(`static/${path}`, hashParam));
 
             return;
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,6 +225,12 @@ module.exports = [
         },
         performance: getPerformanceHints(5 * 1024)
     }),
+    Object.assign({}, config, {
+        entry: {
+            'close3': './static/close3.js'
+        },
+        performance: getPerformanceHints(128 * 1024)
+    }),
 
     // Because both video-blur-effect and rnnoise-processor modules are loaded
     // in a lazy manner using the loadScript function with a hard coded name,


### PR DESCRIPTION
Create a separate chunk for the close3 page in order to enable it to dictate the `readyToCloseFlow` at will, if the appropriate flag is set in interfaceConfig.