### PR TITLE
fix(toolbox) fix for #9380

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -626,6 +626,13 @@ class Toolbox extends Component<Props> {
                 enable: !this.props._chatOpen
             }));
 
+        // Checks if there was any text selected by the user.
+        // Used for when we press simultaneously keys for copying
+        // text messages from the chat board
+        if (window.getSelection().toString() !== '') {
+            return false;
+        }
+
         this._doToggleChat();
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

This fixes the issue with toggling the chat when trying to copy messages by using the keyboard shortcut mixed with other keys. 
-->
