### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10889,8 +10889,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#463e213b3f97fa4b9f56f342be713efcdd74234a",
-      "from": "github:jitsi/lib-jitsi-meet#463e213b3f97fa4b9f56f342be713efcdd74234a",
+      "version": "github:jitsi/lib-jitsi-meet#766711711759c0e8dc6f744f2db041a996972490",
+      "from": "github:jitsi/lib-jitsi-meet#766711711759c0e8dc6f744f2db041a996972490",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#463e213b3f97fa4b9f56f342be713efcdd74234a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#766711711759c0e8dc6f744f2db041a996972490",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(SDP): Move all SDP related files to a different dir. SDP utility classes are spread across RTC and XMPP directories now, moving these class files to a 'sdp' directory.
* fix(stats): Return promise for getStats. Switch to returning a Promise for getStats. Reset frame rate stat to 0 when video is suspended as a result of endpoint falling out of last-n.
* Fix: sysMessageHandler not deleted (#1590)
* task(e2ee): switch back to GCM

https://github.com/jitsi/lib-jitsi-meet/compare/463e213b3f97fa4b9f56f342be713efcdd74234a...766711711759c0e8dc6f744f2db041a996972490

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
