### PR TITLE
jitsi-meet-tokens: disable token_verification while removing

### DIFF
--- a/debian/jitsi-meet-tokens.postrm
+++ b/debian/jitsi-meet-tokens.postrm
@@ -41,7 +41,7 @@ case "$1" in
             sed -i 's/authentication = "token"/authentication = "anonymous"/g' $PROSODY_HOST_CONFIG
             sed -i "s/ app_id=\"$APP_ID\"/ --app_id=\"example_app_id\"/g" $PROSODY_HOST_CONFIG
             sed -i "s/ app_secret=\"$APP_SECRET\"/ --app_secret=\"example_app_secret\"/g" $PROSODY_HOST_CONFIG
-            sed -i 's/ -- "token_verification"/   "token_verification"/g' $PROSODY_HOST_CONFIG
+            sed -i '/^\s*"token_verification"/ s/"token_verification"/-- "token_verification"/' $PROSODY_HOST_CONFIG
 
             if [ -x "/etc/init.d/prosody" ]; then
                 invoke-rc.d prosody restart || true


### PR DESCRIPTION
`token_verification` is enabled while removing `jitsi-meet-tokens' but the opposite is required. This commit fixes this issue.
