### PR TITLE
feat(filmstrip): show thumbnails with video first

### DIFF
--- a/css/filmstrip/_small_video.scss
+++ b/css/filmstrip/_small_video.scss
@@ -49,3 +49,23 @@
         z-index: $zindex3;
     }
 }
+
+
+/**
+ * Sort thumbnails in filmstrip
+ * This is optionally, set by SORTED_FILMSTRIP in interface_config.js
+ */
+
+ #filmstripRemoteVideosContainer.sorted  {
+     
+    /* default value */
+    .videocontainer {
+        order: 2;
+    }
+
+    /* show the thumbnails with video first */
+    .videocontainer.display-video,
+    .videocontainer.display-name-on-video {
+        order: 1;
+    }    
+}    

--- a/interface_config.js
+++ b/interface_config.js
@@ -97,6 +97,11 @@ var interfaceConfig = {
 
     FILM_STRIP_MAX_HEIGHT: 120,
 
+    /**
+     * Whether to show participants with video first in the filmstrip
+     */
+    FILM_STRIP_SORTED: true,
+
     GENERATE_ROOMNAMES_ON_WELCOME_PAGE: true,
 
     /**
@@ -219,6 +224,7 @@ var interfaceConfig = {
      * Whether to show thumbnails in filmstrip as a column instead of as a row.
      */
     VERTICAL_FILMSTRIP: true,
+
 
     // Determines how the video would fit the screen. 'both' would fit the whole
     // screen, 'height' would fit the original video height to the height of the

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -174,6 +174,12 @@ class Filmstrip extends Component <Props> {
             toolbar = this._renderToggleButton();
         }
 
+        // should thumbnails be sorted?
+        // (handled by css in _small_video.scss)
+        if (interfaceConfig.FILM_STRIP_SORTED || typeof interfaceConfig.FILM_STRIP_SORTED === 'undefined') {
+            remoteVideoContainerClassName += ' sorted';
+        }
+
         return (
             <div
                 className = { `filmstrip ${this.props._className}` }


### PR DESCRIPTION
This PR adds the option to sort the thumbnails according to whether a video is available as described by @arthurlogilab in #8461 

It is settable by `FILM_STRIP_SORTED` in `interface_config.js`, which is `true` by default and also defaults to `true` if undefined.

Would be happy about feedback:
- Any reason to not make this the default?
- Is there any convention for naming new config variables?


closes #8461
