### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10889,8 +10889,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#ad5692d6aa42800a1c251e05261ef05bfe2a7f79",
-      "from": "github:jitsi/lib-jitsi-meet#ad5692d6aa42800a1c251e05261ef05bfe2a7f79",
+      "version": "github:jitsi/lib-jitsi-meet#e362c89eb69416bcf6a09908ef50e40b685050fb",
+      "from": "github:jitsi/lib-jitsi-meet#e362c89eb69416bcf6a09908ef50e40b685050fb",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",
@@ -10902,6 +10902,7 @@
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",
+        "promise.allsettled": "1.0.4",
         "sdp-transform": "2.3.0",
         "strophe.js": "1.3.4",
         "strophejs-plugin-disco": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ad5692d6aa42800a1c251e05261ef05bfe2a7f79",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e362c89eb69416bcf6a09908ef50e40b685050fb",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* Add dependency for promise.allSettled. Older chrome versions like M72 do not support Promise.allSettled.
* fix(conference): Enable p2p for unified plan clients.
* fix(TPC): Use addTrack instead of addStream in Unified-plan impl.
* Add missing spaces in debug logs.

https://github.com/jitsi/lib-jitsi-meet/compare/ad5692d6aa42800a1c251e05261ef05bfe2a7f79...e362c89eb69416bcf6a09908ef50e40b685050fb

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
