### PR TITLE
fix(DeviceSelection): Remove video from mobile Safari

### DIFF
--- a/css/modals/device-selection/_device-selection.scss
+++ b/css/modals/device-selection/_device-selection.scss
@@ -129,3 +129,20 @@
         }
     }
 }
+
+.device-selection.video-hidden {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    .column-selectors {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .column-video {
+        order: 1;
+        width: 100%;
+        margin-top: 8px;
+    }
+}

--- a/react/features/device-selection/functions.js
+++ b/react/features/device-selection/functions.js
@@ -13,6 +13,7 @@ import {
     setAudioOutputDeviceId,
     setVideoInputDevice
 } from '../base/devices';
+import { isIosMobileBrowser } from '../base/environment/utils';
 import JitsiMeetJS from '../base/lib-jitsi-meet';
 import { toState } from '../base/redux';
 import {
@@ -33,6 +34,7 @@ export function getDeviceSelectionDialogProps(stateful: Object | Function) {
     const settings = state['features/base/settings'];
     const { conference } = state['features/base/conference'];
     const { permissions } = state['features/base/devices'];
+    const isMobileSafari = isIosMobileBrowser();
     let disableAudioInputChange = !JitsiMeetJS.mediaDevices.isMultipleAudioInputSupported();
     let selectedAudioInputId = settings.micDeviceId;
     let selectedAudioOutputId = getAudioOutputDeviceId();
@@ -62,6 +64,8 @@ export function getDeviceSelectionDialogProps(stateful: Object | Function) {
             !JitsiMeetJS.isCollectingLocalStats(),
         hideAudioOutputSelect: !JitsiMeetJS.mediaDevices
                             .isDeviceChangeAvailable('output'),
+        hideVideoInputPreview: isMobileSafari,
+        hideVideoOutputSelect: isMobileSafari,
         selectedAudioInputId,
         selectedAudioOutputId,
         selectedVideoInputId


### PR DESCRIPTION
Prevents creation of multiple video tracks when opening the settings dialog on iOS Safari.

The new dialog would look like:

<img width="367" alt="Screenshot 2021-06-08 at 15 07 49" src="https://user-images.githubusercontent.com/52234168/121204167-5eb11f00-c87f-11eb-8e9d-29a4c11db583.png">
