### PR TITLE
Thumbnail reordering and participant pane enhancements.

### DIFF
--- a/config.js
+++ b/config.js
@@ -41,6 +41,10 @@ var config = {
         // issues related to insertable streams.
         // disableE2EE: false,
 
+        // Enables/disables thumbnail reordering in the filmstrip. It is enabled by default unless explicitly
+        // disabled by the below option.
+        // enableThumbnailReordering: true,
+
         // P2P test mode disables automatic switching to P2P when there are 2
         // participants in the conference.
         p2pTestMode: false

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -304,17 +304,6 @@ export function getPinnedParticipant(stateful: Object | Function) {
 }
 
 /**
- * Returns the participants that have their hands raised.
- *
- * @param {(Function|Object)} stateful - The (whole) redux state, or redux's {@code getState} function to be used to
- * retrieve the state features/base/participants.
- * @returns {Set<string>}
- */
-export function getRaisedHandParticipants(stateful: Object | Function) {
-    return toState(stateful)['features/base/participants'].raisedHandParticipants;
-}
-
-/**
  * Returns true if the participant is a moderator.
  *
  * @param {string} participant - Participant object.
@@ -484,11 +473,16 @@ export function getSortedParticipantIds(stateful: Object | Function): Array<stri
     const { id } = getLocalParticipant(stateful);
     const remoteParticipants = getRemoteParticipantsSorted(stateful);
     const reorderedParticipants = new Set(remoteParticipants);
-    const raisedHandParticipants = getRaisedHandParticipants(stateful);
+    const raisedHandParticipants = getRaiseHandsQueue(stateful);
     const remoteRaisedHandParticipants = new Set(raisedHandParticipants || []);
 
     for (const participant of remoteRaisedHandParticipants.keys()) {
-        reorderedParticipants.delete(participant);
+        // Avoid duplicates.
+        if (reorderedParticipants.has(participant)) {
+            reorderedParticipants.delete(participant);
+        } else {
+            remoteRaisedHandParticipants.delete(participant);
+        }
     }
 
     // Remove self.

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -61,11 +61,11 @@ const DEFAULT_STATE = {
     haveParticipantWithScreenSharingFeature: false,
     local: undefined,
     pinnedParticipant: undefined,
+    raisedHandsQueue: [],
     remote: new Map(),
     sortedRemoteParticipants: new Map(),
     sortedRemoteScreenshares: new Map(),
-    speakersList: new Map(),
-    raisedHandsQueue: []
+    speakersList: new Map()
 };
 
 /**

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -101,11 +101,19 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
         const { participant } = action;
         const { id, previousSpeakers = [] } = participant;
         const { dominantSpeaker, local } = state;
-        let newSpeakers = [ id, ...previousSpeakers ];
+        const newSpeakers = [ id, ...previousSpeakers ];
+        const sortedSpeakersList = [];
 
-        // Filter out the local participant from the speakers list.
-        newSpeakers = newSpeakers.filter(s => s !== local?.id);
-        const sortedSpeakersList = _sortParticipantsByDisplayname(state, newSpeakers);
+        for (const speaker of newSpeakers) {
+            if (speaker !== local?.id) {
+                const remoteParticipant = state.remote.get(speaker);
+
+                remoteParticipant && sortedSpeakersList.push([ speaker, _getDisplayName(remoteParticipant.name) ]);
+            }
+        }
+
+        // Keep the remote speaker list sorted alphabetically.
+        sortedSpeakersList.sort((a, b) => a[1].localeCompare(b[1]));
 
         // Only one dominant speaker is allowed.
         if (dominantSpeaker) {
@@ -116,7 +124,7 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
             return {
                 ...state,
                 dominantSpeaker: id,
-                speakersList: sortedSpeakersList
+                speakersList: new Map(sortedSpeakersList)
             };
         }
 
@@ -194,7 +202,7 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
     }
     case PARTICIPANT_JOINED: {
         const participant = _participantJoined(action);
-        const { id, isFakeParticipant, pinned } = participant;
+        const { id, isFakeParticipant, name, pinned } = participant;
         const { pinnedParticipant, dominantSpeaker } = state;
 
         if (pinned) {
@@ -230,11 +238,15 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
 
         state.remote.set(id, participant);
 
-        // Insert the new participant and sort it alphabetically.
-        const remoteParticipants = Array.from(state.sortedRemoteParticipants.keys());
+        // Insert the new participant.
+        const displayName = _getDisplayName(name);
+        const sortedRemoteParticipants = Array.from(state.sortedRemoteParticipants);
 
-        remoteParticipants.push(id);
-        state.sortedRemoteParticipants = _sortParticipantsByDisplayname(state, remoteParticipants);
+        sortedRemoteParticipants.push([ id, displayName ]);
+        sortedRemoteParticipants.sort((a, b) => a[1].localeCompare(b[1]));
+
+        // The sort order of participants is preserved since Map remembers the original insertion order of the keys.
+        state.sortedRemoteParticipants = new Map(sortedRemoteParticipants);
 
         if (isFakeParticipant) {
             state.fakeParticipants.set(id, participant);
@@ -467,28 +479,6 @@ function _participantJoined({ participant }) {
         presence,
         role: role || PARTICIPANT_ROLE.NONE
     };
-}
-
-/**
- * Returns a map of the remote participants which are sorted alphabetically by display name.
- *
- * @param {State} state - The redux state.
- * @param {Array<string>} participants - Ids of the participants that need to be sorted.
- * @returns {Map<string, string>}
- */
-function _sortParticipantsByDisplayname(state: Object, participants: Array<string>) {
-    const sortedParticipants = [];
-
-    for (const p of participants) {
-        const remoteParticipant = state.remote.get(p);
-
-        remoteParticipant && sortedParticipants.push([ p, _getDisplayName(remoteParticipant.name) ]);
-    }
-
-    // Keep the remote speaker list sorted alphabetically.
-    sortedParticipants.sort((a, b) => a[1].localeCompare(b[1]));
-
-    return new Map(sortedParticipants);
 }
 
 /**

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -240,10 +240,10 @@ class Filmstrip extends PureComponent <Props> {
         let stop = stopIndex;
 
         if (_thumbnailsReordered) {
-            // In tile view, the start index needs to be offset by 1 because the first thumbnail is that of the local
+            // In tile view, the indices needs to be offset by 1 because the first thumbnail is that of the local
             // endpoint. The remote participants start from index 1.
             if (_currentLayout === LAYOUTS.TILE_VIEW) {
-                start = startIndex > 0 ? startIndex - 1 : 0;
+                start = Math.max(startIndex - 1, 0);
                 stop = stopIndex - 1;
             }
         }

--- a/react/features/filmstrip/components/web/Filmstrip.js
+++ b/react/features/filmstrip/components/web/Filmstrip.js
@@ -528,7 +528,8 @@ class Filmstrip extends PureComponent <Props> {
  */
 function _mapStateToProps(state) {
     const toolbarButtons = getToolbarButtons(state);
-    const { enableThumbnailReordering = true } = state['features/base/config'];
+    const { testing = {} } = state['features/base/config'];
+    const enableThumbnailReordering = testing.enableThumbnailReordering ?? true;
     const { visible, remoteParticipants } = state['features/filmstrip'];
     const reduceHeight = state['features/toolbox'].visible && toolbarButtons.length;
     const remoteVideosVisible = shouldRemoteVideosBeVisible(state);

--- a/react/features/filmstrip/components/web/ThumbnailWrapper.js
+++ b/react/features/filmstrip/components/web/ThumbnailWrapper.js
@@ -104,7 +104,8 @@ function _mapStateToProps(state, ownProps) {
     const _currentLayout = getCurrentLayout(state);
     const { remoteParticipants } = state['features/filmstrip'];
     const remoteParticipantsLength = remoteParticipants.length;
-    const { enableThumbnailReordering = true } = state['features/base/config'];
+    const { testing = {} } = state['features/base/config'];
+    const enableThumbnailReordering = testing.enableThumbnailReordering ?? true;
 
     if (_currentLayout === LAYOUTS.TILE_VIEW) {
         const { columnIndex, rowIndex } = ownProps;

--- a/react/features/filmstrip/functions.any.js
+++ b/react/features/filmstrip/functions.any.js
@@ -12,7 +12,8 @@ import { setRemoteParticipants } from './actions';
  */
 export function updateRemoteParticipants(store: Object, participantId: ?number) {
     const state = store.getState();
-    const { enableThumbnailReordering = true } = state['features/base/config'];
+    const { testing = {} } = state['features/base/config'];
+    const enableThumbnailReordering = testing.enableThumbnailReordering ?? true;
     let reorderedParticipants = [];
 
     if (!enableThumbnailReordering) {

--- a/react/features/filmstrip/middleware.web.js
+++ b/react/features/filmstrip/middleware.web.js
@@ -22,6 +22,15 @@ import './subscriber';
  * The middleware of the feature Filmstrip.
  */
 MiddlewareRegistry.register(store => next => action => {
+    if (action.type === PARTICIPANT_LEFT) {
+        // This has to be executed before we remove the participant from features/base/participants state in order to
+        // remove the related thumbnail component before we need to re-render it. If we do this after next()
+        // we will be in sitation where the participant exists in the remoteParticipants array in features/filmstrip
+        // but doesn't exist in features/base/participants state which will lead to rendering a thumbnail for
+        // non-existing participant.
+        updateRemoteParticipantsOnLeave(store, action.participant?.id);
+    }
+
     const result = next(action);
 
     switch (action.type) {
@@ -48,10 +57,6 @@ MiddlewareRegistry.register(store => next => action => {
     }
     case PARTICIPANT_JOINED: {
         updateRemoteParticipants(store, action.participant?.id);
-        break;
-    }
-    case PARTICIPANT_LEFT: {
-        updateRemoteParticipantsOnLeave(store, action.participant?.id);
         break;
     }
     case SETTINGS_UPDATED: {

--- a/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
@@ -396,7 +396,7 @@ class MeetingParticipantContextMenu extends Component<Props, State> {
         }
 
         const actions
-            = _participant.isFakeParticipant ? (
+            = _participant?.isFakeParticipant ? (
                 <>
                     {_localVideoOwner && (
                         <ContextMenuItem onClick = { this._onStopSharedVideo }>

--- a/react/features/participants-pane/components/web/MeetingParticipantItem.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantItem.js
@@ -170,7 +170,7 @@ function MeetingParticipantItem({
             videoMediaState = { _videoMediaState }
             youText = { youText }>
 
-            {!overflowDrawer && !_participant.isFakeParticipant
+            {!overflowDrawer && !_participant?.isFakeParticipant
                 && <>
                     <ParticipantQuickAction
                         askUnmuteText = { askUnmuteText }
@@ -184,7 +184,7 @@ function MeetingParticipantItem({
                  </>
             }
 
-            {!overflowDrawer && _localVideoOwner && _participant.isFakeParticipant && (
+            {!overflowDrawer && _localVideoOwner && _participant?.isFakeParticipant && (
                 <ParticipantActionEllipsis
                     aria-label = { participantActionEllipsisLabel }
                     onClick = { onContextMenu } />


### PR DESCRIPTION
Match the order in the participants pane with that of the order in the filmstrip. Also move the participants with raised hand to the top of the list.
Move enableThumbnailReordering flag to testing section.
