### PR TITLE
Avoid invoking virtual method on null object

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -124,7 +124,7 @@ public class JitsiMeetActivity extends FragmentActivity
 
     public void leave() {
         JitsiMeetView myView = getJitsiView();
-        if(myView != null) {
+        if (myView != null) {
             myView.leave();
         }
     }

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -123,7 +123,10 @@ public class JitsiMeetActivity extends FragmentActivity
     }
 
     public void leave() {
-        getJitsiView().leave();
+        JitsiMeetView myView = getJitsiView();
+        if(myView != null) {
+            myView.leave();
+        }
     }
 
     private @Nullable JitsiMeetConferenceOptions getConferenceOptions(Intent intent) {


### PR DESCRIPTION
Sometimes in Flutter, it seems like the jitsiView is already destructed before the leave() function is called. This is a 1-in-20 chance which causes the entire Flutter app to crash. This cannot be avoided from a fix in the jitsi_meet module for flutter. Therefore I came here to the actual jitsi_meet source to fix it.

Others have also seen this error occur, so I wanted to share my fix with others as well. So far I have not found anyone else with a similar permanent fix. Here are a few forum posts:
https://github.com/jitsi/jitsi-meet/issues/7105
https://community.jitsi.org/t/how-to-close-a-conference-room-in-android/32228
(there are others but I am too lazy to find them all; none have an answer/fix readily available)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
