### PR TITLE
fix(SmallVideo) screen-sharing indicator

### DIFF
--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -373,7 +373,6 @@ export default class RemoteVideo extends SmallVideo {
 
         if (stream === this.videoStream) {
             this.videoStream = null;
-            this.videoType = undefined;
         }
 
         this.updateView();
@@ -484,7 +483,6 @@ export default class RemoteVideo extends SmallVideo {
 
         if (isVideo) {
             this.videoStream = stream;
-            this.videoType = stream.videoType;
         } else {
             this.audioStream = stream;
         }

--- a/modules/UI/videolayout/SmallVideo.js
+++ b/modules/UI/videolayout/SmallVideo.js
@@ -243,6 +243,10 @@ export default class SmallVideo {
      * or hidden
      */
     setScreenSharing(isScreenSharing) {
+        if (isScreenSharing === this.isScreenSharing) {
+            return;
+        }
+
         this.isScreenSharing = isScreenSharing;
         this.updateView();
         this.updateStatusBar();

--- a/modules/UI/videolayout/VideoLayout.js
+++ b/modules/UI/videolayout/VideoLayout.js
@@ -489,7 +489,7 @@ const VideoLayout = {
     onVideoTypeChanged(id, newVideoType) {
         const remoteVideo = remoteVideos[id];
 
-        if (!remoteVideo || remoteVideo.videoType === newVideoType) {
+        if (!remoteVideo) {
             return;
         }
 


### PR DESCRIPTION
The stream is attached before the video type change event is fired, so comparing
them is too late. Unconditionally update the screen-sharing indicator, and
perform the check for a change right there, to avoid re-renders.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
