### PR TITLE
jitsi-meet-tokens: fixed the first installation check

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -48,9 +48,9 @@ case "$1" in
         db_stop
 
         if [ -f "$PROSODY_HOST_CONFIG" ] ; then
-            # search for --plugin_paths, if this is not enabled this is the
+            # search for the token auth, if this is not enabled this is the
             # first time we install tokens package and needs a config change
-            if grep -q "\-\-plugin_paths" "$PROSODY_HOST_CONFIG"; then
+            if ! egrep -q '^\s*authentication\s*=\s*"token"' "$PROSODY_HOST_CONFIG"; then
                 # enable tokens in prosody host config
                 sed -i 's/--plugin_paths/plugin_paths/g' $PROSODY_HOST_CONFIG
                 sed -i 's/authentication = "anonymous"/authentication = "token"/g' $PROSODY_HOST_CONFIG


### PR DESCRIPTION
`jitsi-meet-tokens` does not check correctly the package status during the installation. It search for `--plugin_paths` which is never exists on the new usual installation and skips the `if` block.

I think searching for an enabled token auth line is a better way to check this.

* if there is no enabled token line then this is the first installation and needs a config change

* if there is an enabled token line then `jitsi-meet-tokens` was installed before
