### PR TITLE
add option to avoid cropping focused video

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -223,7 +223,8 @@ var interfaceConfig = {
     // Determines how the video would fit the screen. 'both' would fit the whole
     // screen, 'height' would fit the original video height to the height of the
     // screen, 'width' would fit the original video width to the width of the
-    // screen respecting ratio.
+    // screen respecting ratio, 'nocrop' would make the video as large as
+    // possible and preserve aspect ratio without cropping.
     VIDEO_LAYOUT_FIT: 'both',
 
     /**

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -99,20 +99,27 @@ function computeCameraVideoSize( // eslint-disable-line max-params
     }
 
     const aspectRatio = videoWidth / videoHeight;
+    const videoSpaceRatio = videoSpaceWidth / videoSpaceHeight;
+
+    if (videoSpaceRatio === aspectRatio) {
+        return [ videoSpaceWidth, videoSpaceHeight ];
+    }
 
     switch (videoLayoutFit) {
     case 'height':
         return [ videoSpaceHeight * aspectRatio, videoSpaceHeight ];
     case 'width':
         return [ videoSpaceWidth, videoSpaceWidth / aspectRatio ];
+    case 'nocrop':
+        return computeCameraVideoSize(
+            videoWidth,
+            videoHeight,
+            videoSpaceWidth,
+            videoSpaceHeight,
+            videoSpaceRatio < aspectRatio ? 'width' : 'height');
     case 'both': {
-        const videoSpaceRatio = videoSpaceWidth / videoSpaceHeight;
         const maxZoomCoefficient = interfaceConfig.MAXIMUM_ZOOMING_COEFFICIENT
             || Infinity;
-
-        if (videoSpaceRatio === aspectRatio) {
-            return [ videoSpaceWidth, videoSpaceHeight ];
-        }
 
         let [ width, height ] = computeCameraVideoSize(
             videoWidth,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

This changeset allows setting `VIDEO_LAYOUT_FIT` to `'nocrop'` in `interface_config.js` in order to make the focused video as large as possible without cropping (while preserving aspect ratio).

This arose from a use case using Jitsi Meet as a teaching tool, as students were getting confused/annoyed by the cropping that happened with screenshare (occasionally through an OBS virtual webcam) when trying to look at code, virtual whiteboards, etc.

I'm not sure if this is useful to (m)any people other than myself, but a quick search shows #6010 and some issues linked from there, all of which seem at least vaguely related to this use case, so I'm happy to share in case it's useful to anyone else.

Feedback is appreciated.  Happy to make changes or clean things up.