### PR TITLE
Update jitsi-meet-prosody.postinst

### DIFF
--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -156,7 +156,7 @@ case "$1" in
 
         # Old versions of jitsi-meet-prosody come with the extra plugin path commented out (https://github.com/jitsi/jitsi-meet/commit/e11d4d3101e5228bf956a69a9e8da73d0aee7949)
         # Make sure it is uncommented, as it contains required modules.
-        if grep -q '--plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }' ;then
+        if grep -q -e '--plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }' ;then
             sed -i 's#--plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }#plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }#g' $PROSODY_HOST_CONFIG
             PROSODY_CONFIG_PRESENT="false"
         fi


### PR DESCRIPTION
Hyphen first in grep expression gives error with message ```grep: unrecognized option '--plugin_paths'``` return value 2 unless escaped or in this case using -e flag.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
