### PR TITLE
feat(rtcstats): send meeting uuid to rtcstats

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -33,6 +33,7 @@ import {
     conferenceLeft,
     conferenceSubjectChanged,
     conferenceTimestampChanged,
+    conferenceUniqueIdSet,
     conferenceWillJoin,
     conferenceWillLeave,
     dataChannelOpened,
@@ -1864,6 +1865,10 @@ export default {
                 APP.store.dispatch(conferenceTimestampChanged(0));
                 APP.store.dispatch(conferenceLeft(room, ...args));
             });
+
+        room.on(
+            JitsiConferenceEvents.CONFERENCE_UNIQUE_ID_SET,
+            (...args) => APP.store.dispatch(conferenceUniqueIdSet(room, ...args)));
 
         room.on(
             JitsiConferenceEvents.AUTH_STATUS_CHANGED,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10343,8 +10343,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#9fdde46694d1c4bc8b7f051cc8d50e0df29ffd07",
-      "from": "github:jitsi/lib-jitsi-meet#9fdde46694d1c4bc8b7f051cc8d50e0df29ffd07",
+      "version": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
+      "from": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#9fdde46694d1c4bc8b7f051cc8d50e0df29ffd07",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",

--- a/react/features/base/conference/actionTypes.js
+++ b/react/features/base/conference/actionTypes.js
@@ -43,6 +43,16 @@ export const CONFERENCE_JOINED = 'CONFERENCE_JOINED';
 export const CONFERENCE_LEFT = 'CONFERENCE_LEFT';
 
 /**
+ * The type of (redux) action which signals that an uuid for a conference has been set.
+ *
+ * {
+ *     type: CONFERENCE_UNIQUE_ID_SET,
+ *     conference: JitsiConference
+ * }
+ */
+export const CONFERENCE_UNIQUE_ID_SET = 'CONFERENCE_UNIQUE_ID_SET';
+
+/**
  * The type of (redux) action, which indicates conference subject changes.
  *
  * {

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -36,6 +36,7 @@ import {
     CONFERENCE_LEFT,
     CONFERENCE_SUBJECT_CHANGED,
     CONFERENCE_TIMESTAMP_CHANGED,
+    CONFERENCE_UNIQUE_ID_SET,
     CONFERENCE_WILL_JOIN,
     CONFERENCE_WILL_LEAVE,
     DATA_CHANNEL_OPENED,
@@ -291,6 +292,22 @@ export function conferenceJoined(conference: Object) {
 export function conferenceLeft(conference: Object) {
     return {
         type: CONFERENCE_LEFT,
+        conference
+    };
+}
+
+/**
+ * Signals that the unique identifier for conference has been set.
+ *
+ * @param {JitsiConference} conference - The JitsiConference instance, where the uuid has been set.
+ * @returns {{
+    *   type: CONFERENCE_JOINED,
+    *   conference: JitsiConference,
+    * }}
+    */
+export function conferenceUniqueIdSet(conference: Object) {
+    return {
+        type: CONFERENCE_UNIQUE_ID_SET,
         conference
     };
 }

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -301,7 +301,7 @@ export function conferenceLeft(conference: Object) {
  *
  * @param {JitsiConference} conference - The JitsiConference instance, where the uuid has been set.
  * @returns {{
-    *   type: CONFERENCE_JOINED,
+    *   type: CONFERENCE_UNIQUE_ID_SET,
     *   conference: JitsiConference,
     * }}
     */

--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -1,9 +1,7 @@
 // @flow
 
 import { getAmplitudeIdentity } from '../analytics';
-import {
-    CONFERENCE_JOINED
-} from '../base/conference';
+import { CONFERENCE_UNIQUE_ID_SET } from '../base/conference';
 import { LIB_WILL_INIT } from '../base/lib-jitsi-meet';
 import { getLocalParticipant } from '../base/participants';
 import { MiddlewareRegistry } from '../base/redux';
@@ -47,13 +45,17 @@ MiddlewareRegistry.register(store => next => action => {
         }
         break;
     }
-    case CONFERENCE_JOINED: {
+    case CONFERENCE_UNIQUE_ID_SET: {
         if (isRtcstatsEnabled(state) && RTCStats.isInitialized()) {
             // Once the conference started connect to the rtcstats server and send data.
             try {
                 RTCStats.connect();
 
                 const localParticipant = getLocalParticipant(state);
+
+                // Unique identifier for a conference session, not to be confused with meeting name
+                // i.e. If all participants leave a meeting it will have a different value on the next join.
+                const meetingUniqueId = action.conference?.getMeetingUniqueId();
 
                 // The current implementation of rtcstats-server is configured to send data to amplitude, thus
                 // we add identity specific information so we can corelate on the amplitude side. If amplitude is
@@ -65,7 +67,8 @@ MiddlewareRegistry.register(store => next => action => {
                 RTCStats.sendIdentityData({
                     ...getAmplitudeIdentity(),
                     ...config,
-                    displayName: localParticipant?.name
+                    displayName: localParticipant?.name,
+                    meetingUniqueId
                 });
             } catch (error) {
                 // If the connection failed do not impact jitsi-meet just silently fail.

--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -55,7 +55,8 @@ MiddlewareRegistry.register(store => next => action => {
 
                 // Unique identifier for a conference session, not to be confused with meeting name
                 // i.e. If all participants leave a meeting it will have a different value on the next join.
-                const meetingUniqueId = action.conference?.getMeetingUniqueId();
+                const { conference } = action;
+                const meetingUniqueId = conference && conference.getMeetingUniqueId();
 
                 // The current implementation of rtcstats-server is configured to send data to amplitude, thus
                 // we add identity specific information so we can corelate on the amplitude side. If amplitude is


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Depends on https://github.com/jitsi/lib-jitsi-meet/pull/1484

Send the conference unique identifier to the rtcstats-server in order to properly distinguish between individual sessions.
