### PR TITLE
Keep room names starting with '_'

### DIFF
--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -349,11 +349,10 @@ export function sendLocalParticipant(
  * @returns {string}
  */
 function safeStartCase(s = '') {
-    if (s.length > 0 && s[0] === '_'){
+    if (s.length > 0 && s[0] === '_') {
         return s.slice(1);
-    } else {
-        return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
-            (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
-            , '');
     }
+    return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
+        (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
+        , '');
 }

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -338,6 +338,8 @@ export function sendLocalParticipant(
 
 /**
  * A safe implementation of lodash#startCase that doesn't deburr the string.
+ * To avoid mixing up corporate names that include capital letters and numbers,
+ * names starting with a '_' are not beautified.
  *
  * NOTE: According to lodash roadmap, lodash v5 will have this function.
  *
@@ -347,7 +349,11 @@ export function sendLocalParticipant(
  * @returns {string}
  */
 function safeStartCase(s = '') {
-    return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
-        (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
-        , '');
+    if (s.length > 0 && s[0] === '_'){
+        return s.slice(1);
+    } else {
+        return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
+            (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
+            , '');
+    }
 }

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -352,6 +352,7 @@ function safeStartCase(s = '') {
     if (s.length > 0 && s[0] === '_') {
         return s.slice(1);
     }
+
     return _.words(`${s}`.replace(/['\u2019]/g, '')).reduce(
         (result, word, index) => result + (index ? ' ' : '') + _.upperFirst(word)
         , '');


### PR DESCRIPTION
To avoid beautifying corporate names including capital letters and numbers, rooms starting with a '_' are only beautified by removing the initial '_'.

Fixes #6468