### PR TITLE
external_api: add api call to get youtube live stream url from the cu…

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -449,11 +449,7 @@ function initCommands() {
             if (conference) {
                 const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
 
-                if (activeSession?.liveStreamViewURL) {
-                    livestreamUrl = activeSession.liveStreamViewURL;
-                } else {
-                    logger.error('No streaming session found');
-                }
+                livestreamUrl = activeSession?.liveStreamViewURL;
             } else {
                 logger.error('Conference is not defined');
             }

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -441,6 +441,27 @@ function initCommands() {
             });
             break;
         }
+        case 'get-livestream-url': {
+            const state = APP.store.getState();
+            const conference = getCurrentConference(state);
+            let livestreamUrl;
+
+            if (conference) {
+                const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
+
+                if (activeSession?.liveStreamViewURL) {
+                    livestreamUrl = activeSession.liveStreamViewURL;
+                } else {
+                    logger.error('No streaming session found');
+                }
+            } else {
+                logger.error('Conference is not defined');
+            }
+            callback({
+                livestreamUrl
+            });
+            break;
+        }
         default:
             return false;
         }

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -754,6 +754,18 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns the youtube livestream url.
+     *
+     * @returns {Promise} - Resolves with "youtube livestream url" if exists, with
+     * undefined if not and rejects on failure.
+     */
+    getLivestreamUrl() {
+        return this._transport.sendRequest({
+            name: 'get-livestream-url'
+        });
+    }
+
+    /**
      * Returns the conference participants information.
      *
      * @returns {Array<Object>} - Returns an array containing participants

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -756,7 +756,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     /**
      * Returns the current livestream url.
      *
-     * @returns {Promise} - Resolves with "youtube livestream url" if exists, with
+     * @returns {Promise} - Resolves with the current livestream URL if exists, with
      * undefined if not and rejects on failure.
      */
     getLivestreamUrl() {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -754,7 +754,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
-     * Returns the youtube livestream url.
+     * Returns the current livestream url.
      *
      * @returns {Promise} - Resolves with "youtube livestream url" if exists, with
      * undefined if not and rejects on failure.


### PR DESCRIPTION
This pull request adds to the Jitsi External API the ability to get the YouTube live stream url for a live stream session.
These changes make use of existing code and makes it available through the Jitsi External (iframe) API.

These changes are important to have in the API, In case we use an Iframe and start the live stream by authenticating inside the Jitsi. With the help of this API, we will get the information of live streaming url and can be used outside of the iframe for user management.