### PR TITLE
Consistent formatting/indentation of files in ./doc

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -6,9 +6,9 @@ muc_mapper_domain_base = "jitmeet.example.com";
 turncredentials_secret = "__turnSecret__";
 
 turncredentials = {
-  { type = "stun", host = "jitmeet.example.com", port = "3478" },
-  { type = "turn", host = "jitmeet.example.com", port = "3478", transport = "udp" },
-  { type = "turns", host = "jitmeet.example.com", port = "5349", transport = "tcp" }
+    { type = "stun", host = "jitmeet.example.com", port = "3478" },
+    { type = "turn", host = "jitmeet.example.com", port = "3478", transport = "udp" },
+    { type = "turns", host = "jitmeet.example.com", port = "5349", transport = "tcp" }
 };
 
 cross_domain_bosh = false;
@@ -17,48 +17,48 @@ consider_bosh_secure = true;
 
 -- https://ssl-config.mozilla.org/#server=haproxy&version=2.1&config=intermediate&openssl=1.1.0g&guideline=5.4
 ssl = {
-  protocol = "tlsv1_2+";
-  ciphers = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
+    protocol = "tlsv1_2+";
+    ciphers = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
 }
 
 VirtualHost "jitmeet.example.com"
-        -- enabled = false -- Remove this line to enable this host
-        authentication = "anonymous"
-        -- Properties below are modified by jitsi-meet-tokens package config
-        -- and authentication above is switched to "token"
-        --app_id="example_app_id"
-        --app_secret="example_app_secret"
-        -- Assign this host a certificate for TLS, otherwise it would use the one
-        -- set in the global section (if any).
-        -- Note that old-style SSL on port 5223 only supports one certificate, and will always
-        -- use the global one.
-        ssl = {
-                key = "/etc/prosody/certs/jitmeet.example.com.key";
-                certificate = "/etc/prosody/certs/jitmeet.example.com.crt";
-        }
-        speakerstats_component = "speakerstats.jitmeet.example.com"
-        conference_duration_component = "conferenceduration.jitmeet.example.com"
-        -- we need bosh
-        modules_enabled = {
-            "bosh";
-            "pubsub";
-            "ping"; -- Enable mod_ping
-            "speakerstats";
-            "turncredentials";
-            "conference_duration";
-            "muc_lobby_rooms";
-        }
-        c2s_require_encryption = false
-        lobby_muc = "lobby.jitmeet.example.com"
-        main_muc = "conference.jitmeet.example.com"
-        -- muc_lobby_whitelist = { "recorder.jitmeet.example.com" } -- Here we can whitelist jibri to enter lobby enabled rooms
+    -- enabled = false -- Remove this line to enable this host
+    authentication = "anonymous"
+    -- Properties below are modified by jitsi-meet-tokens package config
+    -- and authentication above is switched to "token"
+    --app_id="example_app_id"
+    --app_secret="example_app_secret"
+    -- Assign this host a certificate for TLS, otherwise it would use the one
+    -- set in the global section (if any).
+    -- Note that old-style SSL on port 5223 only supports one certificate, and will always
+    -- use the global one.
+    ssl = {
+        key = "/etc/prosody/certs/jitmeet.example.com.key";
+        certificate = "/etc/prosody/certs/jitmeet.example.com.crt";
+    }
+    speakerstats_component = "speakerstats.jitmeet.example.com"
+    conference_duration_component = "conferenceduration.jitmeet.example.com"
+    -- we need bosh
+    modules_enabled = {
+        "bosh";
+        "pubsub";
+        "ping"; -- Enable mod_ping
+        "speakerstats";
+        "turncredentials";
+        "conference_duration";
+        "muc_lobby_rooms";
+    }
+    c2s_require_encryption = false
+    lobby_muc = "lobby.jitmeet.example.com"
+    main_muc = "conference.jitmeet.example.com"
+    -- muc_lobby_whitelist = { "recorder.jitmeet.example.com" } -- Here we can whitelist jibri to enter lobby enabled rooms
 
 Component "conference.jitmeet.example.com" "muc"
     storage = "memory"
     modules_enabled = {
         "muc_meeting_id";
         "muc_domain_mapper";
-        -- "token_verification";
+        --"token_verification";
     }
     admins = { "focusUser@auth.jitmeet.example.com" }
     muc_room_locking = false
@@ -68,7 +68,7 @@ Component "conference.jitmeet.example.com" "muc"
 Component "internal.auth.jitmeet.example.com" "muc"
     storage = "memory"
     modules_enabled = {
-      "ping";
+        "ping";
     }
     admins = { "focusUser@auth.jitmeet.example.com", "jvb@auth.jitmeet.example.com" }
     muc_room_locking = false

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -6,14 +6,14 @@ server {
     server_name jitsi-meet.example.com;
 
     location ^~ /.well-known/acme-challenge/ {
-       default_type "text/plain";
-       root         /usr/share/jitsi-meet;
+        default_type "text/plain";
+        root         /usr/share/jitsi-meet;
     }
     location = /.well-known/acme-challenge/ {
-       return 404;
+        return 404;
     }
     location / {
-       return 301 https://$host$request_uri;
+        return 301 https://$host$request_uri;
     }
 }
 server {
@@ -21,7 +21,7 @@ server {
     listen [::]:443 ssl;
     server_name jitsi-meet.example.com;
 
-# Mozilla Guideline v5.4, nginx 1.17.7, OpenSSL 1.1.1d, intermediate configuration
+    # Mozilla Guideline v5.4, nginx 1.17.7, OpenSSL 1.1.1d, intermediate configuration
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
     ssl_prefer_server_ciphers off;
@@ -58,7 +58,7 @@ server {
         alias /usr/share/jitsi-meet/libs/external_api.min.js;
     }
 
-    #ensure all static content can always be found first
+    # ensure all static content can always be found first
     location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.well-known)/(.*)$
     {
         add_header 'Access-Control-Allow-Origin' '*';
@@ -66,13 +66,13 @@ server {
 
         # cache all versioned files
         if ($arg_v) {
-          expires 1y;
+            expires 1y;
         }
     }
 
     # BOSH
     location = /http-bind {
-        proxy_pass      http://localhost:5280/http-bind;
+        proxy_pass       http://localhost:5280/http-bind;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $http_host;
     }
@@ -89,11 +89,11 @@ server {
 
     # colibri (JVB) websockets for jvb1
     location ~ ^/colibri-ws/default-id/(.*) {
-       proxy_pass http://127.0.0.1:9090/colibri-ws/default-id/$1$is_args$args;
-       proxy_http_version 1.1;
-       proxy_set_header Upgrade $http_upgrade;
-       proxy_set_header Connection "upgrade";
-       tcp_nodelay on;
+        proxy_pass http://127.0.0.1:9090/colibri-ws/default-id/$1$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        tcp_nodelay on;
     }
 
     location ~ ^/([^/?&:'"]+)$ {
@@ -106,13 +106,13 @@ server {
 
     location ~ ^/([^/?&:'"]+)/config.js$
     {
-       set $subdomain "$1.";
-       set $subdir "$1/";
+        set $subdomain "$1.";
+        set $subdir "$1/";
 
-       alias /etc/jitsi/meet/jitsi-meet.example.com-config.js;
+        alias /etc/jitsi/meet/jitsi-meet.example.com-config.js;
     }
 
-    #Anything that didn't match above, and isn't a real file, assume it's a room name and redirect to /
+    # Anything that didn't match above, and isn't a real file, assume it's a room name and redirect to /
     location ~ ^/([^/?&:'"]+)/(.*)$ {
         set $subdomain "$1.";
         set $subdir "$1/";

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -8,50 +8,49 @@
 </VirtualHost>
 
 <VirtualHost *:443>
+    ServerName jitsi-meet.example.com
 
-  ServerName jitsi-meet.example.com
+    # enable HTTP/2, if available
+    Protocols h2 http/1.1
 
-  # enable HTTP/2, if available
-  Protocols h2 http/1.1
+    SSLEngine on
+    SSLProxyEngine on
+    SSLCertificateFile /etc/jitsi/meet/jitsi-meet.example.com.crt
+    SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
 
-  SSLEngine on
-  SSLProxyEngine on
-  SSLCertificateFile /etc/jitsi/meet/jitsi-meet.example.com.crt
-  SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
+    Header always set Strict-Transport-Security "max-age=63072000"
 
-  Header always set Strict-Transport-Security "max-age=63072000"
+    DocumentRoot "/usr/share/jitsi-meet"
+    <Directory "/usr/share/jitsi-meet">
+        Options Indexes MultiViews Includes FollowSymLinks
+        AddOutputFilter Includes html
+        AllowOverride All
+        Order allow,deny
+        Allow from all
+    </Directory>
 
-  DocumentRoot "/usr/share/jitsi-meet"
-  <Directory "/usr/share/jitsi-meet">
-    Options Indexes MultiViews Includes FollowSymLinks
-    AddOutputFilter Includes html
-    AllowOverride All
-    Order allow,deny
-    Allow from all
-  </Directory>
+    ErrorDocument 404 /static/404.html
 
-  ErrorDocument 404 /static/404.html
+    Alias "/config.js" "/etc/jitsi/meet/jitsi-meet.example.com-config.js"
+    <Location /config.js>
+        Require all granted
+    </Location>
 
-  Alias "/config.js" "/etc/jitsi/meet/jitsi-meet.example.com-config.js"
-  <Location /config.js>
-    Require all granted
-  </Location>
+    Alias "/external_api.js" "/usr/share/jitsi-meet/libs/external_api.min.js"
+    <Location /external_api.js>
+        Require all granted
+    </Location>
 
-  Alias "/external_api.js" "/usr/share/jitsi-meet/libs/external_api.min.js"
-  <Location /external_api.js>
-    Require all granted
-  </Location>
+    ProxyPreserveHost on
+    ProxyPass /http-bind http://localhost:5280/http-bind/
+    ProxyPassReverse /http-bind http://localhost:5280/http-bind/
 
-  ProxyPreserveHost on
-  ProxyPass /http-bind http://localhost:5280/http-bind/
-  ProxyPassReverse /http-bind http://localhost:5280/http-bind/
-
-  RewriteEngine on
-  RewriteRule ^/([a-zA-Z0-9]+)$ /index.html
+    RewriteEngine on
+    RewriteRule ^/([a-zA-Z0-9]+)$ /index.html
 </VirtualHost>
 
 # Mozilla Guideline v5.4, Apache 2.4.41, OpenSSL 1.1.1d, intermediate configuration, no OCSP
-SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
-SSLCipherSuite          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
-SSLHonorCipherOrder     off
-SSLSessionTickets       off
+SSLProtocol         all -SSLv3 -TLSv1 -TLSv1.1
+SSLCipherSuite      ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+SSLHonorCipherOrder off
+SSLSessionTickets   off

--- a/doc/example-config-files/multidomain/jitsi.example.com.multidomain.example
+++ b/doc/example-config-files/multidomain/jitsi.example.com.multidomain.example
@@ -10,7 +10,6 @@ server {
     index index.html;
     set $prefix "";
 
-
     # BOSH
     location /http-bind {
         proxy_pass      http://localhost:5280/http-bind;
@@ -44,13 +43,13 @@ server {
 
     location ~ ^/([^/?&:'"]+)/config.js$
     {
-       set $subdomain "$1.";
-       set $subdir "$1/";
+        set $subdomain "$1.";
+        set $subdir "$1/";
 
-       alias /etc/jitsi/meet/{{jitsi_meet_domain_name}}-config.js;
+        alias /etc/jitsi/meet/{{jitsi_meet_domain_name}}-config.js;
     }
 
-    #Anything that didn't match above, and isn't a real file, assume it's a room name and redirect to /
+    # Anything that didn't match above, and isn't a real file, assume it's a room name and redirect to /
     location ~ ^/([^/?&:'"]+)/(.*)$ {
         set $subdomain "$1.";
         set $subdir "$1/";

--- a/doc/example-config-files/multidomain/prosody.cfg.multidomain.example
+++ b/doc/example-config-files/multidomain/prosody.cfg.multidomain.example
@@ -34,55 +34,56 @@ component_ports = { 5347 }
 -- Documentation on modules can be found at: http://prosody.im/doc/modules
 modules_enabled = {
 
-	-- Generally required
-		"roster"; -- Allow users to have a roster. Recommended ;)
-		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
-		"tls"; -- Add support for secure TLS on c2s/s2s connections
-		"dialback"; -- s2s dialback support
-		"disco"; -- Service discovery
-		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+    -- Generally required
+    "roster"; -- Allow users to have a roster. Recommended ;)
+    "saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+    "tls"; -- Add support for secure TLS on c2s/s2s connections
+    "dialback"; -- s2s dialback support
+    "disco"; -- Service discovery
+    "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
 
-	-- Not essential, but recommended
-		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"vcard"; -- Allow users to set vCards
+    -- Not essential, but recommended
+    "private"; -- Private XML storage (for room bookmarks, etc.)
+    "vcard"; -- Allow users to set vCards
 
-	-- These are commented by default as they have a performance impact
-		--"privacy"; -- Support privacy lists
-		"compression"; -- Stream compression (requires the lua-zlib package installed)
+    -- These are commented by default as they have a performance impact
+    --"privacy"; -- Support privacy lists
+    "compression"; -- Stream compression (requires the lua-zlib package installed)
 
-	-- Nice to have
-		"version"; -- Replies to server version requests
-		"uptime"; -- Report how long server has been running
-		"time"; -- Let others know the time here on this server
-		"ping"; -- Replies to XMPP pings with pongs
-		"pep"; -- Enables users to publish their mood, activity, playing music and more
-		"register"; -- Allow users to register on this server using a client and change passwords
+    -- Nice to have
+    "version"; -- Replies to server version requests
+    "uptime"; -- Report how long server has been running
+    "time"; -- Let others know the time here on this server
+    "ping"; -- Replies to XMPP pings with pongs
+    "pep"; -- Enables users to publish their mood, activity, playing music and more
+    "register"; -- Allow users to register on this server using a client and change passwords
 
-	-- Admin interfaces
-		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
-		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
+    -- Admin interfaces
+    "admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+    --"admin_telnet"; -- Opens telnet console interface on localhost port 5582
 
-	-- HTTP modules
-		"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
-		--"http_files"; -- Serve static files from a directory over HTTP
+    -- HTTP modules
+    "bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+    --"http_files"; -- Serve static files from a directory over HTTP
 
-	-- Other specific functionality
-		--"groups"; -- Shared roster support
-		--"announce"; -- Send announcement to all online users
-		--"welcome"; -- Welcome users who register accounts
-		--"watchregistrations"; -- Alert admins of registrations
-		--"motd"; -- Send a message to users when they log in
-		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
-	-- jitsi
-		"smacks";
-		"carbons";
-		"mam";
-		"lastactivity";
-		"offline";
-		"pubsub";
-		"adhoc";
-		"websocket";
-		"http_altconnect";
+    -- Other specific functionality
+    --"groups"; -- Shared roster support
+    --"announce"; -- Send announcement to all online users
+    --"welcome"; -- Welcome users who register accounts
+    --"watchregistrations"; -- Alert admins of registrations
+    --"motd"; -- Send a message to users when they log in
+    --"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+
+    -- jitsi
+    "smacks";
+    "carbons";
+    "mam";
+    "lastactivity";
+    "offline";
+    "pubsub";
+    "adhoc";
+    "websocket";
+    "http_altconnect";
 }
 
 -- domain mapper options, must at least have domain base set to use the mapper
@@ -91,9 +92,9 @@ muc_mapper_domain_base = "jitsi.example.com";
 -- These modules are auto-loaded, but should you want
 -- to disable them then uncomment them here:
 modules_disabled = {
-	-- "offline"; -- Store offline messages
-	-- "c2s"; -- Handle client connections
-	-- "s2s"; -- Handle server-to-server connections
+    --"offline"; -- Store offline messages
+    --"c2s"; -- Handle client connections
+    --"s2s"; -- Handle server-to-server connections
 }
 
 -- Disable account creation by default, for security
@@ -110,7 +111,7 @@ ssl = {
 -- Force clients to use encrypted connections? This option will
 -- prevent clients from authenticating unless they are using encryption.
 
--- c2s_require_encryption = true
+--c2s_require_encryption = true
 
 -- Force certificate authentication for server-to-server connections?
 -- This provides ideal security, but requires servers you communicate
@@ -118,7 +119,7 @@ ssl = {
 -- NOTE: Your version of LuaSec must support certificate verification!
 -- For more information see http://prosody.im/doc/s2s#security
 
--- s2s_secure_auth = false
+--s2s_secure_auth = false
 
 -- Many servers don't support encryption or have invalid or self-signed
 -- certificates. You can list domains here that will not be required to
@@ -159,9 +160,9 @@ authentication = "internal_hashed"
 -- Logging configuration
 -- For advanced logging see http://prosody.im/doc/logging
 log = {
-	info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
-	error = "/var/log/prosody/prosody.err";
-	"*syslog";
+    info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
+    error = "/var/log/prosody/prosody.err";
+    "*syslog";
 }
 
 ----------- Virtual hosts -----------
@@ -171,25 +172,25 @@ log = {
 --VirtualHost "localhost"
 
 VirtualHost "jitsi.example.com"
-	-- enabled = false -- Remove this line to enable this host
-	authentication = "anonymous"
-	-- Assign this host a certificate for TLS, otherwise it would use the one
-	-- set in the global section (if any).
-	-- Note that old-style SSL on port 5223 only supports one certificate, and will always
-	-- use the global one.
-	ssl = {
-		key = "/var/lib/prosody/jitsi.example.com.key";
-		certificate = "/var/lib/prosody/jitsi.example.com.crt";
-	}
+    -- enabled = false -- Remove this line to enable this host
+    authentication = "anonymous"
+    -- Assign this host a certificate for TLS, otherwise it would use the one
+    -- set in the global section (if any).
+    -- Note that old-style SSL on port 5223 only supports one certificate, and will always
+    -- use the global one.
+    ssl = {
+        key = "/var/lib/prosody/jitsi.example.com.key";
+        certificate = "/var/lib/prosody/jitsi.example.com.crt";
+    }
 
-	c2s_require_encryption = false
+    c2s_require_encryption = false
 
 VirtualHost "auth.jitsi.example.com"
-	ssl = {
-		key = "/var/lib/prosody/auth.jitsi.example.com.key";
-		certificate = "/var/lib/prosody/auth.jitsi.example.com.crt";
-	}
-	authentication = "internal_plain"
+    ssl = {
+        key = "/var/lib/prosody/auth.jitsi.example.com.key";
+        certificate = "/var/lib/prosody/auth.jitsi.example.com.crt";
+    }
+    authentication = "internal_plain"
 
 ------ Components ------
 -- You can specify components to add hosts that provide special services,
@@ -209,7 +210,7 @@ VirtualHost "auth.jitsi.example.com"
 -- see: http://prosody.im/doc/components#adding_an_external_component
 --
 --Component "gateway.example.com"
---	component_secret = "password"
+--    component_secret = "password"
 
 Component "conference.jitsi.example.com" "muc"
     modules_enabled = { "muc_domain_mapper" }

--- a/doc/example-config-files/prosody.cfg.lua.example
+++ b/doc/example-config-files/prosody.cfg.lua.example
@@ -34,63 +34,64 @@ component_ports = { 5347 }
 -- Documentation on modules can be found at: http://prosody.im/doc/modules
 modules_enabled = {
 
-	-- Generally required
-		"roster"; -- Allow users to have a roster. Recommended ;)
-		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
-		"tls"; -- Add support for secure TLS on c2s/s2s connections
-		"dialback"; -- s2s dialback support
-		"disco"; -- Service discovery
-		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+    -- Generally required
+    "roster"; -- Allow users to have a roster. Recommended ;)
+    "saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+    "tls"; -- Add support for secure TLS on c2s/s2s connections
+    "dialback"; -- s2s dialback support
+    "disco"; -- Service discovery
+    "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
 
-	-- Not essential, but recommended
-		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"vcard"; -- Allow users to set vCards
+    -- Not essential, but recommended
+    "private"; -- Private XML storage (for room bookmarks, etc.)
+    "vcard"; -- Allow users to set vCards
 
-	-- These are commented by default as they have a performance impact
-		--"privacy"; -- Support privacy lists
-		"compression"; -- Stream compression (requires the lua-zlib package installed)
+    -- These are commented by default as they have a performance impact
+    --"privacy"; -- Support privacy lists
+    "compression"; -- Stream compression (requires the lua-zlib package installed)
 
-	-- Nice to have
-		"version"; -- Replies to server version requests
-		"uptime"; -- Report how long server has been running
-		"time"; -- Let others know the time here on this server
-		"ping"; -- Replies to XMPP pings with pongs
-		"pep"; -- Enables users to publish their mood, activity, playing music and more
-		"register"; -- Allow users to register on this server using a client and change passwords
+    -- Nice to have
+    "version"; -- Replies to server version requests
+    "uptime"; -- Report how long server has been running
+    "time"; -- Let others know the time here on this server
+    "ping"; -- Replies to XMPP pings with pongs
+    "pep"; -- Enables users to publish their mood, activity, playing music and more
+    "register"; -- Allow users to register on this server using a client and change passwords
 
-	-- Admin interfaces
-		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
-		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
+    -- Admin interfaces
+    "admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+    --"admin_telnet"; -- Opens telnet console interface on localhost port 5582
 
-	-- HTTP modules
-		"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
-		--"http_files"; -- Serve static files from a directory over HTTP
+    -- HTTP modules
+    "bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+    --"http_files"; -- Serve static files from a directory over HTTP
 
-	-- Other specific functionality
-		--"groups"; -- Shared roster support
-		--"announce"; -- Send announcement to all online users
-		--"welcome"; -- Welcome users who register accounts
-		--"watchregistrations"; -- Alert admins of registrations
-		--"motd"; -- Send a message to users when they log in
-		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
-	-- jitsi
-		"smacks";
-		"carbons";
-		"mam";
-		"lastactivity";
-		"offline";
-		"pubsub";
-		"adhoc";
-		"websocket";
-		"http_altconnect";
+    -- Other specific functionality
+    --"groups"; -- Shared roster support
+    --"announce"; -- Send announcement to all online users
+    --"welcome"; -- Welcome users who register accounts
+    --"watchregistrations"; -- Alert admins of registrations
+    --"motd"; -- Send a message to users when they log in
+    --"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+
+    -- jitsi
+    "smacks";
+    "carbons";
+    "mam";
+    "lastactivity";
+    "offline";
+    "pubsub";
+    "adhoc";
+    "websocket";
+    "http_altconnect";
 }
 
 -- These modules are auto-loaded, but should you want
 -- to disable them then uncomment them here:
 modules_disabled = {
-	-- "offline"; -- Store offline messages
-	-- "c2s"; -- Handle client connections
-	-- "s2s"; -- Handle server-to-server connections
+    --"offline"; -- Store offline messages
+    --"c2s"; -- Handle client connections
+    --"s2s"; -- Handle server-to-server connections
 }
 
 -- Disable account creation by default, for security
@@ -107,7 +108,7 @@ ssl = {
 -- Force clients to use encrypted connections? This option will
 -- prevent clients from authenticating unless they are using encryption.
 
--- c2s_require_encryption = true
+--c2s_require_encryption = true
 
 -- Force certificate authentication for server-to-server connections?
 -- This provides ideal security, but requires servers you communicate
@@ -115,7 +116,7 @@ ssl = {
 -- NOTE: Your version of LuaSec must support certificate verification!
 -- For more information see http://prosody.im/doc/s2s#security
 
--- s2s_secure_auth = false
+--s2s_secure_auth = false
 
 -- Many servers don't support encryption or have invalid or self-signed
 -- certificates. You can list domains here that will not be required to
@@ -156,9 +157,9 @@ authentication = "internal_hashed"
 -- Logging configuration
 -- For advanced logging see http://prosody.im/doc/logging
 log = {
-	info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
-	error = "/var/log/prosody/prosody.err";
-	"*syslog";
+    info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
+    error = "/var/log/prosody/prosody.err";
+    "*syslog";
 }
 
 ----------- Virtual hosts -----------
@@ -168,25 +169,25 @@ log = {
 --VirtualHost "localhost"
 
 VirtualHost "jitsi.example.com"
-	-- enabled = false -- Remove this line to enable this host
-	authentication = "anonymous"
-	-- Assign this host a certificate for TLS, otherwise it would use the one
-	-- set in the global section (if any).
-	-- Note that old-style SSL on port 5223 only supports one certificate, and will always
-	-- use the global one.
-	ssl = {
-		key = "/var/lib/prosody/jitsi.example.com.key";
-		certificate = "/var/lib/prosody/jitsi.example.com.crt";
-	}
+    -- enabled = false -- Remove this line to enable this host
+    authentication = "anonymous"
+    -- Assign this host a certificate for TLS, otherwise it would use the one
+    -- set in the global section (if any).
+    -- Note that old-style SSL on port 5223 only supports one certificate, and will always
+    -- use the global one.
+    ssl = {
+        key = "/var/lib/prosody/jitsi.example.com.key";
+        certificate = "/var/lib/prosody/jitsi.example.com.crt";
+    }
 
-	c2s_require_encryption = false
+    c2s_require_encryption = false
 
 VirtualHost "auth.jitsi.example.com"
-	ssl = {
-		key = "/var/lib/prosody/auth.jitsi.example.com.key";
-		certificate = "/var/lib/prosody/auth.jitsi.example.com.crt";
-	}
-	authentication = "internal_plain"
+    ssl = {
+        key = "/var/lib/prosody/auth.jitsi.example.com.key";
+        certificate = "/var/lib/prosody/auth.jitsi.example.com.crt";
+    }
+    authentication = "internal_plain"
 
 ------ Components ------
 -- You can specify components to add hosts that provide special services,
@@ -206,7 +207,7 @@ VirtualHost "auth.jitsi.example.com"
 -- see: http://prosody.im/doc/components#adding_an_external_component
 --
 --Component "gateway.example.com"
---	component_secret = "password"
+--    component_secret = "password"
 
 Component "conference.jitsi.example.com" "muc"
 

--- a/doc/example-config-files/scalable/jicofo_config.scalable.example
+++ b/doc/example-config-files/scalable/jicofo_config.scalable.example
@@ -24,4 +24,9 @@ JICOFO_AUTH_PASSWORD=$JICOFO_PASSWORD
 JICOFO_OPTS=""
 
 # adds java system props that are passed to jicofo (default are for home and logging config file)
-JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=jicofo -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi -Djava.util.logging.config.file=/etc/jitsi/jicofo/logging.properties"
+JAVA_SYS_PROPS=" \
+    -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi \
+    -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=jicofo \
+    -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi \
+    -Djava.util.logging.config.file=/etc/jitsi/jicofo/logging.properties \
+"

--- a/doc/example-config-files/scalable/meet.example.com.cfg.lua.scalable.example
+++ b/doc/example-config-files/scalable/meet.example.com.cfg.lua.scalable.example
@@ -6,48 +6,48 @@ muc_mapper_domain_base = "meet.example.com";
 turncredentials_secret = "turncredentials_secret_test";
 
 turncredentials = {
-  { type = "stun", host = "meet.example.com", port = "443" },
-  { type = "turn", host = "meet.example.com", port = "443", transport = "udp" },
-  { type = "turns", host = "meet.example.com", port = "443", transport = "tcp" }
+    { type = "stun", host = "meet.example.com", port = "443" },
+    { type = "turn", host = "meet.example.com", port = "443", transport = "udp" },
+    { type = "turns", host = "meet.example.com", port = "443", transport = "tcp" }
 };
 
 cross_domain_bosh = false;
 consider_bosh_secure = true;
 
 VirtualHost "meet.example.com"
-        -- enabled = false -- Remove this line to enable this host
-        authentication = "anonymous"
-        -- Properties below are modified by jitsi-meet-tokens package config
-        -- and authentication above is switched to "token"
-        --app_id="example_app_id"
-        --app_secret="example_app_secret"
-        -- Assign this host a certificate for TLS, otherwise it would use the one
-        -- set in the global section (if any).
-        -- Note that old-style SSL on port 5223 only supports one certificate, and will always
-        -- use the global one.
-        ssl = {
-                key = "/etc/prosody/certs/meet.example.com.key";
-                certificate = "/etc/prosody/certs/meet.example.com.crt";
-        }
-        speakerstats_component = "speakerstats.meet.example.com"
-        conference_duration_component = "conferenceduration.meet.example.com"
-        -- we need bosh
-        modules_enabled = {
-            "bosh";
-            "pubsub";
-            "ping"; -- Enable mod_ping
-            "speakerstats";
-            "turncredentials";
-            "conference_duration";
-        }
-        c2s_require_encryption = false
+    -- enabled = false -- Remove this line to enable this host
+    authentication = "anonymous"
+    -- Properties below are modified by jitsi-meet-tokens package config
+    -- and authentication above is switched to "token"
+    --app_id="example_app_id"
+    --app_secret="example_app_secret"
+    -- Assign this host a certificate for TLS, otherwise it would use the one
+    -- set in the global section (if any).
+    -- Note that old-style SSL on port 5223 only supports one certificate, and will always
+    -- use the global one.
+    ssl = {
+        key = "/etc/prosody/certs/meet.example.com.key";
+        certificate = "/etc/prosody/certs/meet.example.com.crt";
+    }
+    speakerstats_component = "speakerstats.meet.example.com"
+    conference_duration_component = "conferenceduration.meet.example.com"
+    -- we need bosh
+    modules_enabled = {
+        "bosh";
+        "pubsub";
+        "ping"; -- Enable mod_ping
+        "speakerstats";
+        "turncredentials";
+        "conference_duration";
+    }
+    c2s_require_encryption = false
 
 Component "conference.meet.example.com" "muc"
     storage = "memory"
     modules_enabled = {
         "muc_meeting_id";
         "muc_domain_mapper";
-        -- "token_verification";
+        --"token_verification";
     }
     admins = { "focus@auth.meet.example.com" }
     muc_room_locking = false
@@ -58,7 +58,7 @@ Component "conference.meet.example.com" "muc"
 Component "internal.auth.meet.example.com" "muc"
     storage = "memory"
     modules_enabled = {
-      "ping";
+        "ping";
     }
     admins = { "focus@auth.meet.example.com", "jvb@auth.meet.example.com" }
 
@@ -74,7 +74,6 @@ Component "focus.meet.example.com"
 
 Component "speakerstats.meet.example.com" "speakerstats_component"
     muc_component = "conference.meet.example.com"
-
 
 Component "conferenceduration.meet.example.com" "conference_duration_component"
     muc_component = "conference.meet.example.com"

--- a/doc/example-config-files/scalable/prosody.cfg.lua.scalable.example
+++ b/doc/example-config-files/scalable/prosody.cfg.lua.scalable.example
@@ -13,58 +13,58 @@ network_backend = "epoll"
 -- Documentation for bundled modules can be found at: https://prosody.im/doc/modules
 modules_enabled = {
 
-	-- Generally required
-		"roster"; -- Allow users to have a roster. Recommended ;)
-		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
-		"tls"; -- Add support for secure TLS on c2s/s2s connections
-		"dialback"; -- s2s dialback support
-		"disco"; -- Service discovery
+    -- Generally required
+    "roster"; -- Allow users to have a roster. Recommended ;)
+    "saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+    "tls"; -- Add support for secure TLS on c2s/s2s connections
+    "dialback"; -- s2s dialback support
+    "disco"; -- Service discovery
 
-	-- Not essential, but recommended
-		"carbons"; -- Keep multiple clients in sync
-		"pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
-		"private"; -- Private XML storage (for room bookmarks, etc.)
-		"blocklist"; -- Allow users to block communications with other users
-		"vcard4"; -- User profiles (stored in PEP)
-		"vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
+    -- Not essential, but recommended
+    "carbons"; -- Keep multiple clients in sync
+    "pep"; -- Enables users to publish their avatar, mood, activity, playing music and more
+    "private"; -- Private XML storage (for room bookmarks, etc.)
+    "blocklist"; -- Allow users to block communications with other users
+    "vcard4"; -- User profiles (stored in PEP)
+    "vcard_legacy"; -- Conversion between legacy vCard and PEP Avatar, vcard
 
-	-- Nice to have
-		"version"; -- Replies to server version requests
-		"uptime"; -- Report how long server has been running
-		"time"; -- Let others know the time here on this server
-		"ping"; -- Replies to XMPP pings with pongs
-		"register"; -- Allow users to register on this server using a client and change passwords
-		--"mam"; -- Store messages in an archive and allow users to access it
-		--"csi_simple"; -- Simple Mobile optimizations
+    -- Nice to have
+    "version"; -- Replies to server version requests
+    "uptime"; -- Report how long server has been running
+    "time"; -- Let others know the time here on this server
+    "ping"; -- Replies to XMPP pings with pongs
+    "register"; -- Allow users to register on this server using a client and change passwords
+    --"mam"; -- Store messages in an archive and allow users to access it
+    --"csi_simple"; -- Simple Mobile optimizations
 
-	-- Admin interfaces
-		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
-		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
+    -- Admin interfaces
+    "admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+    --"admin_telnet"; -- Opens telnet console interface on localhost port 5582
 
-	-- HTTP modules
-		--"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
-		--"websocket"; -- XMPP over WebSockets
-		--"http_files"; -- Serve static files from a directory over HTTP
+    -- HTTP modules
+    --"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+    --"websocket"; -- XMPP over WebSockets
+    --"http_files"; -- Serve static files from a directory over HTTP
 
-	-- Other specific functionality
-		--"limits"; -- Enable bandwidth limiting for XMPP connections
-		--"groups"; -- Shared roster support
-		--"server_contact_info"; -- Publish contact information for this service
-		--"announce"; -- Send announcement to all online users
-		--"welcome"; -- Welcome users who register accounts
-		--"watchregistrations"; -- Alert admins of registrations
-		--"motd"; -- Send a message to users when they log in
-		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
-		--"proxy65"; -- Enables a file transfer proxy service which clients behind NAT can use
+    -- Other specific functionality
+    --"limits"; -- Enable bandwidth limiting for XMPP connections
+    --"groups"; -- Shared roster support
+    --"server_contact_info"; -- Publish contact information for this service
+    --"announce"; -- Send announcement to all online users
+    --"welcome"; -- Welcome users who register accounts
+    --"watchregistrations"; -- Alert admins of registrations
+    --"motd"; -- Send a message to users when they log in
+    --"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+    --"proxy65"; -- Enables a file transfer proxy service which clients behind NAT can use
 }
 
 -- These modules are auto-loaded, but should you want
 -- to disable them then uncomment them here:
 modules_disabled = {
-	-- "offline"; -- Store offline messages
-	-- "c2s"; -- Handle client connections
-	-- "s2s"; -- Handle server-to-server connections
-	-- "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+    --"offline"; -- Store offline messages
+    --"c2s"; -- Handle client connections
+    --"s2s"; -- Handle server-to-server connections
+    --"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
 }
 
 -- Disable account creation by default, for security
@@ -85,7 +85,6 @@ s2s_require_encryption = true
 
 s2s_secure_auth = false
 
-
 -- Required for init scripts and prosodyctl
 pidfile = "/var/run/prosody/prosody.pid"
 
@@ -99,12 +98,11 @@ archive_expires_after = "1w" -- Remove archived messages after 1 week
 -- Logging configuration
 -- For advanced logging see https://prosody.im/doc/logging
 log = {
-	info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
-	error = "/var/log/prosody/prosody.err";
-	-- "*syslog"; -- Uncomment this for logging to syslog
-	-- "*console"; -- Log to the console, useful for debugging with daemonize=false
+    info = "/var/log/prosody/prosody.log"; -- Change 'info' to 'debug' for verbose logging
+    error = "/var/log/prosody/prosody.err";
+    --"*syslog"; -- Uncomment this for logging to syslog
+    --"*console"; -- Log to the console, useful for debugging with daemonize=false
 }
-
 
 -- Location of directory to find certificates in (relative to main config file):
 certificates = "certs"

--- a/doc/example-config-files/scalable/videobridge_config.scalable.example
+++ b/doc/example-config-files/scalable/videobridge_config.scalable.example
@@ -15,6 +15,10 @@ JVB_SECRET=$VP_SECRET
 # extra options to pass to the JVB daemon
 JVB_OPTS="--apis=rest,"
 
-
 # adds java system props that are passed to jvb (default are for home and logging config file)
-JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties"
+JAVA_SYS_PROPS=" \
+    -Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi \
+    -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=videobridge \
+    -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi \
+    -Djava.util.logging.config.file=/etc/jitsi/videobridge/logging.properties \
+"


### PR DESCRIPTION
Purely cosmetic changes to the various example files contained in ./doc, to use consistent 4-spaces indentations same as the main code, plus a few other minor formatting changes here or there.
Main purpose - other than 'looks nice' - is to get rid of the occasional mix of space and tabs, as that messes with editor display.

No functional changes.