### PR TITLE
Select screenshare endpoint always when auto pinning

### DIFF
--- a/react/features/base/lastn/middleware.js
+++ b/react/features/base/lastn/middleware.js
@@ -68,14 +68,13 @@ function _updateLastN({ getState }) {
         return;
     }
 
-    const defaultLastN = typeof config.channelLastN === 'undefined' ? -1 : config.channelLastN;
-    let lastN = defaultLastN;
+    let lastN = typeof config.channelLastN === 'undefined' ? -1 : config.channelLastN;
 
-    // Apply last N limit based on the # of participants
+    // Apply last N limit based on the # of participants and channelLastN settings.
     const limitedLastN = limitLastN(participantCount, lastNLimits);
 
     if (limitedLastN !== undefined) {
-        lastN = limitedLastN;
+        lastN = lastN === -1 ? limitedLastN : Math.min(limitedLastN, lastN);
     }
 
     if (typeof appState !== 'undefined' && appState !== 'active') {

--- a/react/features/large-video/actions.any.js
+++ b/react/features/large-video/actions.any.js
@@ -61,8 +61,20 @@ export function selectParticipantInLargeVideo(participant: ?string) {
         const state = getState();
         const participantId = participant ?? _electParticipantInLargeVideo(state);
         const largeVideo = state['features/large-video'];
+        const screenShares = state['features/video-layout'].screenShares;
+        let latestScreenshareParticipantId;
 
-        if (participantId !== largeVideo.participantId) {
+        if (screenShares && screenShares.length) {
+            latestScreenshareParticipantId = screenShares[screenShares.length - 1];
+        }
+
+        // When trying to auto pin screenshare, always select the endpoint even though it happens to be
+        // the large video participant in redux (for the reasons listed above in the large video selection
+        // logic above). The auto pin screenshare logic kicks in after the track is added
+        // (which updates the large video participant and selects all endpoints because of the auto tile
+        // view mode). If the screenshare endpoint is not among the forwarded endpoints from the bridge,
+        // it needs to be selected again at this point.
+        if (participantId !== largeVideo.participantId || participantId === latestScreenshareParticipantId) {
             dispatch({
                 type: SELECT_LARGE_VIDEO_PARTICIPANT,
                 participantId


### PR DESCRIPTION
When trying to auto pin screenshare, always select the endpoint even though it happens to be the large video participant in redux. The auto pin screenshare logic kicks in after the track is added.  If the screenshare endpoint is not among the forwarded endpoints from the bridge, it needs to be selected again.
If limitLastN values are specified and channelLastN < limitLastN, configure channelLastN on the conference.
