### PR TITLE
fix: CLOSE_CHAT calls notifyChatUpdated with the isOpen flag set to false instead of true

### DIFF
--- a/react/features/chat/middleware.js
+++ b/react/features/chat/middleware.js
@@ -104,7 +104,7 @@ MiddlewareRegistry.register(store => next => action => {
         unreadCount = 0;
 
         if (typeof APP !== 'undefined') {
-            APP.API.notifyChatUpdated(unreadCount, true);
+            APP.API.notifyChatUpdated(unreadCount, false);
         }
 
         dispatch(setActiveModalId());


### PR DESCRIPTION
Previously was always true even when closing

Deals with [https://github.com/jitsi/jitsi-meet/issues/9262](https://github.com/jitsi/jitsi-meet/issues/9262)

The close chat action that replaced the toggle always fired the chatUpdated with isOpen as true, meaning it was unusable to detect if chat was open or not.

Apologies if I've missed something here, I don't have the environment to run this and try it out.
