### PR TITLE
Only show more numbers link if multiple numbers are available

### DIFF
--- a/react/features/invite/components/add-people-dialog/web/DialInSection.js
+++ b/react/features/invite/components/add-people-dialog/web/DialInSection.js
@@ -4,21 +4,27 @@ import React from 'react';
 
 import { translate } from '../../../../base/i18n';
 import { connect } from '../../../../base/redux';
-import { getDialInfoPageURL } from '../../../functions';
+import { getDialInfoPageURL, hasMultipleNumbers } from '../../../functions';
 
 import DialInNumber from './DialInNumber';
 
 type Props = {
 
     /**
-     * The object representing the dialIn feature.
+     * The numberic identifier for the current conference, used after dialing a
+     * the number to join the conference.
      */
-    _dialIn: Object,
+    _conferenceID: number,
 
     /**
      * The url of the page containing the dial-in numbers list.
      */
     _dialInfoPageUrl: string,
+
+    /**
+     * If multiple dial-in numbers are available
+     */
+    _hasMultipleNumbers: boolean;
 
     /**
      * The phone number to dial to begin the process of dialing into a
@@ -41,23 +47,24 @@ type Props = {
  * @returns {null|ReactElement}
  */
 function DialInSection({
-    _dialIn,
+    _conferenceID,
     _dialInfoPageUrl,
+    _hasMultipleNumbers,
     phoneNumber,
     t
 }: Props) {
     return (
         <div className = 'invite-more-dialog dial-in-display'>
             <DialInNumber
-                conferenceID = { _dialIn.conferenceID }
+                conferenceID = { _conferenceID }
                 phoneNumber = { phoneNumber } />
-            <a
+            {_hasMultipleNumbers ? <a
                 className = 'more-numbers'
                 href = { _dialInfoPageUrl }
                 rel = 'noopener noreferrer'
                 target = '_blank'>
                 { t('info.moreNumbers') }
-            </a>
+            </a> : null}
         </div>
     );
 }
@@ -72,9 +79,11 @@ function DialInSection({
  * @returns {Props}
  */
 function _mapStateToProps(state) {
+    const dialIn = state['features/invite'];
     return {
-        _dialIn: state['features/invite'],
-        _dialInfoPageUrl: getDialInfoPageURL(state)
+        _conferenceID: dialIn.conferenceID,
+        _dialInfoPageUrl: getDialInfoPageURL(state),
+        _hasMultipleNumbers: hasMultipleNumbers(dialIn.numbers)
     };
 }
 

--- a/react/features/invite/components/add-people-dialog/web/DialInSection.js
+++ b/react/features/invite/components/add-people-dialog/web/DialInSection.js
@@ -80,6 +80,7 @@ function DialInSection({
  */
 function _mapStateToProps(state) {
     const dialIn = state['features/invite'];
+
     return {
         _conferenceID: dialIn.conferenceID,
         _dialInfoPageUrl: getDialInfoPageURL(state),

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -608,7 +608,7 @@ export function hasMultipleNumbers(dialInNumbers: ?Object) {
     // deprecated and will be removed
     const { numbers } = dialInNumbers;
 
-    return Boolean(numbers && Object.values(numbers).map(a => Array.isArray(a) ? a.length : 0)
+    return Boolean(numbers && Object.values(numbers).map(a => (Array.isArray(a) ? a.length : 0))
         .reduce((a, b) => a + b) > 1);
 }
 

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -608,7 +608,8 @@ export function hasMultipleNumbers(dialInNumbers: ?Object) {
     // deprecated and will be removed
     const { numbers } = dialInNumbers;
 
-    return Boolean(numbers && Object.values(numbers).map(a => { return Array.isArray(a) ? a.length : 0 })
+    // eslint-disable-next-line no-confusing-arrow
+    return Boolean(numbers && Object.values(numbers).map(a => Array.isArray(a) ? a.length : 0)
         .reduce((a, b) => a + b) > 1);
 }
 

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -608,7 +608,7 @@ export function hasMultipleNumbers(dialInNumbers: ?Object) {
     // deprecated and will be removed
     const { numbers } = dialInNumbers;
 
-    return Boolean(numbers && Object.values(numbers).map(a => a.length || 0)
+    return Boolean(numbers && Object.values(numbers).map(a => Array.isArray(a) ? a.length : 0)
         .reduce((a, b) => a + b) > 1);
 }
 

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -602,12 +602,14 @@ export function hasMultipleNumbers(dialInNumbers: ?Object) {
     }
 
     if (Array.isArray(dialInNumbers)) {
-        return dialInNumbers.length > 1
+        return dialInNumbers.length > 1;
     }
 
     // deprecated and will be removed
     const { numbers } = dialInNumbers;
-    return Boolean(numbers && Object.values(numbers).map((a) => a.length || 0).reduce((a, b) => a + b) > 1);
+
+    return Boolean(numbers && Object.values(numbers).map(a => a.length || 0)
+        .reduce((a, b) => a + b) > 1);
 }
 
 /**

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -589,6 +589,28 @@ export function shouldDisplayDialIn(dialIn: Object) {
 }
 
 /**
+ * Returns if multiple dial-in numbers are available.
+ *
+ * @param {Array<string>|Object} dialInNumbers - The array or object of
+ * numbers to check.
+ * @private
+ * @returns {boolean}
+ */
+export function hasMultipleNumbers(dialInNumbers: ?Object) {
+    if (!dialInNumbers) {
+        return false;
+    }
+
+    if (Array.isArray(dialInNumbers)) {
+        return dialInNumbers.length > 1
+    }
+
+    // deprecated and will be removed
+    const { numbers } = dialInNumbers;
+    return Boolean(numbers && Object.values(numbers).map((a) => a.length || 0).reduce((a, b) => a + b) > 1);
+}
+
+/**
  * Sets the internal state of which dial-in number to display.
  *
  * @param {Array<string>|Object} dialInNumbers - The array or object of

--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -608,7 +608,7 @@ export function hasMultipleNumbers(dialInNumbers: ?Object) {
     // deprecated and will be removed
     const { numbers } = dialInNumbers;
 
-    return Boolean(numbers && Object.values(numbers).map(a => (Array.isArray(a) ? a.length : 0))
+    return Boolean(numbers && Object.values(numbers).map(a => { return Array.isArray(a) ? a.length : 0 })
         .reduce((a, b) => a + b) > 1);
 }
 


### PR DESCRIPTION
This is a small change that hides the "more numbers" link if only one dial-in number is configured. 
It respects both supported configuration formats. The one described in the swagger spec (https://github.com/jitsi/jitsi-meet/blob/master/resources/cloud-api.swagger#L130) and the one described in the handbook (https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker#display-dial-in-information). 
maybe a good time to also update the handbook because the code states this format is obsolete.