### PR TITLE
feat(iFrame): Emit event when recording status changes, including errors

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1125,6 +1125,23 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that recording has started or stopped.
+     *
+     * @param {boolean} on - True if recording is on, false otherwise.
+     * @param {string} mode - Stream or file.
+     * @param {string} error - Error type or null if success.
+     * @returns {void}
+     */
+    notifyRecordingStatusChanged(on: boolean, mode: string, error?: string) {
+        this._sendEvent({
+            name: 'recording-status-changed',
+            on,
+            mode,
+            error
+        });
+    }
+
+    /**
      * Disposes the allocated resources.
      *
      * @returns {void}

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -86,6 +86,7 @@ const events = {
     'password-required': 'passwordRequired',
     'proxy-connection-event': 'proxyConnectionEvent',
     'raise-hand-updated': 'raiseHandUpdated',
+    'recording-status-changed': 'recordingStatusChanged',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',

--- a/react/features/recording/middleware.js
+++ b/react/features/recording/middleware.js
@@ -183,7 +183,9 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     dispatch(playSound(soundID));
                 }
 
-                APP.API.notifyRecordingStatusChanged(true, mode);
+                if (typeof APP !== 'undefined') {
+                    APP.API.notifyRecordingStatusChanged(true, mode);
+                }
             } else if (updatedSessionData.status === OFF
                 && (!oldSessionData || oldSessionData.status !== OFF)) {
                 dispatch(showStoppedRecordingNotification(
@@ -213,7 +215,9 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     dispatch(playSound(soundOff));
                 }
 
-                APP.API.notifyRecordingStatusChanged(false, mode);
+                if (typeof APP !== 'undefined') {
+                    APP.API.notifyRecordingStatusChanged(false, mode);
+                }
             }
         }
 
@@ -276,5 +280,7 @@ function _showRecordingErrorNotification(recorderSession, dispatch) {
         break;
     }
 
-    APP.API.notifyRecordingStatusChanged(false, mode, error);
+    if (typeof APP !== 'undefined') {
+        APP.API.notifyRecordingStatusChanged(false, mode, error);
+    }
 }

--- a/react/features/recording/middleware.js
+++ b/react/features/recording/middleware.js
@@ -45,6 +45,7 @@ import {
     RECORDING_ON_SOUND_FILE
 } from './sounds';
 
+declare var APP: Object;
 declare var interfaceConfig: Object;
 
 /**
@@ -181,6 +182,8 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                 if (soundID) {
                     dispatch(playSound(soundID));
                 }
+
+                APP.API.notifyRecordingStatusChanged(true, mode);
             } else if (updatedSessionData.status === OFF
                 && (!oldSessionData || oldSessionData.status !== OFF)) {
                 dispatch(showStoppedRecordingNotification(
@@ -209,6 +212,8 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     dispatch(stopSound(soundOn));
                     dispatch(playSound(soundOff));
                 }
+
+                APP.API.notifyRecordingStatusChanged(false, mode);
             }
         }
 
@@ -231,11 +236,11 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
  * @returns {void}
  */
 function _showRecordingErrorNotification(recorderSession, dispatch) {
-    const isStreamMode
-        = recorderSession.getMode()
-            === JitsiMeetJS.constants.recording.mode.STREAM;
+    const mode = recorderSession.getMode();
+    const error = recorderSession.getError();
+    const isStreamMode = mode === JitsiMeetJS.constants.recording.mode.STREAM;
 
-    switch (recorderSession.getError()) {
+    switch (error) {
     case JitsiMeetJS.constants.recording.error.SERVICE_UNAVAILABLE:
         dispatch(showRecordingError({
             descriptionKey: 'recording.unavailable',
@@ -270,4 +275,6 @@ function _showRecordingErrorNotification(recorderSession, dispatch) {
         }));
         break;
     }
+
+    APP.API.notifyRecordingStatusChanged(false, mode, error);
 }


### PR DESCRIPTION
A little while ago I created a similar pull request but after a bit of thought I realized I could improve it further. This pull request features an event emitted to external api when the recording status changes, but it also includes the errors (which previous pull request didn't).

If there are any improvements to be made, please do tell.