### PR TITLE
fix(Toolbar, rn): Button overflow in landscape orientation

### DIFF
--- a/react/features/toolbox/components/native/styles.js
+++ b/react/features/toolbox/components/native/styles.js
@@ -79,7 +79,7 @@ const styles = {
         flexDirection: 'column',
         flexGrow: 0,
         width: '100%',
-        maxWidth: 500,
+        maxWidth: 580,
         marginLeft: 'auto',
         marginRight: 'auto'
     }


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 8 - 2021-04-05 at 13 29 14](https://user-images.githubusercontent.com/37841821/113565152-31dc5380-9613-11eb-9479-1d7589c7205e.png)
vs
![Simulator Screen Shot - iPhone 8 - 2021-04-05 at 13 28 59](https://user-images.githubusercontent.com/37841821/113565148-30ab2680-9613-11eb-854f-90e7a9e04f05.png)

