### PR TITLE
fix(device-selection) Do not create preview when mic selection is disabled

### DIFF
--- a/react/features/device-selection/components/DeviceSelection.js
+++ b/react/features/device-selection/components/DeviceSelection.js
@@ -258,6 +258,12 @@ class DeviceSelection extends AbstractDialogTab<Props, State> {
      * @returns {void}
      */
     _createAudioInputTrack(deviceId) {
+        const { hideAudioInputPreview } = this.props;
+
+        if (hideAudioInputPreview) {
+            return;
+        }
+
         return this._disposeAudioInputPreview()
             .then(() => createLocalTrack('audio', deviceId, 5000))
             .then(jitsiLocalTrack => {


### PR DESCRIPTION
This fixes an issue on mobile Safari when audio is lost after the user opens the device selection menu.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
