### PR TITLE
Show CC button for everyone

### DIFF
--- a/react/features/subtitles/components/AbstractClosedCaptionButton.js
+++ b/react/features/subtitles/components/AbstractClosedCaptionButton.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
-import { isLocalParticipantModerator } from '../../base/participants';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { toggleRequestingSubtitles } from '../actions';
 

--- a/react/features/subtitles/components/AbstractClosedCaptionButton.js
+++ b/react/features/subtitles/components/AbstractClosedCaptionButton.js
@@ -85,7 +85,7 @@ export class AbstractClosedCaptionButton
 export function _abstractMapStateToProps(state: Object, ownProps: Object) {
     const { _requestingSubtitles } = state['features/subtitles'];
     const { transcribingEnabled } = state['features/base/config'];
-    const { visible = Boolean(transcribingEnabled && isLocalParticipantModerator(state)) } = ownProps;
+    const { visible = Boolean(transcribingEnabled) } = ownProps;
 
     return {
         _requestingSubtitles,


### PR DESCRIPTION
The CC button was previously only showing for moderators. This change enables the CC button for everyone.
