### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11071,8 +11071,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
-      "from": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
+      "version": "github:jitsi/lib-jitsi-meet#053a26604da568188a1f99a45a275d1d04e7b8d9",
+      "from": "github:jitsi/lib-jitsi-meet#053a26604da568188a1f99a45a275d1d04e7b8d9",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#3a313a244daf3d54b8ea95e9012b2ae01598b113",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#053a26604da568188a1f99a45a275d1d04e7b8d9",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(JingleSessionPC): Disable unified-plan for p2p chrome. Do not enable unified plan for p2p chrome by default until StartMutedTest is fixed. Fix media direction for case when there are no local and remote sources, should be set to 'inactive' in that case.

https://github.com/jitsi/lib-jitsi-meet/compare/3a313a244daf3d54b8ea95e9012b2ae01598b113...053a26604da568188a1f99a45a275d1d04e7b8d9

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
