### PR TITLE
fix(av-moderation): Fixes approving and dismissing the notification.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11087,8 +11087,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#6a3df11ffa7a2204b579326e23cdaa85a79521d1",
-      "from": "github:jitsi/lib-jitsi-meet#6a3df11ffa7a2204b579326e23cdaa85a79521d1",
+      "version": "github:jitsi/lib-jitsi-meet#40fd6bdeaa5014930373c28c7a2c50c00281f126",
+      "from": "github:jitsi/lib-jitsi-meet#40fd6bdeaa5014930373c28c7a2c50c00281f126",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#5fc4af6dcf8a6e6af9fedbcd654412fd47b1b4ae",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6a3df11ffa7a2204b579326e23cdaa85a79521d1",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#40fd6bdeaa5014930373c28c7a2c50c00281f126",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",

--- a/react/features/av-moderation/actions.js
+++ b/react/features/av-moderation/actions.js
@@ -53,20 +53,20 @@ export const disableModeration = (mediaType: MediaType, actor: Object) => {
  * @returns {Object}
  */
 export function dismissPendingAudioParticipant(participant: Object) {
-    return dismissPendingParticipant(participant, MEDIA_TYPE.AUDIO);
+    return dismissPendingParticipant(participant.id, MEDIA_TYPE.AUDIO);
 }
 
 /**
  * Hides the notification with the participant that asked to unmute.
  *
- * @param {Object} participant - The participant for which the notification to be hidden.
+ * @param {string} id - The participant id for which the notification to be hidden.
  * @param {MediaType} mediaType - The media type.
  * @returns {Object}
  */
-export function dismissPendingParticipant(participant: Object, mediaType: MediaType) {
+export function dismissPendingParticipant(id: string, mediaType: MediaType) {
     return {
         type: DISMISS_PENDING_PARTICIPANT,
-        participant,
+        id,
         mediaType
     };
 }

--- a/react/features/av-moderation/reducer.js
+++ b/react/features/av-moderation/reducer.js
@@ -135,7 +135,7 @@ ReducerRegistry.register('features/av-moderation', (state = initialState, action
         }
 
         if (videoModerationEnabled) {
-            hasStateChanged = _updatePendingParticipant(MEDIA_TYPE.VIDEO, participant, state);
+            hasStateChanged = hasStateChanged || _updatePendingParticipant(MEDIA_TYPE.VIDEO, participant, state);
         }
 
         // If the state has changed we need to return a new object reference in order to trigger subscriber updates.
@@ -183,19 +183,19 @@ ReducerRegistry.register('features/av-moderation', (state = initialState, action
     }
 
     case DISMISS_PENDING_PARTICIPANT: {
-        const { participant, mediaType } = action;
+        const { id, mediaType } = action;
 
         if (mediaType === MEDIA_TYPE.AUDIO) {
             return {
                 ...state,
-                pendingAudio: state.pendingAudio.filter(pending => pending.id !== participant.id)
+                pendingAudio: state.pendingAudio.filter(pending => pending.id !== id)
             };
         }
 
         if (mediaType === MEDIA_TYPE.VIDEO) {
             return {
                 ...state,
-                pendingVideo: state.pendingVideo.filter(pending => pending.id !== participant.id)
+                pendingVideo: state.pendingVideo.filter(pending => pending.id !== id)
             };
         }
 


### PR DESCRIPTION
When participants panel is open and we approve a participant to unmute, the notification was not hidden as we were not correctly updating the state. We were expecting a participant object, but an id of the participant was used.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
