### PR TITLE
Allow to enforce Apache via debconf

### DIFF
--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -68,6 +68,12 @@ case "$1" in
         if [ "$APACHE_INSTALL_CHECK" = "installed" ] || [ "$APACHE_INSTALL_CHECK" = "unpacked" ] ; then
             FORCE_APACHE="true"
         fi
+        # In case user enforces apache and if apache is available, unset nginx.
+        db_get jitsi-meet/enforce_apache
+        if [ -n "$RET" ] && [ "$RET" = "true" ] \
+            && [ "$FORCE_APACHE" = "true" ]; then
+            FORCE_NGINX="false"
+        fi
 
         UPLOADED_CERT_CHOICE="I want to use my own certificate"
         # if first time config ask for certs, or if we are reconfiguring


### PR DESCRIPTION
> If both softwares (nginx/apache) are installed, currently the user is not able to use apache as server. However, in some cases it might be necessary to do so. See #8474

This PR includes a small check for a pre-configured debconf variable `jitsi-meet/enforce_apache`. If set, the postinstallation-script uses apache, even if nginx is installed.

As it is only set via debconf (not as a requested setting on installation) this should be just a small additional option, that is only used if really necessary. Typical installations will still default to nginx, as preferred.
If this PR gets accepted, i would include the corresponding sentence on docs as a small hint, but without detailed istructions.

Greets! :)
Jonas