### PR TITLE
Include xmpp and colibri proxy for apache

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -44,6 +44,9 @@
     ProxyPreserveHost on
     ProxyPass /http-bind http://localhost:5280/http-bind/
     ProxyPassReverse /http-bind http://localhost:5280/http-bind/
+    ProxyPass /xmpp-websocket http://localhost:5280/xmpp-websocket
+    ProxyPassReverse /xmpp-websocket http://localhost:5280/xmpp-websocket
+    ProxyPassMatch ^/colibri-ws/default-id http://localhost:9090
 
     RewriteEngine on
     RewriteRule ^/([a-zA-Z0-9]+)$ /index.html


### PR DESCRIPTION
Including the two proxy-configurations, which existed for nginx, but not for apache. This time i tested it myself already. 🙈 

According to the end of [this forum thread](https://community.jitsi.org/t/colibri-ws-websocket-not-working/88117) one could probably also remove the `ProxyPassReverse` lines, but this i did not test by myself yet and if they are not necessary, they won't have a bad effect anyways.