### PR TITLE
fix: Fix av moderation enable-disable sequence.

### DIFF
--- a/resources/prosody-plugins/mod_av_moderation_component.lua
+++ b/resources/prosody-plugins/mod_av_moderation_component.lua
@@ -136,6 +136,7 @@ function on_message(event)
                         room.av_moderation = {};
                         room.av_moderation_actors = {};
                     end
+                    room.av_moderation[mediaType] = {};
                     room.av_moderation_actors[mediaType] = occupant.nick;
                 end
             else


### PR DESCRIPTION
When you enable and then disable av-moderation just the audio moderation is disabled and video moderation disabling is not signalled to moderated clients.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
