### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11058,8 +11058,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#88560a8a5ed1ce6e7b829d7fc8e460b4c963f119",
-      "from": "github:jitsi/lib-jitsi-meet#88560a8a5ed1ce6e7b829d7fc8e460b4c963f119",
+      "version": "github:jitsi/lib-jitsi-meet#9eb4af1e8018b2f15503c52e0f6d90e187b2628a",
+      "from": "github:jitsi/lib-jitsi-meet#9eb4af1e8018b2f15503c52e0f6d90e187b2628a",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#88560a8a5ed1ce6e7b829d7fc8e460b4c963f119",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#9eb4af1e8018b2f15503c52e0f6d90e187b2628a",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): Return default codec if the local sdp is not available. Get the correct media type when generating the source identifier.

https://github.com/jitsi/lib-jitsi-meet/compare/88560a8a5ed1ce6e7b829d7fc8e460b4c963f119...9eb4af1e8018b2f15503c52e0f6d90e187b2628a

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
