### PR TITLE
fix(toolbox): Fix toolbox not auto-hiding.

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -75,7 +75,7 @@ import {
     setFullScreen,
     setOverflowMenuVisible,
     setToolbarHovered,
-    setToolboxVisible
+    showToolbox
 } from '../../actions';
 import { getToolbarAdditionalButtons, isToolboxVisible } from '../../functions';
 import DownloadButton from '../DownloadButton';
@@ -675,7 +675,7 @@ class Toolbox extends Component<Props> {
      */
     _onTabIn() {
         if (!this.props._visible) {
-            this.props.dispatch(setToolboxVisible(true));
+            this.props.dispatch(showToolbox());
         }
     }
 


### PR DESCRIPTION
Fixed autohide not working in certain scenarios.
Problem was that `_onTabIn` event handler from components/web/Toolbox was writing the visible value directly in store through `setToolboxVisible(true)` action, without doing the extra processing done by `showToolbox` action - like setting the hideToolbar timeout.
When switching to other tab, waiting for more than like 5 seconds, when going back in the meeting tab following flow was happening:
![image](https://user-images.githubusercontent.com/39557534/114699058-77da9b00-9d28-11eb-950e-0b631ca63693.png)

Notice `hideToolba`r being called, which sets visible false in store, but immediately after, the `_onTabIn` event setting visible back to true, but without setting the auto-hide timeout. So from this moment on, the toolbar is always visible.

After the fix:
![image](https://user-images.githubusercontent.com/39557534/114699280-c1c38100-9d28-11eb-923a-7718d156f42d.png)


Notice the _onTabIn calling the correct action, `showToolbox`, which sets the auto-hide timeout properly.
