### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/config.js
+++ b/config.js
@@ -59,8 +59,10 @@ var config = {
         // simulcast is turned off for the desktop share. If presenter is turned
         // on while screensharing is in progress, the max bitrate is automatically
         // adjusted to 2.5 Mbps. This takes a value between 0 and 1 which determines
-        // the probability for this to be enabled.
-        // capScreenshareBitrate: 1 // 0 to disable
+        // the probability for this to be enabled. This setting has been deprecated.
+        // desktopSharingFrameRate.max now determines whether simulcast will be enabled
+        // or disabled for the screenshare.
+        // capScreenshareBitrate: 1 // 0 to disable - deprecated.
 
         // Enable callstats only for a percentage of users.
         // This takes a value between 0 and 100 which determines the probability for

--- a/package-lock.json
+++ b/package-lock.json
@@ -10513,8 +10513,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#3c9913ed61abe28aec1e8268ca62dd59a0ccdfc5",
-      "from": "github:jitsi/lib-jitsi-meet#3c9913ed61abe28aec1e8268ca62dd59a0ccdfc5",
+      "version": "github:jitsi/lib-jitsi-meet#7dedb59b9c022b7220141211b9b0859dbbaa9409",
+      "from": "github:jitsi/lib-jitsi-meet#7dedb59b9c022b7220141211b9b0859dbbaa9409",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#3c9913ed61abe28aec1e8268ca62dd59a0ccdfc5",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#7dedb59b9c022b7220141211b9b0859dbbaa9409",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(quality-control): Switch to new receiver constraints by default. Use the new receiver constraints unless it is explicitly disabled through config.js.

https://github.com/jitsi/lib-jitsi-meet/compare/3c9913ed61abe28aec1e8268ca62dd59a0ccdfc5...7dedb59b9c022b7220141211b9b0859dbbaa9409

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
