### PR TITLE
fix(vpaas): Store billing id in parent lolcaStorage on Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,9 +3325,9 @@
       }
     },
     "@jitsi/js-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-1.0.3.tgz",
-      "integrity": "sha512-m6mZz7R716mHP21lTKQffyM0nNFu3Fe/EHCaOVLFY/vdPsaUl9DhypJqtPIYzRUfPnmnugdaxcxrUeSZQXQzVA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-1.0.5.tgz",
+      "integrity": "sha512-1APQyuqQaYDR+W7cdgzsaBo6x8dpF8sfelcBf3ngNU3Jd+DzuuwUvCMTbr2+cCuy6w59ZAuQ7e2ixCnnOXOW4Q==",
       "requires": {
         "bowser": "2.7.0",
         "js-md5": "0.7.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@atlaskit/theme": "7.0.2",
     "@atlaskit/toggle": "5.0.14",
     "@atlaskit/tooltip": "12.1.13",
-    "@jitsi/js-utils": "1.0.3",
+    "@jitsi/js-utils": "1.0.5",
     "@microsoft/microsoft-graph-client": "1.1.0",
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/google-signin": "3.0.1",

--- a/react/features/base/jitsi-local-storage/setup.web.js
+++ b/react/features/base/jitsi-local-storage/setup.web.js
@@ -2,6 +2,7 @@
 
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
 
+import { browser } from '../lib-jitsi-meet';
 import { parseURLParams } from '../util/parseURLParams';
 
 import logger from './logger';
@@ -23,7 +24,7 @@ function onFakeLocalStorageChanged() {
  * @returns {void}
  */
 function setupJitsiLocalStorage() {
-    if (jitsiLocalStorage.isLocalStorageDisabled()) {
+    if (jitsiLocalStorage.isLocalStorageDisabled() || browser.isSafari()) {
         const urlParams = parseURLParams(window.location);
 
         try {

--- a/react/features/billing-counter/actionTypes.js
+++ b/react/features/billing-counter/actionTypes.js
@@ -1,9 +1,4 @@
 /**
- * Action used to store the billing id.
- */
-export const SET_BILLING_ID = 'SET_BILLING_ID';
-
-/**
  * Action used to store the flag signaling the endpoint has been counted.
  */
 export const SET_ENDPOINT_COUNTED = 'SET_ENDPOINT_COUNTED';

--- a/react/features/billing-counter/actions.js
+++ b/react/features/billing-counter/actions.js
@@ -1,13 +1,10 @@
 // @flow
 
-import uuid from 'uuid';
-
-import { SET_BILLING_ID, SET_ENDPOINT_COUNTED } from './actionTypes';
+import { SET_ENDPOINT_COUNTED } from './actionTypes';
 import { extractVpaasTenantFromPath, getBillingId, sendCountRequest } from './functions';
 
 /**
  * Sends a billing count request when needed.
- * If there is no billingId, it presists one first and sends the request after.
  *
  * @returns {Function}
  */
@@ -20,12 +17,7 @@ export function countEndpoint() {
         const shouldSendRequest = Boolean(baseUrl && jwt && tenant);
 
         if (shouldSendRequest) {
-            let billingId = getBillingId();
-
-            if (!billingId) {
-                billingId = uuid.v4();
-                dispatch(setBillingId(billingId));
-            }
+            const billingId = getBillingId();
 
             sendCountRequest({
                 baseUrl,
@@ -35,19 +27,6 @@ export function countEndpoint() {
             });
             dispatch(setEndpointCounted());
         }
-    };
-}
-
-/**
- * Action used to set the user billing id.
- *
- * @param {string} value - The uid.
- * @returns {Object}
- */
-function setBillingId(value) {
-    return {
-        type: SET_BILLING_ID,
-        value
     };
 }
 

--- a/react/features/billing-counter/functions.js
+++ b/react/features/billing-counter/functions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { jitsiLocalStorage } from '@jitsi/js-utils';
+import uuid from 'uuid';
 
 import { BILLING_ID, VPAAS_TENANT_PREFIX } from './constants';
 import logger from './logger';
@@ -72,20 +73,18 @@ export async function sendCountRequest({ baseUrl, billingId, jwt, tenant }: {
 }
 
 /**
- * Returns the stored billing id.
+ * Returns the stored billing id (or generates a new one if none is present).
  *
  * @returns {string}
  */
 export function getBillingId() {
-    return jitsiLocalStorage.getItem(BILLING_ID);
-}
 
-/**
- * Stores the billing id.
- *
- * @param {string} value - The id to be stored.
- * @returns {void}
- */
-export function setBillingId(value: string) {
-    jitsiLocalStorage.setItem(BILLING_ID, value);
+    let billingId = jitsiLocalStorage.getItem(BILLING_ID);
+
+    if (!billingId) {
+        billingId = uuid.v4();
+        jitsiLocalStorage.setItem(BILLING_ID, billingId);
+    }
+
+    return billingId;
 }

--- a/react/features/billing-counter/middleware.js
+++ b/react/features/billing-counter/middleware.js
@@ -3,9 +3,8 @@ import { CONFERENCE_JOINED } from '../base/conference/actionTypes';
 import { PARTICIPANT_JOINED } from '../base/participants/actionTypes';
 import { MiddlewareRegistry } from '../base/redux';
 
-import { SET_BILLING_ID } from './actionTypes';
 import { countEndpoint } from './actions';
-import { isVpaasMeeting, extractVpaasTenantFromPath, setBillingId } from './functions';
+import { isVpaasMeeting, extractVpaasTenantFromPath } from './functions';
 
 /**
  * The redux middleware for billing counter.
@@ -18,11 +17,6 @@ MiddlewareRegistry.register(store => next => async action => {
     switch (action.type) {
     case CONFERENCE_JOINED: {
         _maybeTrackVpaasConferenceJoin(store.getState());
-
-        break;
-    }
-    case SET_BILLING_ID: {
-        setBillingId(action.value);
 
         break;
     }


### PR DESCRIPTION
Safari browser does not persist data between sessions for iframes hosted on a
different domain. In this case a mechanism of storing the billingId on the
parent localStorage was added.
