### PR TITLE
ref: Moves xmpp logs to be accessed from connection.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -759,7 +759,13 @@ export default {
         }
 
         if (isPrejoinPageEnabled(APP.store.getState())) {
-            _connectionPromise = connect(roomName);
+            _connectionPromise = connect(roomName).then(c => {
+                // we want to initialize it early, in case of errors to be able
+                // to gather logs
+                APP.connection = c;
+
+                return c;
+            });
 
             const { tryCreateLocalTracks, errors } = this.createInitialLocalTracks(initialOptions);
             const tracks = await tryCreateLocalTracks;
@@ -1206,10 +1212,6 @@ export default {
 
     // end used by torture
 
-    getLogs() {
-        return room.getLogs();
-    },
-
     /**
      * Download logs, a function that can be called from console while
      * debugging.
@@ -1218,7 +1220,7 @@ export default {
     saveLogs(filename = 'meetlog.json') {
         // this can be called from console and will not have reference to this
         // that's why we reference the global var
-        const logs = APP.conference.getLogs();
+        const logs = APP.connection.getLogs();
         const data = encodeURIComponent(JSON.stringify(logs, null, '  '));
 
         const elem = document.createElement('a');

--- a/package-lock.json
+++ b/package-lock.json
@@ -17945,8 +17945,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#372020a71d91eb4911cd3fb76164f2ffa0cd8b2f",
-      "from": "github:jitsi/lib-jitsi-meet#372020a71d91eb4911cd3fb76164f2ffa0cd8b2f",
+      "version": "github:jitsi/lib-jitsi-meet#3ac82faa2d6a0e09428b89409b1c89cce08904bf",
+      "from": "github:jitsi/lib-jitsi-meet#3ac82faa2d6a0e09428b89409b1c89cce08904bf",
       "requires": {
         "@jitsi/js-utils": "1.0.0",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#372020a71d91eb4911cd3fb76164f2ffa0cd8b2f",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#3ac82faa2d6a0e09428b89409b1c89cce08904bf",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",


### PR DESCRIPTION
In cases where there is no room like pre-join and lobby screen we still want to be able to debug xmpp messages.

Depends on https://github.com/jitsi/lib-jitsi-meet/pull/1284