### PR TITLE
(fix) main-sv.json - Swedish translation of noPassword was incorrect

### DIFF
--- a/lang/main-sv.json
+++ b/lang/main-sv.json
@@ -320,7 +320,7 @@
         "liveStreamURL": "Livesändning:",
         "moreNumbers": "Fler nummer",
         "noNumbers": "Inga inringningsnummer.",
-        "noPassword": "Inga enheter",
+        "noPassword": "Inget lösenord",
         "noRoom": "Inget rum specificerades för inringning.",
         "numbers": "Inringningsnummer",
         "password": "$t(lockRoomPasswordUppercase):",


### PR DESCRIPTION
Fix Swedish translation of noPassword

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
