### PR TITLE
feat(responsive-ui): Keep aspect ratio for filmstrip self view on mobile web

### DIFF
--- a/react/features/base/responsive-ui/actions.js
+++ b/react/features/base/responsive-ui/actions.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { batch } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { CHAT_SIZE } from '../../chat/constants';
@@ -45,10 +46,13 @@ export function clientResized(clientWidth: number, clientHeight: number) {
             }
         }
 
-        return dispatch({
-            type: CLIENT_RESIZED,
-            clientHeight,
-            clientWidth: availableWidth
+        batch(() => {
+            dispatch({
+                type: CLIENT_RESIZED,
+                clientHeight,
+                clientWidth: availableWidth
+            });
+            dispatch(setAspectRatio(clientWidth, clientHeight));
         });
     };
 }

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -14,6 +14,7 @@ import {
     pinParticipant
 } from '../../../base/participants';
 import { connect } from '../../../base/redux';
+import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
 import { isTestModeEnabled } from '../../../base/testing';
 import {
     getLocalAudioTrack,
@@ -33,6 +34,7 @@ import {
     DISPLAY_MODE_TO_STRING,
     DISPLAY_VIDEO,
     DISPLAY_VIDEO_WITH_NAME,
+    MOBILE_FILMSTRIP_PORTRAIT_RATIO,
     VIDEO_TEST_EVENTS,
     SHOW_TOOLBAR_CONTEXT_MENU_AFTER
 } from '../../constants';
@@ -143,6 +145,11 @@ export type Props = {|
      * Whether we are currently running in a mobile browser.
      */
     _isMobile: boolean,
+
+    /**
+     * Whether we are currently running in a mobile browser in portrait orientation.
+     */
+    _isMobilePortrait: boolean,
 
     /**
      * Indicates whether the participant is screen sharing.
@@ -764,7 +771,9 @@ class Thumbnail extends Component<Props, State> {
         const {
             _defaultLocalDisplayName,
             _disableLocalVideoFlip,
+            _height,
             _isMobile,
+            _isMobilePortrait,
             _isScreenSharing,
             _localFlipX,
             _disableProfile,
@@ -774,10 +783,13 @@ class Thumbnail extends Component<Props, State> {
         const { id } = _participant || {};
         const { audioLevel } = this.state;
         const styles = this._getStyles();
+        const localVideoStyle = {
+            ...styles.thumbnail,
+            height: _isMobilePortrait ? `${Math.floor(_height * MOBILE_FILMSTRIP_PORTRAIT_RATIO)}px` : styles.height
+        };
         const containerClassName = this._getContainerClassName();
         const videoTrackClassName
             = !_disableLocalVideoFlip && _videoTrack && !_isScreenSharing && _localFlipX ? 'flipVideoX' : '';
-
 
         return (
             <span
@@ -795,7 +807,7 @@ class Thumbnail extends Component<Props, State> {
                         onMouseLeave: this._onMouseLeave
                     }
                 ) }
-                style = { styles.thumbnail }>
+                style = { localVideoStyle }>
                 <div className = 'videocontainer__background' />
                 <span id = 'localVideoWrapper'>
                     <VideoTrack
@@ -1043,6 +1055,7 @@ function _mapStateToProps(state, ownProps): Object {
         ? getLocalAudioTrack(tracks) : getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.AUDIO, participantID);
     const _currentLayout = getCurrentLayout(state);
     let size = {};
+    let _isMobilePortrait = false;
     const {
         startSilent,
         disableLocalVideoFlip,
@@ -1078,9 +1091,12 @@ function _mapStateToProps(state, ownProps): Object {
             _height: height
         };
 
+        _isMobilePortrait = _isMobile && state['features/base/responsive-ui'].aspectRatio === ASPECT_RATIO_NARROW;
+
         break;
     }
     case LAYOUTS.TILE_VIEW: {
+
         const { width, height } = state['features/filmstrip'].tileViewDimensions.thumbnailSize;
 
         size = {
@@ -1104,6 +1120,7 @@ function _mapStateToProps(state, ownProps): Object {
         _isCurrentlyOnLargeVideo: state['features/large-video']?.participantId === id,
         _isDominantSpeakerDisabled: interfaceConfig.DISABLE_DOMINANT_SPEAKER_INDICATOR,
         _isMobile,
+        _isMobilePortrait,
         _isScreenSharing: _videoTrack?.videoType === 'desktop',
         _isTestModeEnabled: isTestModeEnabled(state),
         _isVideoPlayable: id && isVideoPlayable(state, id),

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -789,7 +789,7 @@ class Thumbnail extends Component<Props, State> {
 
         styles.thumbnail.height = _isMobilePortrait
             ? `${Math.floor(_height * MOBILE_FILMSTRIP_PORTRAIT_RATIO)}px`
-            : styles.height;
+            : styles.thumbnail.height;
 
         return (
             <span

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -783,13 +783,13 @@ class Thumbnail extends Component<Props, State> {
         const { id } = _participant || {};
         const { audioLevel } = this.state;
         const styles = this._getStyles();
-        const localVideoStyle = {
-            ...styles.thumbnail,
-            height: _isMobilePortrait ? `${Math.floor(_height * MOBILE_FILMSTRIP_PORTRAIT_RATIO)}px` : styles.height
-        };
         const containerClassName = this._getContainerClassName();
         const videoTrackClassName
             = !_disableLocalVideoFlip && _videoTrack && !_isScreenSharing && _localFlipX ? 'flipVideoX' : '';
+
+        styles.thumbnail.height = _isMobilePortrait
+            ? `${Math.floor(_height * MOBILE_FILMSTRIP_PORTRAIT_RATIO)}px`
+            : styles.height;
 
         return (
             <span
@@ -807,7 +807,7 @@ class Thumbnail extends Component<Props, State> {
                         onMouseLeave: this._onMouseLeave
                     }
                 ) }
-                style = { localVideoStyle }>
+                style = { styles.thumbnail }>
                 <div className = 'videocontainer__background' />
                 <span id = 'localVideoWrapper'>
                     <VideoTrack

--- a/react/features/filmstrip/constants.js
+++ b/react/features/filmstrip/constants.js
@@ -221,6 +221,14 @@ export const HORIZONTAL_FILMSTRIP_MARGIN = 39;
  */
 export const SHOW_TOOLBAR_CONTEXT_MENU_AFTER = 600;
 
+
+/**
+ * The ratio for filmstrip self view on mobile portrait mode.
+ *
+ * @type {number}
+ */
+export const MOBILE_FILMSTRIP_PORTRAIT_RATIO = 2.5;
+
 /**
  * The margin for each side of the tile view. Taken away from the available
  * height and width for the tile container to display in.


### PR DESCRIPTION
Right now filmstrip displays self view in landscape mode.
With these changes the aspect ratio of the self view will be maintained
so on portrait mode the thumbnail will be displayed vertically.
Of course this makes sense only on mobile web.

![Screenshot 2021-09-01 at 15 02 50](https://user-images.githubusercontent.com/37841821/131668696-bc382cae-652c-4c26-897c-e8846fa59a35.png)
![Screenshot 2021-09-01 at 15 03 04](https://user-images.githubusercontent.com/37841821/131668699-467fc250-a18a-46e7-9b19-aaf33771d36a.png)

