### PR TITLE
fix: Adds a null check in mod_limits_exceptions.

### DIFF
--- a/resources/prosody-plugins/mod_limits_exception.lua
+++ b/resources/prosody-plugins/mod_limits_exception.lua
@@ -24,7 +24,7 @@ module:hook("authentication-success", function (event)
 			session.throttle = nil;
 		end
 
-		if unlimited_stanza_size_limit then
+		if unlimited_stanza_size_limit and session.stream.set_stanza_size_limit then
 			module:log('info', 'Setting stanza size limits for %s to %s', jid, unlimited_stanza_size_limit)
 			session.stream:set_stanza_size_limit(unlimited_stanza_size_limit);
 		end


### PR DESCRIPTION
It is failing on prosody 0.11.4 with mod_limits_exception.lua:29: attempt to call method 'set_stanza_size_limit' (a nil value).

