### PR TITLE
Revert change to dial in numbers link

### DIFF
--- a/react/features/invite/components/add-people-dialog/web/DialInSection.js
+++ b/react/features/invite/components/add-people-dialog/web/DialInSection.js
@@ -51,13 +51,13 @@ function DialInSection({
             <DialInNumber
                 conferenceID = { _dialIn.conferenceID }
                 phoneNumber = { phoneNumber } />
-            {_dialIn.numbers && _dialIn.numbers.length > 1 ? <a
+            <a
                 className = 'more-numbers'
                 href = { _dialInfoPageUrl }
                 rel = 'noopener noreferrer'
                 target = '_blank'>
                 { t('info.moreNumbers') }
-            </a> : null}
+            </a>
         </div>
     );
 }


### PR DESCRIPTION
Revert a change that might cause an issue in the display of dial in numbers until we have time to investigate the root cause.