### PR TITLE
chore(deps) bump js-utils to 1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2586,9 +2586,9 @@
       }
     },
     "@jitsi/js-utils": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-1.0.5.tgz",
-      "integrity": "sha512-1APQyuqQaYDR+W7cdgzsaBo6x8dpF8sfelcBf3ngNU3Jd+DzuuwUvCMTbr2+cCuy6w59ZAuQ7e2ixCnnOXOW4Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-1.0.6.tgz",
+      "integrity": "sha512-XdLvgzhEhMsrzHBDgBydvWneGXSZ8ycg+dEK9bs2CLQhH5A9cHOOToDl9p/skts7WHQp4C8nkhsNzWC/cRvszQ==",
       "requires": {
         "bowser": "2.7.0",
         "js-md5": "0.7.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@atlaskit/theme": "11.0.2",
     "@atlaskit/toggle": "12.0.3",
     "@atlaskit/tooltip": "17.1.2",
-    "@jitsi/js-utils": "1.0.5",
+    "@jitsi/js-utils": "1.0.6",
     "@microsoft/microsoft-graph-client": "1.1.0",
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/google-signin": "3.0.1",


### PR DESCRIPTION
Fixes a harmless but confusing error in postis processing when using the
Bitwarden Chrome extension, for example.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
