### PR TITLE
feat: jitsi_session: extracts URL parameters from BOSH or WS into session

### DIFF
--- a/resources/prosody-plugins/mod_auth_jitsi-annonymous.lua
+++ b/resources/prosody-plugins/mod_auth_jitsi-annonymous.lua
@@ -1,0 +1,70 @@
+-- Anonymous authentication with extras:
+-- * session resumption
+-- Copyright (C) 2021-present 8x8, Inc.
+
+local new_sasl = require "util.sasl".new;
+local sasl = require "util.sasl";
+local sessions = prosody.full_sessions;
+
+-- define auth provider
+local provider = {};
+
+function provider.test_password(username, password)
+    return nil, "Password based auth not supported";
+end
+
+function provider.get_password(username)
+    return nil;
+end
+
+function provider.set_password(username, password)
+    return nil, "Set password not supported";
+end
+
+function provider.user_exists(username)
+    return nil;
+end
+
+function provider.create_user(username, password)
+    return nil;
+end
+
+function provider.delete_user(username)
+    return nil;
+end
+
+function provider.get_sasl_handler(session)
+    -- Custom session matching so we can resume sesssion even with randomly
+    -- generrated user IDs.
+    local function get_username(self, message)
+        if (session.previd ~= nil) then
+            for _, session1 in pairs(sessions) do
+                if (session1.resumption_token == session.previd) then
+                    self.username = session1.username;
+                    break;
+                end
+            end
+        else
+            self.username = message;
+        end
+
+        return true;
+    end
+
+    return new_sasl(module.host, { anonymous = get_username });
+end
+
+module:provides("auth", provider);
+
+local function anonymous(self, message)
+    -- This calls the handler created in 'provider.get_sasl_handler(session)'
+    local result, err, msg = self.profile.anonymous(self, username, self.realm);
+
+    if result == true then
+        return "success";
+    else
+        return "failure", err, msg;
+    end
+end
+
+sasl.registerMechanism("ANONYMOUS", {"anonymous"}, anonymous);

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -1,5 +1,5 @@
 -- Token authentication
--- Copyright (C) 2015 Atlassian
+-- Copyright (C) 2021-present 8x8, Inc.
 
 local formdecode = require "util.http".formdecode;
 local generate_uuid = require "util.uuid".generate;
@@ -12,6 +12,8 @@ local sessions = prosody.full_sessions;
 if token_util == nil then
     return;
 end
+
+module:depends("jitsi_session");
 
 -- define auth provider
 local provider = {};
@@ -32,18 +34,6 @@ function init_session(event)
         -- other fields will be extracted from the token and set in the session
 
         session.auth_token = query and params.token or nil;
-        -- previd is used together with https://modules.prosody.im/mod_smacks.html
-        -- the param is used to find resumed session and re-use anonymous(random) user id
-        -- (see get_username_from_token)
-        session.previd = query and params.previd or nil;
-
-        -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = params.room;
-        session.jitsi_web_query_prefix = params.prefix or "";
-
-        -- Deprecated, you should use jitsi_web_query_room and jitsi_web_query_prefix
-        session.jitsi_bosh_query_room = session.jitsi_web_query_room;
-        session.jitsi_bosh_query_prefix = session.jitsi_web_query_prefix;
     end
 end
 

--- a/resources/prosody-plugins/mod_av_moderation.lua
+++ b/resources/prosody-plugins/mod_av_moderation.lua
@@ -1,26 +1,6 @@
-local formdecode = require 'util.http'.formdecode;
-
 local avmoderation_component = module:get_option_string('av_moderation_component', 'avmoderation'..module.host);
 
 -- Advertise AV Moderation so client can pick up the address and use it
 module:add_identity('component', 'av_moderation', avmoderation_component);
 
--- Extract 'room' param from URL when session is created
-function update_session(event)
-    local session = event.session;
-
-    if session.jitsi_web_query_room then
-        -- no need for an update
-        return;
-    end
-
-    local query = event.request.url.query;
-    if query ~= nil then
-        local params = formdecode(query);
-        -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = params.room;
-        session.jitsi_web_query_prefix = params.prefix or '';
-    end
-end
-module:hook_global('bosh-session', update_session);
-module:hook_global('websocket-session', update_session);
+module:depends("jitsi_session");

--- a/resources/prosody-plugins/mod_jitsi_session.lua
+++ b/resources/prosody-plugins/mod_jitsi_session.lua
@@ -1,0 +1,27 @@
+-- Jitsi session information
+-- Copyright (C) 2021-present 8x8, Inc.
+module:set_global();
+
+local formdecode = require "util.http".formdecode;
+
+-- Extract the following parameters from the URL and set them in the session:
+-- * previd: for session resumption
+function init_session(event)
+    local session, request = event.session, event.request;
+    local query = request.url.query;
+
+    if query ~= nil then
+        local params = formdecode(query);
+
+        -- previd is used together with https://modules.prosody.im/mod_smacks.html
+        -- the param is used to find resumed session and re-use anonymous(random) user id
+        session.previd = query and params.previd or nil;
+
+        -- The room name and optional prefix from the web query
+        session.jitsi_web_query_room = params.room;
+        session.jitsi_web_query_prefix = params.prefix or "";
+    end
+end
+
+module:hook_global("bosh-session", init_session);
+module:hook_global("websocket-session", init_session);

--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -23,7 +23,8 @@ if not have_async then
     return;
 end
 
-local formdecode = require "util.http".formdecode;
+module:depends("jitsi_session");
+
 local jid_split = require 'util.jid'.split;
 local jid_bare = require 'util.jid'.bare;
 local json = require 'util.json';
@@ -378,24 +379,6 @@ process_host_module(main_muc_component_config, function(host_module, host)
     end);
 end);
 
--- Extract 'room' param from URL when session is created
-function update_session(event)
-    local session = event.session;
-
-    if session.jitsi_web_query_room then
-        -- no need for an update
-        return;
-    end
-
-    local query = event.request.url.query;
-    if query ~= nil then
-        local params = formdecode(query);
-        -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = params.room;
-        session.jitsi_web_query_prefix = params.prefix or '';
-    end
-end
-
 function handle_create_lobby(event)
     local room = event.room;
     room:set_members_only(true);
@@ -407,8 +390,6 @@ function handle_destroy_lobby(event)
     destroy_lobby_room(event.room, event.newjid, event.message);
 end
 
-module:hook_global('bosh-session', update_session);
-module:hook_global('websocket-session', update_session);
 module:hook_global('config-reloaded', load_config);
 module:hook_global('create-lobby-room', handle_create_lobby);
 module:hook_global('destroy-lobby-room', handle_destroy_lobby);

--- a/resources/prosody-plugins/mod_muc_poltergeist.lua
+++ b/resources/prosody-plugins/mod_muc_poltergeist.lua
@@ -11,6 +11,8 @@ if not have_async then
     return;
 end
 
+module:depends("jitsi_session");
+
 local async_handler_wrapper = module:require "util".async_handler_wrapper;
 
 -- Options


### PR DESCRIPTION
Add 2 new modules:

jitsi_session: extracts URL parameters from BOSH or WS sessions and attaches
them to the session
auth_jitsi-annonymous: anonymous authentication with custom session
resumpotion for randomly generated usernames

Co-authored-by: Saúl Ibarra Corretgé <saghul@jitsi.org>
