### PR TITLE
Fixes the issue with turning on the camera for a moment when muted

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2604,6 +2604,20 @@ export default {
         // https://bugs.chromium.org/p/chromium/issues/detail?id=997689
         const hasDefaultMicChanged = newDevices.audioinput === 'default';
 
+        // This is the case when the local video is muted and a preferred device is connected.
+        if (requestedInput.video && this.isLocalVideoMuted()) {
+            // We want to avoid creating a new video track in order to prevent turning on the camera.
+            requestedInput.video = false;
+            APP.store.dispatch(updateSettings({ // Update the current selected camera for the device selection dialog.
+                cameraDeviceId: newDevices.videoinput
+            }));
+            delete newDevices.videoinput;
+
+            // Removing the current video track in order to force the unmute to select the preferred device.
+            this.useVideoStream(null);
+
+        }
+
         promises.push(
             mediaDeviceHelper.createLocalTracksAfterDeviceListChanged(
                     createLocalTracksF,

--- a/conference.js
+++ b/conference.js
@@ -65,6 +65,8 @@ import {
     JitsiTrackEvents
 } from './react/features/base/lib-jitsi-meet';
 import {
+    getStartWithAudioMuted,
+    getStartWithVideoMuted,
     isVideoMutedByUser,
     MEDIA_TYPE,
     setAudioAvailable,
@@ -731,10 +733,10 @@ export default {
         const initialOptions = {
             startAudioOnly: config.startAudioOnly,
             startScreenSharing: config.startScreenSharing,
-            startWithAudioMuted: config.startWithAudioMuted
+            startWithAudioMuted: getStartWithAudioMuted(APP.store.getState())
                 || config.startSilent
                 || isUserInteractionRequiredForUnmute(APP.store.getState()),
-            startWithVideoMuted: config.startWithVideoMuted
+            startWithVideoMuted: getStartWithVideoMuted(APP.store.getState())
                 || isUserInteractionRequiredForUnmute(APP.store.getState())
         };
 

--- a/react/features/base/media/functions.js
+++ b/react/features/base/media/functions.js
@@ -1,8 +1,29 @@
 /* @flow */
 
 import { toState } from '../redux';
+import { getPropertyValue } from '../settings';
 
 import { VIDEO_MUTISM_AUTHORITY } from './constants';
+
+
+// XXX The configurations/preferences/settings startWithAudioMuted and startWithVideoMuted were introduced for
+// conferences/meetings. So it makes sense for these to not be considered outside of conferences/meetings
+// (e.g. WelcomePage). Later on, though, we introduced a "Video <-> Voice" toggle on the WelcomePage which utilizes
+// startAudioOnly outside of conferences/meetings so that particular configuration/preference/setting employs slightly
+// exclusive logic.
+const START_WITH_AUDIO_VIDEO_MUTED_SOURCES = {
+    // We have startWithAudioMuted and startWithVideoMuted here:
+    config: true,
+    settings: true,
+
+    // XXX We've already overwritten base/config with urlParams. However,
+    // settings are more important than the server-side config.
+    // Consequently, we need to read from urlParams anyway:
+    urlParams: true,
+
+    // We don't have startWithAudioMuted and startWithVideoMuted here:
+    jwt: false
+};
 
 /**
  * Determines whether audio is currently muted.
@@ -45,6 +66,26 @@ function _isVideoMutedByAuthority(
 
     // eslint-disable-next-line no-bitwise
     return Boolean(muted & videoMutismAuthority);
+}
+
+/**
+ * Computes the startWithAudioMuted by retrieving its values from config, URL and settings.
+ *
+ * @param {Object|Function} stateful - The redux state object or {@code getState} function.
+ * @returns {boolean} - The computed startWithAudioMuted value that will be used.
+ */
+export function getStartWithAudioMuted(stateful: Object | Function) {
+    return Boolean(getPropertyValue(stateful, 'startWithAudioMuted', START_WITH_AUDIO_VIDEO_MUTED_SOURCES));
+}
+
+/**
+ * Computes the startWithAudioMuted by retrieving its values from config, URL and settings.
+ *
+ * @param {Object|Function} stateful - The redux state object or {@code getState} function.
+ * @returns {boolean} - The computed startWithAudioMuted value that will be used.
+ */
+export function getStartWithVideoMuted(stateful: Object | Function) {
+    return Boolean(getPropertyValue(stateful, 'startWithVideoMuted', START_WITH_AUDIO_VIDEO_MUTED_SOURCES));
 }
 
 /**

--- a/react/features/base/media/middleware.js
+++ b/react/features/base/media/middleware.js
@@ -21,6 +21,7 @@ import {
     MEDIA_TYPE,
     VIDEO_MUTISM_AUTHORITY
 } from './constants';
+import { getStartWithAudioMuted, getStartWithVideoMuted } from './functions';
 import logger from './logger';
 import {
     _AUDIO_INITIAL_MEDIA_STATE,
@@ -133,37 +134,8 @@ function _setRoom({ dispatch, getState }, next, action) {
     const state = getState();
     const { room } = action;
     const roomIsValid = isRoomValid(room);
-
-    // XXX The configurations/preferences/settings startWithAudioMuted,
-    // startWithVideoMuted, and startAudioOnly were introduced for
-    // conferences/meetings. So it makes sense for these to not be considered
-    // outside of conferences/meetings (e.g. WelcomePage). Later on, though, we
-    // introduced a "Video <-> Voice" toggle on the WelcomePage which utilizes
-    // startAudioOnly outside of conferences/meetings so that particular
-    // configuration/preference/setting employs slightly exclusive logic.
-    const mutedSources = {
-        // We have startWithAudioMuted and startWithVideoMuted here:
-        config: true,
-        settings: true,
-
-        // XXX We've already overwritten base/config with urlParams. However,
-        // settings are more important than the server-side config.
-        // Consequently, we need to read from urlParams anyway:
-        urlParams: true,
-
-        // We don't have startWithAudioMuted and startWithVideoMuted here:
-        jwt: false
-    };
-    const audioMuted
-        = roomIsValid
-            ? Boolean(
-                getPropertyValue(state, 'startWithAudioMuted', mutedSources))
-            : _AUDIO_INITIAL_MEDIA_STATE.muted;
-    const videoMuted
-        = roomIsValid
-            ? Boolean(
-                getPropertyValue(state, 'startWithVideoMuted', mutedSources))
-            : _VIDEO_INITIAL_MEDIA_STATE.muted;
+    const audioMuted = roomIsValid ? getStartWithAudioMuted(state) : _AUDIO_INITIAL_MEDIA_STATE.muted;
+    const videoMuted = roomIsValid ? getStartWithVideoMuted(state) : _VIDEO_INITIAL_MEDIA_STATE.muted;
 
     sendAnalytics(
         createStartMutedConfigurationEvent('local', audioMuted, videoMuted));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

 - Currently when startWithVideoMuted flag from the local storage is true we will first create the video track and then mute it which will turn on the light on the camera for a moment. This is concerning for some users! Also in the case when startWithVideoMuted is set trough the URL we don't create a video track at all. This PR will unify the implementation of handling startWithVideoMuted from the URL and localStorage and a video track won't be created at all.
 - The behaviour is similar when the user is muted and there is a device change. This PR changes the implementation to delay the track creation until the moment user unmutes. 