### PR TITLE
fix(logging) Remove logs that are very chatty.

### DIFF
--- a/react/features/base/lastn/middleware.js
+++ b/react/features/base/lastn/middleware.js
@@ -82,7 +82,6 @@ const _updateLastN = debounce(({ dispatch, getState }) => {
         lastNSelected = 1;
     }
 
-    logger.info(`Setting last N to: ${lastNSelected}`);
     dispatch(setLastN(lastNSelected));
 }, 1000); /* Don't send this more often than once a second. */
 

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -31,14 +31,12 @@ import { LocalVideoMenuTriggerButton, RemoteVideoMenuTriggerButton } from '../..
 import { setVolume } from '../../actions.web';
 import {
     DISPLAY_MODE_TO_CLASS_NAME,
-    DISPLAY_MODE_TO_STRING,
     DISPLAY_VIDEO,
     DISPLAY_VIDEO_WITH_NAME,
     VIDEO_TEST_EVENTS,
     SHOW_TOOLBAR_CONTEXT_MENU_AFTER
 } from '../../constants';
 import { isVideoPlayable, computeDisplayMode } from '../../functions';
-import logger from '../../logger';
 
 const JitsiTrackEvents = JitsiMeetJS.events.track;
 
@@ -333,11 +331,8 @@ class Thumbnail extends Component<Props, State> {
      */
     _onDisplayModeChanged() {
         const input = Thumbnail.getDisplayModeInput(this.props, this.state);
-        const displayModeString = DISPLAY_MODE_TO_STRING[this.state.displayMode];
-        const id = this.props._participant?.id;
 
         this._maybeSendScreenSharingIssueEvents(input);
-        logger.debug(`Displaying ${displayModeString} for ${id}, data: [${JSON.stringify(input)}]`);
     }
 
     /**

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -229,7 +229,6 @@ function _updateReceiverVideoConstraints({ getState }) {
         }
     }
 
-    logger.info(`Setting receiver video constraints to ${JSON.stringify(receiverConstraints)}`);
     try {
         conference.setReceiverConstraints(receiverConstraints);
     } catch (error) {


### PR DESCRIPTION
The receiver video constraints that are actually sent to the bridge are logged in LJM and need not be logged in the application.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
