### PR TITLE
fix(toolbox): hide toolbox when mouse outside toolbox area

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -368,10 +368,7 @@ class Toolbox extends Component<Props> {
         return (
             <div
                 className = { rootClassNames }
-                id = 'new-toolbox'
-                onFocus = { this._onTabIn }
-                onMouseOut = { this._onMouseOut }
-                onMouseOver = { this._onMouseOver }>
+                id = 'new-toolbox'>
                 { this._renderToolboxContent() }
             </div>
         );
@@ -1300,7 +1297,11 @@ class Toolbox extends Component<Props> {
 
         return (
             <div className = { containerClassName }>
-                <div className = 'toolbox-content-wrapper'>
+                <div
+                    className = 'toolbox-content-wrapper'
+                    onFocus = { this._onTabIn }
+                    onMouseOut = { this._onMouseOut }
+                    onMouseOver = { this._onMouseOver }>
                     <div className = 'toolbox-content-items'>
                         { this._renderAudioButton() }
                         { this._renderVideoButton() }


### PR DESCRIPTION
Now toolbox is only kept visible when mouse is over the invite or toolbox buttons area.