### PR TITLE
jitsi-meet-tokens: Debian Buster compatibility issue

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Description: Prosody configuration for Jitsi Meet
 
 Package: jitsi-meet-tokens
 Architecture: all
-Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody
+Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl1.0-dev | libssl-dev, luarocks, jitsi-meet-prosody
 Description: Prosody token authentication plugin for Jitsi Meet
 
 Package: jitsi-meet-turnserver

--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -73,9 +73,9 @@ case "$1" in
                 PRTRUNK_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'prosody-trunk' 2>/dev/null | awk '{print $3}' || true)"
                 PR_VER_INSTALLED=$(dpkg-query -f='${Version}\n' --show prosody  2>/dev/null || true)
                 if [ "$PR10_INSTALL_CHECK" = "installed" ] \
-                    || "$PR10_INSTALL_CHECK" = "unpacked"  \
-                    || "$PRTRUNK_INSTALL_CHECK" = "installed"  \
-                    || "$PRTRUNK_INSTALL_CHECK" = "unpacked"  \
+                    || [ "$PR10_INSTALL_CHECK" = "unpacked" ]  \
+                    || [ "$PRTRUNK_INSTALL_CHECK" = "installed" ]  \
+                    || [ "$PRTRUNK_INSTALL_CHECK" = "unpacked" ]  \
                     || dpkg --compare-versions "$PR_VER_INSTALLED" lt "0.11" ; then
                     sed -i 's/module:hook_global(/module:hook(/g' /usr/share/jitsi-meet/prosody-plugins/mod_auth_token.lua
                 fi


### PR DESCRIPTION
The jitsi-meet-tokens can't be installed to Debian Buster.

1- **Missing dependency**
The package tries to install `luacrypto` which is dependent to `openssl1.0-dev`. But `libssl-dev` is on the package depend list and `libssl-dev` forces to install `openssl1.1-dev` on Debian Buster. 

Adding `libssl1.0-dev` to the depend list solves this issue.  Yes, there is no installation candidate for `libssl1.0-dev` on Debian Buster but it can be obtained from the third-party repos.

2- **Faulty command on the postinst script**
There are missing brackets on the postinst script and cause an error


