### PR TITLE
Add fullscreen.enabled flag for mobile platforms (correction)

### DIFF
--- a/react/features/base/flags/constants.js
+++ b/react/features/base/flags/constants.js
@@ -57,6 +57,12 @@ export const CHAT_ENABLED = 'chat.enabled';
 export const FILMSTRIP_ENABLED = 'filmstrip.enabled';
 
 /**
+ * Flag indicating if fullscreen (immersive) mode should be enabled.
+ * Default: enabled (true).
+ */
+export const FULLSCREEN_ENABLED = 'fullscreen.enabled';
+
+/**
  * Flag indicating if the Help button should be enabled.
  * Default: enabled (true).
  */

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -151,6 +151,7 @@ class Conference extends AbstractConference<Props, *> {
      */
     render() {
         const { _fullscreenEnabled } = this.props;
+
         return (
             <Container style = { styles.conference }>
                 <StatusBar

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -5,7 +5,7 @@ import { NativeModules, SafeAreaView, StatusBar } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 
 import { appNavigate } from '../../../app/actions';
-import { PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_ENABLED, FULLSCREEN_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { Container, LoadingIndicator, TintedView } from '../../../base/react';
 import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
@@ -67,6 +67,11 @@ type Props = AbstractProps & {
      * Set to {@code true} when the filmstrip is currently visible.
      */
     _filmstripVisible: boolean,
+
+    /**
+     * The indicator which determines whether fullscreen (immersive) mode is enabled.
+     */
+    _fullscreenEnabled: boolean,
 
     /**
      * The ID of the participant currently on stage (if any)
@@ -145,12 +150,13 @@ class Conference extends AbstractConference<Props, *> {
      * @returns {ReactElement}
      */
     render() {
+        const { _fullscreenEnabled } = this.props;
         return (
             <Container style = { styles.conference }>
                 <StatusBar
                     barStyle = 'light-content'
-                    hidden = { true }
-                    translucent = { true } />
+                    hidden = { _fullscreenEnabled }
+                    translucent = { _fullscreenEnabled } />
                 { this._renderContent() }
             </Container>
         );
@@ -443,6 +449,7 @@ function _mapStateToProps(state) {
         _calendarEnabled: isCalendarEnabled(state),
         _connecting: Boolean(connecting_),
         _filmstripVisible: isFilmstripVisible(state),
+        _fullscreenEnabled: getFeatureFlag(state, FULLSCREEN_ENABLED, true),
         _largeVideoParticipantId: state['features/large-video'].participantId,
         _pictureInPictureEnabled: getFeatureFlag(state, PIP_ENABLED),
         _reducedUI: reducedUI,

--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -75,7 +75,8 @@ function _onImmersiveChange({ getState }) {
         const { enabled: audioOnly } = state['features/base/audio-only'];
         const conference = getCurrentConference(state);
         const dialogOpen = isAnyDialogOpen(state);
-        const fullScreen = conference ? !audioOnly && !dialogOpen : false;
+        const fullscreenEnabled = getFeatureFlag(state, FULLSCREEN_ENABLED, true);
+        const fullScreen = conference ? !audioOnly && !dialogOpen && fullscreenEnabled : false;
 
         _setFullScreen(fullScreen);
     }

--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -7,6 +7,7 @@ import { getCurrentConference } from '../../base/conference';
 import { isAnyDialogOpen } from '../../base/dialog/functions';
 import { Platform } from '../../base/react';
 import { MiddlewareRegistry, StateListenerRegistry } from '../../base/redux';
+import { FULLSCREEN_ENABLED, getFeatureFlag } from '../../base/flags';
 
 import { _SET_IMMERSIVE_LISTENER } from './actionTypes';
 import { _setImmersiveListener as _setImmersiveListenerA } from './actions';
@@ -50,8 +51,9 @@ StateListenerRegistry.register(
         const { enabled: audioOnly } = state['features/base/audio-only'];
         const conference = getCurrentConference(state);
         const dialogOpen = isAnyDialogOpen(state);
+        const fullscreenEnabled = getFeatureFlag(state, FULLSCREEN_ENABLED, true);
 
-        return conference ? !audioOnly && !dialogOpen : false;
+        return conference ? !audioOnly && !dialogOpen && fullscreenEnabled : false;
     },
     /* listener */ fullScreen => _setFullScreen(fullScreen)
 );

--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -5,9 +5,9 @@ import { Immersive } from 'react-native-immersive';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../../base/app';
 import { getCurrentConference } from '../../base/conference';
 import { isAnyDialogOpen } from '../../base/dialog/functions';
+import { FULLSCREEN_ENABLED, getFeatureFlag } from '../../base/flags';
 import { Platform } from '../../base/react';
 import { MiddlewareRegistry, StateListenerRegistry } from '../../base/redux';
-import { FULLSCREEN_ENABLED, getFeatureFlag } from '../../base/flags';
 
 import { _SET_IMMERSIVE_LISTENER } from './actionTypes';
 import { _setImmersiveListener as _setImmersiveListenerA } from './actions';


### PR DESCRIPTION
Change required to account for immersive mode changes on Android, for example when a permission dialog pops up, which calls the _setFullScreen function. Without this change, the Jitsi conference returns to fullscreen even if the corresponding feature flag (FULLSCREEN_ENABLED) is set to false.