### PR TITLE
fix(sip-invite) do not send query params on sip invite request

### DIFF
--- a/react/features/invite/functions.js
+++ b/react/features/invite/functions.js
@@ -827,7 +827,10 @@ export function inviteSipEndpoints( // eslint-disable-line max-params
         return Promise.resolve();
     }
 
-    const baseUrl = locationURL.href.toLowerCase().replace(`/${roomName}`, '');
+    const baseUrl = Object.assign(new URL(locationURL.toString()), {
+        pathname: locationURL.pathname.replace(`/${roomName}`, ''),
+        search: ''
+    });
 
     return fetch(
        sipInviteUrl,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
