### PR TITLE
Remotely set password should not be shown to other moderators to copy

### DIFF
--- a/react/features/security/components/security-dialog/PasswordSection.js
+++ b/react/features/security/components/security-dialog/PasswordSection.js
@@ -5,6 +5,7 @@ import React, { useRef } from 'react';
 
 import { translate } from '../../../base/i18n';
 import { copyText } from '../../../base/util';
+import { LOCKED_REMOTELY } from '../../../room-lock';
 
 import PasswordForm from './PasswordForm';
 
@@ -158,6 +159,14 @@ function PasswordSection({
                         className = 'copy-password'
                         onClick = { onPasswordCopy }>{ t('dialog.copy') }</a>
                 </>
+            );
+        }
+
+        if (locked === LOCKED_REMOTELY) {
+            return (
+                    <a
+                        className = 'remove-password'
+                        onClick = { onPasswordRemove }>{ t('dialog.Remove') }</a>
             );
         }
 

--- a/react/features/security/components/security-dialog/PasswordSection.js
+++ b/react/features/security/components/security-dialog/PasswordSection.js
@@ -164,9 +164,9 @@ function PasswordSection({
 
         if (locked === LOCKED_REMOTELY) {
             return (
-                    <a
-                        className = 'remove-password'
-                        onClick = { onPasswordRemove }>{ t('dialog.Remove') }</a>
+                <a
+                    className = 'remove-password'
+                    onClick = { onPasswordRemove }>{ t('dialog.Remove') }</a>
             );
         }
 


### PR DESCRIPTION
As Mentioned in #7783 , If the Room is locked by a Remote participant, do not show the Copy Option that will have value as undefined.