### PR TITLE
external_api: add ability to kick participant

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -15,6 +15,7 @@ import {
 } from '../../react/features/base/conference';
 import { parseJWTFromURLParams } from '../../react/features/base/jwt';
 import { JitsiRecordingConstants } from '../../react/features/base/lib-jitsi-meet';
+import { kickParticipant } from '../../react/features/base/participants';
 import {
     processExternalDeviceRequest
 } from '../../react/features/device-selection/functions';
@@ -22,7 +23,6 @@ import { isEnabled as isDropboxEnabled } from '../../react/features/dropbox';
 import { toggleE2EE } from '../../react/features/e2ee/actions';
 import { invite } from '../../react/features/invite';
 import { toggleLobbyMode } from '../../react/features/lobby/actions.web';
-import { kickParticipant } from '../../react/features/base/participants';
 import { RECORDING_TYPES } from '../../react/features/recording/constants';
 import { getActiveSession } from '../../react/features/recording/functions';
 import { muteAllParticipants } from '../../react/features/remote-video-menu/actions';

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -22,6 +22,7 @@ import { isEnabled as isDropboxEnabled } from '../../react/features/dropbox';
 import { toggleE2EE } from '../../react/features/e2ee/actions';
 import { invite } from '../../react/features/invite';
 import { toggleLobbyMode } from '../../react/features/lobby/actions.web';
+import { kickParticipant } from '../../react/features/base/participants';
 import { RECORDING_TYPES } from '../../react/features/recording/constants';
 import { getActiveSession } from '../../react/features/recording/functions';
 import { muteAllParticipants } from '../../react/features/remote-video-menu/actions';
@@ -79,6 +80,9 @@ function initCommands() {
         'display-name': displayName => {
             sendAnalytics(createApiEvent('display.name.changed'));
             APP.conference.changeLocalDisplayName(displayName);
+        },
+        'kick-participant': participantId => {
+            APP.store.dispatch(kickParticipant(participantId));
         },
         'mute-everyone': () => {
             sendAnalytics(createApiEvent('muted-everyone'));

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -31,8 +31,8 @@ const commands = {
     displayName: 'display-name',
     e2eeKey: 'e2ee-key',
     email: 'email',
-    toggleLobby: 'toggle-lobby',
     hangup: 'video-hangup',
+    kickParticipant: 'kick-participant',
     muteEveryone: 'mute-everyone',
     password: 'password',
     sendEndpointTextMessage: 'send-endpoint-text-message',
@@ -45,6 +45,7 @@ const commands = {
     toggleAudio: 'toggle-audio',
     toggleChat: 'toggle-chat',
     toggleFilmStrip: 'toggle-film-strip',
+    toggleLobby: 'toggle-lobby',
     toggleShareScreen: 'toggle-share-screen',
     toggleTileView: 'toggle-tile-view',
     toggleVideo: 'toggle-video'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
regarding [#1314](https://github.com/jitsi/lib-jitsi-meet/issues/1314)

This pull request adds the Jitsi External API the ability to kick-off a remote participant from a meeting. It leverages the existing code used in kicking off a remote participant. I have just made it possible to use it through the Jitsi External (iframe) API.