### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10513,8 +10513,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#2b94da12e81626c7b9deb24dd95f8ca2038a2f5a",
-      "from": "github:jitsi/lib-jitsi-meet#2b94da12e81626c7b9deb24dd95f8ca2038a2f5a",
+      "version": "github:jitsi/lib-jitsi-meet#93af5ada959d8cc96bdf11e4761147c72a2e5810",
+      "from": "github:jitsi/lib-jitsi-meet#93af5ada959d8cc96bdf11e4761147c72a2e5810",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#2b94da12e81626c7b9deb24dd95f8ca2038a2f5a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#93af5ada959d8cc96bdf11e4761147c72a2e5810",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(receiveVideoController): Do not send redundant video constraints to the bridge.
* feat(stats): Add a new bridge message "EndpointStats" for stats. Use the new Colibri message "EndpointStats" for broadcasting the local stats. The bridge then will be able to filter the endpoint stats and send them only to the interested parties instead of broadcasting it to all the endpoints in the call.
* Test RTCRtpReceiver.getCapabilities before using

https://github.com/jitsi/lib-jitsi-meet/compare/2b94da12e81626c7b9deb24dd95f8ca2038a2f5a...93af5ada959d8cc96bdf11e4761147c72a2e5810

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
