### PR TITLE
Bind user detail to session if available

### DIFF
--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -295,6 +295,13 @@ function Util:process_and_verify_token(session, acceptedIssuers)
             session.jitsi_meet_context_user = claims["context"]["user"];
           end
 
+          if (session.jitsi_meet_context_user == nil) then
+            local _context = json_safe.decode(claims["context"]);
+            if _context ~= nil then
+                session.jitsi_meet_context_user = _context["user"];
+            end
+          end
+
           if claims["context"]["group"] ~= nil then
             -- Binds any group details to the session
             session.jitsi_meet_context_group = claims["context"]["group"];


### PR DESCRIPTION
For some special cases, when token looks like
```
{
  "context": "{\"user\":{\"id\":\"c5ac307d-6f6a-40ad-86f4-53834ad05339\",\"email\":\"anhht@outlook.com\",\"name\":\"anhht\"},\"group\":\"64cccde9-19b4-4e54-96d8-2ca72a31f355\"}",
  "room": "room452021",
}
```
then json_safe.decode() can not parse context body to metatable, claims["context"]["user"] == nil.

So I have to re-decode claims["context"] again to get user detail. 