### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10254,8 +10254,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#9beb47fe5f5ae9caf0b206588e14fa676479ce31",
-      "from": "github:jitsi/lib-jitsi-meet#9beb47fe5f5ae9caf0b206588e14fa676479ce31",
+      "version": "github:jitsi/lib-jitsi-meet#4c668023b38c92615cd06c4e90006246c3e4aa2c",
+      "from": "github:jitsi/lib-jitsi-meet#4c668023b38c92615cd06c4e90006246c3e4aa2c",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#9beb47fe5f5ae9caf0b206588e14fa676479ce31",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#4c668023b38c92615cd06c4e90006246c3e4aa2c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.19.4",


### PR DESCRIPTION
* fix(TPC): Remove the existing track instead of overwriting. When a second remote track of the same mediatype is received for an endpoint, remove the existing track before creating the new remote track.

https://github.com/jitsi/lib-jitsi-meet/compare/9beb47fe5f5ae9caf0b206588e14fa676479ce31...4c668023b38c92615cd06c4e90006246c3e4aa2c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
