### PR TITLE
fixed misspelled api command

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -34,7 +34,7 @@ const commands = {
     email: 'email',
     toggleLobby: 'toggle-lobby',
     hangup: 'video-hangup',
-    intiatePrivateChat: 'initiate-private-chat',
+    initiatePrivateChat: 'initiate-private-chat',
     kickParticipant: 'kick-participant',
     muteEveryone: 'mute-everyone',
     overwriteConfig: 'overwrite-config',


### PR DESCRIPTION
Fixes #9098

This PR fixes a misspelled command provided by the IFrame API