### PR TITLE
Set receiver video constraint in load-test script, as-if tile view.

### DIFF
--- a/resources/load-test/load-test-participant.js
+++ b/resources/load-test/load-test-participant.js
@@ -29,6 +29,8 @@ let numParticipants = 1;
 let localTracks = [];
 const remoteTracks = {};
 
+let maxFrameHeight = 0;
+
 window.APP = {
     conference: {
         getStats() {
@@ -67,10 +69,32 @@ window.APP = {
 };
 
 /**
+ * Simple emulation of jitsi-meet's screen layout behavior
+ */
+function updateMaxFrameHeight() {
+    var newMaxFrameHeight;
+    if (numParticipants <= 2) {
+        newMaxFrameHeight = 720;
+    }
+    else if (numParticipants <= 4) {
+        newMaxFrameHeight = 360;
+    }
+    else {
+        newMaxFrameHeight = 180;
+    }
+
+    if (room && maxFrameHeight != newMaxFrameHeight) {
+        maxFrameHeight = newMaxFrameHeight;
+        room.setReceiverVideoConstraint(maxFrameHeight);
+    }
+}
+
+/**
  *
  */
 function setNumberOfParticipants() {
     $('#participants').text(numParticipants);
+    updateMaxFrameHeight();
 }
 
 /**
@@ -165,6 +189,7 @@ function onConnectionSuccess() {
     });
     room.on(JitsiMeetJS.events.conference.USER_LEFT, onUserLeft);
     room.join();
+    updateMaxFrameHeight();
 }
 
 /**

--- a/resources/load-test/load-test-participant.js
+++ b/resources/load-test/load-test-participant.js
@@ -72,18 +72,17 @@ window.APP = {
  * Simple emulation of jitsi-meet's screen layout behavior
  */
 function updateMaxFrameHeight() {
-    var newMaxFrameHeight;
+    let newMaxFrameHeight;
+
     if (numParticipants <= 2) {
         newMaxFrameHeight = 720;
-    }
-    else if (numParticipants <= 4) {
+    } else if (numParticipants <= 4) {
         newMaxFrameHeight = 360;
-    }
-    else {
+    } else {
         newMaxFrameHeight = 180;
     }
 
-    if (room && maxFrameHeight != newMaxFrameHeight) {
+    if (room && maxFrameHeight !== newMaxFrameHeight) {
         maxFrameHeight = newMaxFrameHeight;
         room.setReceiverVideoConstraint(maxFrameHeight);
     }


### PR DESCRIPTION
This sets video constraints for the load-test webpage as if it were jitsi-meet receiving tile view in a reasonable window size. 