### PR TITLE
feat(external_api): Control participant pane to show or hide using custom button based on #9490

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -397,7 +397,7 @@ function initCommands() {
                 return;
             }
 
-            if (![ JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM ].includes(mode)) {
+            if (![JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM].includes(mode)) {
                 logger.error('Invalid recording mode provided!');
 
                 return;
@@ -460,96 +460,96 @@ function initCommands() {
         const { name } = request;
 
         switch (name) {
-        case 'capture-largevideo-screenshot' :
-            APP.store.dispatch(captureLargeVideoScreenshot())
-                .then(dataURL => {
-                    let error;
+            case 'capture-largevideo-screenshot':
+                APP.store.dispatch(captureLargeVideoScreenshot())
+                    .then(dataURL => {
+                        let error;
 
-                    if (!dataURL) {
-                        error = new Error('No large video found!');
-                    }
+                        if (!dataURL) {
+                            error = new Error('No large video found!');
+                        }
 
-                    callback({
-                        error,
-                        dataURL
+                        callback({
+                            error,
+                            dataURL
+                        });
                     });
-                });
-            break;
-        case 'invite': {
-            const { invitees } = request;
+                break;
+            case 'invite': {
+                const { invitees } = request;
 
-            if (!Array.isArray(invitees) || invitees.length === 0) {
-                callback({
-                    error: new Error('Unexpected format of invitees')
-                });
+                if (!Array.isArray(invitees) || invitees.length === 0) {
+                    callback({
+                        error: new Error('Unexpected format of invitees')
+                    });
 
+                    break;
+                }
+
+                // The store should be already available because API.init is called
+                // on appWillMount action.
+                APP.store.dispatch(
+                    invite(invitees, true))
+                    .then(failedInvitees => {
+                        let error;
+                        let result;
+
+                        if (failedInvitees.length) {
+                            error = new Error('One or more invites failed!');
+                        } else {
+                            result = true;
+                        }
+
+                        callback({
+                            error,
+                            result
+                        });
+                    });
                 break;
             }
+            case 'is-audio-muted':
+                callback(APP.conference.isLocalAudioMuted());
+                break;
+            case 'is-video-muted':
+                callback(APP.conference.isLocalVideoMuted());
+                break;
+            case 'is-audio-available':
+                callback(audioAvailable);
+                break;
+            case 'is-video-available':
+                callback(videoAvailable);
+                break;
+            case 'is-sharing-screen':
+                callback(Boolean(APP.conference.isSharingScreen));
+                break;
+            case 'get-content-sharing-participants': {
+                const tracks = getState()['features/base/tracks'];
+                const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
 
-            // The store should be already available because API.init is called
-            // on appWillMount action.
-            APP.store.dispatch(
-                invite(invitees, true))
-                .then(failedInvitees => {
-                    let error;
-                    let result;
-
-                    if (failedInvitees.length) {
-                        error = new Error('One or more invites failed!');
-                    } else {
-                        result = true;
-                    }
-
-                    callback({
-                        error,
-                        result
-                    });
+                callback({
+                    sharingParticipantIds
                 });
-            break;
-        }
-        case 'is-audio-muted':
-            callback(APP.conference.isLocalAudioMuted());
-            break;
-        case 'is-video-muted':
-            callback(APP.conference.isLocalVideoMuted());
-            break;
-        case 'is-audio-available':
-            callback(audioAvailable);
-            break;
-        case 'is-video-available':
-            callback(videoAvailable);
-            break;
-        case 'is-sharing-screen':
-            callback(Boolean(APP.conference.isSharingScreen));
-            break;
-        case 'get-content-sharing-participants': {
-            const tracks = getState()['features/base/tracks'];
-            const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
-
-            callback({
-                sharingParticipantIds
-            });
-            break;
-        }
-        case 'get-livestream-url': {
-            const state = APP.store.getState();
-            const conference = getCurrentConference(state);
-            let livestreamUrl;
-
-            if (conference) {
-                const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
-
-                livestreamUrl = activeSession?.liveStreamViewURL;
-            } else {
-                logger.error('Conference is not defined');
+                break;
             }
-            callback({
-                livestreamUrl
-            });
-            break;
-        }
-        default:
-            return false;
+            case 'get-livestream-url': {
+                const state = APP.store.getState();
+                const conference = getCurrentConference(state);
+                let livestreamUrl;
+
+                if (conference) {
+                    const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
+
+                    livestreamUrl = activeSession?.liveStreamViewURL;
+                } else {
+                    logger.error('Conference is not defined');
+                }
+                callback({
+                    livestreamUrl
+                });
+                break;
+            }
+            default:
+                return false;
         }
 
         return true;
@@ -565,12 +565,12 @@ function shouldBeEnabled() {
     return (
         typeof API_ID === 'number'
 
-            // XXX Enable the API when a JSON Web Token (JWT) is specified in
-            // the location/URL because then it is very likely that the Jitsi
-            // Meet (Web) app is being used by an external/wrapping (Web) app
-            // and, consequently, the latter will need to communicate with the
-            // former. (The described logic is merely a heuristic though.)
-            || parseJWTFromURLParams());
+        // XXX Enable the API when a JSON Web Token (JWT) is specified in
+        // the location/URL because then it is very likely that the Jitsi
+        // Meet (Web) app is being used by an external/wrapping (Web) app
+        // and, consequently, the latter will need to communicate with the
+        // former. (The described logic is merely a heuristic though.)
+        || parseJWTFromURLParams());
 }
 
 /**
@@ -791,9 +791,9 @@ class API {
      * @returns {void}
      */
     notifyReceivedChatMessage(
-            { body, id, nick, privateMessage, ts }: {
-                body: *, id: string, nick: string, privateMessage: boolean, ts: *
-            } = {}) {
+        { body, id, nick, privateMessage, ts }: {
+            body: *, id: string, nick: string, privateMessage: boolean, ts: *
+        } = {}) {
         if (APP.conference.isLocalId(id)) {
             return;
         }
@@ -922,8 +922,8 @@ class API {
      * @returns {void}
      */
     notifyDisplayNameChanged(
-            id: string,
-            { displayName, formattedDisplayName }: Object) {
+        id: string,
+        { displayName, formattedDisplayName }: Object) {
         this._sendEvent({
             name: 'display-name-change',
             displayname: displayName,
@@ -941,8 +941,8 @@ class API {
      * @returns {void}
      */
     notifyEmailChanged(
-            id: string,
-            { email }: Object) {
+        id: string,
+        { email }: Object) {
         this._sendEvent({
             name: 'email-change',
             email,
@@ -1292,6 +1292,19 @@ class API {
             on,
             mode,
             error
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that participant pane is hidden or showing.
+     *
+     * @param {boolean} enabled - True if participant pane is showing, false otherwise.
+     * @returns {void}
+     */
+    notifyShowParticipantList(enabled: boolean) {
+        this._sendEvent({
+            name: "show-participant-list",
+            enabled,
         });
     }
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -397,7 +397,7 @@ function initCommands() {
                 return;
             }
 
-            if (![JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM].includes(mode)) {
+            if (![ JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM ].includes(mode)) {
                 logger.error('Invalid recording mode provided!');
 
                 return;
@@ -460,96 +460,96 @@ function initCommands() {
         const { name } = request;
 
         switch (name) {
-            case 'capture-largevideo-screenshot':
-                APP.store.dispatch(captureLargeVideoScreenshot())
-                    .then(dataURL => {
-                        let error;
+        case 'capture-largevideo-screenshot' :
+            APP.store.dispatch(captureLargeVideoScreenshot())
+                .then(dataURL => {
+                    let error;
 
-                        if (!dataURL) {
-                            error = new Error('No large video found!');
-                        }
+                    if (!dataURL) {
+                        error = new Error('No large video found!');
+                    }
 
-                        callback({
-                            error,
-                            dataURL
-                        });
-                    });
-                break;
-            case 'invite': {
-                const { invitees } = request;
-
-                if (!Array.isArray(invitees) || invitees.length === 0) {
                     callback({
-                        error: new Error('Unexpected format of invitees')
+                        error,
+                        dataURL
                     });
+                });
+            break;
+        case 'invite': {
+            const { invitees } = request;
 
-                    break;
-                }
+            if (!Array.isArray(invitees) || invitees.length === 0) {
+                callback({
+                    error: new Error('Unexpected format of invitees')
+                });
 
-                // The store should be already available because API.init is called
-                // on appWillMount action.
-                APP.store.dispatch(
-                    invite(invitees, true))
-                    .then(failedInvitees => {
-                        let error;
-                        let result;
+                break;
+            }
 
-                        if (failedInvitees.length) {
-                            error = new Error('One or more invites failed!');
-                        } else {
-                            result = true;
-                        }
+            // The store should be already available because API.init is called
+            // on appWillMount action.
+            APP.store.dispatch(
+                invite(invitees, true))
+                .then(failedInvitees => {
+                    let error;
+                    let result;
 
-                        callback({
-                            error,
-                            result
-                        });
+                    if (failedInvitees.length) {
+                        error = new Error('One or more invites failed!');
+                    } else {
+                        result = true;
+                    }
+
+                    callback({
+                        error,
+                        result
                     });
-                break;
-            }
-            case 'is-audio-muted':
-                callback(APP.conference.isLocalAudioMuted());
-                break;
-            case 'is-video-muted':
-                callback(APP.conference.isLocalVideoMuted());
-                break;
-            case 'is-audio-available':
-                callback(audioAvailable);
-                break;
-            case 'is-video-available':
-                callback(videoAvailable);
-                break;
-            case 'is-sharing-screen':
-                callback(Boolean(APP.conference.isSharingScreen));
-                break;
-            case 'get-content-sharing-participants': {
-                const tracks = getState()['features/base/tracks'];
-                const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
-
-                callback({
-                    sharingParticipantIds
                 });
-                break;
-            }
-            case 'get-livestream-url': {
-                const state = APP.store.getState();
-                const conference = getCurrentConference(state);
-                let livestreamUrl;
+            break;
+        }
+        case 'is-audio-muted':
+            callback(APP.conference.isLocalAudioMuted());
+            break;
+        case 'is-video-muted':
+            callback(APP.conference.isLocalVideoMuted());
+            break;
+        case 'is-audio-available':
+            callback(audioAvailable);
+            break;
+        case 'is-video-available':
+            callback(videoAvailable);
+            break;
+        case 'is-sharing-screen':
+            callback(Boolean(APP.conference.isSharingScreen));
+            break;
+        case 'get-content-sharing-participants': {
+            const tracks = getState()['features/base/tracks'];
+            const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
 
-                if (conference) {
-                    const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
+            callback({
+                sharingParticipantIds
+            });
+            break;
+        }
+        case 'get-livestream-url': {
+            const state = APP.store.getState();
+            const conference = getCurrentConference(state);
+            let livestreamUrl;
 
-                    livestreamUrl = activeSession?.liveStreamViewURL;
-                } else {
-                    logger.error('Conference is not defined');
-                }
-                callback({
-                    livestreamUrl
-                });
-                break;
+            if (conference) {
+                const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
+
+                livestreamUrl = activeSession?.liveStreamViewURL;
+            } else {
+                logger.error('Conference is not defined');
             }
-            default:
-                return false;
+            callback({
+                livestreamUrl
+            });
+            break;
+        }
+        default:
+            return false;
         }
 
         return true;
@@ -565,12 +565,12 @@ function shouldBeEnabled() {
     return (
         typeof API_ID === 'number'
 
-        // XXX Enable the API when a JSON Web Token (JWT) is specified in
-        // the location/URL because then it is very likely that the Jitsi
-        // Meet (Web) app is being used by an external/wrapping (Web) app
-        // and, consequently, the latter will need to communicate with the
-        // former. (The described logic is merely a heuristic though.)
-        || parseJWTFromURLParams());
+            // XXX Enable the API when a JSON Web Token (JWT) is specified in
+            // the location/URL because then it is very likely that the Jitsi
+            // Meet (Web) app is being used by an external/wrapping (Web) app
+            // and, consequently, the latter will need to communicate with the
+            // former. (The described logic is merely a heuristic though.)
+            || parseJWTFromURLParams());
 }
 
 /**
@@ -791,9 +791,9 @@ class API {
      * @returns {void}
      */
     notifyReceivedChatMessage(
-        { body, id, nick, privateMessage, ts }: {
-            body: *, id: string, nick: string, privateMessage: boolean, ts: *
-        } = {}) {
+            { body, id, nick, privateMessage, ts }: {
+                body: *, id: string, nick: string, privateMessage: boolean, ts: *
+            } = {}) {
         if (APP.conference.isLocalId(id)) {
             return;
         }
@@ -922,8 +922,8 @@ class API {
      * @returns {void}
      */
     notifyDisplayNameChanged(
-        id: string,
-        { displayName, formattedDisplayName }: Object) {
+            id: string,
+            { displayName, formattedDisplayName }: Object) {
         this._sendEvent({
             name: 'display-name-change',
             displayname: displayName,
@@ -941,8 +941,8 @@ class API {
      * @returns {void}
      */
     notifyEmailChanged(
-        id: string,
-        { email }: Object) {
+            id: string,
+            { email }: Object) {
         this._sendEvent({
             name: 'email-change',
             email,
@@ -1301,13 +1301,13 @@ class API {
      * @param {boolean} enabled - True if participant pane is showing, false otherwise.
      * @returns {void}
      */
-    notifyShowParticipantList(enabled: boolean) {
+     notifyShowParticipantList(enabled: boolean) {
         this._sendEvent({
             name: "show-participant-list",
             enabled,
         });
     }
-
+    
     /**
      * Disposes the allocated resources.
      *

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -98,6 +98,7 @@ const events = {
     'proxy-connection-event': 'proxyConnectionEvent',
     'raise-hand-updated': 'raiseHandUpdated',
     'recording-status-changed': 'recordingStatusChanged',
+    'show-participant-list': 'showParticipantList',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',
@@ -167,37 +168,37 @@ function parseArguments(args) {
     const firstArg = args[0];
 
     switch (typeof firstArg) {
-    case 'string': // old arguments format
-    case undefined: {
-        // Not sure which format but we are trying to parse the old
-        // format because if the new format is used everything will be undefined
-        // anyway.
-        const [
-            roomName,
-            width,
-            height,
-            parentNode,
-            configOverwrite,
-            interfaceConfigOverwrite,
-            jwt,
-            onload
-        ] = args;
+        case 'string': // old arguments format
+        case undefined: {
+            // Not sure which format but we are trying to parse the old
+            // format because if the new format is used everything will be undefined
+            // anyway.
+            const [
+                roomName,
+                width,
+                height,
+                parentNode,
+                configOverwrite,
+                interfaceConfigOverwrite,
+                jwt,
+                onload
+            ] = args;
 
-        return {
-            roomName,
-            width,
-            height,
-            parentNode,
-            configOverwrite,
-            interfaceConfigOverwrite,
-            jwt,
-            onload
-        };
-    }
-    case 'object': // new arguments format
-        return args[0];
-    default:
-        throw new Error('Can\'t parse the arguments!');
+            return {
+                roomName,
+                width,
+                height,
+                parentNode,
+                configOverwrite,
+                interfaceConfigOverwrite,
+                jwt,
+                onload
+            };
+        }
+        case 'object': // new arguments format
+            return args[0];
+        default:
+            throw new Error('Can\'t parse the arguments!');
     }
 }
 
@@ -406,9 +407,9 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const iframe = this.getIFrame();
 
         if (!this._isLargeVideoVisible
-                || !iframe
-                || !iframe.contentWindow
-                || !iframe.contentWindow.document) {
+            || !iframe
+            || !iframe.contentWindow
+            || !iframe.contentWindow.document) {
             return;
         }
 
@@ -427,8 +428,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const iframe = this.getIFrame();
 
         if (!iframe
-                || !iframe.contentWindow
-                || !iframe.contentWindow.document) {
+            || !iframe.contentWindow
+            || !iframe.contentWindow.document) {
             return;
         }
 
@@ -475,76 +476,76 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             const userID = data.id;
 
             switch (name) {
-            case 'video-conference-joined': {
-                if (typeof this._tmpE2EEKey !== 'undefined') {
-                    this.executeCommand(commands.e2eeKey, this._tmpE2EEKey);
-                    this._tmpE2EEKey = undefined;
+                case 'video-conference-joined': {
+                    if (typeof this._tmpE2EEKey !== 'undefined') {
+                        this.executeCommand(commands.e2eeKey, this._tmpE2EEKey);
+                        this._tmpE2EEKey = undefined;
+                    }
+
+                    this._myUserID = userID;
+                    this._participants[userID] = {
+                        avatarURL: data.avatarURL
+                    };
                 }
 
-                this._myUserID = userID;
-                this._participants[userID] = {
-                    avatarURL: data.avatarURL
-                };
-            }
-
-            // eslint-disable-next-line no-fallthrough
-            case 'participant-joined': {
-                this._participants[userID] = this._participants[userID] || {};
-                this._participants[userID].displayName = data.displayName;
-                this._participants[userID].formattedDisplayName
-                    = data.formattedDisplayName;
-                changeParticipantNumber(this, 1);
-                break;
-            }
-            case 'participant-left':
-                changeParticipantNumber(this, -1);
-                delete this._participants[userID];
-                break;
-            case 'display-name-change': {
-                const user = this._participants[userID];
-
-                if (user) {
-                    user.displayName = data.displayname;
-                    user.formattedDisplayName = data.formattedDisplayName;
+                // eslint-disable-next-line no-fallthrough
+                case 'participant-joined': {
+                    this._participants[userID] = this._participants[userID] || {};
+                    this._participants[userID].displayName = data.displayName;
+                    this._participants[userID].formattedDisplayName
+                        = data.formattedDisplayName;
+                    changeParticipantNumber(this, 1);
+                    break;
                 }
-                break;
-            }
-            case 'email-change': {
-                const user = this._participants[userID];
+                case 'participant-left':
+                    changeParticipantNumber(this, -1);
+                    delete this._participants[userID];
+                    break;
+                case 'display-name-change': {
+                    const user = this._participants[userID];
 
-                if (user) {
-                    user.email = data.email;
+                    if (user) {
+                        user.displayName = data.displayname;
+                        user.formattedDisplayName = data.formattedDisplayName;
+                    }
+                    break;
                 }
-                break;
-            }
-            case 'avatar-changed': {
-                const user = this._participants[userID];
+                case 'email-change': {
+                    const user = this._participants[userID];
 
-                if (user) {
-                    user.avatarURL = data.avatarURL;
+                    if (user) {
+                        user.email = data.email;
+                    }
+                    break;
                 }
-                break;
-            }
-            case 'on-stage-participant-changed':
-                this._onStageParticipant = userID;
-                this.emit('largeVideoChanged');
-                break;
-            case 'large-video-visibility-changed':
-                this._isLargeVideoVisible = data.isVisible;
-                this.emit('largeVideoChanged');
-                break;
-            case 'video-conference-left':
-                changeParticipantNumber(this, -1);
-                delete this._participants[this._myUserID];
-                break;
-            case 'video-quality-changed':
-                this._videoQuality = data.videoQuality;
-                break;
-            case 'local-storage-changed':
-                jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
+                case 'avatar-changed': {
+                    const user = this._participants[userID];
 
-                // Since this is internal event we don't need to emit it to the consumer of the API.
-                return true;
+                    if (user) {
+                        user.avatarURL = data.avatarURL;
+                    }
+                    break;
+                }
+                case 'on-stage-participant-changed':
+                    this._onStageParticipant = userID;
+                    this.emit('largeVideoChanged');
+                    break;
+                case 'large-video-visibility-changed':
+                    this._isLargeVideoVisible = data.isVisible;
+                    this.emit('largeVideoChanged');
+                    break;
+                case 'video-conference-left':
+                    changeParticipantNumber(this, -1);
+                    delete this._participants[this._myUserID];
+                    break;
+                case 'video-quality-changed':
+                    this._videoQuality = data.videoQuality;
+                    break;
+                case 'local-storage-changed':
+                    jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
+
+                    // Since this is internal event we don't need to emit it to the consumer of the API.
+                    return true;
             }
 
             const eventName = events[name];
@@ -1032,7 +1033,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      */
     sendProxyConnectionEvent(event) {
         this._transport.sendEvent({
-            data: [ event ],
+            data: [event],
             name: 'proxy-connection-event'
         });
     }

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -168,37 +168,37 @@ function parseArguments(args) {
     const firstArg = args[0];
 
     switch (typeof firstArg) {
-        case 'string': // old arguments format
-        case undefined: {
-            // Not sure which format but we are trying to parse the old
-            // format because if the new format is used everything will be undefined
-            // anyway.
-            const [
-                roomName,
-                width,
-                height,
-                parentNode,
-                configOverwrite,
-                interfaceConfigOverwrite,
-                jwt,
-                onload
-            ] = args;
+    case 'string': // old arguments format
+    case undefined: {
+        // Not sure which format but we are trying to parse the old
+        // format because if the new format is used everything will be undefined
+        // anyway.
+        const [
+            roomName,
+            width,
+            height,
+            parentNode,
+            configOverwrite,
+            interfaceConfigOverwrite,
+            jwt,
+            onload
+        ] = args;
 
-            return {
-                roomName,
-                width,
-                height,
-                parentNode,
-                configOverwrite,
-                interfaceConfigOverwrite,
-                jwt,
-                onload
-            };
-        }
-        case 'object': // new arguments format
-            return args[0];
-        default:
-            throw new Error('Can\'t parse the arguments!');
+        return {
+            roomName,
+            width,
+            height,
+            parentNode,
+            configOverwrite,
+            interfaceConfigOverwrite,
+            jwt,
+            onload
+        };
+    }
+    case 'object': // new arguments format
+        return args[0];
+    default:
+        throw new Error('Can\'t parse the arguments!');
     }
 }
 
@@ -407,9 +407,9 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const iframe = this.getIFrame();
 
         if (!this._isLargeVideoVisible
-            || !iframe
-            || !iframe.contentWindow
-            || !iframe.contentWindow.document) {
+                || !iframe
+                || !iframe.contentWindow
+                || !iframe.contentWindow.document) {
             return;
         }
 
@@ -428,8 +428,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const iframe = this.getIFrame();
 
         if (!iframe
-            || !iframe.contentWindow
-            || !iframe.contentWindow.document) {
+                || !iframe.contentWindow
+                || !iframe.contentWindow.document) {
             return;
         }
 
@@ -476,76 +476,76 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             const userID = data.id;
 
             switch (name) {
-                case 'video-conference-joined': {
-                    if (typeof this._tmpE2EEKey !== 'undefined') {
-                        this.executeCommand(commands.e2eeKey, this._tmpE2EEKey);
-                        this._tmpE2EEKey = undefined;
-                    }
-
-                    this._myUserID = userID;
-                    this._participants[userID] = {
-                        avatarURL: data.avatarURL
-                    };
+            case 'video-conference-joined': {
+                if (typeof this._tmpE2EEKey !== 'undefined') {
+                    this.executeCommand(commands.e2eeKey, this._tmpE2EEKey);
+                    this._tmpE2EEKey = undefined;
                 }
 
-                // eslint-disable-next-line no-fallthrough
-                case 'participant-joined': {
-                    this._participants[userID] = this._participants[userID] || {};
-                    this._participants[userID].displayName = data.displayName;
-                    this._participants[userID].formattedDisplayName
-                        = data.formattedDisplayName;
-                    changeParticipantNumber(this, 1);
-                    break;
-                }
-                case 'participant-left':
-                    changeParticipantNumber(this, -1);
-                    delete this._participants[userID];
-                    break;
-                case 'display-name-change': {
-                    const user = this._participants[userID];
+                this._myUserID = userID;
+                this._participants[userID] = {
+                    avatarURL: data.avatarURL
+                };
+            }
 
-                    if (user) {
-                        user.displayName = data.displayname;
-                        user.formattedDisplayName = data.formattedDisplayName;
-                    }
-                    break;
-                }
-                case 'email-change': {
-                    const user = this._participants[userID];
+            // eslint-disable-next-line no-fallthrough
+            case 'participant-joined': {
+                this._participants[userID] = this._participants[userID] || {};
+                this._participants[userID].displayName = data.displayName;
+                this._participants[userID].formattedDisplayName
+                    = data.formattedDisplayName;
+                changeParticipantNumber(this, 1);
+                break;
+            }
+            case 'participant-left':
+                changeParticipantNumber(this, -1);
+                delete this._participants[userID];
+                break;
+            case 'display-name-change': {
+                const user = this._participants[userID];
 
-                    if (user) {
-                        user.email = data.email;
-                    }
-                    break;
+                if (user) {
+                    user.displayName = data.displayname;
+                    user.formattedDisplayName = data.formattedDisplayName;
                 }
-                case 'avatar-changed': {
-                    const user = this._participants[userID];
+                break;
+            }
+            case 'email-change': {
+                const user = this._participants[userID];
 
-                    if (user) {
-                        user.avatarURL = data.avatarURL;
-                    }
-                    break;
+                if (user) {
+                    user.email = data.email;
                 }
-                case 'on-stage-participant-changed':
-                    this._onStageParticipant = userID;
-                    this.emit('largeVideoChanged');
-                    break;
-                case 'large-video-visibility-changed':
-                    this._isLargeVideoVisible = data.isVisible;
-                    this.emit('largeVideoChanged');
-                    break;
-                case 'video-conference-left':
-                    changeParticipantNumber(this, -1);
-                    delete this._participants[this._myUserID];
-                    break;
-                case 'video-quality-changed':
-                    this._videoQuality = data.videoQuality;
-                    break;
-                case 'local-storage-changed':
-                    jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
+                break;
+            }
+            case 'avatar-changed': {
+                const user = this._participants[userID];
 
-                    // Since this is internal event we don't need to emit it to the consumer of the API.
-                    return true;
+                if (user) {
+                    user.avatarURL = data.avatarURL;
+                }
+                break;
+            }
+            case 'on-stage-participant-changed':
+                this._onStageParticipant = userID;
+                this.emit('largeVideoChanged');
+                break;
+            case 'large-video-visibility-changed':
+                this._isLargeVideoVisible = data.isVisible;
+                this.emit('largeVideoChanged');
+                break;
+            case 'video-conference-left':
+                changeParticipantNumber(this, -1);
+                delete this._participants[this._myUserID];
+                break;
+            case 'video-quality-changed':
+                this._videoQuality = data.videoQuality;
+                break;
+            case 'local-storage-changed':
+                jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
+
+                // Since this is internal event we don't need to emit it to the consumer of the API.
+                return true;
             }
 
             const eventName = events[name];
@@ -1033,7 +1033,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      */
     sendProxyConnectionEvent(event) {
         this._transport.sendEvent({
-            data: [event],
+            data: [ event ],
             name: 'proxy-connection-event'
         });
     }


### PR DESCRIPTION
The issue with the External API was that there was no way to customize toggling of the participant pane. Here I have tested and fixed the problem by just creating an event for this job whose listener was already present.
Assume we have a button on Jitsi meet frontend that opens up a participant list on our web application. Pressing on the button should emit the event ‘show-participant-list’ and the web application listening to the event will open the participant list.

Here is how I edited the External API to achieve this functionality:

1. add key value to JSON of events _external_api.js_

`'show-participant-list': 'showParticipantList',`

2. Implement notify function on _api.js_

```
notifyShowParticipantList(enabled: boolean) {
        this._sendEvent({
            name: 'show-participant-list',
            enabled
        });
    }
```