### PR TITLE
Make Spacebar to also act as Push-To-Mute

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -411,7 +411,7 @@
         "keyboardShortcuts": "Keyboard shortcuts",
         "localRecording": "Show or hide local recording controls",
         "mute": "Mute or unmute your microphone",
-        "pushToTalk": "Push to talk",
+        "pushToTalk": "Push to talk/mute",
         "raiseHand": "Raise or lower your hand",
         "showSpeakerStats": "Show speaker stats",
         "toggleChat": "Open or close the chat",

--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -36,6 +36,12 @@ const _shortcutsHelp = new Map();
 let enabled = true;
 
 /**
+ * True is the shortcut SPACE is pressed, i.e. Push-To-Talk/Mute is in action
+ * @type {boolean}
+ */
+let isSpacePressed = false;
+
+/**
  * Maps keycode to character, id of popover for given function and function.
  */
 const KeyboardShortcut = {
@@ -69,12 +75,13 @@ const KeyboardShortcut = {
                 || $(':focus').is('input[type=password]')
                 || $(':focus').is('textarea'))) {
                 if (this._getKeyboardKey(e).toUpperCase() === ' ') {
-                    if (APP.conference.isLocalAudioMuted()) {
+                    if (!isSpacePressed) {
                         sendAnalytics(createShortcutEvent(
                             'push.to.talk',
                             PRESSED));
                         logger.log('Talk shortcut pressed');
-                        APP.conference.muteAudio(false);
+                        APP.conference.toggleAudioMuted(false);
+                        isSpacePressed = true;
                     }
                 }
             }
@@ -200,7 +207,8 @@ const KeyboardShortcut = {
         this.registerShortcut(' ', null, () => {
             sendAnalytics(createShortcutEvent('push.to.talk', RELEASED));
             logger.log('Talk shortcut released');
-            APP.conference.muteAudio(true);
+            APP.conference.toggleAudioMuted(true);
+            isSpacePressed = false;
         });
         this._addShortcutToHelp('SPACE', 'keyboardShortcuts.pushToTalk');
 


### PR DESCRIPTION
Currently, the [SPACE] hotkey acts as a Push-To-Talk button while audio is muted. 

Make the [SPACE] hotkey work as a push button in both cases:
* If audio is *muted*, behave as "Push-To-*Talk*", i.e. temporary *unmute* the audio while holding the space bar.
* If audio is *unmuted*, behave as "Push-To-*Mute*", i.e. temporary *mute* the audio while holding the space bar.

The audio may be still toggled muted/unmuted by the [M] hotkey as before (, even while [SPACE] is holded).

Will close  #9130 .