### PR TITLE
fix(android) add ability to localize notification actions strings

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/OngoingNotification.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/OngoingNotification.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 
+import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
 
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
@@ -96,11 +97,11 @@ class OngoingNotification {
             .setOnlyAlertOnce(true)
             .setSmallIcon(context.getResources().getIdentifier("ic_notification", "drawable", context.getPackageName()));
 
-        NotificationCompat.Action hangupAction = createAction(context, JitsiMeetOngoingConferenceService.Action.HANGUP, "Hang up");
+        NotificationCompat.Action hangupAction = createAction(context, JitsiMeetOngoingConferenceService.Action.HANGUP, R.string.ongoing_notification_action_hang_up);
 
         JitsiMeetOngoingConferenceService.Action toggleAudioAction = isMuted
             ? JitsiMeetOngoingConferenceService.Action.UNMUTE : JitsiMeetOngoingConferenceService.Action.MUTE;
-        String toggleAudioTitle = isMuted ? "Unmute" : "Mute";
+        int toggleAudioTitle = isMuted ? R.string.ongoing_notification_action_unmute : R.string.ongoing_notification_action_mute;
         NotificationCompat.Action audioAction = createAction(context, toggleAudioAction, toggleAudioTitle);
 
         builder.addAction(hangupAction);
@@ -109,11 +110,12 @@ class OngoingNotification {
         return builder.build();
     }
 
-    private static NotificationCompat.Action createAction(Context context, JitsiMeetOngoingConferenceService.Action action, String title) {
+    private static NotificationCompat.Action createAction(Context context, JitsiMeetOngoingConferenceService.Action action, @StringRes int titleId) {
         Intent intent = new Intent(context, JitsiMeetOngoingConferenceService.class);
         intent.setAction(action.getName());
         PendingIntent pendingIntent
             = PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        String title = context.getString(titleId);
         return new NotificationCompat.Action(0, title, pendingIntent);
     }
 }

--- a/android/sdk/src/main/res/values/strings.xml
+++ b/android/sdk/src/main/res/values/strings.xml
@@ -3,4 +3,7 @@
     <string name="dropbox_app_key"></string>
     <string name="ongoing_notification_title">Ongoing meeting</string>
     <string name="ongoing_notification_text">You are currently in a meeting. Tap to return to it.</string>
+    <string name="ongoing_notification_action_hang_up">Hang up</string>
+    <string name="ongoing_notification_action_mute">Mute</string>
+    <string name="ongoing_notification_action_unmute">Unmute</string>
 </resources>


### PR DESCRIPTION
Fix for https://github.com/jitsi/jitsi-meet/issues/6673.
Notification title and message can be localised by overrading string in client app (tools:override="true"). Action button text are hardcoded, which make them english-only.

Solution: move strings to res.
