### PR TITLE
feat(api) allow always hiding remote videos for 1-1 calls

### DIFF
--- a/config.js
+++ b/config.js
@@ -392,7 +392,9 @@ var config = {
     // enableClosePage: false,
 
     // Disable hiding of remote thumbnails when in a 1-on-1 conference call.
-    // disable1On1Mode: false,
+    // Setting this to null, will also disable showing the remote videos
+    // when the toolbar is shown on mouse movements
+    // disable1On1Mode: null | false | true,
 
     // Default language for the user interface.
     // defaultLanguage: 'en',

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -66,6 +66,7 @@ export function shouldRemoteVideosBeVisible(state: Object) {
     // in the filmstrip.
     const participantCount = getParticipantCountWithFake(state);
     let pinnedParticipant;
+    const { disable1On1Mode } = state['features/base/config'];
 
     return Boolean(
         participantCount > 2
@@ -73,11 +74,12 @@ export function shouldRemoteVideosBeVisible(state: Object) {
             // Always show the filmstrip when there is another participant to
             // show and the  local video is pinned, or the toolbar is displayed.
             || (participantCount > 1
+                && disable1On1Mode !== null
                 && (state['features/toolbox'].visible
                     || ((pinnedParticipant = getPinnedParticipant(state))
                         && pinnedParticipant.local)))
 
-            || state['features/base/config'].disable1On1Mode);
+            || disable1On1Mode);
 }
 
 /**


### PR DESCRIPTION
JaaS customer wants remote videos to always be disabled for 1-1 calls.

We already have a config flag, disable1On1Mode, which was used for this exact behaviour, with the exception being that whenever the toolbox is shown on mouse movement / local participant is pinned, the remote video would also be shown regardless of having the above flag set to false.

In order to avoid adding another flag just to prevent this behaviour, I thought it would be better if users would simply make use of the existing disable1On1Mode and explicitly set it to null rather than false, in order to have the remote videos be always hidden 
