### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#8057f12a3990dff2cc5c67e1dc3a42e5fdbe4233",
-      "from": "github:jitsi/lib-jitsi-meet#8057f12a3990dff2cc5c67e1dc3a42e5fdbe4233",
+      "version": "github:jitsi/lib-jitsi-meet#2259d4418574841a782e98df27c44370bb84df45",
+      "from": "github:jitsi/lib-jitsi-meet#2259d4418574841a782e98df27c44370bb84df45",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#8057f12a3990dff2cc5c67e1dc3a42e5fdbe4233",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#2259d4418574841a782e98df27c44370bb84df45",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): fix local resolution/fps stats. Browsers do not generate a 'msid' attribute for ssrcs in unified plan mode, use mediaType as a key for the TrackSSRCInfo map.
* fix(recording): Send participant id when recording starts/stops (#1632)

https://github.com/jitsi/lib-jitsi-meet/compare/8057f12a3990dff2cc5c67e1dc3a42e5fdbe4233...2259d4418574841a782e98df27c44370bb84df45

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
