### PR TITLE
send private message control added to features of token

### DIFF
--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -6,12 +6,13 @@ import { translate } from '../../../base/i18n';
 import { IconMessage } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import {
+    getLocalParticipant, getParticipants } from '../../../base/participants';
+import {
     _mapDispatchToProps,
     _mapStateToProps as _abstractMapStateToProps,
     type Props as AbstractProps
 } from '../../../chat/components/PrivateMessageButton';
 import { isButtonEnabled } from '../../../toolbox/functions.web';
-import { getLocalParticipant, getParticipants } from '../../../base/participants';
 
 import RemoteVideoMenuButton from './RemoteVideoMenuButton';
 
@@ -86,9 +87,8 @@ class PrivateMessageMenuButton extends Component<Props> {
  * @param {Object} state - The Redux state.
  * @param {Props} ownProps - The own props of the component.
  * @returns {Props}
- */
+*/
 function _mapStateToProps(state: Object, ownProps: Props): $Shape<Props> {
-    const localParticipant = getLocalParticipant(state);
     const { enableFeaturesBasedOnToken } = state['features/base/config'];
 
     let privateMessageDisabled;

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -54,7 +54,11 @@ class PrivateMessageMenuButton extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const { participantID, t, _disabled, _hidden } = this.props;
+        const { _disabled, _hidden, participantID, t } = this.props;
+
+        if (_disabled) {
+            return null;
+        }
 
         if (_hidden) {
             return null;
@@ -63,7 +67,7 @@ class PrivateMessageMenuButton extends Component<Props> {
         return (
             <RemoteVideoMenuButton
                 buttonText = { t('toolbar.privateMessage') }
-                displayClass = { _disabled && 'disabled' }
+                displayClass = {  'disabled' && _disabled }
                 icon = { IconMessage }
                 id = { `privmsglink_${participantID}` }
                 onClick = { this._onClick } />

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -9,8 +9,7 @@ import { connect } from '../../../base/redux';
 import {
     _mapDispatchToProps,
     _mapStateToProps as _abstractMapStateToProps,
-    type Props as AbstractProps
-} from '../../../chat/components/PrivateMessageButton';
+    type Props as AbstractProps } from '../../../chat/components/PrivateMessageButton';
 import { isButtonEnabled } from '../../../toolbox/functions.web';
 
 import RemoteVideoMenuButton from './RemoteVideoMenuButton';
@@ -20,6 +19,11 @@ declare var interfaceConfig: Object;
 type Props = AbstractProps & {
 
     /**
+     * True if the private send message button is disabled, hence the button is not enable.
+     */
+    _disabled: boolean,
+
+     /**
      * True if the private chat functionality is disabled, hence the button is not visible.
      */
     _hidden: boolean
@@ -50,7 +54,7 @@ class PrivateMessageMenuButton extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const { participantID, t, _hidden, _disabled } = this.props;
+        const { participantID, t, _disabled, _hidden } = this.props;
 
         if (_hidden) {
             return null;

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -54,7 +54,7 @@ class PrivateMessageMenuButton extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const { _disabled, _hidden, participantID, t } = this.props;
+        const { participantID, t, _disabled, _hidden } = this.props;
 
         if (_disabled) {
             return null;

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -4,9 +4,8 @@ import React, { Component } from 'react';
 
 import { translate } from '../../../base/i18n';
 import { IconMessage } from '../../../base/icons';
+import { getParticipants } from '../../../base/participants';
 import { connect } from '../../../base/redux';
-import {
-    getLocalParticipant, getParticipants } from '../../../base/participants';
 import {
     _mapDispatchToProps,
     _mapStateToProps as _abstractMapStateToProps,

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -67,7 +67,7 @@ class PrivateMessageMenuButton extends Component<Props> {
         return (
             <RemoteVideoMenuButton
                 buttonText = { t('toolbar.privateMessage') }
-                displayClass = {  'disabled' && _disabled }
+                displayClass = { 'disabled' && _disabled }
                 icon = { IconMessage }
                 id = { `privmsglink_${participantID}` }
                 onClick = { this._onClick } />

--- a/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/remote-video-menu/components/web/PrivateMessageMenuButton.js
@@ -67,7 +67,7 @@ class PrivateMessageMenuButton extends Component<Props> {
         return (
             <RemoteVideoMenuButton
                 buttonText = { t('toolbar.privateMessage') }
-                displayClass = { 'disabled' && _disabled }
+                displayClass = { 'disabled' && String(_disabled) }
                 icon = { IconMessage }
                 id = { `privmsglink_${participantID}` }
                 onClick = { this._onClick } />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Disable send private message option button based on token features data.

Hide private message if local participant isGuest and features based on token.
When enableFeaturesBasedOnToken is enabled we were not hiding the private message button for guests.