### PR TITLE
feat(breakout-rooms): adding breakout-rooms

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -43,6 +43,17 @@
     "audioOnly": {
         "audioOnly": "Low bandwidth"
     },
+    "breakoutRooms": {
+        "headings": {
+            "breakoutRoom": "Breakout room #{{index}}"
+        },
+        "actions": {
+            "addRoom": "Add room",
+            "removeRoom": "Remove room",
+            "leaveBreakoutRoom": "Leave breakout room",
+            "sendToBreakoutRoom": "Send to breakout room #{{index}}"
+        }
+    },
     "calendarSync": {
         "addMeetingURL": "Add a meeting link",
         "confirmAddLink": "Do you want to add a Jitsi link to this event?",
@@ -532,7 +543,7 @@
     "participantsPane": {
         "headings": {
             "lobby": "Lobby ({{count}})",
-            "participantsList": "Meeting participants ({{count}})"
+            "mainRoom": "Main room ({{count}})"
         },
         "actions": {
             "muteAll": "Mute all",

--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -19,6 +19,7 @@ import '../base/testing/middleware';
 import '../base/tracks/middleware';
 import '../base/user-interaction/middleware';
 import '../billing-counter/middleware';
+import '../breakout-rooms/middleware';
 import '../calendar-sync/middleware';
 import '../chat/middleware';
 import '../conference/middleware';

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -26,6 +26,7 @@ import '../base/testing/reducer';
 import '../base/tracks/reducer';
 import '../base/user-interaction/reducer';
 import '../billing-counter/reducer';
+import '../breakout-rooms/reducer';
 import '../calendar-sync/reducer';
 import '../chat/reducer';
 import '../deep-linking/reducer';

--- a/react/features/breakout-rooms/actionTypes.js
+++ b/react/features/breakout-rooms/actionTypes.js
@@ -1,0 +1,24 @@
+
+/**
+ * The type of (redux) action to add a new breakout room
+ *
+ */
+export const BREAKOUT_ROOM_ADDED = 'BREAKOUT_ROOM_ADDED';
+
+/**
+ * The type of (redux) action to remove a breakout room
+ *
+ */
+export const BREAKOUT_ROOM_REMOVED = 'BREAKOUT_ROOM_REMOVED';
+
+/**
+ * The type of (redux) action to update the breakout rooms list
+ *
+ */
+export const BREAKOUT_ROOMS_UPDATED = 'BREAKOUT_ROOMS_UPDATED';
+
+/**
+ * The type of (redux) action to send a participant to a breakout room
+ *
+ */
+export const PARTICIPANT_SENT_TO_BREAKOUT_ROOM = 'PARTICIPANT_SENT_TO_BREAKOUT_ROOM';

--- a/react/features/breakout-rooms/actions.js
+++ b/react/features/breakout-rooms/actions.js
@@ -1,0 +1,75 @@
+// @flow
+
+import {
+    BREAKOUT_ROOMS_UPDATED,
+    BREAKOUT_ROOM_ADDED,
+    BREAKOUT_ROOM_REMOVED,
+    PARTICIPANT_SENT_TO_BREAKOUT_ROOM
+} from './actionTypes';
+
+/**
+ * Action to update breakout rooms.
+ *
+ * @param {Object} breakoutRooms - The list of breakout rooms.
+ * @returns {{
+ *      type: BREAKOUT_ROOMS_UPDATED,
+ *      breakoutRooms: Object,
+ * }}
+ */
+export function updateBreakoutRooms(breakoutRooms: Object) {
+    return {
+        type: BREAKOUT_ROOMS_UPDATED,
+        breakoutRooms
+    };
+}
+
+/**
+ * Action to add a breakout room.
+ *
+ * @param {string} breakoutRoomId - The breakout room id.
+ * @returns {{
+ *      type: BREAKOUT_ROOM_ADDED,
+ *      breakoutRoom: Object,
+ * }}
+ */
+export function addBreakoutRoom(breakoutRoomId: string) {
+    return {
+        type: BREAKOUT_ROOM_ADDED,
+        breakoutRoomId
+    };
+}
+
+/**
+ * Action to remove a breakout room.
+ *
+ * @param {string} breakoutRoomId - The breakout room id.
+ * @returns {{
+ *      type: BREAKOUT_ROOM_REMOVED,
+ *      breakoutRoom: Object,
+ * }}
+ */
+export function removeBreakoutRoom(breakoutRoomId: string) {
+    return {
+        type: BREAKOUT_ROOM_REMOVED,
+        breakoutRoomId
+    };
+}
+
+/**
+ * Action to move a participant to a breakout room.
+ *
+ * @param {string} participantId - The participant id.
+ * @param {Object} breakoutRoom - The breakout room.
+ * @returns {{
+ *      type: PARTICIPANT_SENT_TO_BREAKOUT_ROOM,
+ *      participantId: string,
+ *      breakoutRoom: Object,
+ * }}
+ */
+export function sendParticipantToBreakoutRoom(participantId: string, breakoutRoom: Object) {
+    return {
+        type: PARTICIPANT_SENT_TO_BREAKOUT_ROOM,
+        participantId,
+        breakoutRoom
+    };
+}

--- a/react/features/breakout-rooms/components/LeaveButton.js
+++ b/react/features/breakout-rooms/components/LeaveButton.js
@@ -1,0 +1,31 @@
+// @flow
+
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import conference from '../../../../conference';
+import getRoomName from '../../base/config/getRoomName';
+import { Icon, IconHangup } from '../../base/icons';
+
+import { RoomLeaveButton } from './styled';
+
+export const LeaveButton = () => {
+    const { t } = useTranslation();
+
+    const onLeave = useCallback(() => {
+        const mainRoomName = getRoomName();
+
+        conference.switchRoom(mainRoomName);
+    });
+
+    return (
+        <RoomLeaveButton
+            aria-label = { t('breakoutRooms.actions.leaveBreakoutRoom') }
+            onClick = { onLeave }>
+            <Icon
+                size = { 20 }
+                src = { IconHangup } />
+            <span>{ t('breakoutRooms.actions.leaveBreakoutRoom') }</span>
+        </RoomLeaveButton>
+    );
+};

--- a/react/features/breakout-rooms/components/Room.js
+++ b/react/features/breakout-rooms/components/Room.js
@@ -1,0 +1,72 @@
+// @flow
+
+import React, { type Node } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ActionTrigger } from '../constants';
+
+import {
+    Heading,
+    RoomActionsHover,
+    RoomActionsPermanent,
+    RoomContainer
+} from './styled';
+
+/**
+ * Breakout Room actions component mapping depending on trigger type.
+ */
+const Actions = {
+    [ActionTrigger.Hover]: RoomActionsHover,
+    [ActionTrigger.Permanent]: RoomActionsPermanent
+};
+
+type Props = {
+
+    /**
+     * Type of trigger for the breakout room actions
+     */
+    actionsTrigger: ActionTrigger,
+
+    /**
+     * React children
+     */
+    children: Node,
+
+    /**
+     * Is this item highlighted/raised
+     */
+    isHighlighted?: boolean,
+
+    /**
+     * Callback for when the mouse leaves this component
+     */
+    onLeave?: Function,
+
+    /**
+     * Room reference
+     */
+    room: Object,
+}
+
+export const Room = ({
+    children,
+    isHighlighted,
+    onLeave,
+    actionsTrigger = ActionTrigger.Hover,
+    room
+}: Props) => {
+    const RoomActions = Actions[actionsTrigger];
+    const { t } = useTranslation();
+
+    return (
+        <RoomContainer
+            isHighlighted = { isHighlighted }
+            onMouseLeave = { onLeave }
+            trigger = { actionsTrigger }>
+            <Heading>
+                {t('breakoutRooms.headings.breakoutRoom', { index: room.index })}
+            </Heading>
+            <RoomActions children = { children } />
+        </RoomContainer>
+    );
+};

--- a/react/features/breakout-rooms/components/RoomContextMenu.js
+++ b/react/features/breakout-rooms/components/RoomContextMenu.js
@@ -1,0 +1,115 @@
+// @flow
+
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import conference from '../../../../conference';
+import {
+    IconClose,
+    IconMeetingUnlocked
+} from '../../base/icons';
+import { isLocalParticipantModerator } from '../../base/participants';
+import { removeBreakoutRoom } from '../actions';
+import { getComputedOuterHeight } from '../functions';
+
+import {
+    ContextMenu,
+    ContextMenuIcon,
+    ContextMenuItem,
+    ContextMenuItemGroup,
+    ignoredChildClassName
+} from './styled';
+
+
+type Props = {
+
+    /**
+     * Target elements against which positioning calculations are made
+     */
+    offsetTarget: HTMLElement,
+
+    /**
+     * Callback for the mouse entering the component
+     */
+    onEnter: Function,
+
+    /**
+     * Callback for the mouse leaving the component
+     */
+    onLeave: Function,
+
+    /**
+     * Callback for making a selection in the menu
+     */
+    onSelect: Function,
+
+    /**
+     * Room reference
+     */
+    room: Object
+};
+
+export const RoomContextMenu = ({
+    offsetTarget,
+    onEnter,
+    onLeave,
+    onSelect,
+    room
+}: Props) => {
+    const containerRef = useRef(null);
+    const dispatch = useDispatch();
+    const isLocalModerator = useSelector(isLocalParticipantModerator);
+
+    const [ isHidden, setIsHidden ] = useState(true);
+
+    useLayoutEffect(() => {
+        if (room
+            && containerRef.current
+            && offsetTarget?.offsetParent
+            && offsetTarget.offsetParent instanceof HTMLElement
+        ) {
+            const { current: container } = containerRef;
+            const { offsetTop, offsetParent: { offsetHeight, scrollTop } } = offsetTarget;
+            const outerHeight = getComputedOuterHeight(container);
+
+            container.style.top = offsetTop + outerHeight > offsetHeight + scrollTop
+                ? offsetTop - outerHeight
+                : offsetTop;
+
+            setIsHidden(false);
+        } else {
+            setIsHidden(true);
+        }
+    }, [ room, offsetTarget ]);
+
+    const onJoinRoom = useCallback(() => {
+        conference.switchRoom(room.id);
+    }, [ room ]);
+
+    const onRemoveBreakoutRoom = useCallback(() => {
+        dispatch(removeBreakoutRoom(room.id));
+    }, [ dispatch, room ]);
+
+    return (
+        <ContextMenu
+            className = { ignoredChildClassName }
+            innerRef = { containerRef }
+            isHidden = { isHidden }
+            onClick = { onSelect }
+            onMouseEnter = { onEnter }
+            onMouseLeave = { onLeave }>
+            <ContextMenuItemGroup>
+                <ContextMenuItem onClick = { onJoinRoom }>
+                    <ContextMenuIcon src = { IconMeetingUnlocked } />
+                    <span>Join</span>
+                </ContextMenuItem>
+                {isLocalModerator
+                    && <ContextMenuItem onClick = { onRemoveBreakoutRoom }>
+                        <ContextMenuIcon src = { IconClose } />
+                        <span>Remove</span>
+                    </ContextMenuItem>
+                }
+            </ContextMenuItemGroup>
+        </ContextMenu>
+    );
+};

--- a/react/features/breakout-rooms/components/RoomItem.js
+++ b/react/features/breakout-rooms/components/RoomItem.js
@@ -1,0 +1,48 @@
+// @flow
+
+import React from 'react';
+
+import { ActionTrigger } from '../constants';
+
+import { Room } from './Room';
+import { RoomActionEllipsis } from './styled';
+
+type Props = {
+
+    /**
+     * Is this item highlighted
+     */
+    isHighlighted: boolean,
+
+    /**
+     * Callback for the activation of this item's context menu
+     */
+    onContextMenu: Function,
+
+    /**
+     * Callback for the mouse leaving this item
+     */
+    onLeave: Function,
+
+    /**
+     * Room reference
+     */
+    room: Object
+};
+
+export const RoomItem = ({
+    isHighlighted,
+    onContextMenu,
+    onLeave,
+    room
+}: Props) => (
+        <>
+            <Room
+                actionsTrigger = { ActionTrigger.Hover }
+                isHighlighted = { isHighlighted }
+                onLeave = { onLeave }
+                room = { room }>
+                <RoomActionEllipsis onClick = { onContextMenu } />
+            </Room>
+        </>
+);

--- a/react/features/breakout-rooms/components/RoomList.js
+++ b/react/features/breakout-rooms/components/RoomList.js
@@ -1,0 +1,106 @@
+// @flow
+
+import React, { useCallback, useRef, useState } from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { getBreakoutRooms, getIsInBreakoutRoom, findStyledAncestor } from '../functions';
+import theme from '../theme.json';
+
+import { LeaveButton } from './LeaveButton';
+import { RoomContextMenu } from './RoomContextMenu';
+import { RoomItem } from './RoomItem';
+import { RoomContainer } from './styled';
+
+type NullProto = {
+  [key: string]: any,
+  __proto__: null
+};
+
+type RaiseContext = NullProto | {
+
+  /**
+   * Target elements against which positioning calculations are made
+   */
+  offsetTarget?: HTMLElement,
+
+  /**
+   * Room reference
+   */
+  room?: Object,
+};
+
+const initialState = Object.freeze(Object.create(null));
+
+export const RoomList = () => {
+    const isMouseOverMenu = useRef(false);
+    const breakoutRooms = getBreakoutRooms();
+    const isInBreakoutRoom = getIsInBreakoutRoom();
+    const [ raiseContext, setRaiseContext ] = useState<RaiseContext>(initialState);
+
+    const lowerMenu = useCallback(() => {
+        /**
+         * We are tracking mouse movement over the active room item and
+         * the context menu. Due to the order of enter/leave events, we need to
+         * defer checking if the mouse is over the context menu with
+         * queueMicrotask
+         */
+        window.queueMicrotask(() => {
+            if (isMouseOverMenu.current) {
+                return;
+            }
+
+            if (raiseContext !== initialState) {
+                setRaiseContext(initialState);
+            }
+        });
+    }, [ raiseContext ]);
+
+    const raiseMenu = useCallback((room, target) => {
+        setRaiseContext({
+            room,
+            offsetTarget: findStyledAncestor(target, RoomContainer)
+        });
+    }, [ raiseContext ]);
+
+    const toggleMenu = useCallback(room => e => {
+        const { room: raisedRoom } = raiseContext;
+
+        if (raisedRoom && raisedRoom === room) {
+            lowerMenu();
+        } else {
+            raiseMenu(room, e.target);
+        }
+    }, [ raiseContext ]);
+
+    const menuEnter = useCallback(() => {
+        isMouseOverMenu.current = true;
+    }, []);
+
+    const menuLeave = useCallback(() => {
+        isMouseOverMenu.current = false;
+        lowerMenu();
+    }, [ lowerMenu ]);
+
+    return (
+        <ThemeProvider theme = { theme }>
+        <>
+            {isInBreakoutRoom && <LeaveButton />}
+            <div>
+                {breakoutRooms.map(room => (
+                    <RoomItem
+                        isHighlighted = { raiseContext.room === room }
+                        key = { room.id }
+                        onContextMenu = { toggleMenu(room) }
+                        onLeave = { lowerMenu }
+                        room = { room } />
+                ))}
+            </div>
+            <RoomContextMenu
+                onEnter = { menuEnter }
+                onLeave = { menuLeave }
+                onSelect = { lowerMenu }
+                { ...raiseContext } />
+        </>
+        </ThemeProvider>
+    );
+};

--- a/react/features/breakout-rooms/components/index.js
+++ b/react/features/breakout-rooms/components/index.js
@@ -1,0 +1,5 @@
+export * from './LeaveButton';
+export * from './Room';
+export * from './RoomContextMenu';
+export * from './RoomItem';
+export * from './RoomList';

--- a/react/features/breakout-rooms/components/styled.js
+++ b/react/features/breakout-rooms/components/styled.js
@@ -1,0 +1,227 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { Icon, IconHorizontalPoints } from '../../base/icons';
+import { ActionTrigger } from '../constants';
+
+export const ignoredChildClassName = 'ignore-child';
+
+export const Button = styled.button`
+  align-items: center;
+  background-color: ${
+    // eslint-disable-next-line no-confusing-arrow
+    props => props.primary ? '#0056E0' : '#3D3D3D'
+};
+  border: 0;
+  border-radius: 6px;
+  display: flex;
+  font-weight: unset;
+  justify-content: center;
+
+  &:hover {
+    background-color: ${
+    // eslint-disable-next-line no-confusing-arrow
+    props => props.primary ? '#246FE5' : '#525252'
+};
+  }
+`;
+
+export const Container = styled.div`
+  box-sizing: border-box;
+  flex: 1;
+  overflow-y: auto;
+  position: relative;
+  padding: 0 ${props => props.theme.panePadding}px;
+
+  & > * + *:not(.${ignoredChildClassName}) {
+    margin-top: 16px;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const ContextMenu = styled.div.attrs(props => {
+    return {
+        className: props.className
+    };
+})`
+  background-color: #292929;
+  border-radius: 3px;
+  box-shadow: 0px 3px 16px rgba(0, 0, 0, 0.6), 0px 0px 4px 1px rgba(0, 0, 0, 0.25);
+  color: white;
+  font-size: ${props => props.theme.contextFontSize}px;
+  font-weight: ${props => props.theme.contextFontWeight};
+  margin-top: ${props => {
+        const {
+            roomActionButtonHeight,
+            roomItemHeight
+        } = props.theme;
+
+        return ((3 * roomItemHeight) + roomActionButtonHeight) / 4;
+    }}px;
+  position: absolute;
+  right: ${props => props.theme.panePadding}px;
+  top: 0;
+  z-index: 2;
+
+  & > li {
+    list-style: none;
+  }
+
+  ${props => props.isHidden && `
+    pointer-events: none;
+    visibility: hidden;
+  `}
+`;
+
+export const ContextMenuIcon = styled(Icon).attrs({
+    size: 20
+})`
+  & > svg {
+    fill: #a4b8d1;
+  }
+`;
+
+export const ContextMenuItem = styled.div`
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  height: 40px;
+  padding: 8px 16px;
+
+  & > *:not(:last-child) {
+    margin-right: 16px;
+  }
+
+  &:hover {
+    background-color: #525252;
+  }
+`;
+
+export const ContextMenuItemGroup = styled.div`
+  &:not(:empty) {
+    padding: 8px 0;
+  }
+
+  & + &:not(:empty) {
+    border-top: 1px solid #4C4D50;
+  }
+`;
+
+export const Heading = styled.div`
+  color: #d1dbe8;
+  font-style: normal;
+  font-size: 15px;
+  line-height: 24px;
+  margin: 8px 0 ${props => props.theme.panePadding}px;
+`;
+
+export const RoomActionButton = styled(Button)`
+  height: ${props => props.theme.roomActionButtonHeight}px;
+  padding: 6px 10px;
+`;
+
+export const RoomActionEllipsis = styled(RoomActionButton).attrs({
+    children: <Icon src = { IconHorizontalPoints } />,
+    primary: true
+})`
+  padding: 6px;
+`;
+
+export const RoomActions = styled.div`
+  align-items: center;
+  z-index: 1;
+
+  & > *:not(:last-child) {
+    margin-right: 8px;
+  }
+`;
+
+export const RoomActionsHover = styled(RoomActions)`
+  background-color: #292929;
+  bottom: 1px;
+  display: none;
+  position: absolute;
+  right: ${props => props.theme.panePadding};
+  top: 0;
+
+  &:after {
+    content: '';
+    background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, #292929 100%);
+    bottom: 0;
+    display: block;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    transform: translateX(-100%);
+    width: 40px;
+  }
+`;
+
+export const RoomActionsPermanent = styled(RoomActions)`
+  display: flex;
+`;
+
+export const RoomContent = styled.div`
+  align-items: center;
+  box-shadow: inset 0px -1px 0px rgba(255, 255, 255, 0.15);
+  display: flex;
+  flex: 1;
+  height: 100%;
+  overflow: hidden;
+  padding-right: ${props => props.theme.panePadding}px;
+`;
+
+export const RoomContainer = styled.div`
+  align-items: center;
+  color: white;
+  display: flex;
+  font-size: 13px;
+  height: ${props => props.theme.roomItemHeight}px;
+  margin: 0 -${props => props.theme.panePadding}px;
+  padding-left: ${props => props.theme.panePadding}px;
+  position: relative;
+
+  ${props => !props.isHighlighted && '&:hover {'}
+    background-color: #292929;
+
+    & ${RoomActions} {
+      ${props => props.trigger === ActionTrigger.Hover && `
+        display: flex;
+      `}
+    }
+
+    & ${RoomContent} {
+      box-shadow: none;
+    }
+  ${props => !props.isHighlighted && '}'}
+`;
+
+export const RoomLeaveButton = styled(Button).attrs({
+    primary: true
+})`
+  font-size: 15px;
+  height: 40px;
+  width: 100%;
+
+  & > *:not(:last-child) {
+    margin-right: 8px;
+  }
+`;
+
+export const RoomName = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const RoomNameContainer = styled.div`
+  display: flex;
+  flex: 1;
+  margin-right: 8px;
+  overflow: hidden;
+`;

--- a/react/features/breakout-rooms/constants.js
+++ b/react/features/breakout-rooms/constants.js
@@ -1,0 +1,30 @@
+/**
+ * Reducer key for the feature.
+ */
+export const REDUCER_KEY = 'features/breakout-rooms';
+
+/**
+ * The type of json-message which indicates that json carries a
+ * list of breakout rooms.
+ */
+export const JSON_TYPE_BREAKOUT_ROOMS_LIST = 'breakout-rooms-list';
+
+/**
+ * The type of json-message which indicates that json carries
+ * a request for an update of the list of breakout rooms.
+ */
+export const JSON_TYPE_BREAKOUT_ROOMS_REQUEST = 'breakout-rooms-request';
+
+/**
+ * The type of json-message which indicates that json carries
+ * a request for a participant to join a breakout room.
+ */
+export const JSON_TYPE_MOVE_TO_BREAKOUT_ROOM_REQUEST = 'move-to-breakout-room-request';
+
+/**
+ * Enum of possible breakout rooms action triggers.
+ */
+export const ActionTrigger = {
+    Hover: 'ActionTrigger.Hover',
+    Permanent: 'ActionTrigger.Permanent'
+};

--- a/react/features/breakout-rooms/functions.js
+++ b/react/features/breakout-rooms/functions.js
@@ -1,0 +1,126 @@
+import { useSelector } from 'react-redux';
+import uuid from 'uuid';
+
+import getRoomName from '../base/config/getRoomName';
+
+import { REDUCER_KEY } from './constants';
+
+
+/**
+ * Generates a breakout room id.
+ *
+ * @returns {string} Room id.
+ */
+export const getBreakoutRooms = () => {
+    const { breakoutRooms } = useSelector(state => state[REDUCER_KEY]);
+
+    return breakoutRooms || [];
+};
+
+
+/**
+ * Get members of a breakout room.
+ *
+ * @param {string} breakoutRoomId - The breakout room id.
+ * @returns {Array} List of room members.
+ */
+export const getBreakoutRoomMembers = breakoutRoomId => {
+    const { connection } = useSelector(state => state['features/base/connection']);
+    const muc = connection?.options?.hosts?.muc;
+    const members = connection?.xmpp?.connection?.emuc?.rooms[`${breakoutRoomId}@${muc}`]?.members;
+
+    return members ? Object.values(members) : [];
+};
+
+
+/**
+ * Generates a breakout room id.
+ *
+ * @returns {string} Room id.
+ */
+export const getNewBreakoutRoomId = () => {
+    const mainRoom = getRoomName();
+
+    return `${mainRoom}-${uuid.v4()}`;
+};
+
+/**
+ * Get current breakout room.
+ *
+ * @returns {Object} Breakout room.
+ */
+export const getCurrentBreakoutRoom = () => {
+    const { conference } = useSelector(state => state['features/base/conference']);
+    const currentRoomId = conference?.options?.name;
+
+    return getBreakoutRooms().find(room => room.id === currentRoomId) || null;
+};
+
+/**
+ * Determines whether the local participant is in a breakout room.
+ *
+ * @returns {boolean}
+ */
+export const getIsInBreakoutRoom = () => {
+    const mainRoom = getRoomName();
+    const currentBreakoutRoom = getCurrentBreakoutRoom();
+
+    return currentBreakoutRoom !== null && currentBreakoutRoom?.id !== mainRoom;
+};
+
+
+/**
+ * Generates a class attribute value.
+ *
+ * @param {Iterable<string>} args - String iterable.
+ * @returns {string} Class attribute value.
+ */
+export const classList = (...args) => args.filter(Boolean).join(' ');
+
+
+/**
+ * Find the first styled ancestor component of an element.
+ *
+ * @param {Element} target - Element to look up.
+ * @param {StyledComponentClass} component - Styled component reference.
+ * @returns {Element|null} Ancestor.
+ */
+export const findStyledAncestor = (target, component) => {
+    if (!target || target.matches(`.${component.styledComponentId}`)) {
+        return target;
+    }
+
+    return findStyledAncestor(target.parentElement, component);
+};
+
+/**
+ * Get a style property from a style declaration as a float.
+ *
+ * @param {CSSStyleDeclaration} styles - Style declaration.
+ * @param {string} name - Property name.
+ * @returns {number} Float value.
+ */
+export const getFloatStyleProperty = (styles, name) =>
+    parseFloat(styles.getPropertyValue(name));
+
+/**
+ * Gets the outer height of an element, including margins.
+ *
+ * @param {Element} element - Target element.
+ * @returns {number} Computed height.
+ */
+export const getComputedOuterHeight = element => {
+    const computedStyle = getComputedStyle(element);
+
+    return element.offsetHeight
+    + getFloatStyleProperty(computedStyle, 'margin-top')
+    + getFloatStyleProperty(computedStyle, 'margin-bottom');
+};
+
+/**
+ * Returns this feature's root state.
+ *
+ * @param {Object} state - Global state.
+ * @returns {Object} Feature state.
+ */
+export const getState = state => state[REDUCER_KEY];

--- a/react/features/breakout-rooms/logger.js
+++ b/react/features/breakout-rooms/logger.js
@@ -1,0 +1,5 @@
+// @flow
+
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('features/breakout-rooms');

--- a/react/features/breakout-rooms/middleware.js
+++ b/react/features/breakout-rooms/middleware.js
@@ -1,0 +1,194 @@
+// @flow
+
+import conference from '../../../conference';
+import { DATA_CHANNEL_OPENED } from '../base/conference';
+import {
+    getParticipantCount,
+    isLocalParticipantModerator,
+    isParticipantModerator,
+    getParticipantById
+} from '../base/participants';
+import { MiddlewareRegistry } from '../base/redux';
+import { ENDPOINT_MESSAGE_RECEIVED } from '../subtitles';
+
+import {
+    BREAKOUT_ROOM_ADDED,
+    BREAKOUT_ROOM_REMOVED,
+    PARTICIPANT_SENT_TO_BREAKOUT_ROOM
+} from './actionTypes';
+import { updateBreakoutRooms } from './actions';
+import {
+    REDUCER_KEY,
+    JSON_TYPE_BREAKOUT_ROOMS_LIST,
+    JSON_TYPE_BREAKOUT_ROOMS_REQUEST,
+    JSON_TYPE_MOVE_TO_BREAKOUT_ROOM_REQUEST
+} from './constants';
+import logger from './logger';
+
+/**
+ * Middleware that catches actions related to breakout rooms
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(store => next => action => {
+    switch (action.type) {
+    case ENDPOINT_MESSAGE_RECEIVED:
+        return _endpointMessageReceived(store, next, action);
+    case BREAKOUT_ROOM_ADDED:
+        conference.initBreakoutRoom(action.breakoutRoomId);
+
+        // falls through
+    case BREAKOUT_ROOM_REMOVED:
+        return sendBreakoutRooms(store, next, action);
+    case DATA_CHANNEL_OPENED:
+        return sendBreakoutRoomsRequest(store, next, action);
+    case PARTICIPANT_SENT_TO_BREAKOUT_ROOM:
+        return sendBreakoutRoomsMoveParticipantRequest(store, next, action);
+    }
+
+    return next(action);
+});
+
+/**
+ * Notifies the feature breakout rooms that the action
+ * {@code ENDPOINT_MESSAGE_RECEIVED} is being dispatched within a specific redux
+ * store.
+ *
+ * @param {Store} store - The redux store in which the specified {@code action}
+ * is being dispatched.
+ * @param {Dispatch} next - The redux {@code dispatch} function to
+ * dispatch the specified {@code action} to the specified {@code store}.
+ * @param {Action} action - The redux action {@code ENDPOINT_MESSAGE_RECEIVED}
+ * which is being dispatched in the specified {@code store}.
+ * @private
+ * @returns {Object} The value returned by {@code next(action)}.
+ */
+function _endpointMessageReceived(store, next, action) {
+    const { dispatch, getState } = store;
+    const state = getState();
+    const { json, participant } = action;
+    const sender = getParticipantById(state, participant._id);
+
+    try {
+        if (json) {
+            switch (json.type) {
+            case JSON_TYPE_BREAKOUT_ROOMS_LIST:
+                if (isParticipantModerator(sender)) {
+                    const breakoutRooms = json.breakoutRooms;
+
+                    dispatch(updateBreakoutRooms(breakoutRooms));
+                }
+                break;
+            case JSON_TYPE_BREAKOUT_ROOMS_REQUEST:
+                if (isLocalParticipantModerator(state)) {
+                    sendBreakoutRooms(store, next, action);
+                }
+                break;
+            case JSON_TYPE_MOVE_TO_BREAKOUT_ROOM_REQUEST:
+                if (isParticipantModerator(sender)) {
+                    const breakoutRoom = json.breakoutRoom;
+
+                    conference.switchRoom(breakoutRoom.id);
+                }
+                break;
+            }
+        }
+    } catch (error) {
+        logger.error('Error occurred while updating breakout rooms\n', error);
+    }
+
+    return next(action);
+}
+
+/**
+ * Sends the current list of breakout rooms to the other participants.
+ *
+ * @param {Store} store - The redux store in which the specified {@code action}
+ * is being dispatched.
+ * @param {Dispatch} next - The redux {@code dispatch} function to
+ * dispatch the specified {@code action} to the specified {@code store}.
+ * @param {Action} action - The redux action {@code ENDPOINT_MESSAGE_RECEIVED}
+ * which is being dispatched in the specified {@code store}.
+ * @private
+ * @returns {Object} The value returned by {@code next(action)}.
+ */
+function sendBreakoutRooms(store, next, action) {
+    const result = next(action);
+    const state = store.getState();
+    const { breakoutRooms } = state[REDUCER_KEY];
+
+    if (isLocalParticipantModerator(state) && getParticipantCount(state) > 1) {
+        try {
+            const message = {
+                type: JSON_TYPE_BREAKOUT_ROOMS_LIST,
+                breakoutRooms
+            };
+
+            conference.sendEndpointMessage('', message);
+        } catch (e) {
+            logger.error(e);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Sends a request for a list of breakout rooms.
+ *
+ * @param {Store} store - The redux store in which the specified {@code action}
+ * is being dispatched.
+ * @param {Dispatch} next - The redux {@code dispatch} function to
+ * dispatch the specified {@code action} to the specified {@code store}.
+ * @param {Action} action - The redux action {@code ENDPOINT_MESSAGE_RECEIVED}
+ * which is being dispatched in the specified {@code store}.
+ * @private
+ * @returns {Object} The value returned by {@code next(action)}.
+ */
+function sendBreakoutRoomsRequest(store, next, action) {
+    const state = store.getState();
+
+    if (getParticipantCount(state) > 1) {
+        try {
+            const message = {
+                type: JSON_TYPE_BREAKOUT_ROOMS_REQUEST
+            };
+
+            conference.sendEndpointMessage('', message);
+        } catch (e) {
+            logger.error(e);
+        }
+    }
+
+    return next(action);
+}
+
+/**
+ * Sends a request to a user for them to join a breakout room.
+ *
+ * @param {Store} store - The redux store in which the specified {@code action}
+ * is being dispatched.
+ * @param {Dispatch} next - The redux {@code dispatch} function to
+ * dispatch the specified {@code action} to the specified {@code store}.
+ * @param {Action} action - The redux action {@code ENDPOINT_MESSAGE_RECEIVED}
+ * which is being dispatched in the specified {@code store}.
+ * @private
+ * @returns {Object} The value returned by {@code next(action)}.
+ */
+function sendBreakoutRoomsMoveParticipantRequest(store, next, action) {
+    const { participantId, breakoutRoom } = action;
+
+    try {
+        const message = {
+            type: JSON_TYPE_MOVE_TO_BREAKOUT_ROOM_REQUEST,
+            breakoutRoom
+        };
+
+        conference.sendEndpointMessage(participantId, message);
+    } catch (e) {
+        logger.error(e);
+    }
+
+    return next(action);
+}

--- a/react/features/breakout-rooms/reducer.js
+++ b/react/features/breakout-rooms/reducer.js
@@ -1,0 +1,54 @@
+import { ReducerRegistry } from '../base/redux';
+
+import {
+    BREAKOUT_ROOMS_UPDATED,
+    BREAKOUT_ROOM_ADDED,
+    BREAKOUT_ROOM_REMOVED
+} from './actionTypes';
+import { REDUCER_KEY } from './constants';
+
+/**
+ * Default State for 'features/transcription' feature
+ */
+const defaultState = {
+    breakoutRooms: []
+};
+
+/**
+ * Listen for actions for the breakout rooms feature to be used by the actions
+ * to update the breakout room list.
+ */
+ReducerRegistry.register(REDUCER_KEY, (
+        state = defaultState, action) => {
+    switch (action.type) {
+    case BREAKOUT_ROOMS_UPDATED: {
+        return {
+            ...state,
+            breakoutRooms: action.breakoutRooms
+        };
+    }
+    case BREAKOUT_ROOM_ADDED: {
+        const nextIndex = (state.breakoutRooms[state.breakoutRooms.length - 1]?.index || 0) + 1;
+        const breakoutRooms = [
+            ...state.breakoutRooms,
+            { id: action.breakoutRoomId,
+                index: nextIndex }
+        ];
+
+        return {
+            ...state,
+            breakoutRooms
+        };
+    }
+    case BREAKOUT_ROOM_REMOVED: {
+        const breakoutRooms = state.breakoutRooms.filter(room => room.id !== action.breakoutRoomId);
+
+        return {
+            ...state,
+            breakoutRooms
+        };
+    }
+    }
+
+    return state;
+});

--- a/react/features/breakout-rooms/theme.json
+++ b/react/features/breakout-rooms/theme.json
@@ -1,0 +1,9 @@
+{
+  "contextFontSize": 14,
+  "contextFontWeight": 400,
+  "headerSize": 60,
+  "panePadding": 16,
+  "roomActionButtonHeight": 32,
+  "roomItemHeight": 40,
+  "rangeInputThumbSize": 14
+}

--- a/react/features/participants-pane/components/MeetingParticipantContextMenu.js
+++ b/react/features/participants-pane/components/MeetingParticipantContextMenu.js
@@ -8,12 +8,15 @@ import { openDialog } from '../../base/dialog';
 import {
     IconCloseCircle,
     IconCrown,
+    IconMeetingUnlocked,
     IconMessage,
     IconMuteEveryoneElse,
     IconVideoOff
 } from '../../base/icons';
 import { isLocalParticipantModerator } from '../../base/participants';
 import { getIsParticipantVideoMuted } from '../../base/tracks';
+import { sendParticipantToBreakoutRoom } from '../../breakout-rooms/actions';
+import { REDUCER_KEY } from '../../breakout-rooms/constants';
 import { openChat } from '../../chat/actions';
 import { GrantModeratorDialog, KickRemoteParticipantDialog, MuteEveryoneDialog } from '../../video-menu';
 import MuteRemoteParticipantsVideoDialog from '../../video-menu/components/web/MuteRemoteParticipantsVideoDialog';
@@ -66,6 +69,8 @@ export const MeetingParticipantContextMenu = ({
     const containerRef = useRef(null);
     const isLocalModerator = useSelector(isLocalParticipantModerator);
     const isParticipantVideoMuted = useSelector(getIsParticipantVideoMuted(participant));
+    const { breakoutRooms } = useSelector(state => state[REDUCER_KEY]);
+
     const [ isHidden, setIsHidden ] = useState(true);
     const { t } = useTranslation();
 
@@ -117,6 +122,10 @@ export const MeetingParticipantContextMenu = ({
         dispatch(openChat(participant));
     }, [ dispatch, participant ]);
 
+    const sendToBreakoutRoom = useCallback(breakoutRoom => () => {
+        dispatch(sendParticipantToBreakoutRoom(participant.id, breakoutRoom));
+    }, [ dispatch, participant ]);
+
     if (!participant) {
         return null;
     }
@@ -161,6 +170,18 @@ export const MeetingParticipantContextMenu = ({
                     <span>{t('toolbar.accessibilityLabel.privateMessage')}</span>
                 </ContextMenuItem>
             </ContextMenuItemGroup>
+            {breakoutRooms?.length > 0 && isLocalModerator && (
+                <ContextMenuItemGroup>
+                    {breakoutRooms.map(breakoutRoom => (
+                        <ContextMenuItem
+                            key = { breakoutRoom.id }
+                            onClick = { sendToBreakoutRoom(breakoutRoom) }>
+                            <ContextMenuIcon src = { IconMeetingUnlocked } />
+                            <span>{t('breakoutRooms.actions.sendToBreakoutRoom', { index: breakoutRoom?.index })}</span>
+                        </ContextMenuItem>
+                    ))}
+                </ContextMenuItemGroup>
+            )}
         </ContextMenu>
     );
 };

--- a/react/features/participants-pane/components/MeetingParticipantList.js
+++ b/react/features/participants-pane/components/MeetingParticipantList.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { getParticipants } from '../../base/participants';
+import { getCurrentBreakoutRoom, getIsInBreakoutRoom } from '../../breakout-rooms/functions';
 import { findStyledAncestor } from '../functions';
 
 import { InviteButton } from './InviteButton';
@@ -35,9 +36,13 @@ const initialState = Object.freeze(Object.create(null));
 
 export const MeetingParticipantList = () => {
     const isMouseOverMenu = useRef(false);
-    const participants = useSelector(getParticipants, _.isEqual);
+
+    // ToDo: Remove the filtering after the breakout room fake host becomes hidden.
+    const participants = useSelector(getParticipants, _.isEqual).filter(p => p.name);
     const [ raiseContext, setRaiseContext ] = useState<RaiseContext>(initialState);
     const { t } = useTranslation();
+    const isInBreakoutRoom = getIsInBreakoutRoom();
+    const currentBreakoutRoom = getCurrentBreakoutRoom();
 
     const lowerMenu = useCallback(() => {
         /**
@@ -85,7 +90,13 @@ export const MeetingParticipantList = () => {
 
     return (
     <>
-        <Heading>{t('participantsPane.headings.participantsList', { count: participants.length })}</Heading>
+        <Heading> {
+            isInBreakoutRoom
+                ? t('breakoutRooms.headings.breakoutRoom', { index: currentBreakoutRoom.index,
+                    count: participants.length })
+                : t('participantsPane.headings.mainRoom', { count: participants.length })
+        }
+        </Heading>
         <InviteButton />
         <div>
             {participants.map(p => (

--- a/react/features/participants-pane/components/ParticipantsPane.js
+++ b/react/features/participants-pane/components/ParticipantsPane.js
@@ -7,6 +7,9 @@ import { ThemeProvider } from 'styled-components';
 
 import { openDialog } from '../../base/dialog';
 import { isLocalParticipantModerator } from '../../base/participants';
+import { addBreakoutRoom } from '../../breakout-rooms/actions';
+import { RoomList } from '../../breakout-rooms/components';
+import { getNewBreakoutRoomId } from '../../breakout-rooms/functions';
 import { MuteEveryoneDialog } from '../../video-menu/components/';
 import { close } from '../actions';
 import { classList, getParticipantsPaneOpen } from '../functions';
@@ -31,6 +34,7 @@ export const ParticipantsPane = () => {
 
     const closePane = useCallback(() => dispatch(close(), [ dispatch ]));
     const muteAll = useCallback(() => dispatch(openDialog(MuteEveryoneDialog)), [ dispatch ]);
+    const addRoom = useCallback(() => dispatch(addBreakoutRoom(getNewBreakoutRoomId())), [ dispatch ]);
 
     return (
         <ThemeProvider theme = { theme }>
@@ -47,9 +51,13 @@ export const ParticipantsPane = () => {
                         <LobbyParticipantList />
                         <AntiCollapse />
                         <MeetingParticipantList />
+                        <RoomList />
                     </Container>
                     {isLocalModerator && (
                         <Footer>
+                            <FooterButton onClick = { addRoom }>
+                                {t('breakoutRooms.actions.addRoom')}
+                            </FooterButton>
                             <FooterButton onClick = { muteAll }>
                                 {t('participantsPane.actions.muteAll')}
                             </FooterButton>


### PR DESCRIPTION
Implementation of a breakout-rooms feature.

The following functionality is covered:
- integrated into the participants pane
- managed by moderators
- moderators can send participants to breakout-rooms
- participants can choose a breakout room to join
- participants can leave breakout rooms anytime

Screenshots:
<img width="314" alt="Screenshot 2021-05-03 at 15 49 26" src="https://user-images.githubusercontent.com/70745309/116923441-edb29200-ac56-11eb-9f4f-ecd35baa01fa.png">

<img width="314" alt="Screenshot 2021-05-03 at 15 51 32" src="https://user-images.githubusercontent.com/70745309/116923475-f6a36380-ac56-11eb-9257-5775b90d3019.png">
<img width="314" alt="Screenshot 2021-05-03 at 15 53 07" src="https://user-images.githubusercontent.com/70745309/116923497-fdca7180-ac56-11eb-8fee-f70b274b9c45.png">
<img width="314" alt="Screenshot 2021-05-03 at 15 54 59" src="https://user-images.githubusercontent.com/70745309/116923513-03c05280-ac57-11eb-9551-ae37405b64c1.png">
