### PR TITLE
feat: enable XMPP WebSocket on mobile

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,9 +45,12 @@ var config = {
         // disabled by the below option.
         // enableThumbnailReordering: true,
 
+        // Enables XMPP WebSocket (as opposed to BOSH) for the given amount of users.
+        // mobileXmppWsThreshold: 10 // enable XMPP WebSockets on mobile for 10% of the users
+
         // P2P test mode disables automatic switching to P2P when there are 2
         // participants in the conference.
-        p2pTestMode: false
+        // p2pTestMode: false,
 
         // Enables the test specific features consumed by jitsi-meet-torture
         // testMode: false

--- a/connection.js
+++ b/connection.js
@@ -106,9 +106,7 @@ export async function connect(id, password, roomName) {
 
     serviceUrl += `?room=${roomName}`;
 
-    // FIXME Remove deprecated 'bosh' option assignment at some point(LJM will be accepting only 'serviceUrl' option
-    //  in future). It's included for the time being for Jitsi Meet and lib-jitsi-meet versions interoperability.
-    connectionConfig.serviceUrl = connectionConfig.bosh = serviceUrl;
+    connectionConfig.serviceUrl = serviceUrl;
 
     if (connectionConfig.websocketKeepAliveUrl) {
         connectionConfig.websocketKeepAliveUrl += `?room=${roomName}`;

--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -181,7 +181,7 @@ export function initAnalytics({ getState }: { getState: Function }, handlers: Ar
     permanentProperties.appName = getAppName();
 
     // Report if user is using websocket
-    permanentProperties.websocket = navigator.product !== 'ReactNative' && typeof config.websocket === 'string';
+    permanentProperties.websocket = typeof config.websocket === 'string';
 
     // Report if user is using the external API
     permanentProperties.externalApi = typeof API_ID === 'number';

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -275,8 +275,14 @@ function _constructOptions(state) {
     // redux store.
     const options = _.cloneDeep(state['features/base/config']);
 
-    let { bosh } = options;
-    const { websocket } = options;
+    let { bosh, websocket } = options;
+
+    // TESTING: Only enable WebSocket for some percentage of users.
+    if (websocket) {
+        if ((Math.random() * 100) >= (options?.testing?.mobileXmppWsThreshold ?? 0)) {
+            websocket = undefined;
+        }
+    }
 
     // Normalize the BOSH URL.
     if (bosh && !websocket) {
@@ -300,6 +306,8 @@ function _constructOptions(state) {
 
     // WebSocket is preferred over BOSH.
     const serviceUrl = websocket || bosh;
+
+    logger.log(`Using service URL ${serviceUrl}`);
 
     // Append room to the URL's search.
     const { room } = state['features/base/conference'];

--- a/react/features/base/connection/actions.native.js
+++ b/react/features/base/connection/actions.native.js
@@ -275,10 +275,11 @@ function _constructOptions(state) {
     // redux store.
     const options = _.cloneDeep(state['features/base/config']);
 
-    // Normalize the BOSH URL.
     let { bosh } = options;
+    const { websocket } = options;
 
-    if (bosh) {
+    // Normalize the BOSH URL.
+    if (bosh && !websocket) {
         const { locationURL } = state['features/base/connection'];
 
         if (bosh.startsWith('//')) {
@@ -295,14 +296,22 @@ function _constructOptions(state) {
             // eslint-disable-next-line max-len
             bosh = `${protocol}//${host}${contextRoot || '/'}${bosh.substr(1)}`;
         }
+    }
 
-        // Append room to the URL's search.
-        const { room } = state['features/base/conference'];
+    // WebSocket is preferred over BOSH.
+    const serviceUrl = websocket || bosh;
 
-        room && (bosh += `?room=${getBackendSafeRoomName(room)}`);
+    // Append room to the URL's search.
+    const { room } = state['features/base/conference'];
 
-        // FIXME Remove deprecated 'bosh' option assignment at some point.
-        options.serviceUrl = options.bosh = bosh;
+    if (serviceUrl && room) {
+        const roomName = getBackendSafeRoomName(room);
+
+        options.serviceUrl = `${serviceUrl}?room=${roomName}`;
+
+        if (options.websocketKeepAliveUrl) {
+            options.websocketKeepAliveUrl += `?room=${roomName}`;
+        }
     }
 
     return options;


### PR DESCRIPTION
Enables XMPP WebSocket on mobile.

It would be good to land https://github.com/jitsi/lib-jitsi-meet/pull/1303 before merging this PR.