### PR TITLE
feat(presenter): apply 'text' contentHint

### DIFF
--- a/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
+++ b/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
@@ -145,6 +145,7 @@ export default class JitsiStreamPresenterEffect {
 
         // Put emphasis on the text details for the presenter's stream
         // See https://www.w3.org/TR/mst-content-hint/
+        // $FlowExpectedError
         capturedStream.getVideoTracks()[0].contentHint = 'text';
 
         return capturedStream;

--- a/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
+++ b/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
@@ -141,7 +141,13 @@ export default class JitsiStreamPresenterEffect {
             timeMs: 1000 / this._frameRate
         });
 
-        return this._canvas.captureStream(this._frameRate);
+        const capturedStream = this._canvas.captureStream(this._frameRate);
+
+        // Put emphasis on the text details for the presenter's stream
+        // See https://www.w3.org/TR/mst-content-hint/
+        capturedStream.getVideoTracks()[0].contentHint = 'text';
+
+        return capturedStream;
     }
 
     /**


### PR DESCRIPTION
...so that the text is more readable in the presenter mode. Chrome by
default uses 'detail' for screen sharing. I went with the 'text' here,
because the docs[1] say "may take advantage of encoder tools that
optimize for text rendering." - whether that's good specifically for
the presenter mode I don't know. It looked good for me when tested
on Chrome.

https://www.w3.org/TR/mst-content-hint/


PLEASE TEST THIS WITH jitsi-meet I was cherry picking from a branched fork which is not exactly the same.