### PR TITLE
Use redux for local tracks instead of conference.js

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -728,9 +728,7 @@ export default {
                 track.mute();
             }
         });
-        logger.log(`Initialized with ${tracks.length} local tracks`);
 
-        this._localTracksInitialized = true;
         con.addEventListener(JitsiConnectionEvents.CONNECTION_FAILED, _connectionFailedHandler);
         APP.connection = connection = con;
 
@@ -1350,7 +1348,7 @@ export default {
      * @private
      */
     _setLocalAudioVideoStreams(tracks = []) {
-        return tracks.map(track => {
+        const promise = tracks.map(track => {
             if (track.isAudioTrack()) {
                 return this.useAudioStream(track);
             } else if (track.isVideoTrack()) {
@@ -1359,11 +1357,15 @@ export default {
                 return this.useVideoStream(track);
             }
 
-            logger.error(
-                    'Ignored not an audio nor a video track: ', track);
+            logger.error('Ignored not an audio nor a video track: ', track);
 
             return Promise.resolve();
 
+        });
+
+        return promise.then(() => {
+            this._localTracksInitialized = true;
+            logger.log(`Initialized with ${tracks.length} local tracks`);
         });
     },
 

--- a/conference.js
+++ b/conference.js
@@ -1350,7 +1350,7 @@ export default {
 
         });
 
-        return Promise.all(promises).then(() => {
+        return Promise.allSettled(promises).then(() => {
             this._localTracksInitialized = true;
             logger.log(`Initialized with ${tracks.length} local tracks`);
         });

--- a/conference.js
+++ b/conference.js
@@ -1375,24 +1375,10 @@ export default {
 
         return new Promise((resolve, reject) => {
             _replaceLocalVideoTrackQueue.enqueue(onFinish => {
-                const state = APP.store.getState();
-                const oldTrack = getLocalJitsiVideoTrack(state);
-
-                // When the prejoin page is displayed localVideo is not set
-                // so just replace the video track from the store with the new one.
-                if (isPrejoinPageVisible(state)) {
-                    logger.debug(`useVideoStream on the prejoin screen: Replacing ${oldTrack} with ${newTrack}`);
-
-                    return APP.store.dispatch(replaceLocalTrack(oldTrack, newTrack))
-                        .then(resolve)
-                        .catch(error => {
-                            logger.error(`useVideoStream failed on the prejoin screen: ${error}`);
-                            reject(error);
-                        })
-                        .then(onFinish);
-                }
+                const oldTrack = getLocalJitsiVideoTrack(APP.store.getState());
 
                 logger.debug(`useVideoStream: Replacing ${oldTrack} with ${newTrack}`);
+
                 APP.store.dispatch(
                     replaceLocalTrack(oldTrack, newTrack, room))
                     .then(() => {
@@ -1445,22 +1431,11 @@ export default {
     useAudioStream(newTrack) {
         return new Promise((resolve, reject) => {
             _replaceLocalAudioTrackQueue.enqueue(onFinish => {
-                const state = APP.store.getState();
-                const oldTrack = getLocalJitsiAudioTrack(state);
-
-                // When the prejoin page is displayed localAudio is not set
-                // so just replace the audio track from the store with the new one.
-                if (isPrejoinPageVisible(state)) {
-                    return APP.store.dispatch(replaceLocalTrack(oldTrack, newTrack))
-                        .then(resolve)
-                        .catch(reject)
-                        .then(onFinish);
-                }
+                const oldTrack = getLocalJitsiAudioTrack(APP.store.getState());
 
                 APP.store.dispatch(
                 replaceLocalTrack(oldTrack, newTrack, room))
                     .then(() => {
-                        // TODO do it isPrejoinPageVisible conditionally although it would not hurt to run always
                         this.setAudioMuteStatus(this.isLocalAudioMuted());
                     })
                     .then(resolve)

--- a/conference.js
+++ b/conference.js
@@ -1335,7 +1335,7 @@ export default {
      * @private
      */
     _setLocalAudioVideoStreams(tracks = []) {
-        const promise = tracks.map(track => {
+        const promises = tracks.map(track => {
             if (track.isAudioTrack()) {
                 return this.useAudioStream(track);
             } else if (track.isVideoTrack()) {
@@ -1350,7 +1350,7 @@ export default {
 
         });
 
-        return promise.then(() => {
+        return Promise.all(promises).then(() => {
             this._localTracksInitialized = true;
             logger.log(`Initialized with ${tracks.length} local tracks`);
         });
@@ -1378,6 +1378,13 @@ export default {
                 const oldTrack = getLocalJitsiVideoTrack(APP.store.getState());
 
                 logger.debug(`useVideoStream: Replacing ${oldTrack} with ${newTrack}`);
+
+                if (oldTrack === newTrack) {
+                    resolve();
+                    onFinish();
+
+                    return;
+                }
 
                 APP.store.dispatch(
                     replaceLocalTrack(oldTrack, newTrack, room))
@@ -1432,6 +1439,13 @@ export default {
         return new Promise((resolve, reject) => {
             _replaceLocalAudioTrackQueue.enqueue(onFinish => {
                 const oldTrack = getLocalJitsiAudioTrack(APP.store.getState());
+
+                if (oldTrack === newTrack) {
+                    resolve();
+                    onFinish();
+
+                    return;
+                }
 
                 APP.store.dispatch(
                 replaceLocalTrack(oldTrack, newTrack, room))


### PR DESCRIPTION
This PR tries to get rid of `localAudio` and `localVideo` fields in conference.js