### PR TITLE
fix: TypeError: Cannot read property 'isAudioTrack' of undefined

### DIFF
--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -320,7 +320,7 @@ export function getTrackByMediaTypeAndParticipant(
         mediaType,
         participantId) {
     return tracks.find(
-        t => t.participantId === participantId && t.mediaType === mediaType
+        t => Boolean(t.jitsiTrack) && t.participantId === participantId && t.mediaType === mediaType
     );
 }
 

--- a/react/features/prejoin/middleware.js
+++ b/react/features/prejoin/middleware.js
@@ -46,7 +46,9 @@ MiddlewareRegistry.register(store => next => async action => {
             await dispatch(replaceLocalTrack(localVideoTrack.jitsiTrack, null));
         }
 
-        const jitsiTracks = getState()['features/base/tracks'].map(t => t.jitsiTrack);
+        const jitsiTracks = getState()['features/base/tracks']
+            .map(t => t.jitsiTrack)
+            .filter(t => Boolean(t)); // Filter out GUM in progress tracks...
 
         dispatch(setPrejoinPageVisibility(false));
         APP.conference.prejoinStart(jitsiTracks);


### PR DESCRIPTION
Can be reproduced by:

1. Start on the prejoin screen with camera turned off (that must be the initial state)
2. Turn the camera on and quickly join the meeting, before camera preview appears
3. It should crash with TypeError: Cannot read property 'isAudioTrack' of undefined if meeting is joined while get user media for camera is in progress.

