### PR TITLE
Stringify boolean values from jwt user context

### DIFF
--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -183,6 +183,7 @@ function update_presence_identity(
 
     stanza:tag("identity"):tag("user");
     for k, v in pairs(user) do
+        v = tostring(v)
         stanza:tag(k):text(v):up();
     end
     stanza:up();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Stringify boolean values that might appear in the JWT user context in order to avoid stanza parsing error.