### PR TITLE
misc: Add test ids for prejoin buttons

### DIFF
--- a/react/features/base/premeeting/components/web/ActionButton.js
+++ b/react/features/base/premeeting/components/web/ActionButton.js
@@ -70,6 +70,7 @@ function ActionButton({
             {children}
             {hasOptions && <div
                 className = 'options'
+                data-testid = 'prejoin.joinOptions'
                 onClick = { disabled ? undefined : onOptionsClick }>
                 <Icon
                     className = 'icon'

--- a/react/features/prejoin/components/Prejoin.js
+++ b/react/features/prejoin/components/Prejoin.js
@@ -329,6 +329,7 @@ class Prejoin extends Component<Props, State> {
                                     content = { <div className = 'prejoin-preview-dropdown-btns'>
                                         <div
                                             className = 'prejoin-preview-dropdown-btn'
+                                            data-testid = 'prejoin.joinWithoutAudio'
                                             onClick = { joinConferenceWithoutAudio }>
                                             <Icon
                                                 className = 'prejoin-preview-dropdown-icon'
@@ -341,6 +342,7 @@ class Prejoin extends Component<Props, State> {
                                             onClick = { _showDialog }>
                                             <Icon
                                                 className = 'prejoin-preview-dropdown-icon'
+                                                data-testid = 'prejoin.joinByPhone'
                                                 size = { 24 }
                                                 src = { IconPhone } />
                                             { t('prejoin.joinAudioByPhone') }


### PR DESCRIPTION
Creates this PR to match and test it. 
https://github.com/jitsi/jitsi-meet/pull/7544
PR testing seems to check not only branch name but also and the organization/user part and does not match jitsi/jitsi-meet-torture/test-ids-prejoin to vp8x8/jitsi-meet/test-ids-prejoin, so I'm creating jitsi/jitsi-meet/test-ids-prejoin ... 