### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10253,8 +10253,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#087a8e19eb0126ac48c1fa147aba737c8783bd36",
-      "from": "github:jitsi/lib-jitsi-meet#087a8e19eb0126ac48c1fa147aba737c8783bd36",
+      "version": "github:jitsi/lib-jitsi-meet#4191198233ae64e3cb12349069c582724d09537c",
+      "from": "github:jitsi/lib-jitsi-meet#4191198233ae64e3cb12349069c582724d09537c",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",
@@ -10271,7 +10271,7 @@
         "strophejs-plugin-disco": "0.0.2",
         "strophejs-plugin-stream-management": "github:jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
         "uuid": "8.1.0",
-        "webrtc-adapter": "7.5.0"
+        "webrtc-adapter": "7.7.1"
       },
       "dependencies": {
         "@jitsi/js-utils": {
@@ -10282,10 +10282,6 @@
             "bowser": "2.7.0",
             "js-md5": "0.7.3"
           }
-        },
-        "jitsi-meet-logger": {
-          "version": "github:jitsi/jitsi-meet-logger#4add5bac2e4cea73a05f42b7596ee03c7f7a2567",
-          "from": "github:jitsi/jitsi-meet-logger#v1.0.0"
         },
         "js-md5": {
           "version": "0.7.3",
@@ -18391,9 +18387,9 @@
       }
     },
     "webrtc-adapter": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.5.0.tgz",
-      "integrity": "sha512-cUqlw310uLLSYvO8FTNCVmGWSMlMt6vuSDkcYL1nW+RUvAILJ3jEIvAUgFQU5EFGnU+mf9/No14BFv3U+hoxBQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
+      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
       "requires": {
         "rtcpeerconnection-shim": "^1.2.15",
         "sdp": "^2.12.0"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#087a8e19eb0126ac48c1fa147aba737c8783bd36",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#4191198233ae64e3cb12349069c582724d09537c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(JingleSession): Avoid renegotiation when user with no sources leaves the call.
* feat: participant kick reason add
* ref(RTC): remove legacy pc constraints. Stop using the legacy pc constraints that are no longer wired up to WebRTC.
* fix(deps) update webrtc-adapter to v7.7.1

https://github.com/jitsi/lib-jitsi-meet/compare/087a8e19eb0126ac48c1fa147aba737c8783bd36...4191198233ae64e3cb12349069c582724d09537c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
