### PR TITLE
fix(chat) prevent homograph attacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13141,6 +13141,11 @@
         }
       }
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "moment-duration-format": "2.2.2",
     "olm": "https://packages.matrix.org/npm/olm/olm-3.1.4.tgz",
     "pixelmatch": "5.1.0",
+    "punycode": "2.1.1",
     "react": "16.9",
     "react-dom": "16.9",
     "react-emoji-render": "1.2.4",

--- a/react/features/base/react/components/native/Linkify.js
+++ b/react/features/base/react/components/native/Linkify.js
@@ -1,5 +1,6 @@
 // @flow
 
+import punycode from 'punycode';
 import React, { Component } from 'react';
 import ReactLinkify from 'react-linkify';
 import { Text } from 'react-native';
@@ -68,7 +69,7 @@ export default class Linkify extends Component<Props> {
                 key = { key }
                 style = { this.props.linkStyle }
                 url = { decoratedHref }>
-                {decoratedText}
+                { punycode.toASCII(decoratedText) }
             </Link>
         );
     }

--- a/react/features/base/react/components/web/Linkify.js
+++ b/react/features/base/react/components/web/Linkify.js
@@ -1,5 +1,6 @@
 // @flow
 
+import punycode from 'punycode';
 import React, { Component } from 'react';
 import ReactLinkify from 'react-linkify';
 
@@ -44,7 +45,7 @@ export default class Linkify extends Component<Props> {
                 key = { key }
                 rel = 'noopener noreferrer'
                 target = '_blank'>
-                {decoratedText}
+                { punycode.toASCII(decoratedText) }
             </a>
         );
     }


### PR DESCRIPTION
Decode URLs using punycode when rendering, so when http://ebаy.com is sent
we render http://xn--eby-7cd.com/ instead.

Ref: https://github.com/tasti/react-linkify/issues/84

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
![Screenshot 2020-09-25 at 12 01 59](https://user-images.githubusercontent.com/317464/94254719-77fb8080-ff27-11ea-8e73-33bea793e236.png)
![Screenshot 2020-09-25 at 12 01 52](https://user-images.githubusercontent.com/317464/94254725-78941700-ff27-11ea-9f74-807f93aa3642.png)
