### PR TITLE
fix(remote-control) skip on mobile

### DIFF
--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -37,7 +37,6 @@ import '../overlay/middleware';
 import '../recent-list/middleware';
 import '../recording/middleware';
 import '../rejoin/middleware';
-import '../remote-control/middleware';
 import '../room-lock/middleware';
 import '../rtcstats/middleware';
 import '../subtitles/middleware';

--- a/react/features/app/middlewares.web.js
+++ b/react/features/app/middlewares.web.js
@@ -10,6 +10,7 @@ import '../noise-detection/middleware';
 import '../old-client-notification/middleware';
 import '../power-monitor/middleware';
 import '../prejoin/middleware';
+import '../remote-control/middleware';
 import '../shared-video/middleware';
 import '../talk-while-muted/middleware';
 

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -43,7 +43,6 @@ import '../notifications/reducer';
 import '../overlay/reducer';
 import '../recent-list/reducer';
 import '../recording/reducer';
-import '../remote-control/reducer';
 import '../settings/reducer';
 import '../subtitles/reducer';
 import '../toolbox/reducer';

--- a/react/features/app/reducers.web.js
+++ b/react/features/app/reducers.web.js
@@ -8,6 +8,7 @@ import '../no-audio-signal/reducer';
 import '../noise-detection/reducer';
 import '../power-monitor/reducer';
 import '../prejoin/reducer';
+import '../remote-control/reducer';
 import '../screenshot-capture/reducer';
 import '../shared-video/reducer';
 import '../talk-while-muted/reducer';


### PR DESCRIPTION
Middlewares should not be loaded on mobile as there is no way to use the
functionality.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
