### PR TITLE
fix(Filmstrip): Send only visible endpoints to jvb

### DIFF
--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -284,10 +284,10 @@ class Filmstrip extends PureComponent <Props> {
      * @param {Object} data - Information about the rendered items.
      * @returns {void}
      */
-    _onListItemsRendered({ overscanStartIndex, overscanStopIndex }) {
+    _onListItemsRendered({ visibleStartIndex, visibleStopIndex }) {
         const { dispatch } = this.props;
 
-        dispatch(setVisibleRemoteParticipants(overscanStartIndex, overscanStopIndex));
+        dispatch(setVisibleRemoteParticipants(visibleStartIndex, visibleStopIndex));
     }
 
     _onGridItemsRendered: Object => void;
@@ -299,14 +299,14 @@ class Filmstrip extends PureComponent <Props> {
      * @returns {void}
      */
     _onGridItemsRendered({
-        overscanColumnStartIndex,
-        overscanColumnStopIndex,
-        overscanRowStartIndex,
-        overscanRowStopIndex
+        visibleColumnStartIndex,
+        visibleColumnStopIndex,
+        visibleRowStartIndex,
+        visibleRowStopIndex
     }) {
         const { _columns, dispatch } = this.props;
-        const startIndex = (overscanRowStartIndex * _columns) + overscanColumnStartIndex;
-        const endIndex = (overscanRowStopIndex * _columns) + overscanColumnStopIndex;
+        const startIndex = (visibleRowStartIndex * _columns) + visibleColumnStartIndex;
+        const endIndex = (visibleRowStopIndex * _columns) + visibleColumnStopIndex;
 
         dispatch(setVisibleRemoteParticipants(startIndex, endIndex));
     }
@@ -345,6 +345,7 @@ class Filmstrip extends PureComponent <Props> {
                     initialScrollTop = { 0 }
                     itemKey = { this._gridItemKey }
                     onItemsRendered = { this._onGridItemsRendered }
+                    overscanRowCount = { 1 }
                     rowCount = { _rows }
                     rowHeight = { _thumbnailHeight + TILE_VERTICAL_MARGIN }
                     width = { _filmstripWidth }>
@@ -363,6 +364,7 @@ class Filmstrip extends PureComponent <Props> {
             itemKey: this._listItemKey,
             itemSize: 0,
             onItemsRendered: this._onListItemsRendered,
+            overscanCount: 1,
             width: _filmstripWidth,
             style: {
                 willChange: 'auto'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Resolves the issue with the client telling JVB to send video for hidden rows. 

Receiving videos for hidden participants is unnecessary. Also when lastN is set to lower limit enabling the video for a hidden participant would mean that the video of a visible participant may need to be turned off.