### PR TITLE
remove reference to interface_config.js (in comment)

### DIFF
--- a/config.js
+++ b/config.js
@@ -611,8 +611,8 @@ var config = {
     // localRecording: {
     // Enables local recording.
     // Additionally, 'localrecording' (all lowercase) needs to be added to
-    // TOOLBAR_BUTTONS in interface_config.js for the Local Recording
-    // button to show up on the toolbar.
+    // the `toolbarButtons`-array for the Local Recording button to show up
+    // on the toolbar.
     //
     //     enabled: true,
     //


### PR DESCRIPTION
`config.js` referenced `interface_config.js` for adding the local recording button to TOOLBAR_BUTTONS.

Follow this path and interface_config.js would tell you TOOLBAR_BUTTONS has been moved to config.js and points you back there. Thus, remove the reference in comment.