### PR TITLE
Lobby: Redirect rejected user back to server start screen

### DIFF
--- a/react/features/lobby/middleware.js
+++ b/react/features/lobby/middleware.js
@@ -16,6 +16,7 @@ import {
     participantIsKnockingOrUpdated,
     setLobbyModeEnabled,
     startKnocking,
+    cancelKnocking,
     setPasswordJoinFailed
 } from './actions';
 
@@ -118,6 +119,7 @@ function _conferenceFailed({ dispatch, getState }, next, action) {
             hideErrorSupportLink: true,
             titleKey: 'lobby.joinRejectedMessage'
         }));
+        dispatch(cancelKnocking());
     }
 
     return next(action);


### PR DESCRIPTION
Currently the lobby screen is closed and only a small error box is shown to the rejected user.
Everything else looks like the user has joined the session successfully.

Issue jitsi#7337

With dispatch(cancelKnocking() rejected user will be forwarded back to the start screen.
