### PR TITLE
add option for disabling join/leave sounds

### DIFF
--- a/config.js
+++ b/config.js
@@ -670,6 +670,7 @@ var config = {
      dialInNumbersUrl
      dialOutAuthUrl
      dialOutCodesUrl
+     disableJoinLeaveSounds
      disableRemoteControl
      displayJids
      etherpad_base

--- a/config.js
+++ b/config.js
@@ -534,6 +534,10 @@ var config = {
     // Decides whether the start/stop recording audio notifications should play on record.
     // disableRecordAudioNotification: false,
 
+    // Disables the sounds that play when other participants join or leave the
+    // conference (if set to true, these sounds will not be played).
+    // disableJoinLeaveSounds: false,
+
     // Information for the chrome extension banner
     // chromeExtensionBanner: {
     //     // The chrome extension to be installed address
@@ -670,7 +674,6 @@ var config = {
      dialInNumbersUrl
      dialOutAuthUrl
      dialOutCodesUrl
-     disableJoinLeaveSounds
      disableRemoteControl
      displayJids
      etherpad_base

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -84,6 +84,7 @@ export default [
     'disableH264',
     'disableHPF',
     'disableInviteFunctions',
+    'disableJoinLeaveSounds',
     'disableLocalVideoFlip',
     'disableNS',
     'disableProfile',

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -341,7 +341,7 @@ function _maybePlaySounds({ getState, dispatch }, action) {
     const state = getState();
     const { startAudioMuted, disableJoinLeaveSounds } = state['features/base/config'];
 
-    // if we have sounds disabled, don't play anything.
+    // If we have join/leave sounds disabled, don't play anything.
     if (disableJoinLeaveSounds) {
         return;
     }

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -339,7 +339,12 @@ function _localParticipantLeft({ dispatch }, next, action) {
  */
 function _maybePlaySounds({ getState, dispatch }, action) {
     const state = getState();
-    const { startAudioMuted } = state['features/base/config'];
+    const { startAudioMuted, disableJoinLeaveSounds } = state['features/base/config'];
+
+    // if we have sounds disabled, don't play anything.
+    if (disableJoinLeaveSounds) {
+        return;
+    }
 
     // We're not playing sounds for local participant
     // nor when the user is joining past the "startAudioMuted" limit.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

This PR adds an option `disableJoinLeaveSounds` to `config.py`, which can be set to `true` to disable the join/leave sounds (which I and my students found distracting in a large class meeting).  

I couldn't find a way to turn off the sounds with the current configuration options, short of replacing the WAV files with silence.  But if this kind of option already exists, or if there is a cleaner way to do this, I'd be interested to know :)
