### PR TITLE
Revert "fix(external_api) replace special chars in roomName before co…

### DIFF
--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -514,7 +514,7 @@ export function urlObjectToString(o: Object): ?string {
     // pathname
 
     // Web's ExternalAPI roomName
-    const room = _fixRoom(o.roomName || o.room);
+    const room = o.roomName || o.room;
 
     if (room
             && (url.pathname.endsWith('/')


### PR DESCRIPTION
…nstructing URL"

This reverts commit 6f90458ff17f53847c588da941c83791f6198005.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Reverting this for now since it breaks integration for JaaS users due to room name format being `tenant/room`
