### PR TITLE
fix(local-storage) use local storage on WebKit when not in an iframe

### DIFF
--- a/react/features/base/jitsi-local-storage/setup.web.js
+++ b/react/features/base/jitsi-local-storage/setup.web.js
@@ -12,6 +12,20 @@ declare var APP: Object;
 declare var config: Object;
 
 /**
+ * Checks whether we are loaded in an iframe.
+ *
+ * @returns {boolean} Returns {@code true} if loaded in iframe.
+ * @private
+ */
+ function _inIframe() {
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
+    }
+}
+
+/**
  * Handles changes of the fake local storage.
  *
  * @returns {void}
@@ -41,7 +55,9 @@ function shouldUseHostPageLocalStorage(urlParams) {
         return true;
     }
 
-    if (browser.isWebKitBased()) { // Webkit browsers don't persist local storage for third-party iframes.
+    if (browser.isWebKitBased() && _inIframe()) {
+        // WebKit browsers don't persist local storage for third-party iframes.
+
         return true;
     }
 


### PR DESCRIPTION
There should be no need to use the workaround when visiting the site normally.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
