### PR TITLE
fire post-jitsi-authentication event for custom validations and allow external public key load

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -101,6 +101,11 @@ function provider.get_sasl_handler(session)
         else
             self.username = message;
         end
+        
+        local post_auth_result = prosody.events.fire_event("post-jitsi-authentication", session);
+        if post_auth_result ~= nil and (not post_auth_result) then 
+            return post_auth_result, "not-allowed", "post-jitsi-authentication validation failed";
+        end
 
         return res;
 	end


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Allow external modules to add logic in a post-jitsi-authentication-hook
Allow public key fetch from external module
Store kid and tenant in session

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
