### PR TITLE
fix(i18n): LocaleDetector should consider the language tag

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
@@ -47,7 +47,7 @@ class LocaleDetector extends ReactContextBaseJavaModule {
     public Map<String, Object> getConstants() {
         Context context = getReactApplicationContext();
         HashMap<String,Object> constants = new HashMap<>();
-        constants.put("locale", context.getResources().getConfiguration().locale.toString());
+        constants.put("locale", context.getResources().getConfiguration().locale.toLanguageTag());
         return constants;
     }
 

--- a/react/features/base/i18n/languageDetector.native.js
+++ b/react/features/base/i18n/languageDetector.native.js
@@ -20,8 +20,17 @@ export default {
 
     detect() {
         const { LocaleDetector } = NativeModules;
-        const [ lang, region ] = LocaleDetector.locale.replace(/_/, '-').split('-');
-        const locale = `${lang}${region}`;
+        const parts = LocaleDetector.locale.replace(/_/, '-').split('-');
+        const [ lang, regionOrScript, region ] = parts;
+        let locale;
+
+        if (parts.length >= 3) {
+            locale = `${lang}${region}`;
+        } else if (parts.length === 2) {
+            locale = `${lang}${regionOrScript}`;
+        } else {
+            locale = lang;
+        }
 
         if (LANGUAGES.includes(locale)) {
             return locale;


### PR DESCRIPTION
LocaleDetector should consider the language script tag.

* For the language tag format of iOS, please refers the following link:
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html

* For the language tag format of Android, please refers the following link:
https://developer.android.com/reference/java/util/Locale#toLanguageTag()