### PR TITLE
fix(JitsiStreamPresenterEffect): frozen on Safari

### DIFF
--- a/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
+++ b/react/features/stream-effects/presenter/JitsiStreamPresenterEffect.js
@@ -59,6 +59,9 @@ export default class JitsiStreamPresenterEffect {
         this._videoElement.autoplay = true;
         this._videoElement.srcObject = videoStream;
 
+        // autoplay is not enough to start the video on Safari, it's fine to call play() on other platforms as well
+        this._videoElement.play();
+
         // set the style attribute of the div to make it invisible
         videoDiv.style.display = 'none';
 
@@ -132,6 +135,10 @@ export default class JitsiStreamPresenterEffect {
         this._desktopElement.height = parseInt(height, 10);
         this._desktopElement.autoplay = true;
         this._desktopElement.srcObject = desktopStream;
+
+        // autoplay is not enough to start the video on Safari, it's fine to call play() on other platforms as well
+        this._desktopElement.play();
+
         this._canvas.width = parseInt(width, 10);
         this._canvas.height = parseInt(height, 10);
         this._videoFrameTimerWorker = new Worker(timerWorkerScript, { name: 'Presenter effect worker' });


### PR DESCRIPTION
Canvas rendering does not work as expected on Safari - the image stays
still on the first frame. Calling play() on the video tags seems to help.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
