### PR TITLE
Add recording option to toolbox

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1029,6 +1029,13 @@ class Toolbox extends Component<Props, State> {
             <LiveStreamButton
                 key = 'livestreaming'
                 showLabel = { true } />,
+            this._shouldShowButton('recording')
+                && <OverflowMenuItem
+                accessibilityLabel = { t('toolbar.accessibilityLabel.localRecording') }
+                icon = { IconRec }
+                key = 'localrecording'
+                onClick = { this._onToolbarOpenLocalRecordingInfoDialog }
+                text = { t('localRecording.dialogTitle') } />,
             <RecordButton
                 key = 'record'
                 showLabel = { true } />,


### PR DESCRIPTION
The `Record Icon` and dialog are added to the meeting toolbar. The functionality of recording is implemented in **ipade**:

https://github.com/inspired-futures/ipade/blob/e63128b2e888ef9289b4af146e1c06f8b5cfbfcc/docs/custom_ofmeet.js#L494


This functionality should be synced with the enhanced `recording button in the toolbox`.