### PR TITLE
fix(toolbar) restore security button backwards compat

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -945,7 +945,7 @@ class Toolbox extends Component<Props> {
                     key = 'fullscreen'
                     onClick = { this._onToolbarToggleFullScreen }
                     text = { _fullScreen ? t('toolbar.exitFullScreen') : t('toolbar.enterFullScreen') } />,
-            this._shouldShowButton('security')
+            (this._shouldShowButton('security') || this._shouldShowButton('info'))
             && <SecurityDialogButton
                 key = 'security'
                 showLabel = { true } />,


### PR DESCRIPTION
In https://github.com/jitsi/jitsi-meet/pull/8673 we inadvertently removed the
backwards compatibility code which would show the security button when the
"info" button is configured in interface_config. The security button replaced
the info button.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
