### PR TITLE
fix(audio-share): Show button only when supported by browser.

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -972,6 +972,7 @@ class Toolbox extends Component<Props> {
      */
     _renderOverflowMenuContent(additionalButtons: Array<React$Element<any>>) {
         const {
+            _desktopSharingEnabled,
             _feedbackConfigured,
             _fullScreen,
             _isMobile,
@@ -1036,7 +1037,9 @@ class Toolbox extends Component<Props> {
                 && <SharedVideoButton
                     key = 'sharedvideo'
                     showLabel = { true } />,
-            this._shouldShowButton('shareaudio') && isScreenAudioSupported()
+            this._shouldShowButton('shareaudio')
+                && _desktopSharingEnabled
+                && isScreenAudioSupported()
                 && <OverflowMenuItem
                     accessibilityLabel = { t('toolbar.accessibilityLabel.shareaudio') }
                     icon = { IconShareAudio }


### PR DESCRIPTION
Show the audio share button only when its supported. For example, mobile browsers do not support getDisplayMedia yet.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
