### PR TITLE
fixed admin check for token verification

### DIFF
--- a/resources/prosody-plugins/mod_token_verification.lua
+++ b/resources/prosody-plugins/mod_token_verification.lua
@@ -4,8 +4,12 @@
 local log = module._log;
 local host = module.host;
 local st = require "util.stanza";
-local is_admin = require "core.usermanager".is_admin;
+local um_is_admin = require "core.usermanager".is_admin;
 
+
+local function is_admin(jid)
+    return um_is_admin(jid, host);
+end
 
 local parentHostName = string.gmatch(tostring(host), "%w+.(%w.+)")();
 if parentHostName == nil then


### PR DESCRIPTION
This PR follows from the discussion here: https://community.jitsi.org/t/domain-validation-with-jwt-tokens/88602/6

## Overview

This PR fixes issue where domain verification for JWT token fails if admin user is defined in config per host (which is the default) rather than globally. 

Without explicitly specifying `host` in the `is_admin` check, we do not properly detect focus user as admin and does not exclude the focus user from the domain check. This results in a failure during room creation.