### PR TITLE
feat: Makes it possible to hide the "Save Logs" link.

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,6 +94,11 @@ var config = {
     // input and will suggest another valid device if one is present.
     enableNoAudioDetection: true,
 
+    // Enabling this will show a "Save Logs" link in the GSM popover that can be
+    // used to collect debug information (XMPP IQs, SDP offer/answer cycles)
+    // about the call.
+    // enableSaveLogs: false,
+
     // Enabling this will run the lib-jitsi-meet noise detection module which will
     // notify the user if there is noise, other than voice, coming from the current
     // selected microphone. The purpose it to let the user know that the input could

--- a/react/features/connection-indicator/components/web/ConnectionIndicator.js
+++ b/react/features/connection-indicator/components/web/ConnectionIndicator.js
@@ -85,6 +85,12 @@ type Props = AbstractProps & {
     dispatch: Dispatch<any>,
 
     /**
+     * Whether or not should display the "Save Logs" link in the local video
+     * stats table.
+     */
+    enableSaveLogs: boolean,
+
+    /**
      * Whether or not clicking the indicator should display a popover for more
      * details.
      */
@@ -386,6 +392,7 @@ class ConnectionIndicator extends AbstractConnectionIndicator<Props, State> {
                 codec = { codec }
                 connectionSummary = { this._getConnectionStatusTip() }
                 e2eRtt = { e2eRtt }
+                enableSaveLogs = { this.props.enableSaveLogs }
                 framerate = { framerate }
                 isLocalVideo = { this.props.isLocalVideo }
                 maxEnabledResolution = { maxEnabledResolution }
@@ -440,7 +447,8 @@ export function _mapStateToProps(state: Object, ownProps: Props) {
     const participant
         = typeof participantId === 'undefined' ? getLocalParticipant(state) : getParticipantById(state, participantId);
     const props = {
-        _connectionStatus: participant?.connectionStatus
+        _connectionStatus: participant?.connectionStatus,
+        enableSaveLogs: state['features/base/config'].enableSaveLogs
     };
 
     if (conference) {

--- a/react/features/connection-stats/components/ConnectionStatsTable.js
+++ b/react/features/connection-stats/components/ConnectionStatsTable.js
@@ -55,6 +55,11 @@ type Props = {
     e2eRtt: number,
 
     /**
+     * Whether or not should display the "Save Logs" link.
+     */
+    enableSaveLogs: boolean,
+
+    /**
      * The endpoint id of this client.
      */
     participantId: string,
@@ -153,13 +158,13 @@ class ConnectionStatsTable extends Component<Props> {
      * @returns {ReactElement}
      */
     render() {
-        const { isLocalVideo } = this.props;
+        const { isLocalVideo, enableSaveLogs } = this.props;
 
         return (
             <div className = 'connection-info'>
                 { this._renderStatistics() }
                 <div className = 'connection-actions'>
-                    { isLocalVideo ? this._renderSaveLogs() : null}
+                    { isLocalVideo && enableSaveLogs ? this._renderSaveLogs() : null}
                     { this._renderShowMoreLink() }
                 </div>
                 { this.props.shouldShowMore ? this._renderAdditionalStats() : null }


### PR DESCRIPTION
As per @fremzy, the "Save Logs" feature generates a json
file with a bevy of technical information about the
meeting. This log contains the server name, server IP
address, participant's IP addresses (only in p2p sessions)
e.t.c. While this may be a useful feature for the
admin-like 'moderator', it creates unnecessary exposure
when made readily available to all users in the meeting.

This commit fixes #8036 by a config.js option to enable
the link (disabled by default), thus giving the owner of
the deployment the choice of enabling it or not.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
