### PR TITLE
Add mime type mapping for wasm to default Debian nginx config.

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -1,5 +1,9 @@
 server_names_hash_bucket_size 64;
 
+types {
+# nginx's default mime.types doesn't include a mapping for wasm
+    application/wasm     wasm;
+}
 server {
     listen 80;
     listen [::]:80;


### PR DESCRIPTION
nginx's default mime.types file doesn't yet have a content-type mapping for wasm, so this PR includes one in the default jitsi-meet configuration file.

Otherwise you get 
```
olm.js:31 wasm streaming compile failed: TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
(anonymous) @ olm.js:31
olm.js:31 falling back to ArrayBuffer instantiation
(anonymous) @ olm.js:31
```

(and similarly for rnnoise), which means you won't use the WebAssembly-optimized implementations.