### PR TITLE
android: bring back activity to the foreground when exiting PiP

### DIFF
--- a/android/app/src/main/java/org/jitsi/meet/MainActivity.java
+++ b/android/app/src/main/java/org/jitsi/meet/MainActivity.java
@@ -210,6 +210,18 @@ public class MainActivity extends JitsiMeetActivity {
         return super.onKeyUp(keyCode, event);
     }
 
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode);
+
+        Log.d(TAG, "Is in picture-in-picture mode: " + isInPictureInPictureMode);
+
+        if (!isInPictureInPictureMode) {
+            this.startActivity(new Intent(this, getClass())
+                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT));
+        }
+    }
+
     // Helper methods
     //
 


### PR DESCRIPTION
When exiting PiP with by pressing the X the onPictureInPictureModeChanged method
is called. Since onResume is called a while after, in case the maximize button
is called, it's not easy to know if the user pressed the X button, and that was
the cause for exiting PiP.

So, in order to avoid show the user they are still in the meeting, bring the
activity to the foregound so they can hangup.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
