### PR TITLE
feat(config) add flag to enable/disable remote muting in native app.

### DIFF
--- a/react/features/base/flags/constants.js
+++ b/react/features/base/flags/constants.js
@@ -99,6 +99,12 @@ export const IOS_SCREENSHARING_ENABLED = 'ios.screensharing.enabled';
 export const KICK_OUT_ENABLED = 'kick-out.enabled';
 
 /**
+ * Flag indicating if remote mute and "Mute Everyone Else" is enabled.
+ * Default: enabled (true).
+ */
+export const REMOTE_MUTE_ENABLED = 'remote-mute.enabled';
+
+/**
  * Flag indicating if live-streaming should be enabled.
  * Default: auto-detected.
  */

--- a/react/features/video-menu/components/native/RemoteVideoMenu.js
+++ b/react/features/video-menu/components/native/RemoteVideoMenu.js
@@ -6,7 +6,7 @@ import { Text, View } from 'react-native';
 import { Avatar } from '../../../base/avatar';
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { BottomSheet, isDialogOpen } from '../../../base/dialog';
-import { KICK_OUT_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { KICK_OUT_ENABLED, REMOTE_MUTE_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { getParticipantDisplayName } from '../../../base/participants';
 import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
@@ -111,7 +111,7 @@ class RemoteVideoMenu extends PureComponent<Props> {
                 { !_disableGrantModerator && <GrantModeratorButton { ...buttonProps } /> }
                 <PinButton { ...buttonProps } />
                 <PrivateMessageButton { ...buttonProps } />
-                <MuteEveryoneElseButton { ...buttonProps } />
+                { !_disableRemoteMute && <MuteEveryoneElseButton { ...buttonProps } /> }
                 <ConnectionStatusButton { ...buttonProps } />
             </BottomSheet>
         );
@@ -171,11 +171,13 @@ class RemoteVideoMenu extends PureComponent<Props> {
  */
 function _mapStateToProps(state, ownProps) {
     const kickOutEnabled = getFeatureFlag(state, KICK_OUT_ENABLED, true);
+    const remoteMuteEnabled = getFeatureFlag(state, REMOTE_MUTE_ENABLED, true);
     const { participant } = ownProps;
-    const { remoteVideoMenu = {}, disableRemoteMute } = state['features/base/config'];
+    let { remoteVideoMenu = {}, disableRemoteMute } = state['features/base/config'];
     let { disableKick } = remoteVideoMenu;
 
     disableKick = disableKick || !kickOutEnabled;
+    disableRemoteMute = disableRemoteMute || !remoteMuteEnabled;
 
     return {
         _bottomSheetStyles: ColorSchemeRegistry.get(state, 'BottomSheet'),


### PR DESCRIPTION
Added flag to enable/disable remote muting option in Remote Video Menu for native SDKs. Note that the flag affects displaying both "Mute" and "Mute Everyone Else" options on the remote video menu for native apps.

Closes #8181