### PR TITLE
Fix CallKit integration on iOS for conferences requiring moderator

### DIFF
--- a/react/features/mobile/call-integration/middleware.js
+++ b/react/features/mobile/call-integration/middleware.js
@@ -264,8 +264,8 @@ function _conferenceWillJoin({ dispatch, getState }, next, action) {
     const handle = callHandle || url.toString();
     const hasVideo = !isVideoMutedByAudioOnly(state);
 
-    // On iOS, if we already have a callUUID set, dont start a new call
-    if (conference.callUUID && Platform.OS === 'ios') {
+    // If we already have a callUUID set, dont start a new call
+    if (conference.callUUID) {
         return result;
     }
 

--- a/react/features/mobile/call-integration/middleware.js
+++ b/react/features/mobile/call-integration/middleware.js
@@ -264,6 +264,11 @@ function _conferenceWillJoin({ dispatch, getState }, next, action) {
     const handle = callHandle || url.toString();
     const hasVideo = !isVideoMutedByAudioOnly(state);
 
+    // On iOS, if we already have a callUUID set, dont start a new call
+    if (conference.callUUID && Platform.OS === 'ios') {
+        return result;
+    }
+
     // When assigning the call UUID, do so in upper case, since iOS will return
     // it upper cased.
     conference.callUUID = (callUUID || uuid.v4()).toUpperCase();

--- a/react/features/mobile/call-integration/middleware.js
+++ b/react/features/mobile/call-integration/middleware.js
@@ -264,7 +264,7 @@ function _conferenceWillJoin({ dispatch, getState }, next, action) {
     const handle = callHandle || url.toString();
     const hasVideo = !isVideoMutedByAudioOnly(state);
 
-    // If we already have a callUUID set, dont start a new call
+    // If we already have a callUUID set, don't start a new call.
     if (conference.callUUID) {
         return result;
     }


### PR DESCRIPTION
When you join a conference that needs an authenticated moderator, as a guest, Jitsi Meet will continuously try and connect to the meeting every 5 seconds.
For every retry, on iOS, a new CallKit call is created, causing the call to loose audio, and loose control over the call.

This fixes that, by only creating a call on CallKit, if one has'nt already been created.