### PR TITLE
jitsi-meet-tokens: added libssl1.0-dev to the dependencies as an alternative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Description: Prosody configuration for Jitsi Meet
 
 Package: jitsi-meet-tokens
 Architecture: all
-Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl-dev, luarocks, jitsi-meet-prosody, git
+Depends: ${misc:Depends}, prosody-trunk (>= 1nightly747) | prosody-0.11 | prosody (>= 0.11.2), libssl1.0-dev | libssl-dev, luarocks, jitsi-meet-prosody, git
 Description: Prosody token authentication plugin for Jitsi Meet
 
 Package: jitsi-meet-turnserver


### PR DESCRIPTION
I closed [the old pull request](https://github.com/jitsi/jitsi-meet/pull/7607) which has a conflict issue.

`jitsi-meet-tokens` is trying to install `luacrypto` which depends on `libssl1.0-dev` but `jitsi-meet-tokens` also depends on `libssl-dev` which is compiled against `openssl1.1` on Debian Buster. Therefore  it's impossible to install `jitsi-meet-tokens` on Debian Buster if it doesn't accept `libssl1.0-dev` as an alternative to `libssl-dev`
