### PR TITLE
Normalize language format

### DIFF
--- a/react/features/base/i18n/customNavigatorDetector.js
+++ b/react/features/base/i18n/customNavigatorDetector.js
@@ -36,8 +36,7 @@ export default {
             }
         }
 
-        // Fix language format (en-US => enUS)
-        found = found.map<string>(f => f.replace(/[-_]+/g, ''));
+        found = found.map<string>(normalizeLanguage);
 
         return found.length > 0 ? found : undefined;
     },
@@ -47,3 +46,23 @@ export default {
      */
     name: 'customNavigatorDetector'
 };
+
+/**
+ * Normalize language format.
+ *
+ * (en-US => enUS)
+ * (en-gb => enGB)
+ * (es-es => es).
+ *
+ * @param {string} language - Language.
+ * @returns {string} The normalized language.
+ */
+function normalizeLanguage(language) {
+    const [ lang, variant ] = language.replace('_', '-').split('-');
+
+    if (!variant || lang === variant) {
+        return lang;
+    }
+
+    return lang + variant.toUpperCase();
+}


### PR DESCRIPTION
For `navigator.languages` Chrome returns `['es']` but Safari returns `['es-es']` resulting in `eses` format which does not exists.

This PR normalizes the format:
```
en-US => enUS
en-gb => enGB
es-es => es
 ```

fixes #8261 
