### PR TITLE
Apply flags when launching activity from non-activity context

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -34,8 +34,6 @@ import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 import java.util.HashMap;
 import android.app.Activity;
 
-import java.util.Map;
-
 /**
  * A base activity for SDK users to embed. It uses {@link JitsiMeetFragment} to do the heavy
  * lifting and wires the remaining Activity lifecycle methods so it works out of the box.

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -32,6 +32,9 @@ import com.facebook.react.modules.core.PermissionListener;
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 
 import java.util.HashMap;
+import android.app.Activity;
+
+import java.util.Map;
 
 /**
  * A base activity for SDK users to embed. It uses {@link JitsiMeetFragment} to do the heavy
@@ -58,6 +61,9 @@ public class JitsiMeetActivity extends FragmentActivity
         Intent intent = new Intent(context, JitsiMeetActivity.class);
         intent.setAction(ACTION_JITSI_MEET_CONFERENCE);
         intent.putExtra(JITSI_MEET_CONFERENCE_OPTIONS, options);
+        if (!(context instanceof Activity)) {
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        }
         context.startActivity(intent);
     }
 


### PR DESCRIPTION
Check whether context is that of an Activity before launching the Jitsi Conference Activity. If context is not an activity context, apply flag `FLAG_ACTIVITY_NEW_TASK` to the Jitsi Activity Intent to ensure activity can launch without error.

This scenario would manifest when a user attempts to launch the Jitsi Actvity from a Widget... for example.

https://developer.android.com/about/versions/pie/android-9.0-changes-all#fant-required