### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10259,8 +10259,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#08ce96d881fed594d6f347cdb0a4076fdb050d28",
-      "from": "github:jitsi/lib-jitsi-meet#08ce96d881fed594d6f347cdb0a4076fdb050d28",
+      "version": "github:jitsi/lib-jitsi-meet#e60f09b18955deae2dd631dc842d026289d4a74f",
+      "from": "github:jitsi/lib-jitsi-meet#e60f09b18955deae2dd631dc842d026289d4a74f",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#08ce96d881fed594d6f347cdb0a4076fdb050d28",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e60f09b18955deae2dd631dc842d026289d4a74f",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* feat(browser-support): Add support for WKWebview based browsers. Apple added getUserMedia support for WkWebview based browsers like chrome and Firefox on iOS 14.3. These browsers behave as Safari does on iOS. Therefore, extend the Safari checks to these webkit based browsers as well.

https://github.com/jitsi/lib-jitsi-meet/compare/08ce96d881fed594d6f347cdb0a4076fdb050d28...e60f09b18955deae2dd631dc842d026289d4a74f

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
