### PR TITLE
fix(rejoin) fix adding track parameters to rejoin URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4834,9 +4834,9 @@
       }
     },
     "@webcomponents/url": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/url/-/url-0.7.1.tgz",
-      "integrity": "sha512-9oFDpuZ+tAogjPYQPhNEX86Npzb73A4kv9DOPsSO9aWoWgoevoP6eKx+TKMwO8BJxtTpSM9nKenHQTJ56SP2Cw=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@webcomponents/url/-/url-0.7.6.tgz",
+      "integrity": "sha512-u0713SyGVRdct1x+V+gRxDp2zMtHwPGaMjukhENqa6n+8H7Rgw4/lNhsk9DffPo3NoxEHv19iQJaI/Ab8Y+BKw=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@svgr/webpack": "4.3.2",
     "@tensorflow-models/body-pix": "2.0.4",
     "@tensorflow/tfjs": "1.5.1",
-    "@webcomponents/url": "0.7.1",
+    "@webcomponents/url": "0.7.6",
     "amplitude-js": "7.1.1",
     "base64-js": "1.3.1",
     "bc-css-flags": "3.0.0",


### PR DESCRIPTION
The URL polyfill we were using didn't support taking a URL object in the
constructor, the updated one does.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
