### PR TITLE
Add indicator for moderators to participants pane

### DIFF
--- a/react/features/base/participants/constants.js
+++ b/react/features/base/participants/constants.js
@@ -58,6 +58,8 @@ export const PARTICIPANT_JOINED_SOUND_ID = 'PARTICIPANT_JOINED_SOUND';
  */
 export const PARTICIPANT_LEFT_SOUND_ID = 'PARTICIPANT_LEFT_SOUND';
 
+export type ParticipantRole = 'moderator' | 'none' | 'participant';
+
 /**
  * The set of possible XMPP MUC roles for conference participants.
  *

--- a/react/features/participants-pane/components/native/MeetingParticipantItem.js
+++ b/react/features/participants-pane/components/native/MeetingParticipantItem.js
@@ -6,7 +6,8 @@ import { translate } from '../../../base/i18n';
 import {
     getLocalParticipant,
     getParticipantByIdOrUndefined,
-    getParticipantDisplayName
+    getParticipantDisplayName,
+    type ParticipantRole
 } from '../../../base/participants';
 import { connect } from '../../../base/redux';
 import {
@@ -62,6 +63,11 @@ type Props = {
      * True if the participant have raised hand.
      */
     _raisedHand: boolean,
+
+    /**
+    * Participant's role.
+    */
+    _role: ParticipantRole,
 
     /**
      * The redux dispatch function.
@@ -130,7 +136,8 @@ class MeetingParticipantItem extends PureComponent<Props> {
             _isVideoMuted,
             _local,
             _participantID,
-            _raisedHand
+            _raisedHand,
+            _role
         } = this.props;
 
         return (
@@ -142,6 +149,7 @@ class MeetingParticipantItem extends PureComponent<Props> {
                 onPress = { this._onPress }
                 participantID = { _participantID }
                 raisedHand = { _raisedHand }
+                roleState = { _role }
                 videoMediaState = { _isVideoMuted ? MEDIA_STATE.MUTED : MEDIA_STATE.UNMUTED } />
         );
     }
@@ -173,7 +181,8 @@ function mapStateToProps(state, ownProps): Object {
         _local: Boolean(participant?.local),
         _localVideoOwner: Boolean(ownerId === localParticipantId),
         _participantID: participant?.id,
-        _raisedHand: Boolean(participant?.raisedHand)
+        _raisedHand: Boolean(participant?.raisedHand),
+        _role: participant?.role
     };
 }
 

--- a/react/features/participants-pane/components/native/ParticipantItem.js
+++ b/react/features/participants-pane/components/native/ParticipantItem.js
@@ -5,9 +5,10 @@ import type { Node } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { useSelector } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
-import { PARTICIPANT_ROLE, type ParticipantRole } from '../../../base/participants';
+import { PARTICIPANT_ROLE, type ParticipantRole, isEveryoneModerator } from '../../../base/participants';
 import { MEDIA_STATE, type MediaState, AudioStateIcons, VideoStateIcons, RoleStateIcons } from '../../constants';
 
 import { RaisedHandIndicator } from './RaisedHandIndicator';
@@ -85,6 +86,7 @@ function ParticipantItem({
 }: Props) {
 
     const { t } = useTranslation();
+    const allModerators = useSelector(isEveryoneModerator);
 
     return (
         <View style = { styles.participantContainer } >
@@ -104,11 +106,15 @@ function ParticipantItem({
                 {
                     !isKnockingParticipant
                     && <>
-                        {
-                            raisedHand && <RaisedHandIndicator />
-                        }
+
                         <View style = { styles.participantStatesContainer }>
-                            <View style = { styles.participantStateRole }>{RoleStateIcons[roleState]}</View>
+                            {
+                                !allModerators
+                                && <View style = { styles.participantStateRole }>{RoleStateIcons[roleState]}</View>
+                            }
+                            {
+                                raisedHand && <RaisedHandIndicator />
+                            }
                             <View style = { styles.participantStateVideo }>{VideoStateIcons[videoMediaState]}</View>
                             <View>{AudioStateIcons[audioMediaState]}</View>
                         </View>

--- a/react/features/participants-pane/components/native/ParticipantItem.js
+++ b/react/features/participants-pane/components/native/ParticipantItem.js
@@ -7,7 +7,8 @@ import { TouchableOpacity, View } from 'react-native';
 import { Text } from 'react-native-paper';
 
 import { Avatar } from '../../../base/avatar';
-import { MEDIA_STATE, type MediaState, AudioStateIcons, VideoStateIcons } from '../../constants';
+import { PARTICIPANT_ROLE, type ParticipantRole } from '../../../base/participants';
+import { MEDIA_STATE, type MediaState, AudioStateIcons, VideoStateIcons, RoleStateIcons } from '../../constants';
 
 import { RaisedHandIndicator } from './RaisedHandIndicator';
 import styles from './styles';
@@ -55,6 +56,11 @@ type Props = {
     raisedHand: boolean,
 
     /**
+     * State of participant's role
+     */
+    roleState?: ParticipantRole,
+
+    /**
      * Media state for video
      */
     videoMediaState: MediaState
@@ -74,7 +80,8 @@ function ParticipantItem({
     participantID,
     raisedHand,
     audioMediaState = MEDIA_STATE.NONE,
-    videoMediaState = MEDIA_STATE.NONE
+    videoMediaState = MEDIA_STATE.NONE,
+    roleState = PARTICIPANT_ROLE.PARTICIPANT
 }: Props) {
 
     const { t } = useTranslation();
@@ -101,6 +108,7 @@ function ParticipantItem({
                             raisedHand && <RaisedHandIndicator />
                         }
                         <View style = { styles.participantStatesContainer }>
+                            <View style = { styles.participantStateRole }>{RoleStateIcons[roleState]}</View>
                             <View style = { styles.participantStateVideo }>{VideoStateIcons[videoMediaState]}</View>
                             <View>{AudioStateIcons[audioMediaState]}</View>
                         </View>

--- a/react/features/participants-pane/components/native/styles.js
+++ b/react/features/participants-pane/components/native/styles.js
@@ -163,11 +163,16 @@ export default {
     participantStatesContainer: {
         display: 'flex',
         flexDirection: 'row',
+        justifyContent: 'flex-end',
         marginLeft: 'auto',
         width: '15%'
     },
 
     participantStateVideo: {
+        paddingRight: BaseTheme.spacing[3]
+    },
+
+    participantStateRole: {
         paddingRight: BaseTheme.spacing[3]
     },
 

--- a/react/features/participants-pane/components/native/styles.js
+++ b/react/features/participants-pane/components/native/styles.js
@@ -142,7 +142,7 @@ export default {
         flexDirection: 'row',
         overflow: 'hidden',
         paddingLeft: BaseTheme.spacing[3],
-        width: '63%'
+        width: '55%'
     },
 
     participantName: {
@@ -161,11 +161,12 @@ export default {
     },
 
     participantStatesContainer: {
+        alignItems: 'center',
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'flex-end',
         marginLeft: 'auto',
-        width: '15%'
+        width: '45%'
     },
 
     participantStateVideo: {
@@ -180,7 +181,7 @@ export default {
         backgroundColor: BaseTheme.palette.warning02,
         borderRadius: BaseTheme.shape.borderRadius / 2,
         height: BaseTheme.spacing[4],
-        marginLeft: BaseTheme.spacing[2],
+        marginRight: BaseTheme.spacing[3],
         width: BaseTheme.spacing[4]
     },
 

--- a/react/features/participants-pane/components/web/MeetingParticipantItem.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantItem.js
@@ -167,6 +167,7 @@ function MeetingParticipantItem({
             overflowDrawer = { overflowDrawer }
             participantID = { _participantID }
             raisedHand = { _raisedHand }
+            roleState = { _participant?.role }
             videoMediaState = { _videoMediaState }
             youText = { youText }>
 

--- a/react/features/participants-pane/components/web/ParticipantItem.js
+++ b/react/features/participants-pane/components/web/ParticipantItem.js
@@ -4,12 +4,17 @@ import React, { type Node, useCallback } from 'react';
 
 import { Avatar } from '../../../base/avatar';
 import {
+    PARTICIPANT_ROLE,
+    type ParticipantRole
+} from '../../../base/participants';
+import {
     ACTION_TRIGGER,
     AudioStateIcons,
     MEDIA_STATE,
     type ActionTrigger,
     type MediaState,
-    VideoStateIcons
+    VideoStateIcons,
+    RoleStateIcons
 } from '../../constants';
 
 import { RaisedHandIndicator } from './RaisedHandIndicator';
@@ -89,6 +94,11 @@ type Props = {
     raisedHand: boolean,
 
     /**
+     * State of participant's role
+     */
+    roleState?: ParticipantRole,
+
+    /**
      * Media state for video
      */
     videoMediaState: MediaState,
@@ -112,6 +122,7 @@ export default function ParticipantItem({
     actionsTrigger = ACTION_TRIGGER.HOVER,
     audioMediaState = MEDIA_STATE.NONE,
     videoMediaState = MEDIA_STATE.NONE,
+    roleState = PARTICIPANT_ROLE.PARTICIPANT,
     displayName,
     participantID,
     local,
@@ -149,6 +160,7 @@ export default function ParticipantItem({
                 { !local && <ParticipantActions children = { children } /> }
                 <ParticipantStates>
                     { raisedHand && <RaisedHandIndicator /> }
+                    { RoleStateIcons[roleState] }
                     { VideoStateIcons[videoMediaState] }
                     { AudioStateIcons[audioMediaState] }
                 </ParticipantStates>

--- a/react/features/participants-pane/components/web/ParticipantItem.js
+++ b/react/features/participants-pane/components/web/ParticipantItem.js
@@ -28,6 +28,8 @@ import {
     ParticipantStates
 } from './styled';
 
+declare var interfaceConfig: Object;
+
 /**
  * Participant actions component mapping depending on trigger type.
  */
@@ -159,8 +161,8 @@ export default function ParticipantItem({
                 </ParticipantNameContainer>
                 { !local && <ParticipantActions children = { children } /> }
                 <ParticipantStates>
+                    { !interfaceConfig.DISABLE_FOCUS_INDICATOR && RoleStateIcons[roleState] }
                     { raisedHand && <RaisedHandIndicator /> }
-                    { RoleStateIcons[roleState] }
                     { VideoStateIcons[videoMediaState] }
                     { AudioStateIcons[audioMediaState] }
                 </ParticipantStates>

--- a/react/features/participants-pane/constants.js
+++ b/react/features/participants-pane/constants.js
@@ -7,8 +7,10 @@ import {
     IconCameraEmpty,
     IconCameraEmptyDisabled,
     IconMicrophoneEmpty,
-    IconMicrophoneEmptySlash
+    IconMicrophoneEmptySlash,
+    IconModerator
 } from '../base/icons';
+import { PARTICIPANT_ROLE, type ParticipantRole } from '../base/participants/constants';
 
 /**
  * Reducer key for the feature.
@@ -109,4 +111,17 @@ export const VideoStateIcons = {
             src = { IconCameraEmpty } />
     ),
     [MEDIA_STATE.NONE]: null
+};
+
+/**
+ * Icon mapping for possible participant roles.
+ */
+export const RoleStateIcons: {[ParticipantRole]: React$Element<any> | null} = {
+    [PARTICIPANT_ROLE.MODERATOR]: (
+        <Icon
+            size = { 16 }
+            src = { IconModerator } />
+    ),
+    [PARTICIPANT_ROLE.PARTICIPANT]: null,
+    [PARTICIPANT_ROLE.NONE]: null
 };


### PR DESCRIPTION
Adds the star icon to indicate who are moderators in the participants pane. Placed to the left so that the video and audio states remain lined up.