### PR TITLE
fix: prosody: token alg is checked before public key is used

### DIFF
--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -270,6 +270,13 @@ function Util:process_and_verify_token(session, acceptedIssuers)
         if kid == nil then
             return false, "not-allowed", "'kid' claim is missing";
         end
+        local alg = header["alg"];
+        if alg == nil then
+            return false, "not-allowed", "'alg' claim is missing";
+        end
+        if alg.sub(alg,1,2) ~= "RS" then
+            return false, "not-allowed", "'kid' claim only support with RS family";
+        end
         pubKey = self:get_public_key(kid);
         if pubKey == nil then
             return false, "not-allowed", "could not obtain public key";


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
fix: tokens will have 'alg' header checked before assuming pubic key content at URL matches token algorithm
