### PR TITLE
fix(Toolbar): Fix toolbar not hiding on mobile

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1179,8 +1179,10 @@ class Toolbox extends Component<Props> {
                 <div
                     className = 'toolbox-content-wrapper'
                     onFocus = { this._onTabIn }
-                    onMouseOut = { this._onMouseOut }
-                    onMouseOver = { this._onMouseOver }>
+                    { ...(_isMobile ? {} : {
+                        onMouseOut: this._onMouseOut,
+                        onMouseOver: this._onMouseOver
+                    }) }>
                     <DominantSpeakerName />
                     <div className = 'toolbox-content-items'>
                         {mainMenuButtons.map(({ Content, key, ...rest }) => Content !== Separator && (


### PR DESCRIPTION
`onMouseEnter` seems to trigger on mobile, marking the toolbar as "always hovered", therefore the toolbar never hides due to the condition in `react > features > toolbox > actions.web > hideToolbox`