### PR TITLE
feat: Add new codec selection mechanism.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10816,8 +10816,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#7896fc8b92f1416f800b56c87e51fb69700d620d",
-      "from": "github:jitsi/lib-jitsi-meet#7896fc8b92f1416f800b56c87e51fb69700d620d",
+      "version": "github:jitsi/lib-jitsi-meet#1009693f2ee8824452d9822c27f5ca07cd617c52",
+      "from": "github:jitsi/lib-jitsi-meet#1009693f2ee8824452d9822c27f5ca07cd617c52",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#7896fc8b92f1416f800b56c87e51fb69700d620d",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#1009693f2ee8824452d9822c27f5ca07cd617c52",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",


### PR DESCRIPTION
When an endpoint that doesn't support the preferred codec (VP9) joins a conference, all the other endpoints fallback to VP8 until the endpoint leaves the call.
