### PR TITLE
feat: Uses mod_external_services supporting urn:xmpp:extdisco:2.

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -3,12 +3,11 @@ plugin_paths = { "/usr/share/jitsi-meet/prosody-plugins/" }
 -- domain mapper options, must at least have domain base set to use the mapper
 muc_mapper_domain_base = "jitmeet.example.com";
 
-turncredentials_secret = "__turnSecret__";
-
-turncredentials = {
-    { type = "stun", host = "jitmeet.example.com", port = "3478" },
-    { type = "turn", host = "jitmeet.example.com", port = "3478", transport = "udp" },
-    { type = "turns", host = "jitmeet.example.com", port = "5349", transport = "tcp" }
+external_service_secret = "__turnSecret__";
+external_services = {
+     { type = "stun", host = "jitmeet.example.com", port = 3478 },
+     { type = "turn", host = "jitmeet.example.com", port = 3478, transport = "udp", secret = true, ttl = 86400, algorithm = "turn" },
+     { type = "turns", host = "jitmeet.example.com", port = 5349, transport = "tcp", secret = true, ttl = 86400, algorithm = "turn" }
 };
 
 cross_domain_bosh = false;
@@ -44,7 +43,7 @@ VirtualHost "jitmeet.example.com"
         "pubsub";
         "ping"; -- Enable mod_ping
         "speakerstats";
-        "turncredentials";
+        "external_services";
         "conference_duration";
         "muc_lobby_rooms";
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10816,8 +10816,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#94ac35ae818093896e639e74f5fc389b488206a0",
-      "from": "github:jitsi/lib-jitsi-meet#94ac35ae818093896e639e74f5fc389b488206a0",
+      "version": "github:jitsi/lib-jitsi-meet#831716c1601da259905e58a9db23ebdcea3f1ad8",
+      "from": "github:jitsi/lib-jitsi-meet#831716c1601da259905e58a9db23ebdcea3f1ad8",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#94ac35ae818093896e639e74f5fc389b488206a0",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#831716c1601da259905e58a9db23ebdcea3f1ad8",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",

--- a/resources/prosody-plugins/mod_external_services.lua
+++ b/resources/prosody-plugins/mod_external_services.lua
@@ -1,0 +1,233 @@
+
+local dt = require "util.datetime";
+local base64 = require "util.encodings".base64;
+local hashes = require "util.hashes";
+local st = require "util.stanza";
+local jid = require "util.jid";
+local array = require "util.array";
+
+local default_host = module:get_option_string("external_service_host", module.host);
+local default_port = module:get_option_number("external_service_port");
+local default_secret = module:get_option_string("external_service_secret");
+local default_ttl = module:get_option_number("external_service_ttl", 86400);
+
+local configured_services = module:get_option_array("external_services", {});
+
+local access = module:get_option_set("external_service_access", {});
+
+-- https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
+local function behave_turn_rest_credentials(srv, item, secret)
+	local ttl = default_ttl;
+	if type(item.ttl) == "number" then
+		ttl = item.ttl;
+	end
+	local expires = srv.expires or os.time() + ttl;
+	local username;
+	if type(item.username) == "string" then
+		username = string.format("%d:%s", expires, item.username);
+	else
+		username = string.format("%d", expires);
+	end
+	srv.username = username;
+	srv.password = base64.encode(hashes.hmac_sha1(secret, srv.username));
+end
+
+local algorithms = {
+	turn = behave_turn_rest_credentials;
+}
+
+-- filter config into well-defined service records
+local function prepare(item)
+	if type(item) ~= "table" then
+		module:log("error", "Service definition is not a table: %q", item);
+		return nil;
+	end
+
+	local srv = {
+		type = nil;
+		transport = nil;
+		host = default_host;
+		port = default_port;
+		username = nil;
+		password = nil;
+		restricted = nil;
+		expires = nil;
+	};
+
+	if type(item.type) == "string" then
+		srv.type = item.type;
+	else
+		module:log("error", "Service missing mandatory 'type' field: %q", item);
+		return nil;
+	end
+	if type(item.transport) == "string" then
+		srv.transport = item.transport;
+	end
+	if type(item.host) == "string" then
+		srv.host = item.host;
+	end
+	if type(item.port) == "number" then
+		srv.port = item.port;
+	end
+	if type(item.username) == "string" then
+		srv.username = item.username;
+	end
+	if type(item.password) == "string" then
+		srv.password = item.password;
+		srv.restricted = true;
+	end
+	if item.restricted == true then
+		srv.restricted = true;
+	end
+	if type(item.expires) == "number" then
+		srv.expires = item.expires;
+	elseif type(item.ttl) == "number" then
+		srv.expires = os.time() + item.ttl;
+	end
+	if (item.secret == true and default_secret) or type(item.secret) == "string" then
+		local secret_cb = item.credentials_cb or algorithms[item.algorithm] or algorithms[srv.type];
+		local secret = item.secret;
+		if secret == true then
+			secret = default_secret;
+		end
+		if secret_cb then
+			secret_cb(srv, item, secret);
+			srv.restricted = true;
+		end
+	end
+	return srv;
+end
+
+function module.load()
+	-- Trigger errors on startup
+	local services = configured_services / prepare;
+	if #services == 0 then
+		module:log("warn", "No services configured or all had errors");
+	end
+end
+
+-- Ensure only valid items are added in events
+local services_mt = {
+	__index = getmetatable(array()).__index;
+	__newindex = function (self, i, v)
+		rawset(self, i, assert(prepare(v), "Invalid service entry added"));
+	end;
+}
+
+local function handle_services(event)
+	local origin, stanza = event.origin, event.stanza;
+	local action = stanza.tags[1];
+
+	local user_bare = jid.bare(stanza.attr.from);
+	local user_host = jid.host(user_bare);
+	if not ((access:empty() and origin.type == "c2s") or access:contains(user_bare) or access:contains(user_host)) then
+		origin.send(st.error_reply(stanza, "auth", "forbidden"));
+		return true;
+	end
+
+	local reply = st.reply(stanza):tag("services", { xmlns = action.attr.xmlns });
+	local extras = module:get_host_items("external_service");
+	local services = ( configured_services + extras ) / prepare;
+
+	local requested_type = action.attr.type;
+	if requested_type then
+		services:filter(function(item)
+			return item.type == requested_type;
+		end);
+	end
+
+	setmetatable(services, services_mt);
+
+	module:fire_event("external_service/services", {
+			origin = origin;
+			stanza = stanza;
+			reply = reply;
+			requested_type = requested_type;
+			services = services;
+		});
+
+	for _, srv in ipairs(services) do
+		reply:tag("service", {
+				type = srv.type;
+				transport = srv.transport;
+				host = srv.host;
+				port = srv.port and string.format("%d", srv.port) or nil;
+				username = srv.username;
+				password = srv.password;
+				expires = srv.expires and dt.datetime(srv.expires) or nil;
+				restricted = srv.restricted and "1" or nil;
+			}):up();
+	end
+
+	origin.send(reply);
+	return true;
+end
+
+local function handle_credentials(event)
+	local origin, stanza = event.origin, event.stanza;
+	local action = stanza.tags[1];
+
+	if origin.type ~= "c2s" then
+		origin.send(st.error_reply(stanza, "auth", "forbidden"));
+		return true;
+	end
+
+	local reply = st.reply(stanza):tag("credentials", { xmlns = action.attr.xmlns });
+	local extras = module:get_host_items("external_service");
+	local services = ( configured_services + extras ) / prepare;
+	services:filter(function (item)
+		return item.restricted;
+	end)
+
+	local requested_credentials = {};
+	for service in action:childtags("service") do
+		table.insert(requested_credentials, {
+				type = service.attr.type;
+				host = service.attr.host;
+				port = tonumber(service.attr.port);
+			});
+	end
+
+	setmetatable(services, services_mt);
+	setmetatable(requested_credentials, services_mt);
+
+	module:fire_event("external_service/credentials", {
+			origin = origin;
+			stanza = stanza;
+			reply = reply;
+			requested_credentials = requested_credentials;
+			services = services;
+		});
+
+	for req_srv in action:childtags("service") do
+		for _, srv in ipairs(services) do
+			if srv.type == req_srv.attr.type and srv.host == req_srv.attr.host
+				and not req_srv.attr.port or srv.port == tonumber(req_srv.attr.port) then
+				reply:tag("service", {
+						type = srv.type;
+						transport = srv.transport;
+						host = srv.host;
+						port = srv.port and string.format("%d", srv.port) or nil;
+						username = srv.username;
+						password = srv.password;
+						expires = srv.expires and dt.datetime(srv.expires) or nil;
+						restricted = srv.restricted and "1" or nil;
+					}):up();
+			end
+		end
+	end
+
+	origin.send(reply);
+	return true;
+end
+
+-- XEP-0215 v0.7
+module:add_feature("urn:xmpp:extdisco:2");
+module:hook("iq-get/host/urn:xmpp:extdisco:2:services", handle_services);
+module:hook("iq-get/host/urn:xmpp:extdisco:2:credentials", handle_credentials);
+
+-- COMPAT XEP-0215 v0.6
+-- Those still on the old version gets to deal with undefined attributes until they upgrade.
+module:add_feature("urn:xmpp:extdisco:1");
+module:hook("iq-get/host/urn:xmpp:extdisco:1:services", handle_services);
+module:hook("iq-get/host/urn:xmpp:extdisco:1:credentials", handle_credentials);


### PR DESCRIPTION
The old mod_turncredentials.lua is left to continue working for those using old installs.
New install will start using the new module which will no longer be needed with prosody 0.12.

https://hg.prosody.im/prosody-modules/file/4841cf3fded5/mod_external_services/mod_external_services.lua

First we need to merge https://github.com/jitsi/lib-jitsi-meet/pull/1472 and then update the lib-jitsi-meet hash in this PR.