### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2740,9 +2740,8 @@
       }
     },
     "@jitsi/sdp-interop": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jitsi/sdp-interop/-/sdp-interop-1.0.3.tgz",
-      "integrity": "sha512-3dua2TTDWwpFpdEl+sMEei4d/+VgVXMpQRCPdvzzOidiiHnJ0vAJONfndKJmhhaqYv+e71Ry5IPGV1ZSWjIDJw==",
+      "version": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
+      "from": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.3.0"
@@ -11065,11 +11064,11 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
-      "from": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
+      "version": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
+      "from": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
-        "@jitsi/sdp-interop": "1.0.3",
+        "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#60c566795718ad4fe28f31113479ee8bb3c78e5f",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(SDP): Add missing msid for p2p sources.
* fix(TPC): Don't convert plan-b<->unified-plan SDPs for p2p.
* squash: Implement review comments.
* fix(JingleSessionPC): Do not try to re-use inactive mid for new remote ssrcs. The direction was marked as 'inactive' only on Firefox as Safari had audio issues when an inactive mid is re-used. Chrome (in unified-plan) needs the direction of the mid in remote desc to be set to 'inactive' for a 'removetrack' to be fired on the associated media stream whenever a remote source is removed.
* fix(SDP): Drop SSRCs whenever the transceiver direction is 'inactive' or 'recvonly'. This is needed only for JVB connections. Add unit tests for LocalSdpMunger.
* fix: Ignore startAudioMuted/startVideoMuted for p2p. The tracks will not be added when the call switches from jvb to p2p for an endpoint that joins muted by focus.
* fix(RTC): Do not suppress the source updates on Firefox. If the msid attribute is missing, then remove the ssrc from the transformed description so that a source-remove is signaled to Jicofo. This happens when the direction of the transceiver (or m-line) is set to 'inactive' or 'recvonly' on Firefox. Not signaling these source updates creates issues with remote track handling on the other endpoints in the call.
* fix(RTC): Set transceiver direction after RTCRtpSender#replaceTrack. This fixes the issue where TRACK_REMOVED event is not fired when a remote track is removed from the peerconnection. Fixes https://github.com/jitsi/lib-jitsi-meet/issues/1612 and https://github.com/jitsi/jitsi-meet/issues/8482.

https://github.com/jitsi/lib-jitsi-meet/compare/60c566795718ad4fe28f31113479ee8bb3c78e5f...be3e2a69f278f98c5f6f007cef268a9415334241

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
