### PR TITLE
deps: Update latest@lib-jitsi-meet.

### DIFF
--- a/config.js
+++ b/config.js
@@ -261,9 +261,16 @@ var config = {
     //    // the available bandwidth calculated by the browser, but it will be capped by the values specified here.
     //    // This is currently not implemented on app based clients on mobile.
     //    maxBitratesVideo: {
-    //        low: 200000,
-    //        standard: 500000,
-    //        high: 1500000
+    //          VP8 : {
+    //              low: 200000,
+    //              standard: 500000,
+    //              high: 1500000
+    //          },
+    //          VP9: {
+    //              low: 100000,
+    //              standard: 300000,
+    //              high:  1200000
+    //          }
     //    },
     //
     //    // The options can be used to override default thresholds of video thumbnail heights corresponding to

--- a/package-lock.json
+++ b/package-lock.json
@@ -10343,8 +10343,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
-      "from": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
+      "version": "github:jitsi/lib-jitsi-meet#77978f0e621f463ed606fe94dda25ff18f1d5f64",
+      "from": "github:jitsi/lib-jitsi-meet#77978f0e621f463ed606fe94dda25ff18f1d5f64",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#479dd989a081e8ae23ca4f4ab68395a2f76d34d0",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#77978f0e621f463ed606fe94dda25ff18f1d5f64",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",


### PR DESCRIPTION
Add the ability to configure different max bitrates for VP8 and VP9.
Set max bitrate for presenter to 2500 Kbps irrespective of the configured max bitrates for video.
https://github.com/jitsi/lib-jitsi-meet/compare/479dd98...77978f0.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
