### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10889,8 +10889,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#74a90f703526ba3352174877ed822911bfc2cce7",
-      "from": "github:jitsi/lib-jitsi-meet#74a90f703526ba3352174877ed822911bfc2cce7",
+      "version": "github:jitsi/lib-jitsi-meet#7cbd9c8f2abb4fc9b12373a613ac50bd06ca1d96",
+      "from": "github:jitsi/lib-jitsi-meet#7cbd9c8f2abb4fc9b12373a613ac50bd06ca1d96",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",
@@ -10919,10 +10919,6 @@
             "bowser": "2.7.0",
             "js-md5": "0.7.3"
           }
-        },
-        "jitsi-meet-logger": {
-          "version": "github:jitsi/jitsi-meet-logger#4add5bac2e4cea73a05f42b7596ee03c7f7a2567",
-          "from": "github:jitsi/jitsi-meet-logger#v1.0.0"
         },
         "js-md5": {
           "version": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#74a90f703526ba3352174877ed822911bfc2cce7",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#7cbd9c8f2abb4fc9b12373a613ac50bd06ca1d96",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(quality-control): Propagate the height constraints to p2p session. If the application is using the new receiver constraints, propagate the height constraint to the p2p session as well.
* build(deps): bump lodash from 4.17.19 to 4.17.21
* chore(deps): bump hosted-git-info from 2.8.8 to 2.8.9

https://github.com/jitsi/lib-jitsi-meet/compare/74a90f703526ba3352174877ed822911bfc2cce7...7cbd9c8f2abb4fc9b12373a613ac50bd06ca1d96

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
