### PR TITLE
feat: Skips the default tile view when jibri is loading.

### DIFF
--- a/react/features/video-layout/functions.js
+++ b/react/features/video-layout/functions.js
@@ -90,6 +90,8 @@ export function shouldDisplayTileView(state: Object = {}) {
         return tileViewEnabled;
     }
 
+    const { iAmRecorder } = state['features/base/config'];
+
     // None tile view mode is easier to calculate (no need for many negations), so we do
     // that and negate it only once.
     const shouldDisplayNormalMode = Boolean(
@@ -107,6 +109,9 @@ export function shouldDisplayTileView(state: Object = {}) {
 
         // There is a shared YouTube video in the meeting
         || isYoutubeVideoPlaying(state)
+
+        // We want jibri to use stage view by default
+        || iAmRecorder
     );
 
     return !shouldDisplayNormalMode;


### PR DESCRIPTION
Follows me and switching to tile view, still works.