### PR TITLE
Corrected Dutch translation of toggleCamera

### DIFF
--- a/lang/main-nl.json
+++ b/lang/main-nl.json
@@ -696,7 +696,7 @@
             "show": "Op podium weergeven",
             "speakerStats": "Sprekerstatistieken in- of uitschakelen",
             "tileView": "Tegelweergave in- of uitschakelen",
-            "toggleCamera": "Camera in- of uitschakelen",
+            "toggleCamera": "Camera wisselen",
             "toggleFilmstrip": "Filmstrip in- of uitschakelen",
             "videomute": "Video dempen in- of uitschakelen",
             "videoblur": "Video vervagen in- of uitschakelen"


### PR DESCRIPTION
Right now, the translation in the Jitsi app for the Dutch camera toggle feature says "Camera in- of uitschakelen", which translates to "Enable or disable camera", while the button toggles between the front and selfie camera. The better translation would be "Camera wisselen".