### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11064,8 +11064,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
-      "from": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
+      "version": "github:jitsi/lib-jitsi-meet#3fb44f769534a5025df476348df4b6d09fb9a4fd",
+      "from": "github:jitsi/lib-jitsi-meet#3fb44f769534a5025df476348df4b6d09fb9a4fd",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#be3e2a69f278f98c5f6f007cef268a9415334241",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#3fb44f769534a5025df476348df4b6d09fb9a4fd",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(LocalSdpMunger): Fix unit test.
* fix(CodecSelection): Call RTCRtpTransceiver#setCodecPreferences before renegotiation. Call RTCRtpTransceiver#setCodecPreferences with the preferrred codec order before every createOffer/createAnswer. This ensures that the codec preference is enforced even when there is no local description available yet while the preferred codec is being set immediately after media session creation.
* fix(JingleSessionPC): Add a workaround for chrome issue. The 'signalingstatechange' event for 'stable' is fired after the 'iceconnectionstatechange' event for 'completed' is fired on chrome in Unified plan. This prevents the client from switching the media connection to the p2p connection once the ice connection for p2p gets established.
* fix(Logging): Log enhancements. Add a preifx to logs for idenitifying the type of TPC/jingleSessionPC.
* feat(TPC): Enable unified-plan support for Chromium based browsers. This can be controlled through the config.js  option 'enableUnifiedOnChrome'.
* fix(TPC): Do not configure encodings on Safari until reneg. Avoid configuring the encodings on Chromium/Safari until simulcast is configured for the newly added track using SDP munging which happens during the renegotiation.
* fix(TPC): Do not configure encodings on chromium immediately after replace track. Avoid configuring the encodings on chromium immediately after replace track since the encoding params are read-only until the renegotation is done.
* fix: send json message (#1180)

https://github.com/jitsi/lib-jitsi-meet/compare/be3e2a69f278f98c5f6f007cef268a9415334241...3fb44f769534a5025df476348df4b6d09fb9a4fd

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
