### PR TITLE
feat: Drops old prosody dependency (0.10...).

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Description: Configuration for web serving of Jitsi Meet
 
 Package: jitsi-meet-prosody
 Architecture: all
-Depends: openssl, prosody | prosody-trunk | prosody-0.11, lua-sec
+Depends: openssl, prosody (>= 0.11.0) | prosody-trunk | prosody-0.11, lua-sec
 Replaces: jitsi-meet-tokens
 Description: Prosody configuration for Jitsi Meet
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi


### PR DESCRIPTION
Many features work only with 0.11+ prosody versions and there are instructions in the handbook how to install it before installing jitsi-meet.

I have tested it and on 18.04 I get:
```
# apt install jitsi-meet
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 jitsi-meet : Depends: jitsi-meet-prosody (= 1.0.6202-1) but it is not going to be installed
              Recommends: jitsi-meet-turnserver (= 1.0.6202-1) but it is not going to be installed or
                          apache2 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

And if you follow https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart#for-ubuntu-1804-add-prosody-package-repository everything installs with no problem:
```
ii  prosody                          0.11.9-1~bionic1                            amd64        Lightweight Jabber/XMPP server
```