### PR TITLE
fix: Show focus indicator only when navigating via keyboard

### DIFF
--- a/react/features/base/buttons/CopyButton.js
+++ b/react/features/base/buttons/CopyButton.js
@@ -112,7 +112,9 @@ function CopyButton({ className, displayedText, textToCopy, textOnHover, textOnC
             className = { `${className} copy-button${isClicked ? ' clicked' : ''}` }
             onClick = { onClick }
             onMouseOut = { onHoverOut }
-            onMouseOver = { onHoverIn }>
+            onMouseOver = { onHoverIn }
+            role = 'button'
+            tabIndex = { 0 }>
             { renderContent() }
         </div>
     );

--- a/react/features/base/icons/components/Icon.js
+++ b/react/features/base/icons/components/Icon.js
@@ -70,12 +70,17 @@ export default function Icon(props: Props) {
     } = styleTypeToObject(style ?? {});
     const calculatedColor = color ?? styleColor ?? DEFAULT_COLOR;
     const calculatedSize = size ?? styleSize ?? DEFAULT_SIZE;
+    const a11yClickable = onClick ? {
+        role: 'button',
+        tabIndex: 0
+    } : {};
 
     return (
         <Container
             className = { `jitsi-icon ${className}` }
             onClick = { onClick }
-            style = { restStyle }>
+            style = { restStyle }
+            { ...a11yClickable }>
             <IconComponent
                 fill = { calculatedColor }
                 height = { calculatedSize }

--- a/react/features/base/participants/components/ParticipantView.native.js
+++ b/react/features/base/participants/components/ParticipantView.native.js
@@ -213,10 +213,12 @@ class ParticipantView extends Component<Props> {
         return (
             <Container
                 onClick = { renderVideo || renderYoutubeLargeVideo ? undefined : onPress }
+                role = 'button'
                 style = {{
                     ...styles.participantView,
                     ...this.props.style
                 }}
+                tabIndex = { 0 }
                 touchFeedback = { false }>
 
                 <TestHint

--- a/react/features/base/premeeting/components/web/ActionButton.js
+++ b/react/features/base/premeeting/components/web/ActionButton.js
@@ -66,12 +66,16 @@ function ActionButton({
         <div
             className = { `action-btn ${className} ${type} ${disabled ? 'disabled' : ''}` }
             data-testid = { testId ? testId : undefined }
-            onClick = { disabled ? undefined : onClick }>
+            onClick = { disabled ? undefined : onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             {children}
             {hasOptions && <div
                 className = 'options'
                 data-testid = 'prejoin.joinOptions'
-                onClick = { disabled ? undefined : onOptionsClick }>
+                onClick = { disabled ? undefined : onOptionsClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <Icon
                     className = 'icon'
                     size = { 14 }

--- a/react/features/base/premeeting/components/web/CopyMeetingUrl.js
+++ b/react/features/base/premeeting/components/web/CopyMeetingUrl.js
@@ -192,7 +192,9 @@ class CopyMeetingUrl extends Component<Props, State> {
                 onMouseLeave = { _hideCopyLink }>
                 <div
                     className = { `url ${showLinkCopied ? 'done' : ''}` }
-                    onClick = { _copyUrl } >
+                    onClick = { _copyUrl }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <div className = 'copy-meeting-text'>
                         { !showCopyLink && !showLinkCopied && getDecodedURI(url) }
                         { showCopyLink && t('prejoin.copyAndShare') }

--- a/react/features/base/premeeting/components/web/ToggleButton.js
+++ b/react/features/base/premeeting/components/web/ToggleButton.js
@@ -35,7 +35,9 @@ function ToggleButton({ children, isToggled, onClick }: Props) {
     return (
         <div
             className = { className }
-            onClick = { onClick }>
+            onClick = { onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             <div className = 'toggle-button-container'>
                 <div className = 'toggle-button-icon-container'>
                     <Icon

--- a/react/features/base/react/components/native/AvatarListItem.js
+++ b/react/features/base/react/components/native/AvatarListItem.js
@@ -95,7 +95,9 @@ export default class AvatarListItem extends Component<Props> {
         return (
             <Container
                 onClick = { this.props.onPress }
+                role = 'button'
                 style = { styles.listItem }
+                tabIndex = { 0 }
                 underlayColor = { UNDERLAY_COLOR }>
                 <Avatar
                     colorBase = { colorBase }

--- a/react/features/base/react/components/native/NavigateSectionListItem.js
+++ b/react/features/base/react/components/native/NavigateSectionListItem.js
@@ -104,7 +104,9 @@ export default class NavigateSectionListItem extends Component<Props> {
         return (
             <Container
                 onClick = { secondaryAction }
-                style = { styles.secondaryActionContainer }>
+                role = 'button'
+                style = { styles.secondaryActionContainer }
+                tabIndex = { 0 }>
                 <Text style = { styles.secondaryActionLabel }>+</Text>
             </Container>
         );

--- a/react/features/base/react/components/web/MeetingsList.js
+++ b/react/features/base/react/components/web/MeetingsList.js
@@ -166,7 +166,9 @@ export default class MeetingsList extends Component<Props> {
             <Container
                 className = { rootClassName }
                 key = { index }
-                onClick = { onPress }>
+                onClick = { onPress }
+                role = 'button'
+                tabIndex = { 0 }>
                 <Container className = 'left-column'>
                     <Text className = 'date'>
                         { _toDateString(date) }

--- a/react/features/base/react/components/web/NavigateSectionListItem.js
+++ b/react/features/base/react/components/web/NavigateSectionListItem.js
@@ -65,7 +65,9 @@ export default class NavigateSectionListItem<P: Props>
         return (
             <Container
                 className = { rootClassName }
-                onClick = { onPress }>
+                onClick = { onPress }
+                role = 'button'
+                tabIndex = { 0 }>
                 <Container className = 'navigate-section-list-tile-info'>
                     <Text
                         className = 'navigate-section-tile-title'>

--- a/react/features/base/toolbox/components/OverflowMenuItem.web.js
+++ b/react/features/base/toolbox/components/OverflowMenuItem.web.js
@@ -91,7 +91,9 @@ class OverflowMenuItem extends Component<Props> {
             <li
                 aria-label = { accessibilityLabel }
                 className = { className }
-                onClick = { disabled ? null : onClick }>
+                onClick = { disabled ? null : onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <span className = 'overflow-menu-item-icon'>
                     <Icon
                         id = { iconId }

--- a/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
+++ b/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
@@ -67,7 +67,9 @@ class AddMeetingUrlButton extends Component<Props> {
             <Tooltip content = { this.props.t('calendarSync.addMeetingURL') }>
                 <div
                     className = 'button add-button'
-                    onClick = { this._onClick }>
+                    onClick = { this._onClick }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <Icon src = { IconAdd } />
                 </div>
             </Tooltip>

--- a/react/features/calendar-sync/components/CalendarList.web.js
+++ b/react/features/calendar-sync/components/CalendarList.web.js
@@ -124,14 +124,18 @@ class CalendarList extends AbstractPage<Props> {
                     { showSettingsButton
                         && <div
                             className = 'button'
-                            onClick = { this._onOpenSettings }>
+                            onClick = { this._onOpenSettings }
+                            role = 'button'
+                            tabIndex = { 0 }>
                             { t('calendarSync.permissionButton') }
                         </div>
                     }
                     { showRefreshButton
                         && <div
                             className = 'button'
-                            onClick = { this._onRefreshEvents }>
+                            onClick = { this._onRefreshEvents }
+                            role = 'button'
+                            tabIndex = { 0 }>
                             { t('calendarSync.refresh') }
                         </div>
                     }
@@ -167,7 +171,9 @@ class CalendarList extends AbstractPage<Props> {
                     </p>
                     <div
                         className = 'button'
-                        onClick = { this._onRefreshEvents }>
+                        onClick = { this._onRefreshEvents }
+                        role = 'button'
+                        tabIndex = { 0 }>
                         { t('calendarSync.refresh') }
                     </div>
                 </div>
@@ -193,7 +199,9 @@ class CalendarList extends AbstractPage<Props> {
                 </p>
                 <div
                     className = 'button'
-                    onClick = { this._onOpenSettings }>
+                    onClick = { this._onOpenSettings }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     { t('welcomepage.connectCalendarButton') }
                 </div>
             </div>

--- a/react/features/calendar-sync/components/JoinButton.web.js
+++ b/react/features/calendar-sync/components/JoinButton.web.js
@@ -59,7 +59,9 @@ class JoinButton extends Component<Props> {
                 content = { t('calendarSync.joinTooltip') }>
                 <div
                     className = 'button join-button'
-                    onClick = { this._onClick }>
+                    onClick = { this._onClick }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     { t('calendarSync.join') }
                 </div>
             </Tooltip>

--- a/react/features/calendar-sync/components/MicrosoftSignInButton.web.js
+++ b/react/features/calendar-sync/components/MicrosoftSignInButton.web.js
@@ -31,7 +31,9 @@ export default class MicrosoftSignInButton extends Component<Props> {
         return (
             <div
                 className = 'microsoft-sign-in'
-                onClick = { this.props.onClick }>
+                onClick = { this.props.onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <img
                     className = 'microsoft-logo'
                     src = 'images/microsoftLogo.svg' />

--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -135,7 +135,9 @@ class Chat extends AbstractChat<Props> {
             <div className = 'chat-header'>
                 <div
                     className = 'chat-close'
-                    onClick = { this.props._onToggleChat }>
+                    onClick = { this.props._onToggleChat }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <Icon src = { IconClose } />
                 </div>
             </div>

--- a/react/features/chat/components/web/ChatInput.js
+++ b/react/features/chat/components/web/ChatInput.js
@@ -115,6 +115,8 @@ class ChatInput extends Component<Props, State> {
                         <div id = 'smileys'>
                             <Emoji
                                 onClick = { this._onToggleSmileysPanel }
+                                role = 'button'
+                                tabIndex = { 0 }
                                 text = ':)' />
                         </div>
                     </div>

--- a/react/features/chat/components/web/MessageRecipient.js
+++ b/react/features/chat/components/web/MessageRecipient.js
@@ -36,7 +36,10 @@ class MessageRecipient extends AbstractMessageRecipient<Props> {
                         recipient: _privateMessageRecipient
                     }) }
                 </span>
-                <div onClick = { this.props._onRemovePrivateMessageRecipient }>
+                <div
+                    onClick = { this.props._onRemovePrivateMessageRecipient }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <Icon
                         src = { IconCancelSelection } />
                 </div>

--- a/react/features/chat/components/web/SmileysPanel.js
+++ b/react/features/chat/components/web/SmileysPanel.js
@@ -41,6 +41,8 @@ class SmileysPanel extends PureComponent<Props> {
                     <Emoji
                         onClick = { onSelectFunction }
                         onlyEmojiClassName = 'smiley'
+                        role = 'button'
+                        tabIndex = { 0 }
                         text = { smileys[smileyKey] } />
                 </div>
             );

--- a/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.js
+++ b/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.js
@@ -244,7 +244,9 @@ class ChromeExtensionBanner extends PureComponent<Props, State> {
                     </div>
                     <div
                         className = 'chrome-extension-banner__close-container'
-                        onClick = { this._onClosePressed }>
+                        onClick = { this._onClosePressed }
+                        role = 'button'
+                        tabIndex = { 0 }>
                         <Icon
                             className = 'gray'
                             size = { 12 }
@@ -255,7 +257,9 @@ class ChromeExtensionBanner extends PureComponent<Props, State> {
                     className = 'chrome-extension-banner__button-container'>
                     <div
                         className = 'chrome-extension-banner__button-open-url'
-                        onClick = { this._onInstallExtensionClick }>
+                        onClick = { this._onInstallExtensionClick }
+                        role = 'button'
+                        tabIndex = { 0 }>
                         <div
                             className = 'chrome-extension-banner__button-text'>
                             { t('chromeExtensionBanner.buttonText') }

--- a/react/features/conference/components/web/InviteMore.js
+++ b/react/features/conference/components/web/InviteMore.js
@@ -57,7 +57,9 @@ function InviteMore({
                 </div>
                 <div
                     className = 'invite-more-button'
-                    onClick = { onClick }>
+                    onClick = { onClick }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <Icon src = { IconInviteMore } />
                     <div className = 'invite-more-button-text'>
                         {t('addPeople.inviteMorePrompt')}

--- a/react/features/conference/components/web/ParticipantsCount.js
+++ b/react/features/conference/components/web/ParticipantsCount.js
@@ -72,7 +72,9 @@ class ParticipantsCount extends PureComponent<Props> {
         return (
             <div
                 className = 'participants-count'
-                onClick = { this._onClick }>
+                onClick = { this._onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <span className = 'participants-count-number'>
                     {this.props.count}
                 </span>

--- a/react/features/desktop-picker/components/DesktopSourcePreview.js
+++ b/react/features/desktop-picker/components/DesktopSourcePreview.js
@@ -71,7 +71,9 @@ class DesktopSourcePreview extends Component<Props> {
             <div
                 className = { displayClasses }
                 onClick = { this._onClick }
-                onDoubleClick = { this._onDoubleClick }>
+                onDoubleClick = { this._onDoubleClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <div className = 'desktop-source-preview-image-container'>
                     <img
                         className = 'desktop-source-preview-thumbnail'

--- a/react/features/display-name/components/web/DisplayName.js
+++ b/react/features/display-name/components/web/DisplayName.js
@@ -172,7 +172,9 @@ class DisplayName extends Component<Props, State> {
             <span
                 className = 'displayname'
                 id = { elementID }
-                onClick = { this._onStartEditing }>
+                onClick = { this._onStartEditing }
+                role = 'button'
+                tabIndex = { 0 }>
                 { appendSuffix(_nameToDisplay, displayNameSuffix) }
             </span>
         );

--- a/react/features/e2ee/components/E2EESection.js
+++ b/react/features/e2ee/components/E2EESection.js
@@ -106,7 +106,9 @@ class E2EESection extends Component<Props, State> {
                     { !expand && description.substring(0, 100) }
                     { !expand && <span
                         className = 'read-more'
-                        onClick = { this._onExpand }>
+                        onClick = { this._onExpand }
+                        role = 'button'
+                        tabIndex = { 0 }>
                             ... { t('dialog.readMore') }
                     </span> }
                 </p>

--- a/react/features/embed-meeting/components/EmbedMeetingTrigger.js
+++ b/react/features/embed-meeting/components/EmbedMeetingTrigger.js
@@ -39,7 +39,9 @@ function EmbedMeetingTrigger({ t, openEmbedDialog }: Props) {
     return (
         <div
             className = 'embed-meeting-trigger'
-            onClick = { onClick }>
+            onClick = { onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             {t('embedMeeting.title')}
         </div>
     );

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -141,12 +141,14 @@ function Thumbnail(props: Props) {
         <Container
             onClick = { _onClick }
             onLongPress = { participant.local ? undefined : _onShowRemoteVideoMenu }
+            role = 'button'
             style = { [
                 styles.thumbnail,
                 participant.pinned && !tileView
                     ? _styles.thumbnailPinned : null,
                 props.styleOverrides || null
             ] }
+            tabIndex = { 0 }
             touchFeedback = { false }>
 
             <ParticipantView

--- a/react/features/google-api/components/GoogleSignInButton.web.js
+++ b/react/features/google-api/components/GoogleSignInButton.web.js
@@ -25,7 +25,9 @@ class GoogleSignInButton extends AbstractGoogleSignInButton {
         return (
             <div
                 className = 'google-sign-in'
-                onClick = { this.props.onClick }>
+                onClick = { this.props.onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <img
                     className = 'google-logo'
                     src = 'images/googleLogo.svg' />

--- a/react/features/invite/components/add-people-dialog/web/InviteByEmailSection.js
+++ b/react/features/invite/components/add-people-dialog/web/InviteByEmailSection.js
@@ -113,7 +113,9 @@ function InviteByEmailSection({ inviteSubject, inviteText, t }: Props) {
                             key = { idx }
                             position = 'top'>
                             <div
-                                onClick = { _onSelectProvider(url) }>
+                                onClick = { _onSelectProvider(url) }
+                                role = 'button'
+                                tabIndex = { 0 }>
                                 <Icon src = { icon } />
                             </div>
                         </Tooltip>
@@ -129,7 +131,9 @@ function InviteByEmailSection({ inviteSubject, inviteText, t }: Props) {
             <div>
                 <div
                     className = { `invite-more-dialog email-container${isActive ? ' active' : ''}` }
-                    onClick = { _onToggleActiveState }>
+                    onClick = { _onToggleActiveState }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     <span>{t('addPeople.shareInvite')}</span>
                     <Icon src = { IconArrowDownSmall } />
                 </div>
@@ -139,7 +143,9 @@ function InviteByEmailSection({ inviteSubject, inviteText, t }: Props) {
                         position = 'top'>
                         <div
                             className = 'copy-invite-icon'
-                            onClick = { _onCopyText }>
+                            onClick = { _onCopyText }
+                            role = 'button'
+                            tabIndex = { 0 }>
                             <Icon src = { IconCopy } />
                         </div>
                     </Tooltip>

--- a/react/features/invite/components/add-people-dialog/web/LiveStreamSection.js
+++ b/react/features/invite/components/add-people-dialog/web/LiveStreamSection.js
@@ -99,7 +99,9 @@ function LiveStreamSection({ liveStreamViewURL, t }: Props) {
                 className = { `invite-more-dialog stream${isClicked ? ' clicked' : ''}` }
                 onClick = { onClick }
                 onMouseOut = { onHoverOut }
-                onMouseOver = { onHoverIn }>
+                onMouseOver = { onHoverIn }
+                role = 'button'
+                tabIndex = { 0 }>
                 { renderLinkContent() }
             </div>
             <div className = 'invite-more-dialog separator' />

--- a/react/features/prejoin/components/Label.js
+++ b/react/features/prejoin/components/Label.js
@@ -38,7 +38,9 @@ function Label({ children, className, number, onClick }: Props) {
     return (
         <div
             className = { containerClass }
-            onClick = { onClick }>
+            onClick = { onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             {number && <div className = 'prejoin-dialog-label-num'>{number}</div>}
             <span>{children}</span>
         </div>

--- a/react/features/prejoin/components/Prejoin.js
+++ b/react/features/prejoin/components/Prejoin.js
@@ -331,7 +331,9 @@ class Prejoin extends Component<Props, State> {
                                         <div
                                             className = 'prejoin-preview-dropdown-btn'
                                             data-testid = 'prejoin.joinWithoutAudio'
-                                            onClick = { joinConferenceWithoutAudio }>
+                                            onClick = { joinConferenceWithoutAudio }
+                                            role = 'button'
+                                            tabIndex = { 0 }>
                                             <Icon
                                                 className = 'prejoin-preview-dropdown-icon'
                                                 size = { 24 }
@@ -340,7 +342,9 @@ class Prejoin extends Component<Props, State> {
                                         </div>
                                         {hasJoinByPhoneButton && <div
                                             className = 'prejoin-preview-dropdown-btn'
-                                            onClick = { _showDialog }>
+                                            onClick = { _showDialog }
+                                            role = 'button'
+                                            tabIndex = { 0 }>
                                             <Icon
                                                 className = 'prejoin-preview-dropdown-icon'
                                                 data-testid = 'prejoin.joinByPhone'

--- a/react/features/prejoin/components/country-picker/CountryRow.js
+++ b/react/features/prejoin/components/country-picker/CountryRow.js
@@ -44,7 +44,9 @@ class CountryRow extends PureComponent<Props> {
         return (
             <div
                 className = 'cpick-dropdown-entry'
-                onClick = { this._onClick }>
+                onClick = { this._onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <div className = { `prejoin-dialog-flag iti-flag ${code}` } />
                 <div className = 'cpick-dropdown-entry-text'>
                     {`${name} (+${dialCode})`}

--- a/react/features/prejoin/components/country-picker/CountrySelector.js
+++ b/react/features/prejoin/components/country-picker/CountrySelector.js
@@ -26,7 +26,9 @@ function CountrySelector({ country: { code, dialCode }, onClick }: Props) {
     return (
         <div
             className = 'cpick-selector'
-            onClick = { onClick }>
+            onClick = { onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             <div className = { `prejoin-dialog-flag iti-flag ${code}` } />
             <span>{`+${dialCode}`}</span>
             <Icon

--- a/react/features/prejoin/components/dialogs/DialInDialog.js
+++ b/react/features/prejoin/components/dialogs/DialInDialog.js
@@ -91,7 +91,9 @@ function DialinDialog(props: Props) {
             <div>
                 <span
                     className = 'prejoin-dialog-dialin-link'
-                    onClick = { onSmallTextClick }>
+                    onClick = { onSmallTextClick }
+                    role = 'button'
+                    tabIndex = { 0 }>
                     {t('prejoin.viewAllNumbers')}
                 </span>
             </div>

--- a/react/features/settings/components/web/audio/MicrophoneEntry.js
+++ b/react/features/settings/components/web/audio/MicrophoneEntry.js
@@ -155,7 +155,9 @@ export default class MicrophoneEntry extends Component<Props, State> {
         return (
             <div
                 className = 'audio-preview-microphone'
-                onClick = { this._onClick }>
+                onClick = { this._onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <AudioSettingsEntry
                     hasError = { hasError }
                     isSelected = { isSelected }>

--- a/react/features/settings/components/web/audio/SpeakerEntry.js
+++ b/react/features/settings/components/web/audio/SpeakerEntry.js
@@ -103,7 +103,9 @@ export default class SpeakerEntry extends Component<Props> {
         return (
             <div
                 className = 'audio-preview-speaker'
-                onClick = { this._onClick }>
+                onClick = { this._onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <AudioSettingsEntry
                     isSelected = { isSelected }
                     key = { deviceId }>

--- a/react/features/settings/components/web/audio/TestButton.js
+++ b/react/features/settings/components/web/audio/TestButton.js
@@ -19,7 +19,9 @@ export default function TestButton({ onClick }: Props) {
     return (
         <div
             className = 'audio-preview-test-button'
-            onClick = { onClick }>
+            onClick = { onClick }
+            role = 'button'
+            tabIndex = { 0 }>
             Test
         </div>
     );

--- a/react/features/toolbox/components/web/OverflowMenuProfileItem.js
+++ b/react/features/toolbox/components/web/OverflowMenuProfileItem.js
@@ -79,7 +79,9 @@ class OverflowMenuProfileItem extends Component<Props> {
             <li
                 aria-label = { t('toolbar.accessibilityLabel.profile') }
                 className = { classNames }
-                onClick = { this._onClick }>
+                onClick = { this._onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <span className = 'overflow-menu-item-icon'>
                     <Avatar
                         participantId = { _localParticipant.id }

--- a/react/features/video-quality/components/OverflowMenuVideoQualityItem.web.js
+++ b/react/features/video-quality/components/OverflowMenuVideoQualityItem.web.js
@@ -80,7 +80,9 @@ class OverflowMenuVideoQualityItem extends Component<Props> {
                 aria-label =
                     { this.props.t('toolbar.accessibilityLabel.callQuality') }
                 className = 'overflow-menu-item'
-                onClick = { this.props.onClick }>
+                onClick = { this.props.onClick }
+                role = 'button'
+                tabIndex = { 0 }>
                 <span className = 'overflow-menu-item-icon'>
                     <Icon src = { icon } />
                 </span>

--- a/react/features/welcome/components/Tab.js
+++ b/react/features/welcome/components/Tab.js
@@ -69,7 +69,9 @@ export default class Tab extends Component<Props> {
             <div
                 className = { className }
                 key = { index }
-                onClick = { this._onSelect }>
+                onClick = { this._onSelect }
+                role = 'button'
+                tabIndex = { 0 }>
                 { label }
             </div>);
     }


### PR DESCRIPTION
Preserve accessibility when navigating via keyboard but hide the focus border when clicking on buttons in the conference. This uses a polyfill for the `:focus-visible` selector since it does not yet have full browser support.

Tested this via Chrome (Beta) and Firefox on Windows