### PR TITLE
fix(support-url): Hide contact support button when SUPPORT_URL is empty

### DIFF
--- a/react/features/invite/components/add-people-dialog/web/InviteContactsForm.js
+++ b/react/features/invite/components/add-people-dialog/web/InviteContactsForm.js
@@ -511,11 +511,7 @@ class InviteContactsForm extends AbstractAddPeopleDialog<Props, State> {
         const supportString = t('inlineDialogFailure.supportMsg');
         const supportLink = interfaceConfig.SUPPORT_URL;
 
-        if (!supportLink) {
-            return null;
-        }
-
-        const supportLinkContent = (
+        const supportLinkContent = supportLink ? (
             <span>
                 <span>
                     { supportString.padEnd(supportString.length + 1) }
@@ -524,13 +520,14 @@ class InviteContactsForm extends AbstractAddPeopleDialog<Props, State> {
                     <a
                         aria-label = { supportLink }
                         href = { supportLink }
-                        rel = 'noopener noreferrer'>
+                        rel = 'noopener noreferrer'
+                        target = '_blank'>
                         { t('inlineDialogFailure.support') }
                     </a>
                 </span>
                 <span>.</span>
             </span>
-        );
+        ) : null;
 
         return (
             <div className = 'modal-dialog-form-error'>

--- a/react/features/notifications/components/web/Notification.js
+++ b/react/features/notifications/components/web/Notification.js
@@ -116,7 +116,7 @@ class Notification extends AbstractNotification<Props> {
                 }
             ];
 
-            if (!hideErrorSupportLink) {
+            if (!hideErrorSupportLink && interfaceConfig.SUPPORT_URL) {
                 buttons.push({
                     content: this.props.t('dialog.contactSupport'),
                     onClick: this._onOpenSupportLink


### PR DESCRIPTION
- fix issue on error notification on invite contacts
