### PR TITLE
jitsi-meet-tokens: keep plugin_paths while removing

### DIFF
--- a/debian/jitsi-meet-tokens.postrm
+++ b/debian/jitsi-meet-tokens.postrm
@@ -37,7 +37,6 @@ case "$1" in
             APP_SECRET=$RET
 
             # Revert prosody config
-            sed -i 's/plugin_paths/--plugin_paths/g' $PROSODY_HOST_CONFIG
             sed -i 's/authentication = "token"/authentication = "anonymous"/g' $PROSODY_HOST_CONFIG
             sed -i "s/ app_id=\"$APP_ID\"/ --app_id=\"example_app_id\"/g" $PROSODY_HOST_CONFIG
             sed -i "s/ app_secret=\"$APP_SECRET\"/ --app_secret=\"example_app_secret\"/g" $PROSODY_HOST_CONFIG


### PR DESCRIPTION
`plugin_paths` is disabled while removing `jitsi-meet-tokens` but this line is enabled by default and not activated during the `jitsi-meet-tokens` installation. And this will cause errors if there are other enabled modules.

Therefore no need to disable `plugin_paths` while removing the package.
