### PR TITLE
ios: stop using react-native-background-timer

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -259,7 +259,7 @@ PODS:
     - React-cxxreact (= 0.61.5-jitsi.1)
     - React-jsi (= 0.61.5-jitsi.1)
   - React-jsinspector (0.61.5-jitsi.1)
-  - react-native-background-timer (2.1.1):
+  - react-native-background-timer (2.4.0):
     - React
   - react-native-calendar-events (2.0.0):
     - React
@@ -529,7 +529,7 @@ SPEC CHECKSUMS:
   React-jsi: 4f35c1a2273d193a80c1c3831c808413840c260c
   React-jsiexecutor: de1c37cf59ae9adcbf2be82eea0e090dc3f3205e
   React-jsinspector: b76c4e84a7833bb4c90549d59ed53ec299ff912b
-  react-native-background-timer: 0d34748e53a972507c66963490c775321a88f6f2
+  react-native-background-timer: e0384ea2fa5a98f67f84f9c4dc274260ddd674ed
   react-native-calendar-events: 1442fad71a00388f933cfa25512588fec300fcf8
   react-native-keep-awake: eba3137546b10003361b37c761f6c429b59814ae
   react-native-netinfo: 8d8db463bcc5db66a8ac5c48a7d86beb3b92f61a

--- a/package-lock.json
+++ b/package-lock.json
@@ -14481,9 +14481,9 @@
       }
     },
     "react-native-background-timer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-background-timer/-/react-native-background-timer-2.1.1.tgz",
-      "integrity": "sha512-cuXIIv+dcG8a8qkTD8pMzeqOEZCO+UGKglZWIe1osve+yJslmCowYQff+bI9xa7NOt2w+Vtd4L3d9JonlSqODg=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-background-timer/-/react-native-background-timer-2.4.0.tgz",
+      "integrity": "sha512-00DphusbzXUuJDP+SSRe7FJczFWzrCErr+2TdRxYfbQjpDaRk3rXw8nhlQXI5U6KthquEQOrCRMq2F2hi/HKLg=="
     },
     "react-native-calendar-events": {
       "version": "github:jitsi/react-native-calendar-events#928a80e2ffef0d7e84936d7e7e0acc4f53ee8470",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-i18next": "10.11.4",
     "react-linkify": "1.0.0-alpha",
     "react-native": "github:jitsi/react-native#efd2aff5661d75a230e36406b698cfe0ee545be2",
-    "react-native-background-timer": "2.1.1",
+    "react-native-background-timer": "2.4.0",
     "react-native-calendar-events": "github:jitsi/react-native-calendar-events#928a80e2ffef0d7e84936d7e7e0acc4f53ee8470",
     "react-native-callstats": "3.61.0",
     "react-native-collapsible": "1.5.1",

--- a/react/features/mobile/polyfills/browser.js
+++ b/react/features/mobile/polyfills/browser.js
@@ -415,10 +415,12 @@ function _visitNode(node, callback) {
     // Required by:
     // - lib-jitsi-meet
     // - Strophe
-    global.clearTimeout = BackgroundTimer.clearTimeout.bind(BackgroundTimer);
-    global.clearInterval = BackgroundTimer.clearInterval.bind(BackgroundTimer);
-    global.setInterval = BackgroundTimer.setInterval.bind(BackgroundTimer);
-    global.setTimeout = (fn, ms = 0) => BackgroundTimer.setTimeout(fn, ms);
+    if (Platform.OS === 'android') {
+        global.clearTimeout = BackgroundTimer.clearTimeout.bind(BackgroundTimer);
+        global.clearInterval = BackgroundTimer.clearInterval.bind(BackgroundTimer);
+        global.setInterval = BackgroundTimer.setInterval.bind(BackgroundTimer);
+        global.setTimeout = (fn, ms = 0) => BackgroundTimer.setTimeout(fn, ms);
+    }
 
     // localStorage
     if (typeof global.localStorage === 'undefined') {


### PR DESCRIPTION
Ever since facebook/react-native#23674 landed it has
been possible to run timers in the background, assuming your app is allowed to
run in the background already, as is our case. So, stop using the library on
iOS, which will avoid creating needless background tasks.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
