### PR TITLE
fix(ios) fix conference failing when proximity sensor is near

### DIFF
--- a/patches/react-native+0.61.5-jitsi.2.patch
+++ b/patches/react-native+0.61.5-jitsi.2.patch
@@ -11,6 +11,39 @@ index bd48f44..d243ed0 100644
                                 withDispatchGroup:(dispatch_group_t)dispatchGroup
                                  lazilyDiscovered:(BOOL)lazilyDiscovered
  {
+diff --git a/node_modules/react-native/React/Modules/RCTTiming.m b/node_modules/react-native/React/Modules/RCTTiming.m
+index 8a09022..265d7b6 100644
+--- a/node_modules/react-native/React/Modules/RCTTiming.m
++++ b/node_modules/react-native/React/Modules/RCTTiming.m
+@@ -130,6 +130,11 @@ - (void)setBridge:(RCTBridge *)bridge
+                                                object:nil];
+   }
+
++  [[NSNotificationCenter defaultCenter] addObserver:self
++                                           selector:@selector(proximityChanged)
++                                               name:UIDeviceProximityStateDidChangeNotification
++                                             object:nil];
++
+   _bridge = bridge;
+ }
+
+@@ -276,6 +281,16 @@ - (void)didUpdateFrame:(RCTFrameUpdate *)update
+   }
+ }
+
++-(void)proximityChanged
++{
++  BOOL near = [UIDevice currentDevice].proximityState;
++  if (near) {
++    [self appDidMoveToBackground];
++  } else {
++    [self appDidMoveToForeground];
++  }
++}
++
+ - (void)scheduleSleepTimer:(NSDate *)sleepTarget
+ {
+   @synchronized (self) {
 diff --git a/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm b/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
 index 3cb73b5..e4a14b4 100644
 --- a/node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm


### PR DESCRIPTION
React Native links timers to the display, so they cannot run when the display is
not running. Builtin timers already take being in the background into account,
but not the proximity sensor.

Credits: https://github.com/react-native-webrtc/react-native-callkeep/issues/143

Fixes: https://github.com/jitsi/jitsi-meet/issues/9619

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
