### PR TITLE
Hide invite button in participant panel if disabled in config

### DIFF
--- a/react/features/participants-pane/components/MeetingParticipantList.js
+++ b/react/features/participants-pane/components/MeetingParticipantList.js
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 import { getParticipants } from '../../base/participants';
-import { findStyledAncestor } from '../functions';
+import { findStyledAncestor, shouldRenderInviteButton } from '../functions';
 
 import { InviteButton } from './InviteButton';
 import { MeetingParticipantContextMenu } from './MeetingParticipantContextMenu';
@@ -36,6 +36,7 @@ const initialState = Object.freeze(Object.create(null));
 export const MeetingParticipantList = () => {
     const isMouseOverMenu = useRef(false);
     const participants = useSelector(getParticipants, _.isEqual);
+    const showInviteButton = useSelector(shouldRenderInviteButton);
     const [ raiseContext, setRaiseContext ] = useState<RaiseContext>(initialState);
     const { t } = useTranslation();
 
@@ -86,7 +87,7 @@ export const MeetingParticipantList = () => {
     return (
     <>
         <Heading>{t('participantsPane.headings.participantsList', { count: participants.length })}</Heading>
-        <InviteButton />
+        {showInviteButton && <InviteButton />}
         <div>
             {participants.map(p => (
                 <MeetingParticipantItem

--- a/react/features/participants-pane/functions.js
+++ b/react/features/participants-pane/functions.js
@@ -1,3 +1,8 @@
+// @flow
+
+import { getFeatureFlag, INVITE_ENABLED } from '../base/flags';
+import { toState } from '../base/redux';
+
 import { REDUCER_KEY } from './constants';
 
 /**
@@ -64,3 +69,17 @@ const getState = state => state[REDUCER_KEY];
  */
 export const getParticipantsPaneOpen = state => Boolean(getState(state)?.isOpen);
 
+/**
+ * Returns true if the invite button should be rendered.
+ *
+ * @param {Object|Function} stateful - Object or function that can be resolved
+ * to the Redux state.
+ * @returns {boolean}
+ */
+export function shouldRenderInviteButton(stateful: Object | Function) {
+    const state = toState(stateful);
+    const { disableInviteFunctions } = state['features/base/config'];
+    const flagEnabled = getFeatureFlag(state, INVITE_ENABLED, true);
+
+    return flagEnabled && !disableInviteFunctions;
+}

--- a/react/features/participants-pane/functions.js
+++ b/react/features/participants-pane/functions.js
@@ -1,4 +1,3 @@
-// @flow
 
 import { getFeatureFlag, INVITE_ENABLED } from '../base/flags';
 import { toState } from '../base/redux';
@@ -72,14 +71,12 @@ export const getParticipantsPaneOpen = state => Boolean(getState(state)?.isOpen)
 /**
  * Returns true if the invite button should be rendered.
  *
- * @param {Object|Function} stateful - Object or function that can be resolved
- * to the Redux state.
+ * @param {Object} state - Global state.
  * @returns {boolean}
  */
-export function shouldRenderInviteButton(stateful: Object | Function) {
-    const state = toState(stateful);
-    const { disableInviteFunctions } = state['features/base/config'];
+export const shouldRenderInviteButton = state => {
+    const { disableInviteFunctions } = toState(state)['features/base/config'];
     const flagEnabled = getFeatureFlag(state, INVITE_ENABLED, true);
 
     return flagEnabled && !disableInviteFunctions;
-}
+};


### PR DESCRIPTION
Hide invite button in new Participants Panel if invite feature is disabled in config.

This follows conversation with @damencho on https://community.jitsi.org/t/disabling-all-invite-functions/82035/33?u=shawn

