### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10343,8 +10343,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#84357ce1a8d06c67a502709877130520aaf71592",
-      "from": "github:jitsi/lib-jitsi-meet#84357ce1a8d06c67a502709877130520aaf71592",
+      "version": "github:jitsi/lib-jitsi-meet#d1f0ab4d5a691f438f7d4c7446f29273b1b8fcdc",
+      "from": "github:jitsi/lib-jitsi-meet#d1f0ab4d5a691f438f7d4c7446f29273b1b8fcdc",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#84357ce1a8d06c67a502709877130520aaf71592",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#d1f0ab4d5a691f438f7d4c7446f29273b1b8fcdc",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.19",
     "moment": "2.19.4",


### PR DESCRIPTION
* fix(GUM-permissions): cache permissions on init.
* feat: Reuse billingId from localstorage as jitsiMeetId.
* fix(example) simplify
* feat(docs) mvoe API documentatrion to the handbook

https://github.com/jitsi/lib-jitsi-meet/compare/84357ce1a8d06c67a502709877130520aaf71592...d1f0ab4d5a691f438f7d4c7446f29273b1b8fcdc
