### PR TITLE
jitsi-meet-tokens: added git to the dependency list

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Description: Prosody configuration for Jitsi Meet
 
 Package: jitsi-meet-tokens
 Architecture: all
-Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody, git
+Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody
 Description: Prosody token authentication plugin for Jitsi Meet
 
 Package: jitsi-meet-turnserver

--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -48,9 +48,9 @@ case "$1" in
         db_stop
 
         if [ -f "$PROSODY_HOST_CONFIG" ] ; then
-            # search for --plugin_paths, if this is not enabled this is the
+            # search for the token auth, if this is not enabled this is the
             # first time we install tokens package and needs a config change
-            if grep -q "\-\-plugin_paths" "$PROSODY_HOST_CONFIG"; then
+            if ! egrep -q '^\s*authentication\s*=\s*"token"' "$PROSODY_HOST_CONFIG"; then
                 # enable tokens in prosody host config
                 sed -i 's/--plugin_paths/plugin_paths/g' $PROSODY_HOST_CONFIG
                 sed -i 's/authentication = "anonymous"/authentication = "token"/g' $PROSODY_HOST_CONFIG


### PR DESCRIPTION
`jitsi-meet-tokens` has a missing dependency. `luajwtjitsi` could not be installed if `git` does not exist.

This is the output during the installation:

```
Installing https://luarocks.org/luajwtjitsi-1.3-7.rockspec

Error: 'git' program not found. Make sure Git is installed and is available in your PATH (or you may want to edit the 'variables.GIT' value in file '/etc/luarocks/config.lua')
Failed to install luajwtjitsi - try installing it manually
```
