### PR TITLE
Fix typeof Comparison to undefined

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -170,7 +170,7 @@ function parseArguments(args) {
 
     switch (typeof firstArg) {
     case 'string': // old arguments format
-    case undefined: {
+    case 'undefined': {
         // Not sure which format but we are trying to parse the old
         // format because if the new format is used everything will be undefined
         // anyway.

--- a/react/features/mobile/watchos/middleware.js
+++ b/react/features/mobile/watchos/middleware.js
@@ -98,7 +98,7 @@ function _appWillMount({ dispatch, getState }) {
 
         switch (command) {
         case CMD_HANG_UP:
-            if (typeof getCurrentConferenceUrl(getState()) !== undefined) {
+            if (typeof getCurrentConferenceUrl(getState()) !== 'undefined') {
                 dispatch(appNavigate(undefined));
             }
             break;


### PR DESCRIPTION
[`typeof` will always return a string value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#description), no matter the input\*. Specifically, it never returns `undefined`, but instead the string value `"undefined"`.

This means the affected switch branch is unreachable in its current state. This PR fixes the comparison.

\* There is one [exception](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#errors) which doesn't apply here, because it would throw a `ReferenceError` and would still not be handled by this branch.