### PR TITLE
fix(UI): Add playsinline attribute for remote video.

### DIFF
--- a/modules/UI/videolayout/RemoteVideo.js
+++ b/modules/UI/videolayout/RemoteVideo.js
@@ -221,6 +221,8 @@ export default class RemoteVideo extends SmallVideo {
 
         streamElement.autoplay = !config.testing?.noAutoPlayVideo;
         streamElement.id = `remoteVideo_${stream.getId()}`;
+        streamElement.mute = true;
+        streamElement.playsInline = true;
 
         // Put new stream element always in front
         streamElement = UIUtils.prependChild(this.container, streamElement);


### PR DESCRIPTION
For the video to play on Safari mobile browser, the playsInline attribute needs to be set to true. Set the mute attribute as well which was accidentally removed in code refactor.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
