### PR TITLE
fix typo

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -707,7 +707,7 @@
             "kick": "Teilnehmer entfernen",
             "lobbyButton": "Lobbymodus ein-/ausschalten",
             "localRecording": "Lokale Aufzeichnungssteuerelemente ein-/ausschalten",
-            "lockRoom": "Konferenzpasswort ein-/auschalten",
+            "lockRoom": "Konferenzpasswort ein-/ausschalten",
             "moreActions": "Menü „Weitere Aktionen“ ein-/ausschalten",
             "moreActionsMenu": "Menü „Weitere Aktionen“",
             "moreOptions": "Menü „Weitere Optionen“",


### PR DESCRIPTION
`auschalten` > `ausschalten`