### PR TITLE
fix(largeVideo): Hide video controls from right-click menu

### DIFF
--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -210,6 +210,10 @@
     object-fit: cover;
 }
 
+#largeVideo {
+    pointer-events: none;
+}
+
 #largeVideo,
 #largeVideoWrapper,
 #largeVideoContainer {


### PR DESCRIPTION
Video controls are currently enabled for the large video (a.k.a stage view). This PR hides the video controls from the `<video/>` element for the large video by applying the `pointer-events: none;` CSS property.

Before:
![Hide_Show_Controls_Before](https://user-images.githubusercontent.com/2506677/114435768-8c852a80-9b92-11eb-871a-b77cf1496850.gif)

After:
![Hide_Show_Controls_After](https://user-images.githubusercontent.com/2506677/114435783-9149de80-9b92-11eb-8ab1-ac76714725e3.gif)