### PR TITLE
fix: Fixes errors in prosody about string formatting and nil values.

### DIFF
--- a/resources/prosody-plugins/mod_polls.lua
+++ b/resources/prosody-plugins/mod_polls.lua
@@ -22,7 +22,7 @@ local function get_poll_message(stanza)
 		return nil;
 	end
 	local data = json.decode(json_data);
-	if data.type ~= "new-poll" and data.type ~= "answer-poll" then
+	if not data or (data.type ~= "new-poll" and data.type ~= "answer-poll") then
 		return nil;
 	end
 	return data;
@@ -42,7 +42,7 @@ end
 module:hook("muc-room-created", function(event)
 	local room = event.room;
 	if is_healthcheck_room(room.jid) then return end
-	module:log("debug", "setting up polls in room "..tostring(room));
+	module:log("debug", "setting up polls in room %s", room.jid);
 	room.polls = {
 		by_id = {};
 		order = {};

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -128,9 +128,9 @@ function Util:get_public_key(keyId)
     local content = self.cache:get(keyId);
     if content == nil then
         -- If the key is not found in the cache.
-        module:log("debug", "Cache miss for key: "..keyId);
+        module:log("debug", "Cache miss for key: %s", keyId);
         local keyurl = path.join(self.asapKeyServer, hex.to(sha256(keyId))..'.pem');
-        module:log("debug", "Fetching public key from: "..keyurl);
+        module:log("debug", "Fetching public key from: %s", keyurl);
         content = http_get_with_retry(keyurl, nr_retries);
         if content ~= nil then
             self.cache:set(keyId, content);
@@ -138,7 +138,7 @@ function Util:get_public_key(keyId)
         return content;
     else
         -- If the key is in the cache, use it.
-        module:log("debug", "Cache hit for key: "..keyId);
+        module:log("debug", "Cache hit for key: %s", keyId);
         return content;
     end
 end


### PR DESCRIPTION
error   Traceback[c2s]: /usr/lib/prosody/util/format.lua:59: invalid option '%b' to 'format'
stack traceback:

mod_polls.lua:25: attempt to index local 'data' (a nil value)
stack traceback:

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
