### PR TITLE
Fix webpack-dev-server on Windows

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,7 +102,7 @@ const config = {
             // dependencies including lib-jitsi-meet.
 
             loader: 'expose-loader?$!expose-loader?jQuery',
-            test: /\/node_modules\/jquery\/.*\.js$/
+            test: /[/\\]node_modules[/\\]jquery[/\\].*\.js$/
         }, {
             // Allow CSS to be imported into JavaScript.
 


### PR DESCRIPTION
## Summary
This PR allows path separator of `\` in addition to `/` in jQuery's path name, enabling `make dev` server to work on Windows 10.

## Need
The issue fixed by this PR is exactly #6844. I started a fresh checkout, ran `npm install`, and then `make dev`, and encountered the following error when loading `https://localhost:8080` in Chrome:
```
translation.js:27 Uncaught ReferenceError: $ is not defined
```
The browser page remains gray and fails to load.

The same error (though likely older versions of Jitsi) is reported by different people on https://stackoverflow.com/questions/57197208/jitsi-meet-compiled-from-source-but-got-error-when-run-dev-server and https://community.jitsi.org/t/get-javascript-error-when-compiled-from-source-and-start-with-dev-server/19048 and https://github.com/jitsi/jitsi-meet/issues/4488, suggesting that this issue is common to Windows developers.

With this PR, everything works fine in my environment.

## Related Work
PR #6845 attempted to fix this in another way, replacing the path regex with `require.resolve`. It seems that that change was too drastic to pass all tests in all cases (see [this comment](https://github.com/jitsi/jitsi-meet/pull/6845#issuecomment-634120180)). Hopefully this much simpler change will fix all settings. It is inspired by [this comment](https://github.com/jitsi/jitsi-meet/pull/6845#issuecomment-633657455) which says "I think it caused by the path divider".

