### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#89a7e2d9cdd24f48f95f6668ae4d8db1b635cf36",
-      "from": "github:jitsi/lib-jitsi-meet#89a7e2d9cdd24f48f95f6668ae4d8db1b635cf36",
+      "version": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
+      "from": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#89a7e2d9cdd24f48f95f6668ae4d8db1b635cf36",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(codec-selection): Fix VP9 codec switching issue in Chrome unified-plan. Munge only the m-line that corresponds to the source that the browser will be sending. Do not select VP9 on Firefox. Detect support for RTCRtpTransceiver#setCodecPreferences correctly.

https://github.com/jitsi/lib-jitsi-meet/compare/89a7e2d9cdd24f48f95f6668ae4d8db1b635cf36...3a313a244daf3d54b8ea95e9012b2ae01598b113
