### PR TITLE
fix: speakerstats_component, attempt to index (a nil value)

### DIFF
--- a/resources/prosody-plugins/mod_speakerstats_component.lua
+++ b/resources/prosody-plugins/mod_speakerstats_component.lua
@@ -40,6 +40,11 @@ function on_message(event)
             log("warn", "No room found %s", roomAddress);
             return false;
         end
+ 
+        if not room.speakerStats then
+            log("warn", "No speakerStats found for %s", roomAddress);
+            return false;
+        end
 
         local roomSpeakerStats = room.speakerStats;
         local from = event.stanza.attr.from;
@@ -185,6 +190,10 @@ function occupant_leaving(event)
     local room = event.room;
 
     if is_healthcheck_room(room.jid) then
+        return;
+    end
+ 
+    if not room.speakerStats then
         return;
     end
 


### PR DESCRIPTION
In some situation `mod_speakerstats_component.lua` gives the following errors. I tried to reproduce the error in my test environment but no success... I only see this errors on my production server after a prolonged high load.

I couldn't find the root cause but the commit fixes the symptons. Sometimes there is no `speakerStats` for the existing room or no room at the occupant leave time.

When checked the community forum, it seems that this problem isn't new.
https://community.jitsi.org/t/duration-time-not-showing/41206/35



```
Oct 01 06:01:59 c2s555e1f6ba990 error   Traceback[c2s]: ...itsi-meet/prosody-plugins/mod_speakerstats_component.lua:193: attempt to index field 'speakerStats' (a nil value)
stack traceback:
        ...itsi-meet/prosody-plugins/mod_speakerstats_component.lua:193: in function '?'
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/modules/muc/muc.lib.lua:557: in function </usr/lib/prosody/modules/muc/muc.lib.lua:497>
        (...tail calls...)
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/core/stanza_router.lua:180: in function 'core_post_stanza'
        /usr/lib/prosody/core/stanza_router.lua:127: in function 'core_process_stanza'
        /usr/lib/prosody/modules/mod_c2s.lua:276: in function 'func'
        /usr/lib/prosody/util/async.lua:127: in function </usr/lib/prosody/util/async.lua:125>
```

```
Oct 01 07:19:07 mod_bosh        error   Traceback[bosh]: ...itsi-meet/prosody-plugins/mod_speakerstats_component.lua:53: attempt to index local 'roomSpeakerStats' (a nil value)
stack traceback:
        ...itsi-meet/prosody-plugins/mod_speakerstats_component.lua:53: in function '?'
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/core/stanza_router.lua:180: in function 'core_post_stanza'
        /usr/lib/prosody/core/stanza_router.lua:127: in function 'dispatch_stanza'
        /usr/lib/prosody/modules/mod_bosh.lua:305: in function 'func'
        /usr/lib/prosody/util/async.lua:127: in function </usr/lib/prosody/util/async.lua:125>
stack traceback:
        /usr/lib/prosody/util/async.lua:211: in function 'run'
        /usr/lib/prosody/modules/mod_bosh.lua:447: in function 'cb_handlestanza'
        /usr/lib/prosody/util/xmppstream.lua:182: in function </usr/lib/prosody/util/xmppstream.lua:162>
        [C]: in function 'parse'
        /usr/lib/prosody/util/xmppstream.lua:282: in function 'feed'
        /usr/lib/prosody/modules/mod_bosh.lua:133: in function '?'
        /usr/lib/prosody/util/events.lua:79: in function </usr/lib/prosody/util/events.lua:75>
        (...tail calls...)
        /usr/lib/prosody/net/http/server.lua:228: in function </usr/lib/prosody/net/http/server.lua:176>
        [C]: in function 'xpcall'
        /usr/lib/prosody/net/http/server.lua:108: in function 'process_next'
        /usr/lib/prosody/net/http/server.lua:124: in function 'success_cb'
        /usr/lib/prosody/net/http/parser.lua:177: in function 'feed'
        /usr/lib/prosody/net/http/server.lua:155: in function </usr/lib/prosody/net/http/server.lua:154>
        (...tail calls...)
        /usr/lib/prosody/net/server_select.lua:915: in function </usr/lib/prosody/net/server_select.lua:899>
        [C]: in function 'xpcall'
        /usr/bin/prosody:80: in function 'loop'
        /usr/bin/prosody:90: in main chunk
        [C]: in ?
```
