### PR TITLE
fix(e2ee) handle Olm initialization error

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,10 @@ import translation from './modules/translation/translation';
 
 // Initialize Olm as early as possible.
 if (window.Olm) {
-    window.Olm.init();
+    window.Olm.init().catch(e => {
+        console.error('Failed to initialize Olm, E2EE will be disabled', e);
+        delete window.Olm;
+    });
 }
 
 window.APP = {


### PR DESCRIPTION
If the WASM code could not be loaded, fail to initialize if and remove it from
globals so the E2EE option becomes unavailable, since it will be non-functional.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
