### PR TITLE
fix: Send SS stopped analytics event when SS was started in video muted state

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1588,10 +1588,6 @@ export default {
         if (didHaveVideo) {
             promise = promise.then(() => createLocalTracksF({ devices: [ 'video' ] }))
                 .then(([ stream ]) => this.useVideoStream(stream))
-                .then(() => {
-                    sendAnalytics(createScreenSharingEvent('stopped'));
-                    logger.log('Screen sharing stopped.');
-                })
                 .catch(error => {
                     logger.error('failed to switch back to local video', error);
 
@@ -1608,6 +1604,8 @@ export default {
         return promise.then(
             () => {
                 this.videoSwitchInProgress = false;
+                sendAnalytics(createScreenSharingEvent('stopped'));
+                logger.info('Screen sharing stopped.');
             },
             error => {
                 this.videoSwitchInProgress = false;


### PR DESCRIPTION
We found few instances in callstats where we couldn't find a corresponding SS stopped event for a SS started event.
Turns out we do not send the event when there is no video to switch to after the share is stopped.