### PR TITLE
Add fullscreen.enabled flag for mobile platforms (correction)

### DIFF
--- a/react/features/mobile/full-screen/middleware.js
+++ b/react/features/mobile/full-screen/middleware.js
@@ -75,7 +75,8 @@ function _onImmersiveChange({ getState }) {
         const { enabled: audioOnly } = state['features/base/audio-only'];
         const conference = getCurrentConference(state);
         const dialogOpen = isAnyDialogOpen(state);
-        const fullScreen = conference ? !audioOnly && !dialogOpen : false;
+        const fullscreenEnabled = getFeatureFlag(state, FULLSCREEN_ENABLED, true);
+        const fullScreen = conference ? !audioOnly && !dialogOpen && fullscreenEnabled : false;
 
         _setFullScreen(fullScreen);
     }


### PR DESCRIPTION
Change required to account for immersive mode changes on Android, for example when a permission dialog pops up, which calls the `_setFullScreen` function. Without this change, the Jitsi conference returns to fullscreen even if the corresponding feature flag `FULLSCREEN_ENABLED` is set to false.
