### PR TITLE
fix(large-video): Always pin screenshare to large-video if it exists.

### DIFF
--- a/react/features/large-video/actions.any.js
+++ b/react/features/large-video/actions.any.js
@@ -170,5 +170,5 @@ function _electParticipantInLargeVideo(state) {
         return participant.id;
     }
 
-    return participants.find(p => p.local);
+    return participants.find(p => p.local)?.id;
 }

--- a/react/features/large-video/actions.any.js
+++ b/react/features/large-video/actions.any.js
@@ -129,49 +129,46 @@ function _electLastVisibleRemoteVideo(tracks) {
  * @returns {(string|undefined)}
  */
 function _electParticipantInLargeVideo(state) {
-    // 1. If a participant is pinned, they will be shown in the LargeVideo (
-    //    regardless of whether they are local or remote).
+    // 1. If a participant is pinned, they will be shown in the LargeVideo
+    // (regardless of whether they are local or remote).
     const participants = state['features/base/participants'];
     let participant = participants.find(p => p.pinned);
-    let id = participant && participant.id;
 
-    if (!id) {
-        // 2. No participant is pinned so get the dominant speaker. But the
-        //    local participant won't be displayed in LargeVideo even if she is
-        //    the dominant speaker.
-        participant = participants.find(p => p.dominantSpeaker && !p.local);
-        id = participant && participant.id;
-
-        if (!id) {
-            // 3. There is no dominant speaker so select the remote participant
-            //    who last had visible video.
-            const tracks = state['features/base/tracks'];
-            const videoTrack = _electLastVisibleRemoteVideo(tracks);
-
-            id = videoTrack && videoTrack.participantId;
-
-            if (!id) {
-                // 4. It's possible there is no participant with visible video.
-                //    This can happen for a number of reasons:
-                //    - there is only one participant (i.e. the local user),
-                //    - other participants joined with video muted.
-                //    As a last resort, pick the last participant who joined the
-                //    conference (regardless of whether they are local or
-                //    remote).
-                //
-                // HOWEVER: We don't want to show poltergeist or other bot type participants on stage
-                // automatically, because it's misleading (users may think they are already
-                // joined and maybe speaking).
-                for (let i = participants.length; i > 0 && !participant; i--) {
-                    const p = participants[i - 1];
-
-                    !p.botType && (participant = p);
-                }
-
-                id = participant && participant.id;
-            }
-        }
+    if (participant) {
+        return participant.id;
     }
 
-    return id;
+    // 2. Next, pick the most recent remote screenshare that was added to the conference.
+    const remoteScreenShares = state['features/video-layout'].remoteScreenShares;
+
+    if (remoteScreenShares?.length) {
+        return remoteScreenShares[remoteScreenShares.length - 1];
+    }
+
+    // 3. Next, pick the dominant speaker (other than self).
+    participant = participants.find(p => p.dominantSpeaker && !p.local);
+    if (participant) {
+        return participant.id;
+    }
+
+    // 4. Next, pick the most recent participant with video.
+    const tracks = state['features/base/tracks'];
+    const videoTrack = _electLastVisibleRemoteVideo(tracks);
+
+    if (videoTrack) {
+        return videoTrack.participantId;
+    }
+
+    // 5. As a last resort, select the participant that joined last (other than poltergist or other bot type
+    // participants).
+    for (let i = participants.length; i > 0 && !participant; i--) {
+        const p = participants[i - 1];
+
+        !p.botType && (participant = p);
+    }
+    if (participant) {
+        return participant.id;
+    }
+
+    return participants.find(p => p.local);
 }


### PR DESCRIPTION
Set higher preference for screenshare over dominant speaker when trying to elect a participant for large-video. This prevents the dominant speaker from taking over the stage when a user toggles tile view on and off while a screenshare is in progress.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
