### PR TITLE
fix(jitsi-meet-web-config.postinst) allow cert and key pre-selection

### DIFF
--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -30,6 +30,7 @@ case "$1" in
             db_set jitsi-videobridge/jvb-hostname "localhost"
             db_input critical jitsi-videobridge/jvb-hostname || true
             db_go
+            db_get jitsi-videobridge/jvb-hostname
         fi
         JVB_HOSTNAME="$RET"
 

--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -75,15 +75,21 @@ case "$1" in
             CERT_CHOICE="$RET"
 
             if [ "$CERT_CHOICE" = "$UPLOADED_CERT_CHOICE" ] ; then
-                db_set jitsi-meet/cert-path-key "/etc/ssl/$JVB_HOSTNAME.key"
-                db_input critical jitsi-meet/cert-path-key || true
-                db_go
                 db_get jitsi-meet/cert-path-key
+                if [ -z "$RET" ] ; then
+                    db_set jitsi-meet/cert-path-key "/etc/ssl/$JVB_HOSTNAME.key"
+                    db_input critical jitsi-meet/cert-path-key || true
+                    db_go
+                    db_get jitsi-meet/cert-path-key
+                fi
                 CERT_KEY="$RET"
-                db_set jitsi-meet/cert-path-crt "/etc/ssl/$JVB_HOSTNAME.crt"
-                db_input critical jitsi-meet/cert-path-crt || true
-                db_go
                 db_get jitsi-meet/cert-path-crt
+                if [ -z "$RET" ] ; then
+                    db_set jitsi-meet/cert-path-crt "/etc/ssl/$JVB_HOSTNAME.crt"
+                    db_input critical jitsi-meet/cert-path-crt || true
+                    db_go
+                    db_get jitsi-meet/cert-path-crt
+                fi
                 CERT_CRT="$RET"
             else
                 # create self-signed certs


### PR DESCRIPTION
jitsi-meet-web-config 1.0.4466-1 ignores selection of cert and key path.
Postinst script overrides cert-path-key and cert-path-crt with defaults.

You can reproduce like this (replace your.domain.local with your own FQDN):
```
echo -e "jitsi-videobridge2\tjitsi-videobridge/jvb-hostname\tstring\tyour.domain.local" | debconf-set-selections
echo -e "jitsi-meet-web-config\tjitsi-meet/cert-choice\tselect\tI want to use my own certificate" | debconf-set-selections
echo -e "jitsi-meet-web-config\tjitsi-meet/cert-path-key\tstring\t/etc/letsencrypt/live/your.domain.local/privkey.pem" | debconf-set-selections
echo -e "jitsi-meet-web-config\tjitsi-meet/cert-path-crt\tstring\t/etc/letsencrypt/live/your.domain.local/fullchain.pem" | debconf-set-selections
apt install jitsi-meet

grep ssl_certificate /etc/nginx/sites-enabled/*.conf
```