### PR TITLE
(fix): Do not allow external css customization for static prejoin

### DIFF
--- a/static/prejoin.html
+++ b/static/prejoin.html
@@ -16,10 +16,6 @@
           const showAvatar = params.get('showAvatar') === 'true';
           const showJoinActions = params.get('showJoinActions') === 'true';
           const showSkipPrejoin = params.get('showSkipPrejoin') === 'true';
-          const css = params.get('style');
-          const style = document.createElement('style');
-          style.appendChild(document.createTextNode(css));
-          document.head.appendChild(style);
 
           JitsiMeetJS.app.renderEntryPoint({
               Component: JitsiMeetJS.app.entryPoints.PREJOIN,


### PR DESCRIPTION
This prevents CSS spoofing.

