### PR TITLE
FEAT: Automatically copy invite URL after creating a room

### DIFF
--- a/react/features/base/premeeting/components/web/CopyMeetingUrl.js
+++ b/react/features/base/premeeting/components/web/CopyMeetingUrl.js
@@ -136,6 +136,16 @@ class CopyMeetingUrl extends Component<Props, State> {
     }
 
     /**
+     * Implements React's {@link Component#componentDidMount()}. Invoked
+     * immediately before mounting occurs.
+     *
+     * @inheritdoc
+     */
+    componentDidMount() {
+        setTimeout(this._copyUrl, 2000);
+    }
+
+    /**
      * Implements React's {@link Component#render()}.
      *
      * @inheritdoc


### PR DESCRIPTION
Resolves #7501
- Automatically copy invite URL after creating a room