### PR TITLE
chore(replace-participant) Send `readyToClose` event when a replaced …

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2186,6 +2186,10 @@ export default {
                     id: localParticipant.id,
                     isReplaced
                 }));
+
+                // we send readyToClose when kicked participant is replace so that
+                // embedding app can choose to dispose the iframe API on the handler.
+                APP.API.notifyReadyToClose();
             }
             APP.store.dispatch(kickedOut(room, participant));
         });


### PR DESCRIPTION
…participant is kicked

- the embedding app can decide to dispose the iframe in this case
