### PR TITLE
Set default audio volume to 0.7, to allow raising of relative volume

### DIFF
--- a/react/features/base/avatar/components/web/StatelessAvatar.js
+++ b/react/features/base/avatar/components/web/StatelessAvatar.js
@@ -55,7 +55,7 @@ export default class StatelessAvatar extends AbstractStatelessAvatar<Props> {
                     style = { this._getAvatarStyle(this.props.color) }>
                     <Icon
                         size = '50%'
-                        src = { `https://jitsi.revspace.nl/?uri=${url}` } />
+                        src = { `https://jitsi.revspace.nl/imageproxy?uri=${url}` } />
                 </div>
             );
         }
@@ -68,7 +68,7 @@ export default class StatelessAvatar extends AbstractStatelessAvatar<Props> {
                         data-testid = { this.props.testId }
                         id = { this.props.id }
                         onError = { this.props.onAvatarLoadError }
-                        src = { `https://jitsi.revspace.nl/?uri=${url}` }
+                        src = { `https://jitsi.revspace.nl/imageproxy?uri=${url}` }
                         style = { this._getAvatarStyle() } />
                 </div>
             );

--- a/react/features/base/avatar/components/web/StatelessAvatar.js
+++ b/react/features/base/avatar/components/web/StatelessAvatar.js
@@ -55,7 +55,7 @@ export default class StatelessAvatar extends AbstractStatelessAvatar<Props> {
                     style = { this._getAvatarStyle(this.props.color) }>
                     <Icon
                         size = '50%'
-                        src = { url } />
+                        src = { `https://jitsi.revspace.nl/?uri=${url}` } />
                 </div>
             );
         }
@@ -68,7 +68,7 @@ export default class StatelessAvatar extends AbstractStatelessAvatar<Props> {
                         data-testid = { this.props.testId }
                         id = { this.props.id }
                         onError = { this.props.onAvatarLoadError }
-                        src = { url }
+                        src = { `https://jitsi.revspace.nl/?uri=${url}` }
                         style = { this._getAvatarStyle() } />
                 </div>
             );

--- a/react/features/base/avatar/functions.js
+++ b/react/features/base/avatar/functions.js
@@ -50,5 +50,9 @@ export function getInitials(s: ?string) {
         (initials.length < 2) && (initials += w.substr(0, 1).toUpperCase());
     }
 
+    if (s === "f0x") {
+        return s;
+    }
+
     return initials;
 }

--- a/react/features/base/media/components/web/AudioTrack.js
+++ b/react/features/base/media/components/web/AudioTrack.js
@@ -210,6 +210,8 @@ export default class AudioTrack extends Component<Props> {
         this._ref = audioElement;
         const { onInitialVolumeSet } = this.props;
 
+        this._ref.volume = 0.7;
+
         if (this._ref && onInitialVolumeSet) {
             onInitialVolumeSet(this._ref.volume);
         }

--- a/react/features/base/media/components/web/AudioTrack.js
+++ b/react/features/base/media/components/web/AudioTrack.js
@@ -210,7 +210,9 @@ export default class AudioTrack extends Component<Props> {
         this._ref = audioElement;
         const { onInitialVolumeSet } = this.props;
 
-        this._ref.volume = 0.7;
+        if (this._ref !== null) {
+            this._ref.volume = 0.5;
+        }
 
         if (this._ref && onInitialVolumeSet) {
             onInitialVolumeSet(this._ref.volume);

--- a/react/features/chat/middleware.js
+++ b/react/features/chat/middleware.js
@@ -253,7 +253,8 @@ function _handleReceivedMessage({ dispatch, getState }, { id, message, privateMe
     const { isOpen: isChatOpen } = state['features/chat'];
 
     if (!isChatOpen) {
-        dispatch(playSound(INCOMING_MSG_SOUND_ID));
+        // No more woosh
+        // dispatch(playSound(INCOMING_MSG_SOUND_ID));
     }
 
     // Provide a default for for the case when a message is being

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1112,26 +1112,6 @@ class Toolbox extends Component<Props, State> {
         const overflowMenuAdditionalButtons = [];
         const mainMenuAdditionalButtons = [];
 
-        if (this._showDesktopSharingButton()) {
-            buttons.has('desktop')
-                ? mainMenuAdditionalButtons.push(<ToolbarButton
-                    accessibilityLabel = { t('toolbar.accessibilityLabel.shareYourScreen') }
-                    disabled = { !_desktopSharingEnabled }
-                    icon = { IconShareDesktop }
-                    key = 'desktop'
-                    onClick = { this._onToolbarToggleScreenshare }
-                    toggled = { _screensharing }
-                    tooltip = { t(_desktopSharingEnabled
-                        ? 'dialog.shareYourScreen' : _desktopSharingDisabledTooltipKey) } />)
-                : overflowMenuAdditionalButtons.push(<OverflowMenuItem
-                    accessibilityLabel = { t('toolbar.accessibilityLabel.shareYourScreen') }
-                    icon = { IconShareDesktop }
-                    iconId = 'share-desktop'
-                    key = 'desktop'
-                    onClick = { this._onToolbarToggleScreenshare }
-                    text = { t(`toolbar.${_screensharing ? 'stopScreenSharing' : 'startScreenSharing'}`) } />);
-        }
-
         if (this._shouldShowButton('chat')) {
             buttons.has('chat')
                 ? mainMenuAdditionalButtons.push(<div
@@ -1153,23 +1133,6 @@ class Toolbox extends Component<Props, State> {
                     text = { t(`toolbar.${_chatOpen ? 'closeChat' : 'openChat'}`) } />);
         }
 
-        if (this._shouldShowButton('raisehand')) {
-            buttons.has('raisehand')
-                ? mainMenuAdditionalButtons.push(<ToolbarButton
-                    accessibilityLabel = { t('toolbar.accessibilityLabel.raiseHand') }
-                    icon = { IconRaisedHand }
-                    key = 'raisehand'
-                    onClick = { this._onToolbarToggleRaiseHand }
-                    toggled = { _raisedHand }
-                    tooltip = { t(`toolbar.${_raisedHand ? 'lowerYourHand' : 'raiseYourHand'}`) } />)
-                : overflowMenuAdditionalButtons.push(<OverflowMenuItem
-                    accessibilityLabel = { t('toolbar.accessibilityLabel.raiseHand') }
-                    icon = { IconRaisedHand }
-                    key = 'raisehand'
-                    onClick = { this._onToolbarToggleRaiseHand }
-                    text = { t(`toolbar.${_raisedHand ? 'lowerYourHand' : 'raiseYourHand'}`) } />);
-        }
-
         if (this._shouldShowButton('tileview')) {
             buttons.has('tileview')
                 ? mainMenuAdditionalButtons.push(
@@ -1183,22 +1146,33 @@ class Toolbox extends Component<Props, State> {
         }
 
         if (this._shouldShowButton('invite')) {
-            buttons.has('invite')
-                ? mainMenuAdditionalButtons.push(
-                    <ToolbarButton
-                        accessibilityLabel = { t('toolbar.accessibilityLabel.invite') }
-                        icon = { IconInviteMore }
-                        key = 'invite'
-                        onClick = { this._onToolbarOpenInvite }
-                        tooltip = { t('toolbar.invite') } />)
-                : overflowMenuAdditionalButtons.push(
-                    <OverflowMenuItem
-                        accessibilityLabel = { t('toolbar.accessibilityLabel.invite') }
-                        icon = { IconInviteMore }
-                        key = 'invite'
-                        onClick = { this._onToolbarOpenInvite }
-                        text = { t('toolbar.invite') } />
-                );
+            overflowMenuAdditionalButtons.push(
+                <OverflowMenuItem
+                    accessibilityLabel = { t('toolbar.accessibilityLabel.invite') }
+                    icon = { IconInviteMore }
+                    key = 'invite'
+                    onClick = { this._onToolbarOpenInvite }
+                    text = { t('toolbar.invite') } />
+            );
+        }
+
+        if (this._shouldShowButton('raisehand')) {
+            overflowMenuAdditionalButtons.push(<OverflowMenuItem
+                accessibilityLabel = { t('toolbar.accessibilityLabel.raiseHand') }
+                icon = { IconRaisedHand }
+                key = 'raisehand'
+                onClick = { this._onToolbarToggleRaiseHand }
+                text = { t(`toolbar.${_raisedHand ? 'lowerYourHand' : 'raiseYourHand'}`) } />);
+        }
+
+        if (this._showDesktopSharingButton()) {
+            overflowMenuAdditionalButtons.push(<OverflowMenuItem
+                accessibilityLabel = { t('toolbar.accessibilityLabel.shareYourScreen') }
+                icon = { IconShareDesktop }
+                iconId = 'share-desktop'
+                key = 'desktop'
+                onClick = { this._onToolbarToggleScreenshare }
+                text = { t(`toolbar.${_screensharing ? 'stopScreenSharing' : 'startScreenSharing'}`) } />);
         }
 
         return {


### PR DESCRIPTION
Setting relative volume control for other participants is great, but currently only allows setting others' volume lower. As the `<audio>` element has a max of 1 (the default), to accomplish this the default has to be lowered (0.7 in this case) so you have some headspace to raise individual participants