### PR TITLE
Etherpad on join

### DIFF
--- a/config.js
+++ b/config.js
@@ -635,6 +635,7 @@ var config = {
      disableRemoteControl
      displayJids
      etherpad_base
+     openSharedDocumentOnJoin
      externalConnectUrl
      firefox_fake_device
      googleApiApplicationClientID

--- a/config.js
+++ b/config.js
@@ -367,6 +367,13 @@ var config = {
     // When 'true', it shows an intermediate page before joining, where the user can configure their devices.
     // prejoinPageEnabled: false,
 
+    // If etherpad integration is enabled, setting this to true will
+    // automatically open the etherpad when a participant joins.  This
+    // does not affect the mobile app since opening an etherpad
+    // obscures the conference controls -- it's better to let users
+    // choose to open the pad on their own in that case.
+    // openSharedDocumentOnJoin: false,
+
     // If true, shows the unsafe room name warning label when a room name is
     // deemed unsafe (due to the simplicity in the name) and a password is not
     // set or the lobby is not enabled.
@@ -635,7 +642,6 @@ var config = {
      disableRemoteControl
      displayJids
      etherpad_base
-     openSharedDocumentOnJoin
      externalConnectUrl
      firefox_fake_device
      googleApiApplicationClientID

--- a/modules/UI/UI.js
+++ b/modules/UI/UI.js
@@ -229,6 +229,10 @@ UI.initEtherpad = name => {
     const url = new URL(name, config.etherpad_base);
 
     APP.store.dispatch(setDocumentUrl(url.toString()));
+
+    if (config.openSharedDocumentOnJoin) {
+        etherpadManager.toggleEtherpad();
+    }
 };
 
 /**

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -128,6 +128,7 @@ export default [
     'localRecording',
     'maxFullResolutionParticipants',
     'openBridgeChannel',
+    'openSharedDocumentOnJoin',
     'opusMaxAverageBitrate',
     'p2p',
     'pcStatsInterval',


### PR DESCRIPTION
For sites that focus on collaborative editing during meetings, add an option which, when set, will automatically open etherpad when a participant joins using a browser.

The native mobile app is unchanged.  Because it uses the entire screen for the etherpad, opening it on joining may be confusing for users.  In that case, the current behavior is maintained.
