### PR TITLE
fix: Fixes uncaught exception on malformed jwt.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -82,7 +82,7 @@ function checkForAttachParametersAndConnect(id, password, connection) {
  */
 function connect(id, password, roomName) {
     const connectionConfig = Object.assign({}, config);
-    const { issuer, jwt } = APP.store.getState()['features/base/jwt'];
+    const { jwt } = APP.store.getState()['features/base/jwt'];
 
     // Use Websocket URL for the web app if configured. Note that there is no 'isWeb' check, because there's assumption
     // that this code executes only on web browsers/electron. This needs to be changed when mobile and web are unified.
@@ -94,11 +94,7 @@ function connect(id, password, roomName) {
     //  in future). It's included for the time being for Jitsi Meet and lib-jitsi-meet versions interoperability.
     connectionConfig.serviceUrl = connectionConfig.bosh = serviceUrl;
 
-    const connection
-        = new JitsiMeetJS.JitsiConnection(
-            null,
-            jwt && issuer && issuer !== 'anonymous' ? jwt : undefined,
-            connectionConfig);
+    const connection = new JitsiMeetJS.JitsiConnection(null, jwt, connectionConfig);
 
     if (config.iAmRecorder) {
         connection.addFeature(DISCO_JIBRI_FEATURE);
@@ -211,10 +207,9 @@ export function openConnection({ id, password, retry, roomName }) {
 
     return connect(id, password, roomName).catch(err => {
         if (retry) {
-            const { issuer, jwt } = APP.store.getState()['features/base/jwt'];
+            const { jwt } = APP.store.getState()['features/base/jwt'];
 
-            if (err === JitsiConnectionErrors.PASSWORD_REQUIRED
-                    && (!jwt || issuer === 'anonymous')) {
+            if (err === JitsiConnectionErrors.PASSWORD_REQUIRED && !jwt) {
                 return AuthHandler.requestAuth(roomName, connect);
             }
         }

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -80,12 +80,8 @@ export function connect(id: ?string, password: ?string) {
         const state = getState();
         const options = _constructOptions(state);
         const { locationURL } = state['features/base/connection'];
-        const { issuer, jwt } = state['features/base/jwt'];
-        const connection
-            = new JitsiMeetJS.JitsiConnection(
-                options.appId,
-                jwt && issuer && issuer !== 'anonymous' ? jwt : undefined,
-                options);
+        const { jwt } = state['features/base/jwt'];
+        const connection = new JitsiMeetJS.JitsiConnection(options.appId, jwt, options);
 
         connection[JITSI_CONNECTION_URL_KEY] = locationURL;
 

--- a/react/features/base/jwt/logger.js
+++ b/react/features/base/jwt/logger.js
@@ -1,0 +1,5 @@
+// @flow
+
+import { getLogger } from '../logging/functions';
+
+export default getLogger('features/base/jwt');

--- a/react/features/base/jwt/middleware.js
+++ b/react/features/base/jwt/middleware.js
@@ -13,6 +13,7 @@ import { MiddlewareRegistry } from '../redux';
 import { SET_JWT } from './actionTypes';
 import { setJWT } from './actions';
 import { parseJWTFromURLParams } from './functions';
+import logger from './logger';
 
 declare var APP: Object;
 
@@ -133,7 +134,13 @@ function _setJWT(store, next, action) {
 
             action.isGuest = !enableUserRolesBasedOnToken;
 
-            const jwtPayload = jwtDecode(jwt);
+            let jwtPayload;
+
+            try {
+                jwtPayload = jwtDecode(jwt);
+            } catch (e) {
+                logger.error(e);
+            }
 
             if (jwtPayload) {
                 const { context, iss } = jwtPayload;


### PR DESCRIPTION
Does not skip passing jwt even when malformed to allow getting the error, terminating the connection and showing the warning. We were not passing jwt when malformed and were successfully joining a conference for deployments where no token is allowed.
