### PR TITLE
fix(vpaas): Make user media permission message more generic

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -678,6 +678,7 @@
     },
     "startupoverlay": {
         "policyText": " ",
+        "genericTitle": "The meeting needs to use your microphone and camera.",
         "title": "{{app}} needs to use your microphone and camera."
     },
     "suspendedoverlay": {

--- a/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
+++ b/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
@@ -32,8 +32,7 @@ class UserMediaPermissionsOverlay extends AbstractUserMediaPermissionsOverlay {
                     <span className = 'inlay__icon icon-camera' />
                     <h3 className = 'inlay__title'>
                         {
-                            t('startupoverlay.title',
-                                { app: interfaceConfig.APP_NAME })
+                            t('startupoverlay.genericTitle')
                         }
                     </h3>
                     <span className = 'inlay__text'>


### PR DESCRIPTION
This message was made more generic to accomodate JaaS users.