### PR TITLE
WIP feat(prosody) detacch session resumption from token auth

### DIFF
--- a/resources/prosody-plugins/mod_auth_jitsi-annonymous.lua
+++ b/resources/prosody-plugins/mod_auth_jitsi-annonymous.lua
@@ -1,0 +1,74 @@
+-- Anonymous authentication with extras:
+-- * session resumption
+-- Copyright (C) 2021-present 8x8, Inc.
+
+local new_sasl = require "util.sasl".new;
+local sasl = require "util.sasl";
+local sessions = prosody.full_sessions;
+
+
+-- define auth provider
+local provider = {};
+
+local host = module.host;
+
+
+function provider.test_password(username, password)
+	return nil, "Password based auth not supported";
+end
+
+function provider.get_password(username)
+	return nil;
+end
+
+function provider.set_password(username, password)
+	return nil, "Set password not supported";
+end
+
+function provider.user_exists(username)
+	return nil;
+end
+
+function provider.create_user(username, password)
+	return nil;
+end
+
+function provider.delete_user(username)
+	return nil;
+end
+
+function provider.get_sasl_handler(session)
+    -- Custom session matching so we can resume sesssion even with randomly
+    -- generrated user IDs.
+	local function get_username(self, message)
+        if (session.previd ~= nil) then
+            for _, session1 in pairs(sessions) do
+                if (session1.resumption_token == session.previd) then
+                    self.username = session1.username;
+                    break;
+                end
+        	end
+        else
+            self.username = message;
+        end
+
+        return true;
+	end
+
+	return new_sasl(host, { anonymous = get_username });
+end
+
+module:provides("auth", provider);
+
+local function anonymous(self, message)
+    -- This calls the handler created in 'provider.get_sasl_handler(session)'
+	local result, err, msg = self.profile.anonymous(self, username, self.realm);
+
+	if result == true then
+		return "success";
+	else
+		return "failure", err, msg;
+	end
+end
+
+sasl.registerMechanism("ANONYMOUS", {"anonymous"}, anonymous);

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -1,5 +1,5 @@
 -- Token authentication
--- Copyright (C) 2015 Atlassian
+-- Copyright (C) 2015-present 8x8, Inc.
 
 local formdecode = require "util.http".formdecode;
 local generate_uuid = require "util.uuid".generate;
@@ -26,24 +26,10 @@ function init_session(event)
 	if query ~= nil then
         local params = formdecode(query);
 
-        -- The following fields are filled in the session, by extracting them
-        -- from the query and no validation is beeing done.
         -- After validating auth_token will be cleaned in case of error and few
         -- other fields will be extracted from the token and set in the session
 
         session.auth_token = query and params.token or nil;
-        -- previd is used together with https://modules.prosody.im/mod_smacks.html
-        -- the param is used to find resumed session and re-use anonymous(random) user id
-        -- (see get_username_from_token)
-        session.previd = query and params.previd or nil;
-
-        -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = params.room;
-        session.jitsi_web_query_prefix = params.prefix or "";
-
-        -- Deprecated, you should use jitsi_web_query_room and jitsi_web_query_prefix
-        session.jitsi_bosh_query_room = session.jitsi_web_query_room;
-        session.jitsi_bosh_query_prefix = session.jitsi_web_query_prefix;
     end
 end
 

--- a/resources/prosody-plugins/mod_jitsi_session.lua
+++ b/resources/prosody-plugins/mod_jitsi_session.lua
@@ -1,0 +1,30 @@
+-- Jitsi session information
+-- Copyright (C) 2021-present 8x8, Inc.
+
+local formdecode = require "util.http".formdecode;
+local sessions = prosody.full_sessions;
+
+
+local host = module.host;
+
+-- Extract the following parameters from the URL and set them in the session:
+-- * previd: for session resumption
+function init_session(event)
+	local session, request = event.session, event.request;
+	local query = request.url.query;
+
+	if query ~= nil then
+        local params = formdecode(query);
+
+        -- previd is used together with https://modules.prosody.im/mod_smacks.html
+        -- the param is used to find resumed session and re-use anonymous(random) user id
+        session.previd = query and params.previd or nil;
+
+        -- The room name and optional prefix from the web query
+        session.jitsi_web_query_room = params.room;
+        session.jitsi_web_query_prefix = params.prefix or "";
+    end
+end
+
+module:hook_global("bosh-session", init_session);
+module:hook_global("websocket-session", init_session);


### PR DESCRIPTION
Add 2 new modules:

- jitsi_session: extracts URL parameters from BOSH or WS sessions and attaches
  them to the session
- auth_jitsi-annonymous: anonymous authentication with custom session
  resumpotion for randomly generated usernames

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
