### PR TITLE
Add: remoteVideoMenu.disableGrantModerator option

### DIFF
--- a/config.js
+++ b/config.js
@@ -671,7 +671,9 @@ var config = {
     // Options related to the remote participant menu.
     // remoteVideoMenu: {
     //     // If set to true the 'Kick out' button will be disabled.
-    //     disableKick: true
+    //     disableKick: true,
+    //     // If set to true the 'Grant moderator' button will be disabled.
+    //     disableGrantModerator: true
     // },
 
     // If set to true all muting operations of remote participants will be disabled.

--- a/react/features/video-menu/components/native/RemoteVideoMenu.js
+++ b/react/features/video-menu/components/native/RemoteVideoMenu.js
@@ -102,30 +102,13 @@ class RemoteVideoMenu extends PureComponent<Props> {
             styles: this.props._bottomSheetStyles.buttons
         };
 
-        const buttons = [];
-
-        if (!_disableRemoteMute) {
-            buttons.push(<MuteButton { ...buttonProps } />);
-        }
-
-        if (!_disableGrantModerator) {
-            buttons.push(<GrantModeratorButton { ...buttonProps } />);
-        }
-
-        if (!_disableKick) {
-            buttons.push(<KickButton { ...buttonProps } />);
-        }
-
-        buttons.push(<PinButton { ...buttonProps } />);
-        buttons.push(<PrivateMessageButton { ...buttonProps } />);
-
         return (
             <BottomSheet
                 onCancel = { this._onCancel }
                 renderHeader = { this._renderMenuHeader }>
                 { !_disableRemoteMute && <MuteButton { ...buttonProps } /> }
                 { !_disableKick && <KickButton { ...buttonProps } /> }
-                <GrantModeratorButton { ...buttonProps } />
+                { !_disableGrantModerator && <GrantModeratorButton { ...buttonProps } /> }
                 <PinButton { ...buttonProps } />
                 <PrivateMessageButton { ...buttonProps } />
                 <MuteEveryoneElseButton { ...buttonProps } />

--- a/react/features/video-menu/components/native/RemoteVideoMenu.js
+++ b/react/features/video-menu/components/native/RemoteVideoMenu.js
@@ -54,6 +54,11 @@ type Props = {
     _disableRemoteMute: boolean,
 
     /**
+     * Whether or not to display the grant moderator button.
+     */
+    _disableGrantModerator: Boolean,
+
+    /**
      * True if the menu is currently open, false otherwise.
      */
     _isOpen: boolean,
@@ -89,13 +94,30 @@ class RemoteVideoMenu extends PureComponent<Props> {
      * @inheritdoc
      */
     render() {
-        const { _disableKick, _disableRemoteMute, participant } = this.props;
+        const { _disableKick, _disableRemoteMute, _disableGrantModerator, participant } = this.props;
         const buttonProps = {
             afterClick: this._onCancel,
             showLabel: true,
             participantID: participant.id,
             styles: this.props._bottomSheetStyles.buttons
         };
+
+        const buttons = [];
+
+        if (!_disableRemoteMute) {
+            buttons.push(<MuteButton { ...buttonProps } />);
+        }
+
+        if (!_disableGrantModerator) {
+            buttons.push(<GrantModeratorButton { ...buttonProps } />);
+        }
+
+        if (!_disableKick) {
+            buttons.push(<KickButton { ...buttonProps } />);
+        }
+
+        buttons.push(<PinButton { ...buttonProps } />);
+        buttons.push(<PrivateMessageButton { ...buttonProps } />);
 
         return (
             <BottomSheet

--- a/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -250,7 +250,7 @@ function _mapStateToProps(state, ownProps) {
     const { participantID } = ownProps;
     const localParticipant = getLocalParticipant(state);
     const { remoteVideoMenu = {}, disableRemoteMute } = state['features/base/config'];
-    const { disableKick , disableGrantModerator} = remoteVideoMenu;
+    const { disableKick, disableGrantModerator } = remoteVideoMenu;
     let _remoteControlState = null;
     const participant = getParticipantById(state, participantID);
     const _isRemoteControlSessionActive = participant?.remoteControlSessionStatus ?? false;

--- a/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -44,6 +44,11 @@ type Props = {
     _disableRemoteMute: Boolean,
 
     /**
+     * Whether or not to display the grant moderator button.
+     */
+    _disableGrantModerator: Boolean,
+
+    /**
      * Whether or not the participant is a conference moderator.
      */
     _isModerator: boolean,
@@ -136,6 +141,7 @@ class RemoteVideoMenuTriggerButton extends Component<Props> {
         const {
             _disableKick,
             _disableRemoteMute,
+            _disableGrantModerator,
             _isModerator,
             dispatch,
             initialVolumeValue,
@@ -170,11 +176,13 @@ class RemoteVideoMenuTriggerButton extends Component<Props> {
                 );
             }
 
-            buttons.push(
-                <GrantModeratorButton
-                    key = 'grant-moderator'
-                    participantID = { participantID } />
-            );
+            if (!_disableGrantModerator) {
+                buttons.push(
+                    <GrantModeratorButton
+                        key = 'grant-moderator'
+                        participantID = { participantID } />
+                );
+            }
 
             if (!_disableKick) {
                 buttons.push(
@@ -242,7 +250,7 @@ function _mapStateToProps(state, ownProps) {
     const { participantID } = ownProps;
     const localParticipant = getLocalParticipant(state);
     const { remoteVideoMenu = {}, disableRemoteMute } = state['features/base/config'];
-    const { disableKick } = remoteVideoMenu;
+    const { disableKick , disableGrantModerator} = remoteVideoMenu;
     let _remoteControlState = null;
     const participant = getParticipantById(state, participantID);
     const _isRemoteControlSessionActive = participant?.remoteControlSessionStatus ?? false;
@@ -283,7 +291,8 @@ function _mapStateToProps(state, ownProps) {
         _disableRemoteMute: Boolean(disableRemoteMute),
         _remoteControlState,
         _menuPosition,
-        _overflowDrawer: overflowDrawer
+        _overflowDrawer: overflowDrawer,
+        _disableGrantModerator: Boolean(disableGrantModerator)
     };
 }
 


### PR DESCRIPTION
Add config.js option `remoteVideoMenu.disableGrantModerator` to be able to disable the '**Grant moderator**' button.
(in addition to `disableKick` and `disableRemoteMute`)

CLA already signed, see https://github.com/jitsi/lib-jitsi-meet/pull/1156