### PR TITLE
fix(tracks) Fix mobile safari issue with startMuted.

### DIFF
--- a/react/features/prejoin/middleware.js
+++ b/react/features/prejoin/middleware.js
@@ -2,7 +2,8 @@
 
 import { CONFERENCE_JOINED } from '../base/conference';
 import { updateConfig } from '../base/config';
-import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../base/media';
+import { isIosMobileBrowser } from '../base/environment/utils';
+import { MEDIA_TYPE, SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../base/media';
 import { MiddlewareRegistry } from '../base/redux';
 import { updateSettings } from '../base/settings';
 import {
@@ -46,7 +47,10 @@ MiddlewareRegistry.register(store => next => async action => {
 
         // Do not signal audio/video tracks if the user joins muted.
         for (const track of localTracks) {
-            if (track.muted) {
+            // Always add the audio track on mobile Safari because of a known issue where audio playout doesn't happen
+            // if the user joins audio and video muted.
+            if (track.muted
+                && !(isIosMobileBrowser() && track.jitsiTrack && track.jitsiTrack.getType() === MEDIA_TYPE.AUDIO)) {
                 await dispatch(replaceLocalTrack(track.jitsiTrack, null));
             }
         }


### PR DESCRIPTION
On mobile Safari, when a user joins both audio and video muted, browser doesn't playout the remote audio because of a webkit bug. As a workaround, always add the audio track to peerconnection and then mute the track if needed.
This also fixes the issue where unmuting microphone doesn't work sometimes.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
