### PR TITLE
fix(setAudioOutputDeviceId): check if supported

### DIFF
--- a/react/features/base/devices/functions.js
+++ b/react/features/base/devices/functions.js
@@ -267,6 +267,12 @@ export function setAudioOutputDeviceId(
 
     logger.debug(`setAudioOutputDevice: ${String(newLabel)}[${newId}]`);
 
+    if (!JitsiMeetJS.mediaDevices.isDeviceChangeAvailable('output')) {
+        logger.warn('Adjusting audio output is not supported');
+
+        return Promise.resolve();
+    }
+
     return JitsiMeetJS.mediaDevices.setAudioOutputDevice(newId)
         .then(() => {
             const newSettings = {


### PR DESCRIPTION
Check if adjusting audio output is supported rather than always fail on Safari for example.