### PR TITLE
fix(ios) create audio track early

### DIFF
--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -55,9 +55,12 @@ export function createDesiredLocalTracks(...desiredTypes) {
         dispatch(destroyLocalDesktopTrackIfExists());
 
         if (desiredTypes.length === 0) {
-            const { audio, video } = state['features/base/media'];
+            const { video } = state['features/base/media'];
 
-            audio.muted || desiredTypes.push(MEDIA_TYPE.AUDIO);
+            // XXX: Always create the audio track early, even if it will be muted.
+            // This fixes a timing issue when adding the track to the conference which
+            // manifests primarily on iOS 15.
+            desiredTypes.push(MEDIA_TYPE.AUDIO);
 
             // XXX When the app is coming into the foreground from the
             // background in order to handle a URL, it may realize the new


### PR DESCRIPTION
In iOS 15 we observe that not creating the audio track early may result in not
getting audio after unmuting for the first time.

Creating the audio track early means the first unmute doesn't need to add the
track to the conference, resulting in a much faster operation.

Note that creating the track early doesn't mean we will start unmuted, the track
will be muted.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
