### PR TITLE
fix(ios) fix black screen when using Bluetooth in iOS 15

### DIFF
--- a/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
+++ b/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
@@ -176,6 +176,13 @@ class AudioRoutePickerDialog extends Component<Props, State> {
 
         for (const device of devices) {
             const infoMap = deviceInfoMap[device.type];
+
+            // Skip devices with unknown type.
+            if (!infoMap) {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
             const text = device.type === 'BLUETOOTH' && device.name ? device.name : infoMap.text;
 
             if (infoMap) {


### PR DESCRIPTION
Fixes: https://github.com/jitsi/jitsi-meet/issues/9996

On iOS 15 Bluetooth devices are reported twice for some reason, one with the
normal type "Bluetooth" but another type without a know (to me) type, and the
uid ends in "-reference".

While we send those unkwno devices to JS, we were not filtering them properly.
This patch skips them altogether.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
