### PR TITLE
feat(Filmstrip): Reorder the visible participants in the filmstrip.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2106,7 +2106,7 @@ export default {
 
         room.on(
             JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED,
-            id => APP.store.dispatch(dominantSpeakerChanged(id, room)));
+            (dominant, previous) => APP.store.dispatch(dominantSpeakerChanged(dominant, previous, room)));
 
         room.on(
             JitsiConferenceEvents.CONFERENCE_CREATED_TIMESTAMP,

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -170,7 +170,7 @@ function _addConferenceListeners(conference, dispatch, state) {
 
     conference.on(
         JitsiConferenceEvents.DOMINANT_SPEAKER_CHANGED,
-        id => dispatch(dominantSpeakerChanged(id, conference)));
+        (dominant, previous) => dispatch(dominantSpeakerChanged(dominant, previous, conference)));
 
     conference.on(
         JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED,

--- a/react/features/base/participants/actionTypes.js
+++ b/react/features/base/participants/actionTypes.js
@@ -6,7 +6,9 @@
  * {
  *     type: DOMINANT_SPEAKER_CHANGED,
  *     participant: {
- *         id: string
+ *         conference: JitsiConference,
+ *         id: string,
+ *         previousSpeakers: Array<string>
  *     }
  * }
  */

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -31,7 +31,8 @@ import logger from './logger';
 /**
  * Create an action for when dominant speaker changes.
  *
- * @param {string} id - Participant's ID.
+ * @param {string} dominantSpeaker - Participant ID of the dominant speaker.
+ * @param {Array<string>} previousSpeakers - Participant IDs of the previous speakers.
  * @param {JitsiConference} conference - The {@code JitsiConference} associated
  * with the participant identified by the specified {@code id}. Only the local
  * participant is allowed to not specify an associated {@code JitsiConference}
@@ -40,16 +41,18 @@ import logger from './logger';
  *     type: DOMINANT_SPEAKER_CHANGED,
  *     participant: {
  *         conference: JitsiConference,
- *         id: string
+ *         id: string,
+ *         previousSpeakers: Array<string>
  *     }
  * }}
  */
-export function dominantSpeakerChanged(id, conference) {
+export function dominantSpeakerChanged(dominantSpeaker, previousSpeakers, conference) {
     return {
         type: DOMINANT_SPEAKER_CHANGED,
         participant: {
             conference,
-            id
+            id: dominantSpeaker,
+            previousSpeakers
         }
     };
 }

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -14,6 +14,8 @@ import {
 import { LOCAL_PARTICIPANT_DEFAULT_ID, PARTICIPANT_ROLE } from './constants';
 import { isParticipantModerator } from './functions';
 
+declare var interfaceConfig: Object;
+
 /**
  * Participant object.
  * @typedef {Object} Participant
@@ -227,12 +229,14 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
         state.remote.set(id, participant);
 
         // Insert the new participant.
-        const displayName = name ?? 'Fellow Jitser';
+        const displayName = name
+            ?? (typeof interfaceConfig === 'object' ? interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME : 'Fellow Jitser');
         const sortedRemoteParticipants = Array.from(state.sortedRemoteParticipants);
 
         sortedRemoteParticipants.push([ id, displayName ]);
         sortedRemoteParticipants.sort((a, b) => a[1].localeCompare(b[1]));
 
+        // The sort order of participants is preserved since Map remembers the original insertion order of the keys.
         state.sortedRemoteParticipants = new Map(sortedRemoteParticipants);
 
         if (isFakeParticipant) {

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -59,7 +59,7 @@ const DEFAULT_STATE = {
     haveParticipantWithScreenSharingFeature: false,
     local: undefined,
     pinnedParticipant: undefined,
-    previousSpeakers: undefined,
+    previousSpeakers: [],
     remote: new Map()
 };
 
@@ -275,6 +275,9 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
         if (dominantSpeaker === id) {
             state.dominantSpeaker = undefined;
         }
+
+        // Remove the participant from the list of previous speakers.
+        state.previousSpeakers = state.previousSpeakers.filter(speaker => speaker !== id);
 
         if (pinnedParticipant === id) {
             state.pinnedParticipant = undefined;

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -53,13 +53,14 @@ const PARTICIPANT_PROPS_TO_OMIT_WHEN_UPDATE = [
 ];
 
 const DEFAULT_STATE = {
-    haveParticipantWithScreenSharingFeature: false,
     dominantSpeaker: undefined,
     everyoneIsModerator: false,
-    pinnedParticipant: undefined,
+    fakeParticipants: new Map(),
+    haveParticipantWithScreenSharingFeature: false,
     local: undefined,
-    remote: new Map(),
-    fakeParticipants: new Map()
+    pinnedParticipant: undefined,
+    previousSpeakers: undefined,
+    remote: new Map()
 };
 
 /**
@@ -93,7 +94,7 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
     }
     case DOMINANT_SPEAKER_CHANGED: {
         const { participant } = action;
-        const { id } = participant;
+        const { id, previousSpeakers = [] } = participant;
         const { dominantSpeaker } = state;
 
         // Only one dominant speaker is allowed.
@@ -104,7 +105,8 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
         if (_updateParticipantProperty(state, id, 'dominantSpeaker', true)) {
             return {
                 ...state,
-                dominantSpeaker: id
+                dominantSpeaker: id,
+                previousSpeakers
             };
         }
 

--- a/react/features/filmstrip/actionTypes.js
+++ b/react/features/filmstrip/actionTypes.js
@@ -51,6 +51,15 @@ export const SET_TILE_VIEW_DIMENSIONS = 'SET_TILE_VIEW_DIMENSIONS';
 export const SET_HORIZONTAL_VIEW_DIMENSIONS = 'SET_HORIZONTAL_VIEW_DIMENSIONS';
 
 /**
+ * The type of (redux) action which sets the reordered list of the remote participants in the filmstrip.
+ * {
+ *      type: SET_REMOTE_PARTICIPANTS,
+ *      participants: Array<string>
+ * }
+ */
+export const SET_REMOTE_PARTICIPANTS = 'SET_REMOTE_PARTICIPANTS';
+
+/**
  * The type of (redux) action which sets the dimensions of the thumbnails in vertical view.
  *
  * {

--- a/react/features/filmstrip/actions.web.js
+++ b/react/features/filmstrip/actions.web.js
@@ -5,6 +5,7 @@ import { getLocalParticipant, getRemoteParticipants, pinParticipant } from '../b
 
 import {
     SET_HORIZONTAL_VIEW_DIMENSIONS,
+    SET_REMOTE_PARTICIPANTS,
     SET_TILE_VIEW_DIMENSIONS,
     SET_VERTICAL_VIEW_DIMENSIONS,
     SET_VISIBLE_REMOTE_PARTICIPANTS,
@@ -24,6 +25,23 @@ import {
     calculateThumbnailSizeForTileView,
     calculateThumbnailSizeForVerticalView
 } from './functions';
+
+/**
+ * Sets the list of the reordered remote participants based on which the visible participants in the filmstrip will be
+ * determined.
+ *
+ * @param {Array<string>} participants - The list of the remote participant endpoint IDs.
+ * @returns {{
+        type: SET_REMOTE_PARTICIPANTS,
+        participants: Array<string>
+    }}
+ */
+export function setRemoteParticipants(participants: String[]) {
+    return {
+        type: SET_REMOTE_PARTICIPANTS,
+        participants
+    };
+}
 
 /**
  * Sets the dimensions of the tile view grid.

--- a/react/features/filmstrip/actions.web.js
+++ b/react/features/filmstrip/actions.web.js
@@ -36,7 +36,7 @@ import {
         participants: Array<string>
     }}
  */
-export function setRemoteParticipants(participants: String[]) {
+export function setRemoteParticipants(participants: Array<string>) {
     return {
         type: SET_REMOTE_PARTICIPANTS,
         participants

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -269,11 +269,11 @@ class Filmstrip extends PureComponent <Props> {
             return `empty-${index}`;
         }
 
-        if (index === _remoteParticipantsLength) {
+        if (index === 0) {
             return 'local';
         }
 
-        return _remoteParticipants[index];
+        return _remoteParticipants[index - 1];
     }
 
     _onListItemsRendered: Object => void;
@@ -287,7 +287,7 @@ class Filmstrip extends PureComponent <Props> {
     _onListItemsRendered({ visibleStartIndex, visibleStopIndex }) {
         const { dispatch } = this.props;
 
-        dispatch(setVisibleRemoteParticipants(visibleStartIndex, visibleStopIndex));
+        dispatch(setVisibleRemoteParticipants(visibleStartIndex, visibleStopIndex + 1));
     }
 
     _onGridItemsRendered: Object => void;
@@ -305,9 +305,12 @@ class Filmstrip extends PureComponent <Props> {
         visibleRowStopIndex
     }) {
         const { _columns, dispatch } = this.props;
-        const startIndex = (visibleRowStartIndex * _columns) + visibleColumnStartIndex;
+        let startIndex = (visibleRowStartIndex * _columns) + visibleColumnStartIndex;
         const endIndex = (visibleRowStopIndex * _columns) + visibleColumnStopIndex;
 
+        // In tile view, the start index needs to be offset by 1 because the first participant is the local
+        // participant.
+        startIndex = startIndex > 0 ? startIndex - 1 : 0;
         dispatch(setVisibleRemoteParticipants(startIndex, endIndex));
     }
 

--- a/react/features/filmstrip/components/web/ThumbnailWrapper.js
+++ b/react/features/filmstrip/components/web/ThumbnailWrapper.js
@@ -126,7 +126,8 @@ function _mapStateToProps(state, ownProps) {
             return {};
         }
 
-        if (index === remoteParticipantsLength) {
+        // Make the local participant as the first thumbnail (top left corner) in tile view.
+        if (index === 0) {
             return {
                 _participantID: 'local',
                 _horizontalOffset: horizontalOffset
@@ -134,7 +135,7 @@ function _mapStateToProps(state, ownProps) {
         }
 
         return {
-            _participantID: remoteParticipants[index],
+            _participantID: remoteParticipants[index - 1],
             _horizontalOffset: horizontalOffset
         };
     }

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -35,6 +35,24 @@ import {
 declare var interfaceConfig: Object;
 
 /**
+ * Compare function that defines the sort order for sorting the participants alphabetically.
+ *
+ * @param {string} a - First element for comparison.
+ * @param {string} b - Second element for comparison.
+ * @returns {number}
+ * @private
+ */
+function _compareDisplayNames(a, b) {
+    const nameA = a.name.toUpperCase();
+    const nameB = b.name.toUpperCase();
+    const result = nameA > nameB
+        ? 1
+        : nameA < nameB ? -1 : 0;
+
+    return result;
+}
+
+/**
  * Returns true if the filmstrip on mobile is visible, false otherwise.
  *
  * NOTE: Filmstrip on web behaves differently to mobile, much simpler, but so
@@ -264,4 +282,16 @@ export function computeDisplayMode(input: Object) {
 
     // check hovering and change state to avatar with name
     return isHovered ? DISPLAY_AVATAR_WITH_NAME : DISPLAY_AVATAR;
+}
+
+/**
+ * Calculates the reordered list of participants that are sorted alphabetically by display names.
+ *
+ * @param {Array<Object>} participants - The remote participants.
+ * @returns {Array<string>}
+ */
+export function sortRemoteParticipants(participants: Array<Object>): Array<String> {
+    return participants
+        .sort(_compareDisplayNames)
+        .map(p => p.id);
 }

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -43,8 +43,8 @@ declare var interfaceConfig: Object;
  * @private
  */
 function _compareDisplayNames(a, b) {
-    const nameA = a.name.toUpperCase();
-    const nameB = b.name.toUpperCase();
+    const nameA = a.name && a.name.toUpperCase();
+    const nameB = b.name && b.name.toUpperCase();
     const result = nameA > nameB
         ? 1
         : nameA < nameB ? -1 : 0;

--- a/react/features/filmstrip/middleware.web.js
+++ b/react/features/filmstrip/middleware.web.js
@@ -52,4 +52,3 @@ MiddlewareRegistry.register(store => next => action => {
 
     return result;
 });
-

--- a/react/features/filmstrip/reducer.js
+++ b/react/features/filmstrip/reducer.js
@@ -79,21 +79,20 @@ const DEFAULT_STATE = {
     visibleParticipantsEndIndex: 0,
 
     /**
-     * The visible participants in the filmstrip.
-     *
-     * @public
-     * @type {Array<string>}
-     */
-    visibleParticipants: [],
-
-
-    /**
      * The start index in the remote participants array that is visible in the filmstrip.
      *
      * @public
      * @type {number}
      */
-    visibleParticipantsStartIndex: 0
+    visibleParticipantsStartIndex: 0,
+
+    /**
+     * The visible remote participants in the filmstrip.
+     *
+     * @public
+     * @type {Set}
+     */
+    visibleRemoteParticipants: new Set()
 };
 
 ReducerRegistry.register(
@@ -121,9 +120,9 @@ ReducerRegistry.register(
             const { visibleParticipantsStartIndex: startIndex, visibleParticipantsEndIndex: endIndex } = state;
 
             state.remoteParticipants = action.participants;
-            state.visibleParticipants = state.remoteParticipants.slice(startIndex, endIndex + 1);
+            state.visibleRemoteParticipants = new Set(state.remoteParticipants.slice(startIndex, endIndex));
 
-            return state;
+            return { ...state };
         }
         case SET_TILE_VIEW_DIMENSIONS:
             return {
@@ -147,13 +146,14 @@ ReducerRegistry.register(
                     [action.participantId]: action.volume
                 }
             };
-        case SET_VISIBLE_REMOTE_PARTICIPANTS:
+        case SET_VISIBLE_REMOTE_PARTICIPANTS: {
             return {
                 ...state,
                 visibleParticipantsStartIndex: action.startIndex,
                 visibleParticipantsEndIndex: action.endIndex,
-                visibleParticipants: state.remoteParticipants.slice(action.startIndex, action.endIndex + 1)
+                visibleRemoteParticipants: new Set(state.remoteParticipants.slice(action.startIndex, action.endIndex))
             };
+        }
         case PARTICIPANT_LEFT: {
             const { id, local } = action.participant;
 

--- a/react/features/filmstrip/reducer.js
+++ b/react/features/filmstrip/reducer.js
@@ -90,7 +90,7 @@ const DEFAULT_STATE = {
      * The visible remote participants in the filmstrip.
      *
      * @public
-     * @type {Set}
+     * @type {Set<string>}
      */
     visibleRemoteParticipants: new Set()
 };

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -22,8 +22,8 @@ declare var APP: Object;
  * scrolling through the thumbnails prompting updates to the selected endpoints.
  */
 StateListenerRegistry.register(
-    /* selector */ state => state['features/filmstrip'].visibleParticipants,
-    /* listener */ debounce((visibleParticipants, store) => {
+    /* selector */ state => state['features/filmstrip'].visibleRemoteParticipants,
+    /* listener */ debounce((visibleRemoteParticipants, store) => {
         _updateReceiverVideoConstraints(store);
     }, 100));
 
@@ -191,11 +191,11 @@ function _updateReceiverVideoConstraints({ getState }) {
     const { maxReceiverVideoQuality, preferredVideoQuality } = state['features/video-quality'];
     const { participantId: largeVideoParticipantId } = state['features/large-video'];
     const maxFrameHeight = Math.min(maxReceiverVideoQuality, preferredVideoQuality);
-    let { visibleParticipants } = state['features/filmstrip'];
+    let { visibleRemoteParticipants } = state['features/filmstrip'];
 
     // TODO: implement this on mobile.
     if (navigator.product === 'ReactNative') {
-        visibleParticipants = Array.from(state['features/base/participants'].remote.keys());
+        visibleRemoteParticipants = new Set(Array.from(state['features/base/participants'].remote.keys()));
     }
 
     const receiverConstraints = {
@@ -208,22 +208,22 @@ function _updateReceiverVideoConstraints({ getState }) {
 
     // Tile view.
     if (shouldDisplayTileView(state)) {
-        if (!visibleParticipants?.length) {
+        if (!visibleRemoteParticipants?.size) {
             return;
         }
 
-        visibleParticipants.forEach(participantId => {
+        visibleRemoteParticipants.forEach(participantId => {
             receiverConstraints.constraints[participantId] = { 'maxHeight': maxFrameHeight };
         });
 
     // Stage view.
     } else {
-        if (!visibleParticipants?.length && !largeVideoParticipantId) {
+        if (!visibleRemoteParticipants?.size && !largeVideoParticipantId) {
             return;
         }
 
-        if (visibleParticipants?.length > 0) {
-            visibleParticipants.forEach(participantId => {
+        if (visibleRemoteParticipants?.size > 0) {
+            visibleRemoteParticipants.forEach(participantId => {
                 receiverConstraints.constraints[participantId] = { 'maxHeight': VIDEO_QUALITY_LEVELS.LOW };
             });
         }


### PR DESCRIPTION
The participants are ordered alphabetically and the endpoints with screenshares and dominant speakers (in that order) are bumped to the top of the list.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
