### PR TITLE
fix(password) set input type to "password"

### DIFF
--- a/react/features/room-lock/components/PasswordRequiredPrompt.web.js
+++ b/react/features/room-lock/components/PasswordRequiredPrompt.web.js
@@ -104,7 +104,7 @@ class PasswordRequiredPrompt extends Component<Props, State> {
                     name = 'lockKey'
                     onChange = { this._onPasswordChanged }
                     shouldFitContainer = { true }
-                    type = 'text'
+                    type = 'password'
                     value = { this.state.password } />
             </div>
         );


### PR DESCRIPTION
This will make browsers not cache results in cleartext.

Co-authored-by: Tim Dittler <t.dittler@heinlein-support.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
