### PR TITLE
Fixed the issue #9354

### DIFF
--- a/react/features/base/media/components/AbstractVideoTrack.js
+++ b/react/features/base/media/components/AbstractVideoTrack.js
@@ -102,14 +102,7 @@ export default class AbstractVideoTrack<P: Props> extends Component<P> {
 
         const stream = render && videoTrack
             ? videoTrack.jitsiTrack.getOriginalStream() : null;
-
-        // Actual zoom is currently only enabled if the stream is a desktop
-        // stream.
-        const zoomEnabled
-            = this.props.zoomEnabled
-                && stream
-                && videoTrack
-                && videoTrack.videoType === 'desktop';
+        const zoomEnabled = true;
 
         return (
             <Video


### PR DESCRIPTION
The jitsimeet mobile app was scaling the participant video and this was casing the video edged to be clipped off.
This fix will ensure that the participant video in jitsi-meet mobile app maintains its aspect ratio.