### PR TITLE
jitsi-meet-tokens: added git to the dependency list (2)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Description: Prosody configuration for Jitsi Meet
 
 Package: jitsi-meet-tokens
 Architecture: all
-Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody
+Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody, git
 Description: Prosody token authentication plugin for Jitsi Meet
 
 Package: jitsi-meet-turnserver


### PR DESCRIPTION
_I sent [a similar pull request](https://github.com/jitsi/jitsi-meet/pull/7616) before but it was closed because of the dublicated commits. Sorry for that. I prepared a clean pull request for the same issue._

`jitsi-meet-tokens` has a missing dependency. `luajwtjitsi` could not be installed if git does not exist.

This is the output during the installation:

```
Installing https://luarocks.org/luajwtjitsi-1.3-7.rockspec

Error: 'git' program not found. Make sure Git is installed and is available in your PATH (or you may want to edit the 'variables.GIT' value in file '/etc/luarocks/config.lua')
Failed to install luajwtjitsi - try installing it manually
```