### PR TITLE
feat: allow avatars from same origin even if disableThirdPartyRequests is true

### DIFF
--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -59,10 +59,17 @@ export function isAnalyticsEnabled(stateful: Function | Object) {
  * {@code false}, otherwise.
  */
 export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string) {
-    const { disableThirdPartyRequests, gravatarBaseURL } = toState(stateful)['features/base/config'];
+    const state = toState(stateful);
+    const { locationURL } = state['features/base/connection'];
+    const { disableThirdPartyRequests, gravatarBaseURL } = state['features/base/config'];
 
     if (disableThirdPartyRequests) {
-        return avatarURL && avatarURL.startsWith(window.location.origin);
+        if (!locationURL || !locationURL.origin) {
+            return false;
+        }
+
+        return avatarURL && avatarURL.startsWith(locationURL.origin);
+
     } else if (gravatarBaseURL) {
         return avatarURL && avatarURL.startsWith(gravatarBaseURL);
     }

--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -49,6 +49,28 @@ export function isAnalyticsEnabled(stateful: Function | Object) {
 }
 
 /**
+ * Determines whether an avatar URL is valid.
+ *
+ * @param {Function|Object} stateful - The redux store, state, or
+ * {@code getState} function.
+ * @param {string} avatarURL - The avatar url to check.
+ * @returns {boolean} If the URL matches the origin and disableThirdPartyRequests
+ * is defined, or the URL matches the gravatarBaseURL, {@code true};
+ * {@code false}, otherwise.
+ */
+export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string) {
+    const { disableThirdPartyRequests, gravatarBaseURL } = toState(stateful)['features/base/config'];
+
+    if (disableThirdPartyRequests) {
+        return avatarURL && avatarURL.startsWith(window.location.origin);
+    } else if (gravatarBaseURL) {
+        return avatarURL && avatarURL.startsWith(gravatarBaseURL);
+    }
+
+    return true;
+}
+
+/**
  * Determines whether a specific {@link JitsiConferenceErrors} instance
  * indicates a fatal {@link JitsiConference} error.
  *

--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -54,14 +54,14 @@ export function isAnalyticsEnabled(stateful: Function | Object) {
  * @param {Function|Object} stateful - The redux store, state, or
  * {@code getState} function.
  * @param {string} avatarURL - The avatar url to check.
- * @returns {boolean} If the URL matches the origin and disableThirdPartyRequests
- * is defined, or the URL matches the gravatarBaseURL, {@code true};
+ * @returns {boolean} If the URL does not match the origin and disableThirdPartyRequests
+ * is defined, {@code false}; otherwise {@code true};
  * {@code false}, otherwise.
  */
 export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string) {
     const state = toState(stateful);
     const { locationURL } = state['features/base/connection'];
-    const { disableThirdPartyRequests, gravatarBaseURL } = state['features/base/config'];
+    const { disableThirdPartyRequests } = state['features/base/config'];
 
     if (disableThirdPartyRequests) {
         if (!locationURL || !locationURL.origin) {
@@ -69,9 +69,6 @@ export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string)
         }
 
         return avatarURL && avatarURL.startsWith(locationURL.origin);
-
-    } else if (gravatarBaseURL) {
-        return avatarURL && avatarURL.startsWith(gravatarBaseURL);
     }
 
     return true;

--- a/react/features/base/lib-jitsi-meet/functions.any.js
+++ b/react/features/base/lib-jitsi-meet/functions.any.js
@@ -49,32 +49,6 @@ export function isAnalyticsEnabled(stateful: Function | Object) {
 }
 
 /**
- * Determines whether an avatar URL is valid.
- *
- * @param {Function|Object} stateful - The redux store, state, or
- * {@code getState} function.
- * @param {string} avatarURL - The avatar url to check.
- * @returns {boolean} If the URL does not match the origin and disableThirdPartyRequests
- * is defined, {@code false}; otherwise {@code true};
- * {@code false}, otherwise.
- */
-export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string) {
-    const state = toState(stateful);
-    const { locationURL } = state['features/base/connection'];
-    const { disableThirdPartyRequests } = state['features/base/config'];
-
-    if (disableThirdPartyRequests) {
-        if (!locationURL || !locationURL.origin) {
-            return false;
-        }
-
-        return avatarURL && avatarURL.startsWith(locationURL.origin);
-    }
-
-    return true;
-}
-
-/**
  * Determines whether a specific {@link JitsiConferenceErrors} instance
  * indicates a fatal {@link JitsiConference} error.
  *

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -3,7 +3,7 @@
 import { getGravatarURL } from '@jitsi/js-utils/avatar';
 import type { Store } from 'redux';
 
-import { isAvatarUrlValid, JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
+import { JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, shouldRenderVideoTrack } from '../media';
 import { toState } from '../redux';
 import { getTrackByMediaTypeAndParticipant } from '../tracks';
@@ -74,6 +74,38 @@ export function getFirstLoadableAvatarUrl(participant: Object, store: Store<any,
     }
 
     return fullPromise;
+}
+
+/**
+ * Determines whether an avatar URL is valid.
+ *
+ * @param {Function|Object} stateful - The redux store, state, or
+ * {@code getState} function.
+ * @param {string} avatarURL - The avatar url to check.
+ * @returns {boolean} If the URL does not match the origin and disableThirdPartyRequests
+ * is defined, {@code false}; otherwise {@code true};
+ * {@code false}, otherwise.
+ */
+export function isAvatarUrlValid(stateful: Function | Object, avatarURL: string) {
+    const state = toState(stateful);
+    const { locationURL } = state['features/base/connection'];
+    const { disableThirdPartyRequests } = state['features/base/config'];
+
+    if (disableThirdPartyRequests) {
+        if (!locationURL || !locationURL.origin) {
+            return false;
+        }
+
+        try {
+            const url = new URL(avatarURL);
+
+            return url.origin === locationURL.origin;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -3,7 +3,7 @@
 import { getGravatarURL } from '@jitsi/js-utils/avatar';
 import type { Store } from 'redux';
 
-import { JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
+import { isAvatarUrlValid, JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, shouldRenderVideoTrack } from '../media';
 import { toState } from '../redux';
 import { getTrackByMediaTypeAndParticipant } from '../tracks';
@@ -438,7 +438,7 @@ async function _getFirstLoadableAvatarUrl(participant, store) {
                 if (AVATAR_CHECKED_URLS.get(url)) {
                     return url;
                 }
-            } else {
+            } else if (isAvatarUrlValid(store, url)) {
                 try {
                     const finalUrl = await preloadImage(url);
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -471,9 +471,8 @@ function _participantJoinedOrUpdated(store, next, action) {
     // Only run this if the config is populated, otherwise we preload external resources
     // even if disableThirdPartyRequests is set to true in config
     if (Object.keys(getState()['features/base/config']).length) {
-        const { disableThirdPartyRequests } = getState()['features/base/config'];
 
-        if (!disableThirdPartyRequests && (avatarURL || email || id || name)) {
+        if (avatarURL || email || id || name) {
             const participantId = !id && local ? getLocalParticipant(getState()).id : id;
             const updatedParticipant = getParticipantById(getState(), participantId);
 

--- a/react/features/lobby/middleware.js
+++ b/react/features/lobby/middleware.js
@@ -169,9 +169,8 @@ function _conferenceJoined({ dispatch }, next, action) {
 function _findLoadableAvatarForKnockingParticipant(store, { id }) {
     const { dispatch, getState } = store;
     const updatedParticipant = getState()['features/lobby'].knockingParticipants.find(p => p.id === id);
-    const { disableThirdPartyRequests } = getState()['features/base/config'];
 
-    if (!disableThirdPartyRequests && updatedParticipant && !updatedParticipant.loadableAvatarUrl) {
+    if (updatedParticipant && !updatedParticipant.loadableAvatarUrl) {
         getFirstLoadableAvatarUrl(updatedParticipant, store).then(loadableAvatarUrl => {
             if (loadableAvatarUrl) {
                 dispatch(participantIsKnockingOrUpdated({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Enable and validate avatars against the `gravatarBaseURL` (if defined in config.js) even if `disableThirdPartyRequests` is true.

The goal here is to allow the fetching of avatars even though third party requests are disabled. By configuring the `gravatarBaseURL`, one indicates that they wish to use a specific gravatar server (for instance a self hosted one).
If `gravatarBaseURL`  and `disableThirdPartyRequests` are defined in config.js, avatar urls that do not match `gravatarBaseURL` are discarded. This validation also prevents a user from pushing an arbitrary not accepted url that would be fetched by other participants.