### PR TITLE
fix(virtual-background) fix tainted canvas when using the CDN

### DIFF
--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.js
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.js
@@ -43,6 +43,7 @@ export default class JitsiStreamBackgroundEffect {
 
         if (this._options.virtualBackground.isVirtualBackground) {
             this._virtualImage = document.createElement('img');
+            this._virtualImage.crossOrigin = 'anonymous';
             this._virtualImage.src = this._options.virtualBackground.virtualSource;
         }
         this._model = model;


### PR DESCRIPTION
When we use a CDN the images come from an origin different than the site so
unless we mark them for CORS the canvas where they are painted will be tainted.

Ref: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
