### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11117,8 +11117,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "github:jitsi/lib-jitsi-meet#0646bc3403807dbf1370c88f028d9e0a16bcab1a",
-      "from": "github:jitsi/lib-jitsi-meet#0646bc3403807dbf1370c88f028d9e0a16bcab1a",
+      "version": "github:jitsi/lib-jitsi-meet#ae70962bfaa1e6c91dc7a8ecdff983740b99b874",
+      "from": "github:jitsi/lib-jitsi-meet#ae70962bfaa1e6c91dc7a8ecdff983740b99b874",
       "requires": {
         "@jitsi/js-utils": "1.0.2",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#0646bc3403807dbf1370c88f028d9e0a16bcab1a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#ae70962bfaa1e6c91dc7a8ecdff983740b99b874",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(Jingle) Log the extracted info from Jingle IQ.
* ref(Jingle) Alpha sort and prefix the local functions with '_'
* ref(Jingle) Log formatted source information. Instead of logging the full IQs for Jingle messages like session-initiate, source-add and source-remove which can be very long, log just the formatted source information.
* ref(RTC) rename iceConfig to pcConfig. It makes more sense to call it pcConfig since it is the RTCConfiguration object passed to the WebRTC peerconnection.
* fix(logging) Log only the imp events on remote tracks. Log only the important events that we care about on the HTMLMediaElement that the remote tracks are attached to.

https://github.com/jitsi/lib-jitsi-meet/compare/0646bc3403807dbf1370c88f028d9e0a16bcab1a...ae70962bfaa1e6c91dc7a8ecdff983740b99b874

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
