### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#fad985e95a9e8a4fb8a1b8b1ad2cfef75370c866",
-      "from": "github:jitsi/lib-jitsi-meet#fad985e95a9e8a4fb8a1b8b1ad2cfef75370c866",
+      "version": "github:jitsi/lib-jitsi-meet#d5e60583b8c1702ef97b1a3b957e2012aa91d538",
+      "from": "github:jitsi/lib-jitsi-meet#d5e60583b8c1702ef97b1a3b957e2012aa91d538",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",
@@ -15892,9 +15892,9 @@
       }
     },
     "sdp": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.2.tgz",
-      "integrity": "sha512-boRjiof+/Ca8kq0dFgHTs9HD3/a5rCAJLDCi9DTFyTq+PerwPXkffVgAyLWAL0KGp9ZpkH1o8GV+vz8UehdPBQ=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
+      "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A=="
     },
     "sdp-transform": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#fad985e95a9e8a4fb8a1b8b1ad2cfef75370c866",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#d5e60583b8c1702ef97b1a3b957e2012aa91d538",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): Filter ssrcs differently while extracting the SSRC map from SDP. Use 'msid' for plan-b clients and 'cname' for unified-plan clients.

https://github.com/jitsi/lib-jitsi-meet/compare/fad985e95a9e8a4fb8a1b8b1ad2cfef75370c866...d5e60583b8c1702ef97b1a3b957e2012aa91d538

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
