### PR TITLE
fix(RN): crash on undefined state['features/dynamic-branding']

### DIFF
--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -30,6 +30,7 @@ import '../chat/reducer';
 import '../deep-linking/reducer';
 import '../device-selection/reducer';
 import '../dropbox/reducer';
+import '../dynamic-branding/reducer';
 import '../etherpad/reducer';
 import '../filmstrip/reducer';
 import '../follow-me/reducer';

--- a/react/features/dynamic-branding/index.js
+++ b/react/features/dynamic-branding/index.js
@@ -1,4 +1,2 @@
 export * from './actions';
 export * from './functions';
-
-import './reducer';


### PR DESCRIPTION
Import 'dynamic-branding' reducer on all platforms to have the default state initialized.