### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11065,8 +11065,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#f95a455c0808f55e42af9902a1b8c3fe57417c81",
-      "from": "github:jitsi/lib-jitsi-meet#f95a455c0808f55e42af9902a1b8c3fe57417c81",
+      "version": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
+      "from": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#f95a455c0808f55e42af9902a1b8c3fe57417c81",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(caps): Disable TCC on Firefox. There is a known issue with Firefox where the BWE gets halved on every renegotiation causing the low upload bitrates from the Firefox clients.
* fix: Drops unused config, fixes jitsi/lib-jitsi-meet#1620.
* fix(e2ee): destroys olm session on disabling e2ee

https://github.com/jitsi/lib-jitsi-meet/compare/f95a455c0808f55e42af9902a1b8c3fe57417c81...60c566795718ad4fe28f31113479ee8bb3c78e5f

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
