### PR TITLE
feat(vpaas): Add name from jwt to prejoin screen for vpaas meetings

### DIFF
--- a/css/_premeeting-screens.scss
+++ b/css/_premeeting-screens.scss
@@ -148,7 +148,8 @@
             }
         }
 
-        input.field {
+        input.field,
+        div.field {
             background-color: transparent;
             border: 1px solid transparent;
             color: white;

--- a/react/features/base/jwt/functions.js
+++ b/react/features/base/jwt/functions.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import jwtDecode from 'jwt-decode';
+
 import { parseURLParams } from '../util';
 
 /**
@@ -13,4 +15,16 @@ import { parseURLParams } from '../util';
  */
 export function parseJWTFromURLParams(url: URL = window.location) {
     return parseURLParams(url, true, 'search').jwt;
+}
+
+/**
+ * Returns the user name after decoding the jwt.
+ *
+ * @param {Object} state - The app state.
+ * @returns {string}
+ */
+export function getJwtName(state: Object) {
+    const jwtData = jwtDecode(state['features/base/jwt'].jwt);
+
+    return jwtData?.context?.user?.name || '';
 }

--- a/react/features/prejoin/components/Name.js
+++ b/react/features/prejoin/components/Name.js
@@ -1,0 +1,112 @@
+// @flow
+
+import React, { PureComponent } from 'react';
+
+import { translate } from '../../base/i18n';
+import { getJwtName } from '../../base/jwt/functions';
+import { InputField } from '../../base/premeeting';
+import { connect } from '../../base/redux';
+import { updateSettings } from '../../base/settings';
+import { isVpaasMeeting } from '../../billing-counter/functions';
+
+type Props = {
+
+    /**
+     * Flag signaling if the name is editable or not.
+     */
+    isEditable: boolean,
+
+    /**
+     * Joins the current meeting.
+     */
+    joinConference: Function,
+
+    /**
+     * Updates settings.
+     */
+    updateSettings: Function,
+
+    /**
+     * The name of the user that is about to join.
+     */
+    value: string,
+
+    /**
+     * Used for translation.
+     */
+    t: Function
+};
+
+/**
+ * Component that displays the name in the prejoin screen.
+ */
+class Name extends PureComponent<Props> {
+    /**
+     * Initializes a new {@code Name} instance.
+     *
+     * @inheritdoc
+     */
+    constructor(props) {
+        super(props);
+
+        this._onChange = this._onChange.bind(this);
+    }
+
+    _onChange: () => void;
+
+    /**
+     * Sets the guest participant name.
+     *
+     * @param {string} displayName - Participant name.
+     * @returns {void}
+     */
+    _onChange(displayName) {
+        this.props.updateSettings({
+            displayName
+        });
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { isEditable, joinConference, t, value } = this.props;
+
+        return isEditable ? (
+            <InputField
+                autoFocus = { true }
+                onChange = { this._onChange }
+                onSubmit = { joinConference }
+                placeHolder = { t('dialog.enterDisplayName') }
+                value = { value } />
+        )
+            : <div className = 'field'>{value}</div>
+        ;
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the React {@code Component} props.
+ *
+ * @param {Object} state - The redux state.
+ * @param {Object} ownProps - The props passed to the component.
+ * @returns {Object}
+ */
+const mapStateToProps = (state, ownProps) => {
+    const isEditable = !isVpaasMeeting(state);
+    const name = isEditable ? ownProps.value : getJwtName(state);
+
+    return {
+        isEditable,
+        name
+    };
+};
+
+const mapDispatchToProps = {
+    updateSettings
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate(Name));

--- a/react/features/prejoin/components/Prejoin.js
+++ b/react/features/prejoin/components/Prejoin.js
@@ -7,9 +7,9 @@ import { getRoomName } from '../../base/conference';
 import { translate } from '../../base/i18n';
 import { Icon, IconPhone, IconVolumeOff } from '../../base/icons';
 import { isVideoMutedByUser } from '../../base/media';
-import { ActionButton, InputField, PreMeetingScreen, ToggleButton } from '../../base/premeeting';
+import { ActionButton, PreMeetingScreen, ToggleButton } from '../../base/premeeting';
 import { connect } from '../../base/redux';
-import { getDisplayName, updateSettings } from '../../base/settings';
+import { getDisplayName } from '../../base/settings';
 import { getLocalJitsiVideoTrack } from '../../base/tracks';
 import { isButtonEnabled } from '../../toolbox/functions.web';
 import {
@@ -26,8 +26,10 @@ import {
     isPrejoinSkipped
 } from '../functions';
 
+import Name from './Name';
 import JoinByPhoneDialog from './dialogs/JoinByPhoneDialog';
 import DeviceStatus from './preview/DeviceStatus';
+
 
 declare var interfaceConfig: Object;
 
@@ -62,11 +64,6 @@ type Props = {
      * The name of the user that is about to join.
      */
     name: string,
-
-    /**
-     * Updates settings.
-     */
-    updateSettings: Function,
 
     /**
      * The name of the meeting that is about to be joined.
@@ -176,7 +173,6 @@ class Prejoin extends Component<Props, State> {
         this._onToggleButtonClick = this._onToggleButtonClick.bind(this);
         this._onDropdownClose = this._onDropdownClose.bind(this);
         this._onOptionsClick = this._onOptionsClick.bind(this);
-        this._setName = this._setName.bind(this);
     }
     _onJoinButtonClick: () => void;
 
@@ -240,19 +236,6 @@ class Prejoin extends Component<Props, State> {
         });
     }
 
-    _setName: () => void;
-
-    /**
-     * Sets the guest participant name.
-     *
-     * @param {string} displayName - Participant name.
-     * @returns {void}
-     */
-    _setName(displayName) {
-        this.props.updateSettings({
-            displayName
-        });
-    }
 
     _closeDialog: () => void;
 
@@ -298,7 +281,7 @@ class Prejoin extends Component<Props, State> {
             videoTrack
         } = this.props;
 
-        const { _closeDialog, _onDropdownClose, _onJoinButtonClick, _onOptionsClick, _setName, _showDialog } = this;
+        const { _closeDialog, _onDropdownClose, _onJoinButtonClick, _onOptionsClick, _showDialog } = this;
         const { showJoinByPhoneButtons, showError } = this.state;
 
         return (
@@ -314,13 +297,9 @@ class Prejoin extends Component<Props, State> {
                 {showJoinActions && (
                     <div className = 'prejoin-input-area-container'>
                         <div className = 'prejoin-input-area'>
-                            <InputField
-                                autoFocus = { true }
-                                onChange = { _setName }
-                                onSubmit = { joinConference }
-                                placeHolder = { t('dialog.enterDisplayName') }
+                            <Name
+                                joinConference = { joinConference }
                                 value = { name } />
-
                             {showError && <div
                                 className = 'prejoin-error'
                                 data-testid = 'prejoin.errorMessage'>{t('prejoin.errorMissingName')}</div>}
@@ -445,8 +424,7 @@ const mapDispatchToProps = {
     joinConferenceWithoutAudio: joinConferenceWithoutAudioAction,
     joinConference: joinConferenceAction,
     setJoinByPhoneDialogVisiblity: setJoinByPhoneDialogVisiblityAction,
-    setSkipPrejoin: setSkipPrejoinAction,
-    updateSettings
+    setSkipPrejoin: setSkipPrejoinAction
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(translate(Prejoin));


### PR DESCRIPTION
For vpaas meetings, the name displayed on the prejoin screen is now taken from the jwt.