### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10259,8 +10259,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#e83fb93d2dc6f4e66aeb0caea4035e6e6d642e07",
-      "from": "github:jitsi/lib-jitsi-meet#e83fb93d2dc6f4e66aeb0caea4035e6e6d642e07",
+      "version": "github:jitsi/lib-jitsi-meet#d31b5a2d5e94d9847f5ce7452e610f6959c347ee",
+      "from": "github:jitsi/lib-jitsi-meet#d31b5a2d5e94d9847f5ce7452e610f6959c347ee",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e83fb93d2dc6f4e66aeb0caea4035e6e6d642e07",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#d31b5a2d5e94d9847f5ce7452e610f6959c347ee",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(conference): Do not signal muted tracks on join. Do not add the muted audio/video tracks to the peerconnection on join. The tracks will be added when the user unmutes for the first time. This reduces the number of remote sources that will be added when a participant joins a large call where everyone joins muted (startAudioMuted/startVideoMuted setting).

https://github.com/jitsi/lib-jitsi-meet/compare/e83fb93d2dc6f4e66aeb0caea4035e6e6d642e07...d31b5a2d5e94d9847f5ce7452e610f6959c347ee

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
