### PR TITLE
feat: Add feature flag for help button

### DIFF
--- a/react/features/base/flags/constants.js
+++ b/react/features/base/flags/constants.js
@@ -57,6 +57,12 @@ export const CHAT_ENABLED = 'chat.enabled';
 export const FILMSTRIP_ENABLED = 'filmstrip.enabled';
 
 /**
+ * Flag indicating if the Help button should be enabled.
+ * Default: enabled (true).
+ */
+export const HELP_BUTTON_ENABLED = 'help.enabled';
+
+/**
  * Flag indicating if invite functionality should be enabled.
  * Default: enabled (true).
  */

--- a/react/features/toolbox/components/HelpButton.js
+++ b/react/features/toolbox/components/HelpButton.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
+import { getFeatureFlag, HELP_BUTTON_ENABLED } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { IconHelp } from '../../base/icons';
 import { connect } from '../../base/redux';
@@ -45,7 +46,8 @@ class HelpButton extends AbstractButton<Props, *> {
  */
 function _mapStateToProps(state: Object) {
     const { userDocumentationURL } = state['features/base/config'].deploymentUrls || {};
-    const visible = typeof userDocumentationURL === 'string';
+    const enabled = getFeatureFlag(state, HELP_BUTTON_ENABLED, true);
+    const visible = typeof userDocumentationURL === 'string' && enabled;
 
     return {
         _userDocumentationURL: userDocumentationURL,


### PR DESCRIPTION
Introduces a new feature flag (`help.enabled`) and uses that to determine the visibility of the 'Help' button in a call.