### PR TITLE
Prejoin screen ignores ifame API parameters

### DIFF
--- a/react/features/base/settings/middleware.js
+++ b/react/features/base/settings/middleware.js
@@ -9,6 +9,7 @@ import { MiddlewareRegistry } from '../redux';
 import { parseURLParams } from '../util';
 
 import { SETTINGS_UPDATED } from './actionTypes';
+import { updateSettings } from './actions';
 import { handleCallIntegrationChange, handleCrashReportingChange } from './functions';
 
 /**
@@ -160,10 +161,18 @@ function _updateLocalParticipantFromUrl({ dispatch, getState }) {
     const localParticipant = getLocalParticipant(getState());
 
     if (localParticipant) {
+        const displayName = _.escape(urlDisplayName);
+        const email = _.escape(urlEmail);
+
         dispatch(participantUpdated({
             ...localParticipant,
-            email: _.escape(urlEmail),
-            name: _.escape(urlDisplayName)
+            email,
+            name: displayName
+        }));
+
+        dispatch(updateSettings({
+            displayName,
+            email
         }));
     }
 }

--- a/react/features/device-selection/functions.js
+++ b/react/features/device-selection/functions.js
@@ -86,7 +86,6 @@ export function processExternalDeviceRequest( // eslint-disable-line max-params
     }
     const state = getState();
     const settings = state['features/base/settings'];
-    const { conference } = state['features/base/conference'];
     let result = true;
 
     switch (request.name) {
@@ -165,7 +164,7 @@ export function processExternalDeviceRequest( // eslint-disable-line max-params
     case 'setDevice': {
         const { device } = request;
 
-        if (!conference) {
+        if (!areDeviceLabelsInitialized(state)) {
             dispatch(addPendingDeviceRequest({
                 type: 'devices',
                 name: 'setDevice',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

- [x] userInfo display name and email to follow the normal flows and to be stored in features/base/settings and from there to localStorage.

- [x] fix the issue on prejoined screen where the devices passed trough the iframe api are ignored when A/V permissions are not granted. 