### PR TITLE
jitsi-meet-tokens: enable token_verification during installation

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -58,6 +58,7 @@ case "$1" in
                 sed -i "s/ --app_id=\"example_app_id\"/ app_id=\"$APP_ID\"/g" $PROSODY_HOST_CONFIG
                 sed -i "s/ --app_secret=\"example_app_secret\"/ app_secret=\"$APP_SECRET\"/g" $PROSODY_HOST_CONFIG
                 sed -i 's/ --modules_enabled = { "token_verification" }/ modules_enabled = { "token_verification" }/g' $PROSODY_HOST_CONFIG
+                sed -i '/^\s*--\s*"token_verification"/ s/--\s*//' $PROSODY_HOST_CONFIG
 
                 # Install luajwt
                 if ! luarocks install luajwtjitsi; then


### PR DESCRIPTION
The postinst script is searching for `--modules_enabled = { "token_verification" }`. But there is no such a line on the standard config file. This is from a typical config file

```
    modules_enabled = {
        "muc_meeting_id";
        "muc_domain_mapper";
        -- "token_verification";
    }
```

I added a `sed` command for this format.
Please, don't add the `g flag` to `sed`.


