### PR TITLE
fix(UI): Re-compute large-video width only once if the chat window is open.

### DIFF
--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -331,7 +331,7 @@ export default class LargeVideoManager {
          * the chat. We re-compute the width again after the chat window is closed. This is needed when
          * custom styling is configured on the large video container through the iFrame API.
          */
-        if (isOpen) {
+        if (isOpen && !this.resizedForChat) {
             widthToUse -= CHAT_SIZE;
             this.resizedForChat = true;
         } else if (this.resizedForChat) {


### PR DESCRIPTION
Deduct the chat window width from large-video width only once if we keep toggling between stage view and grid view while the chat window is open.


