### PR TITLE
Android: Update dependencies and build tools

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,17 +78,17 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
 
     if (!rootProject.ext.libreBuild) {
-        implementation 'com.google.android.gms:play-services-auth:16.0.1'
+        implementation 'com.google.android.gms:play-services-auth:19.0.0'
 
         // Firebase
         //  - Crashlytics
         //  - Dynamic Links
-        implementation 'com.google.firebase:firebase-analytics:17.5.0'
-        implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
-        implementation 'com.google.firebase:firebase-dynamic-links:19.1.0'
+        implementation 'com.google.firebase:firebase-analytics:18.0.0'
+        implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
+        implementation 'com.google.firebase:firebase-dynamic-links:19.1.1'
     }
 
     implementation project(':sdk')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
-        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -47,12 +47,12 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'org.webkit:android-jsc:+'
 
-    implementation 'com.dropbox.core:dropbox-core-sdk:3.0.8'
+    implementation 'com.dropbox.core:dropbox-core-sdk:3.1.5'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.squareup.duktape:duktape-android:1.3.0'
 
     if (!rootProject.ext.libreBuild) {
-        implementation 'com.amplitude:android-sdk:2.14.1'
+        implementation 'com.amplitude:android-sdk:2.29.1'
         implementation(project(":react-native-google-signin")) {
             exclude group: 'com.google.android.gms'
             exclude group: 'androidx'
@@ -73,7 +73,7 @@ dependencies {
     implementation project(':react-native-webview')
     implementation project(':react-native-splash-screen')
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
 }
 
 


### PR DESCRIPTION
Updates:
 - Gradle to 4.1.1
 - Gradle wrapper to 6.7
 - Some other minor dependencies

On an other note, the Android SDK tools probably also need to be updated soon to support Android 11 properly. The API could be raised to Level 30 (see [android/build.gradle#L19-L24](https://github.com/EwoutH/jitsi-meet/blob/master/android/build.gradle#L19-L24)). The support library could be replaced with AndroidX, see [Migrating to AndroidX](https://developer.android.com/jetpack/androidx/migrate).