### PR TITLE
fix(prejoin): disposed track was added to the conference

### DIFF
--- a/react/features/prejoin/middleware.js
+++ b/react/features/prejoin/middleware.js
@@ -33,7 +33,7 @@ MiddlewareRegistry.register(store => next => async action => {
         const { getState, dispatch } = store;
         const state = getState();
         const { userSelectedSkipPrejoin } = state['features/prejoin'];
-        const localTracks = getLocalTracks(state['features/base/tracks']);
+        let localTracks = getLocalTracks(state['features/base/tracks']);
         const { options } = action;
 
         options && store.dispatch(updateConfig(options));
@@ -48,6 +48,12 @@ MiddlewareRegistry.register(store => next => async action => {
                 await dispatch(replaceLocalTrack(track.jitsiTrack, null));
             }
         }
+
+        // Re-fetch the local tracks after muted tracks have been removed above.
+        // This is needed, because the tracks are effectively disposed by the replaceLocalTrack and should not be used
+        // anymore.
+        localTracks = getLocalTracks(getState()['features/base/tracks']);
+
         const jitsiTracks = localTracks.map(t => t.jitsiTrack);
 
         dispatch(setPrejoinPageVisibility(false));


### PR DESCRIPTION
It is not 100% clear to me when it happens, but I think it could happen
in some race condition where a track is unmuted when it's being disposed
or something around those lines.

The fact is that any muted tracks are disposed by replaceLocalTrack(track.jitsiTrack, null) and they should not be used anymore.

Supposedly fixes a crash:

Failed to add local track to conference Track has been already disposed

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
