### PR TITLE
Add DialDtmfDialog

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -324,6 +324,13 @@
     "documentSharing": {
         "title": "Freigegebenes Dokument"
     },
+    "dialDtmf": {
+        "title": "DTMF-Töne wählen",
+        "numbers": "Ziffern",
+        "numbersPlaceholder": "z.B. 12345#",
+        "toneDuration": "Dauer je Ziffer (ms)",
+        "pauseDuration": "Pause nach Ziffer (ms)"
+    },
     "e2ee": {
         "labelToolTip": "Audio- und Videodaten dieser Unterhaltung sind jetzt zwischen den Personen verschlüsselt"
     },
@@ -708,6 +715,7 @@
             "chat": "Chatfenster ein-/ausblenden",
             "document": "Geteiltes Dokument schließen",
             "download": "Unsere Apps herunterladen",
+            "dtmf": "DTMF-Töne wählen",
             "embedMeeting": "Konferenz einbetten",
             "feedback": "Feedback hinterlassen",
             "fullScreen": "Vollbildmodus ein-/ausschalten",
@@ -759,6 +767,7 @@
         "documentClose": "Geteiltes Dokument schließen",
         "documentOpen": "Geteiltes Dokument öffnen",
         "download": "Unsere Apps herunterladen",
+        "dtmf": "DTMF-Töne wählen",
         "e2ee": "Ende-zu-Ende-Verschlüsselung",
         "embedMeeting": "Konferenz einbetten",
         "enterFullScreen": "Vollbildmodus",

--- a/lang/main.json
+++ b/lang/main.json
@@ -330,6 +330,13 @@
     "documentSharing": {
         "title": "Shared Document"
     },
+    "dialDtmf": {
+        "title": "Dial DTMF Tones",
+        "numbers": "Number sequence",
+        "numbersPlaceholder": "e.g. 12345#",
+        "toneDuration": "Tone duration (ms)",
+        "pauseDuration": "Pause between tones (ms)"
+    },
     "e2ee": {
         "labelToolTip": "Audio and Video Communication on this call is end-to-end encrypted"
     },
@@ -722,6 +729,7 @@
             "chat": "Toggle chat window",
             "document": "Toggle shared document",
             "download": "Download our apps",
+            "dtmf": "Dial DTMF tones",
             "embedMeeting": "Embed meeting",
             "feedback": "Leave feedback",
             "fullScreen": "Toggle full screen",
@@ -775,6 +783,7 @@
         "documentOpen": "Open shared document",
         "download": "Download our apps",
         "e2ee": "End-to-End Encryption",
+        "dtmf": "Dial DTMF tones",
         "embedMeeting": "Embed meeting",
         "enterFullScreen": "View full screen",
         "enterTileView": "Enter tile view",

--- a/react/features/dtmf/components/DialDtmfDialog.js
+++ b/react/features/dtmf/components/DialDtmfDialog.js
@@ -1,0 +1,203 @@
+// @flow
+
+import { FieldTextStateless } from '@atlaskit/field-text';
+import React, { Component } from 'react';
+
+import { sendTones } from '../../base/conference';
+import { Dialog } from '../../base/dialog';
+import { translate } from '../../base/i18n';
+import { connect } from '../../base/redux';
+
+declare var APP: Object;
+
+type Props = {
+
+    /**
+     * Invoked to obtain translated strings.
+     */
+    t: Function
+};
+
+/**
+ * The type of the React {@code Component} state of {@link DialDtmfDialog}.
+ */
+type State = {
+
+    /**
+     * The currently entered number sequence.
+     */
+    numbers: string,
+
+    /**
+     * The currently entered tone duration (ms).
+     */
+    toneDuration: number,
+
+    /**
+     * The currently entered pause duration (ms).
+     */
+    pauseDuration: number
+};
+
+/**
+ * A dialog that allows to dial a DTMF number sequence.
+ */
+class DialDtmfDialog extends Component<Props, State> {
+
+    /**
+     * Initializes a new {@code DialDtmfDialog} instance.
+     *
+     * @param {Object} props - The read-only React {@code Component} props with
+     * which the new instance is to be initialized.
+     */
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            /**
+             * The currently entered number sequence.
+             *
+             * @type {string}
+             */
+            numbers: '',
+
+            /**
+             * The currently entered tone duration (ms).
+             *
+             * @type {number}
+             */
+            toneDuration: 150,
+
+            /**
+             * The currently entered pause duration (ms).
+             *
+             * @type {number}
+             */
+            pauseDuration: 40
+        };
+
+        // Bind event handlers so they are only bound once for every instance.
+        this._onNumbersChange = this._onNumbersChange.bind(this);
+        this._onToneDurationChange = this._onToneDurationChange.bind(this);
+        this._onPauseDurationChange = this._onPauseDurationChange.bind(this);
+        this._onSubmit = this._onSubmit.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        const { numbers, toneDuration, pauseDuration } = this.state;
+        const { t } = this.props;
+
+        return (
+            <Dialog
+                onSubmit = { this._onSubmit }
+                titleKey = { 'dialDtmf.title' }
+                width = 'small'>
+                <div className = 'dial-dtmf-dialog'>
+                    <FieldTextStateless
+                        autoFocus = { true }
+                        compact = { true }
+                        isSpellCheckEnabled = { false }
+                        label = { t('dialDtmf.numbers') }
+                        name = 'numbers'
+                        okDisabled = { false }
+                        onChange = { this._onNumbersChange }
+                        placeholder = { t('dialDtmf.numbersPlaceholder') }
+                        shouldFitContainer = { true }
+                        type = 'text'
+                        value = { numbers } />
+                    <FieldTextStateless
+                        compact = { true }
+                        isSpellCheckEnabled = { false }
+                        label = { t('dialDtmf.toneDuration') }
+                        name = 'toneDuration'
+                        okDisabled = { false }
+                        onChange = { this._onToneDurationChange }
+                        shouldFitContainer = { true }
+                        type = 'text'
+                        value = { toneDuration } />
+                    <FieldTextStateless
+                        compact = { true }
+                        isSpellCheckEnabled = { false }
+                        label = { t('dialDtmf.pauseDuration') }
+                        name = 'pauseDuration'
+                        okDisabled = { false }
+                        onChange = { this._onPauseDurationChange }
+                        shouldFitContainer = { true }
+                        type = 'text'
+                        value = { pauseDuration } />
+                </div>
+            </Dialog>
+        );
+    }
+
+    _onNumbersChange: (event: Object) => void;
+
+    /**
+     * Updates the known entered number sequence.
+     *
+     * @param {Object} event - The DOM event from updating the textfield for the
+     * number sequence.
+     * @private
+     * @returns {void}
+     */
+    _onNumbersChange(event) {
+        this.setState({ numbers: event.target.value });
+    }
+
+    _onToneDurationChange: (event: Object) => void;
+
+    /**
+     * Updates the known entered tone duration.
+     *
+     * @param {Object} event - The DOM event from updating the textfield for the
+     * tone duration.
+     * @private
+     * @returns {void}
+     */
+    _onToneDurationChange(event) {
+        this.setState({ toneDuration: event.target.value });
+    }
+
+    _onPauseDurationChange: (event: Object) => void;
+
+    /**
+     * Updates the known entered pause duration.
+     *
+     * @param {Object} event - The DOM event from updating the textfield for the
+     * pause duration.
+     * @private
+     * @returns {void}
+     */
+    _onPauseDurationChange(event) {
+        this.setState({ pauseDuration: event.target.value });
+    }
+
+    _onSubmit: () => void;
+
+    /**
+     * Dispatches the entered numbers for submission.
+     *
+     * @private
+     * @returns {boolean} Returns true to close the dialog.
+     */
+    _onSubmit() {
+        const { numbers, toneDuration, pauseDuration } = this.state;
+
+        APP.store.dispatch(sendTones(numbers, toneDuration, pauseDuration));
+
+        return true;
+    }
+}
+
+const mapStateToProps = () => {
+    return {
+    };
+};
+
+export default translate(connect(mapStateToProps)(DialDtmfDialog));

--- a/react/features/dtmf/components/index.js
+++ b/react/features/dtmf/components/index.js
@@ -1,0 +1,1 @@
+export { default as DialDtmfDialog } from './DialDtmfDialog';

--- a/react/features/dtmf/index.js
+++ b/react/features/dtmf/index.js
@@ -1,0 +1,1 @@
+export * from './components';

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -23,7 +23,8 @@ import {
     IconPresentation,
     IconRaisedHand,
     IconRec,
-    IconShareDesktop
+    IconShareDesktop,
+    IconTileView
 } from '../../../base/icons';
 import JitsiMeetJS from '../../../base/lib-jitsi-meet';
 import {
@@ -37,6 +38,7 @@ import { getLocalVideoTrack, toggleScreensharing } from '../../../base/tracks';
 import { isVpaasMeeting } from '../../../billing-counter/functions';
 import { ChatCounter, toggleChat } from '../../../chat';
 import { InviteMore } from '../../../conference';
+import { DialDtmfDialog } from '../../../dtmf';
 import { EmbedMeetingDialog } from '../../../embed-meeting';
 import { SharedDocumentButton } from '../../../etherpad';
 import { openFeedbackDialog } from '../../../feedback';
@@ -253,6 +255,7 @@ class Toolbox extends Component<Props> {
         this._onToolbarToggleRaiseHand = this._onToolbarToggleRaiseHand.bind(this);
         this._onToolbarToggleScreenshare = this._onToolbarToggleScreenshare.bind(this);
         this._onToolbarOpenLocalRecordingInfoDialog = this._onToolbarOpenLocalRecordingInfoDialog.bind(this);
+        this._onToolbarOpenDtmf = this._onToolbarOpenDtmf.bind(this);
         this._onShortcutToggleTileView = this._onShortcutToggleTileView.bind(this);
     }
 
@@ -414,6 +417,16 @@ class Toolbox extends Component<Props> {
         this.props.dispatch(openDialog(SpeakerStats, {
             conference: this.props._conference
         }));
+    }
+
+    /**
+     * Callback invoked to display {@code DialDtmfDialog}.
+     *
+     * @private
+     * @returns {void}
+     */
+    _doOpenDtmf() {
+        this.props.dispatch(openDialog(DialDtmfDialog));
     }
 
     /**
@@ -871,6 +884,22 @@ class Toolbox extends Component<Props> {
         this.props.dispatch(openDialog(LocalRecordingInfoDialog));
     }
 
+    _onToolbarOpenDtmf: () => void;
+
+    /**
+     * Creates an analytics toolbar event and dispatches an action for opening
+     * the DTMF modal.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onToolbarOpenDtmf() {
+        sendAnalytics(createToolbarEvent('dtmf'));
+
+        this._doOpenDtmf();
+    }
+
+
     /**
      * Returns true if the desktop sharing button should be visible and
      * false otherwise.
@@ -1058,7 +1087,14 @@ class Toolbox extends Component<Props> {
             this._shouldShowButton('help')
                 && <HelpButton
                     key = 'help'
-                    showLabel = { true } />
+                    showLabel = { true } />,
+            this._shouldShowButton('dtmf')
+                && <OverflowMenuItem
+                    accessibilityLabel = { t('toolbar.accessibilityLabel.dtmf') }
+                    icon = { IconTileView }
+                    key = 'dtmf'
+                    onClick = { this._onToolbarOpenDtmf }
+                    text = { t('toolbar.dtmf') } />
         ];
     }
 


### PR DESCRIPTION
Adds a simple dialog to dial number sequences:

<img src="https://user-images.githubusercontent.com/1845525/112650706-f213b000-8e4b-11eb-98d8-22ccadefe881.png" width=50% height=50%>

To enable, add ‘dtmf’ to TOOLBAR_BUTTONS in interface_config.js

Solves https://github.com/jitsi/jitsi-meet/issues/6332

8x8 CLA completed 2021-03-26