### PR TITLE
fix(virtual-background) use a DOM element for storing the image

### DIFF
--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -26,10 +26,10 @@ export default class JitsiStreamBackgroundEffect {
     _segmentationMask: Object;
     _segmentationMaskCanvas: Object;
     _renderMask: Function;
+    _virtualImage: HTMLImageElement;
     isEnabled: Function;
     startEffect: Function;
     stopEffect: Function;
-    virtualImage: Image;
 
     /**
      * Represents a modified video MediaStream track.
@@ -42,8 +42,8 @@ export default class JitsiStreamBackgroundEffect {
         this._options = options;
 
         if (this._options.virtualBackground.isVirtualBackground) {
-            this.virtualImage = new Image();
-            this.virtualImage.src = this._options.virtualBackground.virtualSource;
+            this._virtualImage = document.createElement('img');
+            this._virtualImage.src = this._options.virtualBackground.virtualSource;
         }
         this._model = model;
         this._options = options;
@@ -113,7 +113,7 @@ export default class JitsiStreamBackgroundEffect {
 
         this._outputCanvasCtx.globalCompositeOperation = 'destination-over';
         if (this._options.virtualBackground.isVirtualBackground) {
-            this._outputCanvasCtx.drawImage(this.virtualImage, 0, 0);
+            this._outputCanvasCtx.drawImage(this._virtualImage, 0, 0);
         } else {
             this._outputCanvasCtx.filter = `blur(${blurValue})`;
             this._outputCanvasCtx.drawImage(this._inputVideoElement, 0, 0);


### PR DESCRIPTION
THis will reuse the previously cached image and obey the base href.

Ref:
https://stackoverflow.com/questions/6241716/is-there-a-difference-between-new-image-and-document-createelementimg

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
