### PR TITLE
#7037: Issue #7037 fixed. Using youtube sharing in jitsi while using external api works

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -319,7 +319,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow = 'camera; microphone; display-capture';
+        this._frame.allow = 'camera; microphone; display-capture; autoplay;';
         this._frame.src = this._url;
         this._frame.name = frameName;
         this._frame.id = frameName;


### PR DESCRIPTION
The issue was that if you used youtube video sharing while uisng external api , the video was not auto playing in chrome.
With this fix, the reported issue #7037 will be resolved.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
