### PR TITLE
Fix validation for root rooms

### DIFF
--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -239,7 +239,7 @@ end
 function extract_subdomain(room_node)
     -- optimization, skip matching if there is no subdomain, no [subdomain] part in the beginning of the node
     if not starts_with(room_node, '[') then
-        return room_node;
+        return nil,room_node;
     end
 
     return room_node:match("^%[([^%]]+)%](.+)$");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Partially revert 895c92217a16e63e1e4652db1944957249b30f37
by removing extract_subdomain method call because for root(public) conferences it returns the name of the room and not nil as previously. 
Because of this target_subdomain will have the name of the room and you will end up checking real room testandrei@conference.domain against [testandrei]testandrei@conference.domain.