### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10513,8 +10513,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#1f3f85978d0dee8e7f89c1aba8deee5109537453",
-      "from": "github:jitsi/lib-jitsi-meet#1f3f85978d0dee8e7f89c1aba8deee5109537453",
+      "version": "github:jitsi/lib-jitsi-meet#baa78aca40541b87b44d5218bcdef2a7be5fee59",
+      "from": "github:jitsi/lib-jitsi-meet#baa78aca40541b87b44d5218bcdef2a7be5fee59",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#1f3f85978d0dee8e7f89c1aba8deee5109537453",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#baa78aca40541b87b44d5218bcdef2a7be5fee59",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(SS): Implement a 2500Kbps limit for VP9 SS.
* fix(RTC): Remove stream effect before disposing the track. Remove the effect instead of stopping it so that the original stream is restored on both the local track and on the peerconnection. Fixes issues when a stream with effect applied is replaced on the pc after it is muted, also fixes https://github.com/jitsi/lib-jitsi-meet/issues/1537.
* fix: Drops unused config.

https://github.com/jitsi/lib-jitsi-meet/compare/1f3f85978d0dee8e7f89c1aba8deee5109537453...baa78aca40541b87b44d5218bcdef2a7be5fee59

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
