### PR TITLE
fix(presenter): Do not change the video mute state on presenter mute.

### DIFF
--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -153,12 +153,10 @@ MiddlewareRegistry.register(store => next => action => {
             const isVideoTrack = jitsiTrack.type !== MEDIA_TYPE.AUDIO;
 
             if (isVideoTrack) {
+                // Do not change the video mute state for local presenter tracks.
                 if (jitsiTrack.type === MEDIA_TYPE.PRESENTER) {
                     APP.conference.mutePresenter(muted);
-                }
-
-                // Make sure we change the video mute state only for camera tracks.
-                if (jitsiTrack.isLocal() && jitsiTrack.videoType !== 'desktop') {
+                } else if (jitsiTrack.isLocal()) {
                     APP.conference.setVideoMuteStatus(muted);
                 } else {
                     APP.UI.setVideoMuted(participantID, muted);


### PR DESCRIPTION
This fixes the issue where the local preview appears muted when presenter camera is turned on and then off while screenshare is in progress.
