### PR TITLE
fix: stopRecording external API doesn't stop recording because of invalid param

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -284,7 +284,7 @@ function initCommands() {
          * @param {string} mode - `file` or `stream`.
          * @returns {void}
          */
-        'stop-recording': mode => {
+        'stop-recording': ({ mode }) => {
             const state = APP.store.getState();
             const conference = getCurrentConference(state);
 


### PR DESCRIPTION
Hi guys!
My Jitsi running setup:

```
jitsi-meet               2.0.4384-1
jitsi-meet-prosody       1.0.3969-1
jitsi-meet-web           1.0.4337-1
jitsi-meet-web-config    1.0.3969-1
jitsi-videobridge2       2.1-164-gfdce823f-1
```

If I run startRecording with external_api.js it works, but I can't stop the recording because of this error line: [ERROR REFERENCE](https://github.com/jitsi/jitsi-meet/blob/4bfc80ecb913f0614fa158392bd958dc6d9a0671/modules/API/API.js#L298)

Working with the compiled boundle.js I discovered that the passed mode argument is an object and not a string (`"file" | "stream"`..) so the check and next function call fail.

I didn't test this fix because I don't know how to compile the entire jitsi project, maybe someone with more knowledge about this repo could check it?

Hope this will help :)
Simone