### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11117,8 +11117,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#2820d649ea72c69134c77825a86068a505220119",
-      "from": "github:jitsi/lib-jitsi-meet#2820d649ea72c69134c77825a86068a505220119",
+      "version": "github:jitsi/lib-jitsi-meet#b0d27fa8daef615d45fe566a0385f66facfcf025",
+      "from": "github:jitsi/lib-jitsi-meet#b0d27fa8daef615d45fe566a0385f66facfcf025",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#98cd62cc00f92c8c2430e52ca746a86813658e83",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#2820d649ea72c69134c77825a86068a505220119",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#b0d27fa8daef615d45fe566a0385f66facfcf025",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(browser-support): Add audio track to pc always on mobile Safari. On mobile Safari, if a user joins audio and video muted, the browser doesn't decode the incoming audio. Workaround is to always add the audio track to pc and mute it if needed.
* feat: JSON encoded sources.

https://github.com/jitsi/lib-jitsi-meet/compare/2820d649ea72c69134c77825a86068a505220119...b0d27fa8daef615d45fe566a0385f66facfcf025

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
