### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10513,8 +10513,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#8b3dc59374aae1bd73ad70286259899222bcc07b",
-      "from": "github:jitsi/lib-jitsi-meet#8b3dc59374aae1bd73ad70286259899222bcc07b",
+      "version": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
+      "from": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#8b3dc59374aae1bd73ad70286259899222bcc07b",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(stats): Use promise-based getStats on all browsers. Get rid of the browser specific keys and use the standard spec-compliant fields for stats. Get the resolution/fps for remote streams from 'inbound-rtp' stats. Use the 'track' stats for the local resolution/fps since these take the active simulcast streams into account.

https://github.com/jitsi/lib-jitsi-meet/compare/8b3dc59374aae1bd73ad70286259899222bcc07b...ca325f5ef93f853d12ad39ceb40b9bac6b05a56c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
