### PR TITLE
feat: Customizable buttons for welcome page, prejoin screen and conference

### DIFF
--- a/config.js
+++ b/config.js
@@ -453,6 +453,13 @@ var config = {
     //    'tileview', 'select-background', 'download', 'help', 'mute-everyone', 'mute-video-everyone', 'security'
     // ],
 
+    // Show customizable buttons on welcome page, prejoin page and in conference
+    // Useful for linking to a privacy notice which needs to be presented to the
+    // user as soon as any data is collected (in the EU).
+    // customButtons: [
+    //    {'id': 'privacy-button', 'text': 'Privacy notice', 'url': '/static/privacy.html'}
+    // ]
+
     // Stats
     //
 

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -199,7 +199,6 @@ body.welcome-page {
         border-radius: 3px;
         color: $welcomePageDescriptionColor;
         padding: 4px;
-        position: absolute;
         top: 32px;
         right: 32px;
         z-index: $zindex2;

--- a/css/custom-buttons/buttons.scss
+++ b/css/custom-buttons/buttons.scss
@@ -1,0 +1,34 @@
+.custom-button-container {
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    .custom-button {
+        background-color: white;
+        color: #000000 !important;
+        font-weight: 900;
+        font-size: small;
+        align-self: center;
+        mix-blend-mode: screen;
+        margin-left: 5px;
+    }
+}
+
+.custom-button-on-conference {
+    margin-bottom: 8px;
+}
+
+.custom-button-on-prejoin {
+    margin-top: 16px;
+}
+
+.left-header-group {
+    position: absolute;
+    top: 32px;
+    right: 32px;
+    display: flex;
+    align-items: center;
+
+    &> * {
+        margin-left: 5px;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -104,5 +104,6 @@ $flagsImagePath: "../images/";
 @import 'connection-status';
 @import 'drawer';
 @import 'participants-pane';
+@import 'custom-buttons/buttons.scss';
 
 /* Modules END */

--- a/react/features/base/premeeting/components/web/PreMeetingScreen.js
+++ b/react/features/base/premeeting/components/web/PreMeetingScreen.js
@@ -2,6 +2,7 @@
 
 import React, { PureComponent } from 'react';
 
+import { CustomButtonContainer } from '../../../../custom-buttons';
 import { AudioSettingsButton, VideoSettingsButton } from '../../../../toolbox/components/web';
 import { VideoBackgroundButton } from '../../../../virtual-background';
 import { checkBlurSupport } from '../../../../virtual-background/functions';
@@ -116,6 +117,7 @@ export default class PreMeetingScreen extends PureComponent<Props> {
                         </>
                     )}
                     { this.props.children }
+                    <CustomButtonContainer onPrejoin = 'true' />
                     <div className = 'media-btn-container'>
                         <div className = 'toolbox-content'>
                             <div className = 'toolbox-content-items'>

--- a/react/features/custom-buttons/components/CustomButton.js
+++ b/react/features/custom-buttons/components/CustomButton.js
@@ -1,0 +1,47 @@
+import Button from '@atlaskit/button';
+import React from 'react';
+
+/**
+ * Custom button which opens specified url.
+ *
+ * @augments Component
+ */
+export class CustomButton extends React.PureComponent {
+
+    /**
+     * Instantiates a new {@code CustomButton}.
+     *
+     * @inheritdoc
+     */
+    constructor(props) {
+        super(props);
+
+        this._onClick = this._onClick.bind(this);
+    }
+
+    /**
+     * Handler opens the button's url.
+     *
+     * @returns {void}
+     */
+    _onClick() {
+        window.open(this.props.url, '_blank');
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+        return (
+            <Button
+                { ...this.props }
+                onClick = { this._onClick }>
+                { this.props.text }
+            </Button>
+        );
+    }
+}
+

--- a/react/features/custom-buttons/components/CustomButtonContainer.js
+++ b/react/features/custom-buttons/components/CustomButtonContainer.js
@@ -1,0 +1,87 @@
+// @flow
+
+import React from 'react';
+
+import { connect } from '../../base/redux';
+
+import { CustomButton } from './CustomButton';
+
+/**
+ * The type of the React {@code Component} props of {@link CustomButtons}.
+ */
+type Props = {
+
+    /**
+     * List of buttons to be displayed as specified in config.js.
+     */
+    _buttons: Array<Object>,
+
+    /**
+     * Flag signaling if the buttons are rendered on the conference screen.
+     */
+    onConference: boolean,
+
+    /**
+     * Flag signaling if the buttons are rendered on the prejoin screen.
+     */
+    onPrejoin: boolean
+}
+
+
+/**
+ * Implements customizable buttons with static links.
+ *
+ * @extends Component
+ */
+class CustomButtonContainer extends React.PureComponent<Props> {
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     * @returns {ReactElement}
+     */
+    render() {
+
+        const containerClassName = `custom-button-container
+            ${this.props.onConference ? 'custom-button-on-conference' : ''}
+            ${this.props.onPrejoin ? 'custom-button-on-prejoin' : ''}`;
+        const buttons = [];
+
+        for (const button of this.props._buttons) {
+            buttons.push(
+                <CustomButton
+                    className = 'custom-button'
+                    key = { `custom-button${button.text}` }
+                    text = { button.text }
+                    url = { button.url } />
+            );
+        }
+
+        return (
+            <div className = { containerClassName } >
+                { buttons }
+            </div>
+        );
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the React {@code Component} props.
+ *
+ * @param {Object} state - The redux state.
+ * @param {Object} ownProps - The props passed to the component.
+ * @returns {Object}
+ */
+function _mapStateToProps(state: Object, ownProps: Props) {
+
+    const { customButtons } = state['features/base/config'];
+    const { onConference, onPrejoin } = ownProps;
+
+    return {
+        _buttons: customButtons || [],
+        onConference: Boolean(onConference),
+        onPrejoin: Boolean(onPrejoin)
+    };
+}
+export default connect(_mapStateToProps)(CustomButtonContainer);

--- a/react/features/custom-buttons/components/index.js
+++ b/react/features/custom-buttons/components/index.js
@@ -1,0 +1,1 @@
+export { default as CustomButtonContainer } from './CustomButtonContainer';

--- a/react/features/custom-buttons/index.js
+++ b/react/features/custom-buttons/index.js
@@ -1,0 +1,1 @@
+export * from './components';

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -37,6 +37,7 @@ import { OverflowMenuItem } from '../../../base/toolbox/components';
 import { getLocalVideoTrack, toggleScreensharing } from '../../../base/tracks';
 import { isVpaasMeeting } from '../../../billing-counter/functions';
 import { ChatCounter, toggleChat } from '../../../chat';
+import { CustomButtonContainer } from '../../../custom-buttons';
 import { EmbedMeetingDialog } from '../../../embed-meeting';
 import { SharedDocumentButton } from '../../../etherpad';
 import { openFeedbackDialog } from '../../../feedback';
@@ -1302,6 +1303,7 @@ class Toolbox extends Component<Props> {
                     onFocus = { this._onTabIn }
                     onMouseOut = { this._onMouseOut }
                     onMouseOver = { this._onMouseOver }>
+                    <CustomButtonContainer onConference = 'true' />
                     <div className = 'toolbox-content-items'>
                         { this._renderAudioButton() }
                         { this._renderVideoButton() }

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -8,6 +8,7 @@ import { Icon, IconWarning } from '../../base/icons';
 import { Watermarks } from '../../base/react';
 import { connect } from '../../base/redux';
 import { CalendarList } from '../../calendar-sync';
+import { CustomButtonContainer } from '../../custom-buttons';
 import { RecentList } from '../../recent-list';
 import { SettingsButton, SETTINGS_TABS } from '../../settings';
 
@@ -188,15 +189,18 @@ class WelcomePage extends AbstractWelcomePage {
                 </div>
 
                 <div className = 'header'>
-                    <div className = 'welcome-page-settings'>
-                        <SettingsButton
-                            defaultTab = { SETTINGS_TABS.CALENDAR } />
-                        { showAdditionalToolbarContent
-                            ? <div
-                                className = 'settings-toolbar-content'
-                                ref = { this._setAdditionalToolbarContentRef } />
-                            : null
-                        }
+                    <div className = 'left-header-group'>
+                        <CustomButtonContainer />
+                        <div className = 'welcome-page-settings'>
+                            <SettingsButton
+                                defaultTab = { SETTINGS_TABS.CALENDAR } />
+                            { showAdditionalToolbarContent
+                                ? <div
+                                    className = 'settings-toolbar-content'
+                                    ref = { this._setAdditionalToolbarContentRef } />
+                                : null
+                            }
+                        </div>
                     </div>
                     <div className = 'header-image' />
                     <div className = 'header-container'>


### PR DESCRIPTION
This PR adds the option to define buttons in the config.js which will show up on the welcome page, the prejoin page and in on the conference screen.
The buttons will open the specified url in a new tab.

We use this with our customers to prominently display a link to the privacy policy or other legal notices.
Having the buttons visible on the prejoin page and the conference makes sure any user joining a conference directly with a link still sees the link to the privacy policy.
