### PR TITLE
Typo: In static/close.js 

### DIFF
--- a/static/close.js
+++ b/static/close.js
@@ -11,7 +11,7 @@ const hints = [
 ];
 
 /**
- * Get a random hint meessage from hint array.
+ * Get a random hint message from hint array.
  *
  * @return {string} the hint message.
  */


### PR DESCRIPTION
There's a typo in line number 14, "meessage" should be "message".

<!--
Thank you for your pull request. Please provide a thorough description below.
There's a typo in line number 14, "meessage" should be "message".
Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
