### PR TITLE
Additional setting to order participants in speaker stats

### DIFF
--- a/config.js
+++ b/config.js
@@ -150,6 +150,13 @@ var config = {
     // Specifies whether there will be a search field in speaker stats or not
     // disableSpeakerStatsSearch: false,
 
+    // Specifies whether participants in speaker stats should be ordered or not, and with what priority
+    // speakerStatsOrder: [
+    //  'role', <- Moderators on top
+    //  'name', <- Alphabetically by name
+    //  'hasLeft', <- The ones that have left in the bottom
+    // ] <- the order of the array elements determines priority
+
     // How many participants while in the tile view mode, before the receiving video quality is reduced from HD to SD.
     // Use -1 to disable.
     // maxFullResolutionParticipants: 2,

--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -42,6 +42,7 @@ import '../recording/middleware';
 import '../rejoin/middleware';
 import '../room-lock/middleware';
 import '../rtcstats/middleware';
+import '../speaker-stats/middleware';
 import '../subtitles/middleware';
 import '../toolbox/middleware';
 import '../transcribing/middleware';

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -46,6 +46,7 @@ import '../reactions/reducer';
 import '../recent-list/reducer';
 import '../recording/reducer';
 import '../settings/reducer';
+import '../speaker-stats/reducer';
 import '../subtitles/reducer';
 import '../screen-share/reducer';
 import '../toolbox/reducer';

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -101,6 +101,7 @@ export default [
     'disableShortcuts',
     'disableShowMoreStats',
     'disableSpeakerStatsSearch',
+    'speakerStatsOrder',
     'disableSimulcast',
     'disableThirdPartyRequests',
     'disableTileView',

--- a/react/features/base/util/helpers.js
+++ b/react/features/base/util/helpers.js
@@ -185,3 +185,19 @@ function parseShorthandColor(color) {
 
     return [ r, g, b ];
 }
+
+/**
+ * Sorts an object by a sort function, same functionality as array.sort().
+ *
+ * @param {Object} object - The data object.
+ * @param {Function} callback - The sort function.
+ * @returns {void}
+ */
+export function objectSort(object: Object, callback: Function) {
+    return Object.entries(object)
+        .sort(([ , a ], [ , b ]) => callback(a, b))
+        .reduce((row, [ key, value ]) => {
+            return { ...row,
+                [key]: value };
+        }, {});
+}

--- a/react/features/speaker-stats/actionTypes.js
+++ b/react/features/speaker-stats/actionTypes.js
@@ -1,0 +1,42 @@
+// @flow
+
+/**
+ * Action type to start search.
+ *
+ * {
+ *     type: INIT_SEARCH
+ * }
+ */
+export const INIT_SEARCH = 'INIT_SEARCH';
+
+/**
+ * Action type to start stats retrieval.
+ *
+ * {
+ *     type: INIT_UPDATE_STATS,
+ *     reorder: boolean
+ * }
+ */
+export const INIT_UPDATE_STATS = 'INIT_UPDATE_STATS';
+
+/**
+ * Action type to update stats.
+ *
+ * {
+ *     type: UPDATE_STATS,
+ *     stats: Object
+ * }
+ */
+export const UPDATE_STATS = 'UPDATE_STATS';
+
+/**
+ * Action type to reorder stats.
+ *
+ * {
+ *     type: REORDER_STATS,
+ *     stats: Object
+ * }
+ *
+ * @protected
+ */
+export const REORDER_STATS = 'REORDER_STATS';

--- a/react/features/speaker-stats/actionTypes.js
+++ b/react/features/speaker-stats/actionTypes.js
@@ -14,7 +14,8 @@ export const INIT_SEARCH = 'INIT_SEARCH';
  *
  * {
  *     type: INIT_UPDATE_STATS,
- *     reorder: boolean
+ *     reorder: boolean,
+ *     getSpeakerStats: Function
  * }
  */
 export const INIT_UPDATE_STATS = 'INIT_UPDATE_STATS';

--- a/react/features/speaker-stats/actionTypes.js
+++ b/react/features/speaker-stats/actionTypes.js
@@ -14,7 +14,6 @@ export const INIT_SEARCH = 'INIT_SEARCH';
  *
  * {
  *     type: INIT_UPDATE_STATS,
- *     reorder: boolean,
  *     getSpeakerStats: Function
  * }
  */
@@ -36,7 +35,5 @@ export const UPDATE_STATS = 'UPDATE_STATS';
  * {
  *     type: INIT_REORDER_STATS
  * }
- *
- * @protected
  */
 export const INIT_REORDER_STATS = 'INIT_REORDER_STATS';

--- a/react/features/speaker-stats/actionTypes.js
+++ b/react/features/speaker-stats/actionTypes.js
@@ -31,13 +31,12 @@ export const INIT_UPDATE_STATS = 'INIT_UPDATE_STATS';
 export const UPDATE_STATS = 'UPDATE_STATS';
 
 /**
- * Action type to reorder stats.
+ * Action type to initiate reordering of the stats.
  *
  * {
- *     type: REORDER_STATS,
- *     stats: Object
+ *     type: INIT_REORDER_STATS
  * }
  *
  * @protected
  */
-export const REORDER_STATS = 'REORDER_STATS';
+export const INIT_REORDER_STATS = 'INIT_REORDER_STATS';

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -23,14 +23,12 @@ export function initSearch(criteria: string) {
 /**
  * Gets the new stats and triggers update.
  *
- * @param {boolean} reorder - Should reorder or not.
  * @param {Function} getSpeakerStats - Function to get the speaker stats.
  * @returns {Object}
  */
-export function initUpdateStats(reorder: boolean, getSpeakerStats: Function) {
+export function initUpdateStats(getSpeakerStats: Function) {
     return {
         type: INIT_UPDATE_STATS,
-        reorder,
         getSpeakerStats
     };
 }

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -13,7 +13,7 @@ import {
  * @param {string} criteria - The search criteria.
  * @returns {Function}
  */
-export function initSearch(criteria) {
+export function initSearch(criteria: string) {
     return {
         type: INIT_SEARCH,
         criteria
@@ -26,7 +26,7 @@ export function initSearch(criteria) {
  * @param {boolean} reorder - Should reorder or not.
  * @returns {Function}
  */
-export function initUpdateStats(reorder = false) {
+export function initUpdateStats(reorder: boolean = false) {
     return {
         type: INIT_UPDATE_STATS,
         reorder

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -4,7 +4,7 @@ import {
     INIT_SEARCH,
     INIT_UPDATE_STATS,
     UPDATE_STATS,
-    REORDER_STATS
+    INIT_REORDER_STATS
 } from './actionTypes';
 
 /**
@@ -49,14 +49,12 @@ export function updateStats(stats: Object) {
 }
 
 /**
- * Reorders the stats with new stats.
+ * Initiates reordering of the stats.
  *
- * @param {Object} stats - The new stats.
  * @returns {Object}
  */
-export function reorderStats(stats: Object) {
+export function initReorderStats() {
     return {
-        type: REORDER_STATS,
-        stats
+        type: INIT_REORDER_STATS
     };
 }

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -11,7 +11,7 @@ import {
  * Starts a search by criteria.
  *
  * @param {string} criteria - The search criteria.
- * @returns {Function}
+ * @returns {Object}
  */
 export function initSearch(criteria: string) {
     return {
@@ -24,12 +24,14 @@ export function initSearch(criteria: string) {
  * Gets the new stats and triggers update.
  *
  * @param {boolean} reorder - Should reorder or not.
- * @returns {Function}
+ * @param {Function} getSpeakerStats - Function to get the speaker stats.
+ * @returns {Object}
  */
-export function initUpdateStats(reorder: boolean = false) {
+export function initUpdateStats(reorder: boolean, getSpeakerStats: Function) {
     return {
         type: INIT_UPDATE_STATS,
-        reorder
+        reorder,
+        getSpeakerStats
     };
 }
 
@@ -37,7 +39,7 @@ export function initUpdateStats(reorder: boolean = false) {
  * Updates the stats with new stats.
  *
  * @param {Object} stats - The new stats.
- * @returns {Function}
+ * @returns {Object}
  */
 export function updateStats(stats: Object) {
     return {
@@ -50,7 +52,7 @@ export function updateStats(stats: Object) {
  * Reorders the stats with new stats.
  *
  * @param {Object} stats - The new stats.
- * @returns {Function}
+ * @returns {Object}
  */
 export function reorderStats(stats: Object) {
     return {

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -1,0 +1,60 @@
+// @flow
+
+import {
+    INIT_SEARCH,
+    INIT_UPDATE_STATS,
+    UPDATE_STATS,
+    REORDER_STATS
+} from './actionTypes';
+
+/**
+ * Starts a search by criteria.
+ *
+ * @param {string} criteria - The search criteria.
+ * @returns {Function}
+ */
+export function initSearch(criteria) {
+    return {
+        type: INIT_SEARCH,
+        criteria
+    };
+}
+
+/**
+ * Gets the new stats and triggers update.
+ *
+ * @param {boolean} reorder - Should reorder or not.
+ * @returns {Function}
+ */
+export function initUpdateStats(reorder = false) {
+    return {
+        type: INIT_UPDATE_STATS,
+        reorder
+    };
+}
+
+/**
+ * Updates the stats with new stats.
+ *
+ * @param {Object} stats - The new stats.
+ * @returns {Function}
+ */
+export function updateStats(stats: Object) {
+    return {
+        type: UPDATE_STATS,
+        stats
+    };
+}
+
+/**
+ * Reorders the stats with new stats.
+ *
+ * @param {Object} stats - The new stats.
+ * @returns {Function}
+ */
+export function reorderStats(stats: Object) {
+    return {
+        type: REORDER_STATS,
+        stats
+    };
+}

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -31,7 +31,7 @@ type Props = {
     /**
      * The speaker paricipant stats.
      */
-    _stats: Array<String>,
+    _stats: Object,
 
     /**
      * The search criteria.
@@ -79,7 +79,7 @@ class SpeakerStats extends Component<Props> {
      * @inheritdoc
      */
     componentDidMount() {
-        this._updateInterval = setInterval(this._updateStats, SPEAKER_STATS_RELOAD_INTERVAL);
+        this._updateInterval = setInterval(() => this._updateStats(false), SPEAKER_STATS_RELOAD_INTERVAL);
     }
 
     /**
@@ -173,7 +173,7 @@ class SpeakerStats extends Component<Props> {
         APP.store.dispatch(initSearch(escapeRegexp(criteria)));
     }
 
-    _updateStats: (reorder: boolean) => void;
+    _updateStats: (reorder: ?boolean) => void;
 
     /**
      * Update the internal state with the latest speaker stats.
@@ -194,6 +194,8 @@ class SpeakerStats extends Component<Props> {
  * @private
  * @returns {{
  *     _localDisplayName: ?string,
+ *     _stats: Object,
+ *     _criteria: string,
  * }}
  */
 function _mapStateToProps(state) {

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -44,6 +44,11 @@ type Props = {
     conference: Object,
 
     /**
+     * Redux store dispatch method.
+     */
+    dispatch: Dispatch<any>,
+
+    /**
      * The function to translate human-readable text.
      */
     t: Function
@@ -170,7 +175,7 @@ class SpeakerStats extends Component<Props> {
      * @protected
      */
     _onSearch(criteria = '') {
-        APP.store.dispatch(initSearch(escapeRegexp(criteria)));
+        this.props.dispatch(initSearch(escapeRegexp(criteria)));
     }
 
     _updateStats: (reorder: ?boolean) => void;
@@ -183,7 +188,7 @@ class SpeakerStats extends Component<Props> {
      * @private
      */
     _updateStats(reorder = false) {
-        APP.store.dispatch(initUpdateStats(reorder));
+        this.props.dispatch(initUpdateStats(reorder, () => this.props.conference.getSpeakerStats()));
     }
 }
 

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import type { Dispatch } from 'redux';
 
 import { Dialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
@@ -15,7 +16,6 @@ import SpeakerStatsItem from './SpeakerStatsItem';
 import SpeakerStatsLabels from './SpeakerStatsLabels';
 import SpeakerStatsSearch from './SpeakerStatsSearch';
 
-declare var APP: Object;
 declare var interfaceConfig: Object;
 
 /**

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -75,7 +75,7 @@ class SpeakerStats extends Component<Props> {
         this._updateStats = this._updateStats.bind(this);
         this._onSearch = this._onSearch.bind(this);
 
-        this._updateStats(true);
+        this._updateStats();
     }
 
     /**
@@ -84,7 +84,7 @@ class SpeakerStats extends Component<Props> {
      * @inheritdoc
      */
     componentDidMount() {
-        this._updateInterval = setInterval(() => this._updateStats(false), SPEAKER_STATS_RELOAD_INTERVAL);
+        this._updateInterval = setInterval(() => this._updateStats(), SPEAKER_STATS_RELOAD_INTERVAL);
     }
 
     /**
@@ -178,17 +178,16 @@ class SpeakerStats extends Component<Props> {
         this.props.dispatch(initSearch(escapeRegexp(criteria)));
     }
 
-    _updateStats: (reorder: ?boolean) => void;
+    _updateStats: () => void;
 
     /**
      * Update the internal state with the latest speaker stats.
      *
-     * @param {boolean} reorder - Should reorder boolean or not.
      * @returns {void}
      * @private
      */
-    _updateStats(reorder = false) {
-        this.props.dispatch(initUpdateStats(reorder, () => this.props.conference.getSpeakerStats()));
+    _updateStats() {
+        this.props.dispatch(initUpdateStats(() => this.props.conference.getSpeakerStats()));
     }
 }
 

--- a/react/features/speaker-stats/components/SpeakerStats.js
+++ b/react/features/speaker-stats/components/SpeakerStats.js
@@ -4,10 +4,12 @@ import React, { Component } from 'react';
 
 import { Dialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
-import { getLocalParticipant, getParticipantById, PARTICIPANT_ROLE } from '../../base/participants';
+import { getLocalParticipant } from '../../base/participants';
 import { connect } from '../../base/redux';
-import { escapeRegexp, objectSort } from '../../base/util';
-import { getSpeakerStatsOrder } from '../functions';
+import { escapeRegexp } from '../../base/util';
+import { initUpdateStats, initSearch } from '../actions';
+import { SPEAKER_STATS_RELOAD_INTERVAL } from '../constants';
+import { getSpeakerStats, getSearchCriteria } from '../functions';
 
 import SpeakerStatsItem from './SpeakerStatsItem';
 import SpeakerStatsLabels from './SpeakerStatsLabels';
@@ -27,9 +29,14 @@ type Props = {
     _localDisplayName: string,
 
     /**
-     * The configuration setting to order paricipants.
+     * The speaker paricipant stats.
      */
-    _speakerStatsOrder: Array<String>,
+    _stats: Array<String>,
+
+    /**
+     * The search criteria.
+     */
+    _criteria: string,
 
     /**
      * The JitsiConference from which stats will be pulled.
@@ -43,27 +50,11 @@ type Props = {
 };
 
 /**
- * The type of the React {@code Component} state of {@link SpeakerStats}.
- */
-type State = {
-
-    /**
-     * The stats summary provided by the JitsiConference.
-     */
-    stats: Object,
-
-    /**
-     * The search input criteria.
-     */
-    criteria: string,
-};
-
-/**
  * React component for displaying a list of speaker stats.
  *
  * @extends Component
  */
-class SpeakerStats extends Component<Props, State> {
+class SpeakerStats extends Component<Props> {
     _updateInterval: IntervalID;
 
     /**
@@ -75,14 +66,11 @@ class SpeakerStats extends Component<Props, State> {
     constructor(props) {
         super(props);
 
-        this.state = {
-            stats: this._getSpeakerStats(),
-            criteria: ''
-        };
-
         // Bind event handlers so they are only bound once per instance.
         this._updateStats = this._updateStats.bind(this);
         this._onSearch = this._onSearch.bind(this);
+
+        this._updateStats(true);
     }
 
     /**
@@ -91,7 +79,7 @@ class SpeakerStats extends Component<Props, State> {
      * @inheritdoc
      */
     componentDidMount() {
-        this._updateInterval = setInterval(this._updateStats, 1000);
+        this._updateInterval = setInterval(this._updateStats, SPEAKER_STATS_RELOAD_INTERVAL);
     }
 
     /**
@@ -111,14 +99,14 @@ class SpeakerStats extends Component<Props, State> {
      * @returns {ReactElement}
      */
     render() {
-        const userIds = Object.keys(this.state.stats);
+        const userIds = Object.keys(this.props._stats);
         const items = userIds.map(userId => this._createStatsItem(userId));
 
         return (
             <Dialog
-                cancelKey = { 'dialog.close' }
+                cancelKey = 'dialog.close'
                 submitDisabled = { true }
-                titleKey = { 'speakerStats.speakerStats' }>
+                titleKey = 'speakerStats.speakerStats'>
                 <div className = 'speaker-stats'>
                     <SpeakerStatsSearch onSearch = { this._onSearch } />
                     <SpeakerStatsLabels />
@@ -126,100 +114,6 @@ class SpeakerStats extends Component<Props, State> {
                 </div>
             </Dialog>
         );
-    }
-
-    /**
-     * Update the internal state with the latest speaker stats.
-     *
-     * @returns {void}
-     * @private
-     */
-    _getSpeakerStats() {
-        const stats = { ...this.props.conference.getSpeakerStats() };
-
-        if (this.state?.criteria) {
-            const searchRegex = new RegExp(this.state.criteria, 'gi');
-
-            for (const id in stats) {
-                if (stats[id].hasOwnProperty('_isLocalStats')) {
-                    const name = stats[id].isLocalStats() ? this.props._localDisplayName : stats[id].getDisplayName();
-
-                    if (!name || !name.match(searchRegex)) {
-                        delete stats[id];
-                    }
-                }
-            }
-        }
-
-        if (this.props._speakerStatsOrder.length) {
-            return this._getSortedSpeakerStats(stats);
-        }
-
-        return stats;
-    }
-
-    /**
-     * Get sorted speaker stats based on a configuration setting.
-     *
-     * @param {Object} stats - Unordered speaker stats.
-     * @returns {Object} - Ordered speaker stats.
-     * @private
-     */
-    _getSortedSpeakerStats(stats) {
-        for (const id in stats) {
-            if (stats[id].hasOwnProperty('_hasLeft') && !stats[id].hasLeft()) {
-                if (this.props._speakerStatsOrder.includes('name')) {
-                    const { _localDisplayName } = this.props;
-
-                    if (stats[id].isLocalStats()) {
-                        stats[id].setDisplayName(_localDisplayName);
-                    }
-                }
-
-                if (this.props._speakerStatsOrder.includes('role')) {
-                    const participant = getParticipantById(APP.store.getState(), stats[id].getUserId());
-
-                    stats[id].isModerator = participant.role === PARTICIPANT_ROLE.MODERATOR;
-                }
-            }
-        }
-
-        return objectSort(stats, (currentParticipant, nextParticipant) => {
-            if (this.props._speakerStatsOrder.includes('hasLeft')) {
-                if (nextParticipant.hasLeft() && !currentParticipant.hasLeft()) {
-                    return -1;
-                } else if (currentParticipant.hasLeft() && !nextParticipant.hasLeft()) {
-                    return 1;
-                }
-            }
-
-            let result;
-
-            for (const sortCriteria of this.props._speakerStatsOrder) {
-                switch (sortCriteria) {
-                case 'role':
-                    if (!nextParticipant.isModerator && currentParticipant.isModerator) {
-                        result = -1;
-                    } else if (!currentParticipant.isModerator && nextParticipant.isModerator) {
-                        result = 1;
-                    } else {
-                        result = 0;
-                    }
-                    break;
-                case 'name':
-                    result = (currentParticipant.getDisplayName() || '').localeCompare(
-                        nextParticipant.getDisplayName() || ''
-                    );
-                    break;
-                }
-
-                if (result !== 0) {
-                    break;
-                }
-            }
-
-            return result;
-        });
     }
 
     /**
@@ -231,9 +125,9 @@ class SpeakerStats extends Component<Props, State> {
      * @private
      */
     _createStatsItem(userId) {
-        const statsModel = this.state.stats[userId];
+        const statsModel = this.props._stats[userId];
 
-        if (!statsModel) {
+        if (!statsModel || statsModel.hidden) {
             return null;
         }
 
@@ -252,7 +146,7 @@ class SpeakerStats extends Component<Props, State> {
                 = displayName ? `${displayName} (${meString})` : meString;
         } else {
             displayName
-                = this.state.stats[userId].getDisplayName()
+                = this.props._stats[userId].getDisplayName()
                     || interfaceConfig.DEFAULT_REMOTE_DISPLAY_NAME;
         }
 
@@ -276,27 +170,20 @@ class SpeakerStats extends Component<Props, State> {
      * @protected
      */
     _onSearch(criteria = '') {
-        this.setState({
-            ...this.state,
-            criteria: escapeRegexp(criteria)
-        });
+        APP.store.dispatch(initSearch(escapeRegexp(criteria)));
     }
 
-    _updateStats: () => void;
+    _updateStats: (reorder: boolean) => void;
 
     /**
      * Update the internal state with the latest speaker stats.
      *
+     * @param {boolean} reorder - Should reorder boolean or not.
      * @returns {void}
      * @private
      */
-    _updateStats() {
-        const stats = this._getSpeakerStats();
-
-        this.setState({
-            ...this.state,
-            stats
-        });
+    _updateStats(reorder = false) {
+        APP.store.dispatch(initUpdateStats(reorder));
     }
 }
 
@@ -307,7 +194,6 @@ class SpeakerStats extends Component<Props, State> {
  * @private
  * @returns {{
  *     _localDisplayName: ?string,
- *     _speakerStatsOrder: Array<string>
  * }}
  */
 function _mapStateToProps(state) {
@@ -321,7 +207,8 @@ function _mapStateToProps(state) {
          * @type {string|undefined}
          */
         _localDisplayName: localParticipant && localParticipant.name,
-        _speakerStatsOrder: getSpeakerStatsOrder(state)
+        _stats: getSpeakerStats(state),
+        _criteria: getSearchCriteria(state)
     };
 }
 

--- a/react/features/speaker-stats/constants.js
+++ b/react/features/speaker-stats/constants.js
@@ -1,0 +1,1 @@
+export const SPEAKER_STATS_RELOAD_INTERVAL = 1000;

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -9,3 +9,13 @@
 export function isSpeakerStatsSearchDisabled(state: Object) {
     return state['features/base/config']?.disableSpeakerStatsSearch;
 }
+
+/**
+ * Gets whether participants in speaker stats should be ordered or not, and with what priority.
+ *
+ * @param {*} state - The redux state.
+ * @returns {Array<string>} - The speaker stats order array or an empty array.
+ */
+export function getSpeakerStatsOrder(state: Object) {
+    return state['features/base/config']?.speakerStatsOrder ?? [];
+}

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -56,7 +56,7 @@ export function getSearchCriteria(state: Object) {
  * @returns {Object} - Ordered speaker stats.
  * @public
  */
-export function getSortedSpeakerStats(state) {
+export function getSortedSpeakerStats(state: Object) {
     const stats = _.cloneDeep(getSpeakerStats(state));
     const orderConfig = getSpeakerStatsOrder(state);
 
@@ -147,7 +147,7 @@ function getEnhancedStatsForOrdering(state, stats, orderConfig) {
  * @returns {Object} - Filtered speaker stats.
  * @public
  */
-export function filterBySearchCriteria(state, stats) {
+export function filterBySearchCriteria(state: Object, stats: ?Object) {
     const filteredStats = _.cloneDeep(stats ?? getSpeakerStats(state));
     const criteria = getSearchCriteria(state);
 

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -1,5 +1,10 @@
 // @flow
 
+import _ from 'lodash';
+
+import { getLocalParticipant, getParticipantById, PARTICIPANT_ROLE } from '../base/participants';
+import { objectSort } from '../base/util';
+
 /**
  * Checks if the speaker stats search is disabled.
  *
@@ -17,5 +22,148 @@ export function isSpeakerStatsSearchDisabled(state: Object) {
  * @returns {Array<string>} - The speaker stats order array or an empty array.
  */
 export function getSpeakerStatsOrder(state: Object) {
-    return state['features/base/config']?.speakerStatsOrder ?? [];
+    return state['features/base/config']?.speakerStatsOrder ?? [
+        'role',
+        'name',
+        'hasLeft'
+    ];
+}
+
+/**
+ * Gets speaker stats.
+ *
+ * @param {*} state - The redux state.
+ * @returns {Object} - The speaker stats.
+ */
+export function getSpeakerStats(state: Object) {
+    return state['features/speaker-stats']?.stats ?? {};
+}
+
+/**
+ * Gets speaker stats search criteria.
+ *
+ * @param {*} state - The redux state.
+ * @returns {string} - The search criteria.
+ */
+export function getSearchCriteria(state: Object) {
+    return state['features/speaker-stats']?.criteria ?? '';
+}
+
+/**
+ * Get sorted speaker stats based on a configuration setting.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Object} - Ordered speaker stats.
+ * @public
+ */
+export function getSortedSpeakerStats(state) {
+    const stats = _.cloneDeep(getSpeakerStats(state));
+    const orderConfig = getSpeakerStatsOrder(state);
+
+    if (orderConfig) {
+        const enhancedStats = getEnhancedStatsForOrdering(state, stats, orderConfig);
+        const sortedStats = objectSort(enhancedStats, (currentParticipant, nextParticipant) => {
+            if (orderConfig.includes('hasLeft')) {
+                if (nextParticipant.hasLeft() && !currentParticipant.hasLeft()) {
+                    return -1;
+                } else if (currentParticipant.hasLeft() && !nextParticipant.hasLeft()) {
+                    return 1;
+                }
+            }
+
+            let result;
+
+            for (const sortCriteria of orderConfig) {
+                switch (sortCriteria) {
+                case 'role':
+                    if (!nextParticipant.isModerator && currentParticipant.isModerator) {
+                        result = -1;
+                    } else if (!currentParticipant.isModerator && nextParticipant.isModerator) {
+                        result = 1;
+                    } else {
+                        result = 0;
+                    }
+                    break;
+                case 'name':
+                    result = (currentParticipant.displayName || '').localeCompare(
+                        nextParticipant.displayName || ''
+                    );
+                    break;
+                }
+
+                if (result !== 0) {
+                    break;
+                }
+            }
+
+            return result;
+        });
+
+        return sortedStats;
+    }
+}
+
+/**
+ * Enhance speaker stats to include data needed for ordering.
+ *
+ * @param {Object} state - The redux state.
+ * @param {Object} stats - Speaker stats.
+ * @param {Array<string>} orderConfig - Ordering configuration.
+ * @returns {Object} - Enhanced speaker stats.
+ * @public
+ */
+function getEnhancedStatsForOrdering(state, stats, orderConfig) {
+    if (!orderConfig) {
+        return stats;
+    }
+
+    for (const id in stats) {
+        if (stats[id].hasOwnProperty('_hasLeft') && !stats[id].hasLeft()) {
+            if (orderConfig.includes('name')) {
+                const localParticipant = getLocalParticipant(state);
+
+                if (stats[id].isLocalStats()) {
+                    stats[id].setDisplayName(localParticipant.name);
+                }
+            }
+
+            if (orderConfig.includes('role')) {
+                const participant = getParticipantById(state, stats[id].getUserId());
+
+                stats[id].isModerator = participant.role === PARTICIPANT_ROLE.MODERATOR;
+            }
+        }
+    }
+
+    return stats;
+}
+
+/**
+ * Filter stats by search criteria.
+ *
+ * @param {Object} state - The redux state.
+ * @param {Object | undefined} stats - The unfiltered stats.
+ *
+ * @returns {Object} - Filtered speaker stats.
+ * @public
+ */
+export function filterBySearchCriteria(state, stats) {
+    const filteredStats = _.cloneDeep(stats ?? getSpeakerStats(state));
+    const criteria = getSearchCriteria(state);
+
+    if (criteria) {
+        const searchRegex = new RegExp(criteria, 'gi');
+
+        for (const id in filteredStats) {
+            if (filteredStats[id].hasOwnProperty('_isLocalStats')) {
+                const name = filteredStats[id].getDisplayName();
+
+                if (!name || !name.match(searchRegex)) {
+                    filteredStats[id].hidden = true;
+                }
+            }
+        }
+    }
+
+    return filteredStats;
 }

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -67,7 +67,7 @@ export function getPendingReorder(state: Object) {
  * @returns {Object} - Ordered speaker stats.
  * @public
  */
-export function getSortedSpeakerStats(state, stats) {
+export function getSortedSpeakerStats(state: Object, stats: Object) {
     const orderConfig = getSpeakerStatsOrder(state);
 
     if (orderConfig) {

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -50,14 +50,24 @@ export function getSearchCriteria(state: Object) {
 }
 
 /**
+ * Gets if speaker stats reorder is pending.
+ *
+ * @param {*} state - The redux state.
+ * @returns {boolean} - The pending reorder flag.
+ */
+export function getPendingReorder(state: Object) {
+    return state['features/speaker-stats']?.pendingReorder ?? false;
+}
+
+/**
  * Get sorted speaker stats based on a configuration setting.
  *
  * @param {Object} state - The redux state.
+ * @param {Object} stats - The current speaker stats.
  * @returns {Object} - Ordered speaker stats.
  * @public
  */
-export function getSortedSpeakerStats(state: Object) {
-    const stats = _.cloneDeep(getSpeakerStats(state));
+export function getSortedSpeakerStats(state, stats) {
     const orderConfig = getSpeakerStatsOrder(state);
 
     if (orderConfig) {
@@ -130,7 +140,7 @@ function getEnhancedStatsForOrdering(state, stats, orderConfig) {
             if (orderConfig.includes('role')) {
                 const participant = getParticipantById(state, stats[id].getUserId());
 
-                stats[id].isModerator = participant.role === PARTICIPANT_ROLE.MODERATOR;
+                stats[id].isModerator = participant && participant.role === PARTICIPANT_ROLE.MODERATOR;
             }
         }
     }

--- a/react/features/speaker-stats/middleware.js
+++ b/react/features/speaker-stats/middleware.js
@@ -1,0 +1,64 @@
+// @flow
+
+import {
+    PARTICIPANT_JOINED,
+    PARTICIPANT_KICKED,
+    PARTICIPANT_LEFT,
+    PARTICIPANT_UPDATED
+} from '../base/participants/actionTypes';
+import { MiddlewareRegistry } from '../base/redux';
+
+import { INIT_SEARCH, INIT_UPDATE_STATS } from './actionTypes';
+import { reorderStats, updateStats } from './actions';
+import { SPEAKER_STATS_RELOAD_INTERVAL } from './constants';
+import { filterBySearchCriteria, getSortedSpeakerStats } from './functions';
+
+declare var APP: Object;
+
+let reorderTimeoutHandle;
+
+MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+
+    case INIT_SEARCH: {
+        const state = getState();
+        const stats = filterBySearchCriteria(state);
+
+        dispatch(updateStats(stats));
+        break;
+    }
+
+    case INIT_UPDATE_STATS:
+    case PARTICIPANT_JOINED:
+    case PARTICIPANT_LEFT:
+    case PARTICIPANT_KICKED:
+    case PARTICIPANT_UPDATED: {
+        let reorderFlag = true;
+
+        if (action.type === INIT_UPDATE_STATS) {
+            const state = getState();
+            const speakerStats = { ...APP.conference.getSpeakerStats() };
+            const stats = filterBySearchCriteria(state, speakerStats);
+
+            dispatch(updateStats(stats));
+
+            reorderFlag = Boolean(action.reorder);
+        }
+
+        if (reorderFlag) {
+            clearTimeout(reorderTimeoutHandle);
+            reorderTimeoutHandle = setTimeout(() => {
+                const newState = getState();
+
+                dispatch(reorderStats(getSortedSpeakerStats(newState)));
+            }, SPEAKER_STATS_RELOAD_INTERVAL);
+        }
+
+        break;
+    }
+    }
+
+    return result;
+});

--- a/react/features/speaker-stats/middleware.js
+++ b/react/features/speaker-stats/middleware.js
@@ -37,9 +37,9 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
     case PARTICIPANT_UPDATED: {
         let reorderFlag = true;
 
-        if (action.type === INIT_UPDATE_STATS) {
+        if (action.type === INIT_UPDATE_STATS && action.getSpeakerStats) {
             const state = getState();
-            const speakerStats = { ...APP.conference.getSpeakerStats() };
+            const speakerStats = { ...action.getSpeakerStats() };
             const stats = filterBySearchCriteria(state, speakerStats);
 
             dispatch(updateStats(stats));

--- a/react/features/speaker-stats/middleware.js
+++ b/react/features/speaker-stats/middleware.js
@@ -13,8 +13,6 @@ import { reorderStats, updateStats } from './actions';
 import { SPEAKER_STATS_RELOAD_INTERVAL } from './constants';
 import { filterBySearchCriteria, getSortedSpeakerStats } from './functions';
 
-declare var APP: Object;
-
 let reorderTimeoutHandle;
 
 MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {

--- a/react/features/speaker-stats/reducer.js
+++ b/react/features/speaker-stats/reducer.js
@@ -16,7 +16,7 @@ import {
  * @type {Object}
  */
 const INITIAL_STATE = {
-    stats: [],
+    stats: {},
     criteria: ''
 };
 

--- a/react/features/speaker-stats/reducer.js
+++ b/react/features/speaker-stats/reducer.js
@@ -1,0 +1,109 @@
+// @flow
+
+import _ from 'lodash';
+
+import { ReducerRegistry } from '../base/redux';
+
+import {
+    INIT_SEARCH,
+    UPDATE_STATS,
+    REORDER_STATS
+} from './actionTypes';
+
+/**
+ * The initial state of the feature speaker-stats.
+ *
+ * @type {Object}
+ */
+const INITIAL_STATE = {
+    stats: [],
+    criteria: ''
+};
+
+ReducerRegistry.register('features/speaker-stats', (state = _getInitialState(), action) => {
+    switch (action.type) {
+    case INIT_SEARCH:
+        return _updateCriteria(state, action);
+    case UPDATE_STATS:
+        return _updateStats(state, action);
+    case REORDER_STATS:
+        return _reorderStats(state, action);
+    }
+
+    return state;
+});
+
+/**
+ * Gets the initial state of the feature speaker-stats.
+ *
+ * @returns {Object}
+ */
+function _getInitialState() {
+    return INITIAL_STATE;
+}
+
+/**
+ * Reduces a specific Redux action INIT_SEARCH of the feature
+ * speaker-stats.
+ *
+ * @param {Object} state - The Redux state of the feature speaker-stats.
+ * @param {Action} action - The Redux action INIT_SEARCH to reduce.
+ * @private
+ * @returns {Object} The new state after the reduction of the specified action.
+ */
+function _updateCriteria(state, { criteria }) {
+    return _.assign(
+        {},
+        state,
+        { criteria },
+    );
+}
+
+/**
+ * Reduces a specific Redux action UPDATE_STATS of the feature
+ * speaker-stats.
+ *
+ * @param {Object} state - The Redux state of the feature speaker-stats.
+ * @param {Action} action - The Redux action UPDATE_STATS to reduce.
+ * @private
+ * @returns {Object} The new state after the reduction of the specified action.
+ */
+function _updateStats(state, { stats }) {
+    const finalStats = _.cloneDeep(state.stats);
+
+    // Avoid reordering the object properties
+    const finalKeys = Object.keys(stats);
+
+    finalKeys.forEach(newStatId => {
+        finalStats[newStatId] = _.clone(stats[newStatId]);
+    });
+
+    Object.keys(finalStats).forEach(key => {
+        if (!finalKeys.includes(key)) {
+            delete finalStats[key];
+        }
+    });
+
+    return _.assign(
+        {},
+        state,
+        { stats: finalStats },
+    );
+}
+
+/**
+ * Reduces a specific Redux action REORDER_STATS of the feature
+ * speaker-stats.
+ *
+ * @param {Object} state - The Redux state of the feature speaker-stats.
+ * @param {Action} action - The Redux action REORDER_STATS to reduce.
+ * @private
+ * @returns {Object} The new state after the reduction of the specified action.
+ */
+function _reorderStats(state, { stats }) {
+    return _.assign(
+        {},
+        state,
+        { stats },
+    );
+}

--- a/react/features/speaker-stats/reducer.js
+++ b/react/features/speaker-stats/reducer.js
@@ -28,7 +28,7 @@ ReducerRegistry.register('features/speaker-stats', (state = _getInitialState(), 
     case UPDATE_STATS:
         return _updateStats(state, action);
     case INIT_REORDER_STATS:
-        return _initReorderStats(state, action);
+        return _initReorderStats(state);
     }
 
     return state;

--- a/react/features/speaker-stats/reducer.js
+++ b/react/features/speaker-stats/reducer.js
@@ -63,17 +63,22 @@ function _updateCriteria(state, { criteria }) {
 /**
  * Reduces a specific Redux action UPDATE_STATS of the feature
  * speaker-stats.
+ * The speaker stats order is based on the stats object properties.
+ * When updating without reordering, the new stats object properties are reordered
+ * as the last in state, otherwise the order would be lost on each update.
+ * If there was already a pending reorder, the stats object properties already have
+ * the correct order, so the property order is not changing.
  *
  * @param {Object} state - The Redux state of the feature speaker-stats.
  * @param {Action} action - The Redux action UPDATE_STATS to reduce.
  * @private
- * @returns {Object} The new state after the reduction of the specified action.
+ * @returns {Object} - The new state after the reduction of the specified action.
  */
 function _updateStats(state, { stats }) {
     const finalStats = state.pendingReorder ? stats : state.stats;
 
     if (!state.pendingReorder) {
-        // Avoid reordering the object properties
+        // Avoid reordering the speaker stats object properties
         const finalKeys = Object.keys(stats);
 
         finalKeys.forEach(newStatId => {


### PR DESCRIPTION
This is an implementation of #9742

Speaker stats participants are now reordered after each retrieval if the setting is configured, else it works the same as before.