### PR TITLE
Add isomorphic environment variables support #7290

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ ios/app/dropbox.key
 ios/app/GoogleService-Info.plist
 
 .vscode
+
+# Isomorphic environment variables
+.env.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9909,6 +9909,12 @@
         "is-wsl": "^1.1.0"
       }
     },
+    "optional-require": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.2.tgz",
+      "integrity": "sha512-HZubVd6IfHsbnpdNF/ICaSAzBUEW1TievpkjY3tB4Jnk8L7+pJ3conPzUt3Mn/6OZx9uzTDOHYPGA8/AxYHBOg==",
+      "dev": true
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "imports-loader": "0.7.1",
     "jetifier": "1.6.4",
     "metro-react-native-babel-preset": "0.56.0",
+    "optional-require": "^1.0.2",
     "sass": "1.26.8",
     "string-replace-loader": "2.1.1",
     "style-loader": "0.19.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,21 @@
 /* global __dirname */
 
 const CircularDependencyPlugin = require('circular-dependency-plugin');
+const optionalRequire = require('optional-require')(require);
 const process = require('process');
+const { EnvironmentPlugin } = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+
+const dotenv = optionalRequire(`${__dirname}/.env.json`);
 
 /**
  * The URL of the Jitsi Meet deployment to be proxy to in the context of
  * development with webpack-dev-server.
  */
 const devServerProxyTarget
-    = process.env.WEBPACK_DEV_SERVER_PROXY_TARGET || 'https://alpha.jitsi.net';
+    = (dotenv && dotenv.WEBPACK_DEV_SERVER_PROXY_TARGET)
+    || process.env.WEBPACK_DEV_SERVER_PROXY_TARGET
+    || 'https://alpha.jitsi.net';
 
 const analyzeBundle = process.argv.indexOf('--analyze-bundle') !== -1;
 const detectCircularDeps = process.argv.indexOf('--detect-circular-deps') !== -1;
@@ -167,6 +173,10 @@ const config = {
                 allowAsyncCycles: false,
                 exclude: /node_modules/,
                 failOnError: false
+            }),
+        EnvironmentPlugin
+            && new EnvironmentPlugin({
+                'process.env': JSON.stringify(dotenv || process.env)
             })
     ].filter(Boolean),
     resolve: {


### PR DESCRIPTION
Hello. Thanks to bot's (stale) notify. I create this PR and hope this may help to make environment variables more handy. It's isomorphic so can be used at any part of this project - webpack and client side as well. For example to set `WEBPACK_DEV_SERVER_PROXY_TARGET`. I'm sure that it's pretty secure way. Please check and share your thoughts.

ref: #7290