### PR TITLE
fix(safari): Ensure simulcast stream resolutions don't change.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10771,8 +10771,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#301e3a22dd76341b15d3846ab539e713d8e7569b",
-      "from": "github:jitsi/lib-jitsi-meet#301e3a22dd76341b15d3846ab539e713d8e7569b",
+      "version": "github:jitsi/lib-jitsi-meet#7fcdcc26ab7b9f05fb460a8485a361fb46943b61",
+      "from": "github:jitsi/lib-jitsi-meet#7fcdcc26ab7b9f05fb460a8485a361fb46943b61",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#301e3a22dd76341b15d3846ab539e713d8e7569b",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#7fcdcc26ab7b9f05fb460a8485a361fb46943b61",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",


### PR DESCRIPTION
Safari 14.1 has a bug where it returns 720p for every simulcast stream when RTCRtpSender.getParameters is called even though the stream resolutions are different.
By using the encodings config used when source was added, on every RTCRtpSender.setParameters call, we ensure that simulcast stream resolutions don't change.
chore(deps) lib-jitsi-meet@latest
