### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10513,8 +10513,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
-      "from": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
+      "version": "github:jitsi/lib-jitsi-meet#0dc1540a44131d4c287993d2cfe0ed8e5ae70d4c",
+      "from": "github:jitsi/lib-jitsi-meet#0dc1540a44131d4c287993d2cfe0ed8e5ae70d4c",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ca325f5ef93f853d12ad39ceb40b9bac6b05a56c",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#0dc1540a44131d4c287993d2cfe0ed8e5ae70d4c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(JingleSession): Increase the ICE candidate gathering timeout to 150ms. This will reduce the numbers of transport-info IQs sent by the client.
* fix(TPC): Fix error handling for getStats.

https://github.com/jitsi/lib-jitsi-meet/compare/ca325f5ef93f853d12ad39ceb40b9bac6b05a56c...0dc1540a44131d4c287993d2cfe0ed8e5ae70d4c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
