### PR TITLE
fix(prejoin): Fix moving content when device status bar is toggled

### DIFF
--- a/css/_prejoin.scss
+++ b/css/_prejoin.scss
@@ -62,12 +62,15 @@
     &-status {
         align-items: center;
         align-self: stretch;
+        bottom: 0;
         color: #fff;
         display: flex;
         font-size: 13px;
         min-height: 24px;
         justify-content: center;
+        position: absolute;
         text-align: center;
+        width: 100%;
         z-index: 1;
 
         &--warning {

--- a/css/_premeeting-screens.scss
+++ b/css/_premeeting-screens.scss
@@ -104,6 +104,7 @@
         flex: 1;
         flex-direction: column;
         justify-content: flex-end;
+        padding-bottom: 24px;
         z-index: $toolbarZ + 2;
 
         .title {


### PR DESCRIPTION
This can be tested by turning off both the mic and the camera on the prejoin screen. 
The content should not move anymore.