### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
-      "from": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
+      "version": "github:jitsi/lib-jitsi-meet#f974007ca6e27592625b83e38d22c6756ac286cb",
+      "from": "github:jitsi/lib-jitsi-meet#f974007ca6e27592625b83e38d22c6756ac286cb",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#f974007ca6e27592625b83e38d22c6756ac286cb",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(JingleSessionPC): Do not check if the ssrc already exists in the RD when adding a ssrc-group from source-add.
* feat: Switch to unified plan on chrome by default unless explicitly disabled.
* fix(VADAudioAnalyser): NPE error evaluating this._vadEmitter.on (#1652)
* Small fix in tokens doc.

https://github.com/jitsi/lib-jitsi-meet/compare/b43a9fa0eea73ba48d805fba97d0cd3fb9d8d07a...f974007ca6e27592625b83e38d22c6756ac286cb
