### PR TITLE
fix(participants) no preload gravatars if disableThirdPartyRequests

### DIFF
--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -407,16 +407,20 @@ function _participantJoinedOrUpdated(store, next, action) {
     // to the new avatar and emit out change events if necessary.
     const result = next(action);
 
-    const { disableThirdPartyRequests } = getState()['features/base/config'];
+    // Only run this if the config is populated, otherwise we preload external resources
+    // even if disableThirdPartyRequests is set to true in config
+    if (Object.keys(getState()['features/base/config']).length) {
+        const { disableThirdPartyRequests } = getState()['features/base/config'];
 
-    if (!disableThirdPartyRequests && (avatarURL || email || id || name)) {
-        const participantId = !id && local ? getLocalParticipant(getState()).id : id;
-        const updatedParticipant = getParticipantById(getState(), participantId);
+        if (!disableThirdPartyRequests && (avatarURL || email || id || name)) {
+            const participantId = !id && local ? getLocalParticipant(getState()).id : id;
+            const updatedParticipant = getParticipantById(getState(), participantId);
 
-        getFirstLoadableAvatarUrl(updatedParticipant, store)
-            .then(url => {
-                dispatch(setLoadableAvatarUrl(participantId, url));
-            });
+            getFirstLoadableAvatarUrl(updatedParticipant, store)
+                .then(url => {
+                    dispatch(setLoadableAvatarUrl(participantId, url));
+                });
+        }
     }
 
     // Notify external listeners of potential avatarURL changes.


### PR DESCRIPTION
Previously gravatars (external resources) were preloaded even if
disableThirdPartyRequests was set to true in the config, as the
config may be empty at the time of preloading.

Closes: #5670
Signed-off-by: Christoph Settgast <csett86@web.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
