### PR TITLE
fix(build) reduce bundle size by about 700K

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,7 +142,8 @@ const config = {
         // value that is a mock (/index.js).
         __filename: true,
 
-        // Provide an empty 'fs' module.
+        // Provide some empty Node modules (required by olm).
+        crypto: 'empty',
         fs: 'empty'
     },
     optimization: {
@@ -190,7 +191,7 @@ module.exports = [
         entry: {
             'app.bundle': './app.js'
         },
-        performance: getPerformanceHints(4.5 * 1024 * 1024)
+        performance: getPerformanceHints(4 * 1024 * 1024)
     }),
     Object.assign({}, config, {
         entry: {


### PR DESCRIPTION
app.bundle.js before: 3851549 after: 4506493.

The culprit for the bloat was Olm. It feature-detects the environment in order
to pick a suitable random byte generator, and alas Webpack includes the None
crypto pollyfill. This is due to the existence of the "node" block in our
Webpack configuration file.

The solution is to provide empty modules to make bundling work, as we did
already for the fs module, since we know they are not used at runtime.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
