### PR TITLE
i18n Update: moment locale

### DIFF
--- a/react/features/base/i18n/dateUtil.js
+++ b/react/features/base/i18n/dateUtil.js
@@ -19,9 +19,7 @@ require('moment/locale/fr');
 require('moment/locale/hy-am');
 require('moment/locale/it');
 require('moment/locale/nb');
-
-// OC is not available. Please submit OC translation to the MomentJS project.
-
+require('moment/locale/oc-lnc');
 require('moment/locale/pl');
 require('moment/locale/pt');
 require('moment/locale/pt-br');


### PR DESCRIPTION
It's now included as shows https://momentjs.com/
but the code is specific oc-lnc and not simply "oc" as used in Jitsi.
I don't know if it matters.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
