### PR TITLE
feat(Filmstrip): Collapse filmstrip to avoid toolbar overlap on mobile

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -46,6 +46,7 @@ $menuBG:#242528;
 $newToolbarFontSize: 24px;
 $newToolbarHangupFontSize: 32px;
 $newToolbarSize: 48px;
+$newToolbarSizeMobile: 60px;
 $newToolbarSizeWithPadding: calc(#{$newToolbarSize} + 24px);
 $toolbarTitleFontSize: 19px;
 $overflowMenuItemColor: #fff;

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -35,6 +35,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
+        transition: margin-bottom .3s ease-in;
     }
 
     .filmstrip {
@@ -46,7 +47,6 @@
         position: absolute;
         top: 0;
         width: 100%;
-        transition: height .3s ease-in;
 
         @media (min-width: 581px) {
             &.shift-right {
@@ -60,8 +60,10 @@
         }
 
         &.collapse {
-            height: calc(100% - #{$newToolbarSizeMobile});
-            margin-bottom: $newToolbarSizeMobile;
+            #remoteVideos {
+                height: calc(100% - #{$newToolbarSizeMobile}) !important;
+                margin-bottom: $newToolbarSizeMobile;
+            }
 
             .remote-videos {
                 // !important is needed here as overflow is set via element.style in a FixedSizeGrid.

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -60,8 +60,8 @@
         }
 
         &.collapse {
-            height: calc(100% - #{$newToolbarSize});
-            margin-bottom: $newToolbarSize;
+            height: calc(100% - #{$newToolbarSizeMobile});
+            margin-bottom: $newToolbarSizeMobile;
         }
     }
 

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -46,6 +46,7 @@
         position: absolute;
         top: 0;
         width: 100%;
+        transition: height .3s ease-in;
 
         @media (min-width: 581px) {
             &.shift-right {
@@ -56,6 +57,11 @@
                     width: calc(100vw - #{$sidebarWidth});
                 }
             }
+        }
+
+        &.collapse {
+            height: calc(100% - #{$newToolbarSize});
+            margin-bottom: $newToolbarSize;
         }
     }
 

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -53,7 +53,7 @@
                 margin-left: $sidebarWidth;
                 width: calc(100% - #{$sidebarWidth});
 
-                .remote-videos{
+                .remote-videos {
                     width: calc(100vw - #{$sidebarWidth});
                 }
             }
@@ -62,6 +62,11 @@
         &.collapse {
             height: calc(100% - #{$newToolbarSizeMobile});
             margin-bottom: $newToolbarSizeMobile;
+
+            .remote-videos {
+                // !important is needed here as overflow is set via element.style in a FixedSizeGrid.
+                overflow: hidden auto !important;
+            }
         }
     }
 

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -18,7 +18,13 @@ import { showToolbox } from '../../../toolbox/actions.web';
 import { isButtonEnabled, isToolboxVisible } from '../../../toolbox/functions.web';
 import { LAYOUTS, getCurrentLayout } from '../../../video-layout';
 import { setFilmstripVisible, setVisibleRemoteParticipants } from '../../actions';
-import { ASPECT_RATIO_BREAKPOINT, TILE_HORIZONTAL_MARGIN, TILE_VERTICAL_MARGIN, TOOLBAR_HEIGHT } from '../../constants';
+import {
+    ASPECT_RATIO_BREAKPOINT,
+    TILE_HORIZONTAL_MARGIN,
+    TILE_VERTICAL_MARGIN,
+    TOOLBAR_HEIGHT,
+    TOOLBAR_HEIGHT_MOBILE
+} from '../../constants';
 import { shouldRemoteVideosBeVisible } from '../../functions';
 
 import AudioTracksContainer from './AudioTracksContainer';
@@ -494,7 +500,7 @@ function _mapStateToProps(state) {
     } = state['features/filmstrip'].tileViewDimensions;
     const _currentLayout = getCurrentLayout(state);
     const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
-    const filmstripOverflows = filmstripHeight >= clientHeight - TOOLBAR_HEIGHT;
+    const filmstripOverflows = (clientHeight - filmstripHeight) / 2 < TOOLBAR_HEIGHT_MOBILE;
     const collapseTileView = reduceHeight
         && filmstripOverflows
         && isMobileBrowser()
@@ -508,7 +514,7 @@ function _mapStateToProps(state) {
     switch (_currentLayout) {
     case LAYOUTS.TILE_VIEW:
         _thumbnailSize = tileViewThumbnailSize;
-        remoteFilmstripHeight = filmstripHeight - (collapseTileView ? TOOLBAR_HEIGHT : 0);
+        remoteFilmstripHeight = filmstripHeight - (collapseTileView ? TOOLBAR_HEIGHT_MOBILE : 0);
         remoteFilmstripWidth = filmstripWidth;
         break;
     case LAYOUTS.VERTICAL_FILMSTRIP_VIEW: {

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -499,12 +499,25 @@ function _mapStateToProps(state) {
         thumbnailSize: tileViewThumbnailSize
     } = state['features/filmstrip'].tileViewDimensions;
     const _currentLayout = getCurrentLayout(state);
+
     const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
-    const filmstripOverflows = (clientHeight - filmstripHeight) / 2 < TOOLBAR_HEIGHT_MOBILE;
+    const availableSpace = clientHeight - filmstripHeight;
+    let filmstripPadding = 0;
+
+    if (availableSpace > 0) {
+        const paddingValue = TOOLBAR_HEIGHT_MOBILE - availableSpace;
+
+        if (paddingValue > 0) {
+            filmstripPadding = paddingValue;
+        }
+    } else {
+        filmstripPadding = TOOLBAR_HEIGHT_MOBILE;
+    }
+
     const collapseTileView = reduceHeight
-        && filmstripOverflows
         && isMobileBrowser()
         && clientWidth <= ASPECT_RATIO_BREAKPOINT;
+
     const className = `${remoteVideosVisible ? '' : 'hide-videos'} ${
         reduceHeight ? 'reduce-height' : ''
     } ${shiftRight ? 'shift-right' : ''} ${collapseTileView ? 'collapse' : ''}`.trim();
@@ -514,7 +527,7 @@ function _mapStateToProps(state) {
     switch (_currentLayout) {
     case LAYOUTS.TILE_VIEW:
         _thumbnailSize = tileViewThumbnailSize;
-        remoteFilmstripHeight = filmstripHeight - (collapseTileView ? TOOLBAR_HEIGHT_MOBILE : 0);
+        remoteFilmstripHeight = filmstripHeight - (collapseTileView && filmstripPadding > 0 ? filmstripPadding : 0);
         remoteFilmstripWidth = filmstripWidth;
         break;
     case LAYOUTS.VERTICAL_FILMSTRIP_VIEW: {

--- a/react/features/filmstrip/constants.js
+++ b/react/features/filmstrip/constants.js
@@ -164,6 +164,11 @@ export const TILE_HORIZONTAL_MARGIN = 4;
 export const TOOLBAR_HEIGHT = 72;
 
 /**
+ * The height of the whole toolbar.
+ */
+export const TOOLBAR_HEIGHT_MOBILE = 60;
+
+/**
  * The size of the horizontal border of a thumbnail.
  *
  * @type {number}


### PR DESCRIPTION
<img width="407" alt="Screen Shot 2021-07-06 at 11 24 34" src="https://user-images.githubusercontent.com/52234168/124567646-df4a4780-de4c-11eb-832a-dc08f83117e0.png">
