### PR TITLE
fix(vpaas): Change billing-counter url when localStorage not available

### DIFF
--- a/react/features/billing-counter/actions.js
+++ b/react/features/billing-counter/actions.js
@@ -1,8 +1,5 @@
 // @flow
-
-import uuid from 'uuid';
-
-import { SET_BILLING_ID, SET_ENDPOINT_COUNTED } from './actionTypes';
+import { SET_ENDPOINT_COUNTED } from './actionTypes';
 import { extractVpaasTenantFromPath, getBillingId, sendCountRequest } from './functions';
 
 /**
@@ -20,34 +17,14 @@ export function countEndpoint() {
         const shouldSendRequest = Boolean(baseUrl && jwt && tenant);
 
         if (shouldSendRequest) {
-            let billingId = getBillingId();
-
-            if (!billingId) {
-                billingId = uuid.v4();
-                dispatch(setBillingId(billingId));
-            }
-
             sendCountRequest({
+                billingId: getBillingId(),
                 baseUrl,
-                billingId,
                 jwt,
                 tenant
             });
             dispatch(setEndpointCounted());
         }
-    };
-}
-
-/**
- * Action used to set the user billing id.
- *
- * @param {string} value - The uid.
- * @returns {Object}
- */
-function setBillingId(value) {
-    return {
-        type: SET_BILLING_ID,
-        value
     };
 }
 


### PR DESCRIPTION
* If local storage is not available, the url used for billing counter should not contain a `billingId`.

