### PR TITLE
fix(external-api): Avoid naming event 'error'

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1333,7 +1333,7 @@ class API {
      */
     notifyError(error: Object) {
         this._sendEvent({
-            name: 'error',
+            name: 'error-occurred',
             error
         });
     }

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -81,7 +81,7 @@ const events = {
     'device-list-changed': 'deviceListChanged',
     'display-name-change': 'displayNameChange',
     'email-change': 'emailChange',
-    'error': 'error',
+    'error-occurred': 'errorOccurred',
     'endpoint-text-message-received': 'endpointTextMessageReceived',
     'feedback-submitted': 'feedbackSubmitted',
     'feedback-prompt-displayed': 'feedbackPromptDisplayed',


### PR DESCRIPTION
- EventEmmitter treats 'error' as a special case and throws error.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
