### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#0cdfb79c2e7144a349edad9e9fceaa2e81c74313",
-      "from": "github:jitsi/lib-jitsi-meet#0cdfb79c2e7144a349edad9e9fceaa2e81c74313",
+      "version": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
+      "from": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#0cdfb79c2e7144a349edad9e9fceaa2e81c74313",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): Do not remove ssrcs from remote desc for p2p. In unified plan, re-use of m-line (i.e., adding an SSRC, removing it and then adding it back) causes the browser to not render the media on Chrome and Safari. The WebRTC spec is not clear as to how browsers have to behave, this doesn't cause any issues on Firefox. As a workaround, only change the media direction and leave the ssrc in the remote desc. This automatically triggers a 'removetrack' event on the associated MediaStream and the track can be removed from the UI.
* Drops old prosody versions from the tokens instructions

https://github.com/jitsi/lib-jitsi-meet/compare/0cdfb79c2e7144a349edad9e9fceaa2e81c74313...b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
