### PR TITLE
fix(Filmstrip): Fix scrollbars around filmstrip

### DIFF
--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -120,3 +120,7 @@
         }
     }
 }
+
+.indicator-icon-container {
+    display: inline-block;
+}


### PR DESCRIPTION
The spans had a larger height than intended due to the default `display: inline`, causing scrollbars in Firefox. This, together with the css changes introduced in the pagination PRs, sorts out https://github.com/jitsi/jitsi-meet/issues/8586 
