### PR TITLE
fix(ios) fix crash on WebSocket errors

### DIFF
--- a/patches/react-native+0.61.5-jitsi.2.patch
+++ b/patches/react-native+0.61.5-jitsi.2.patch
@@ -1,3 +1,22 @@
+diff --git a/node_modules/react-native/Libraries/WebSocket/RCTWebSocketModule.m b/node_modules/react-native/Libraries/WebSocket/RCTWebSocketModule.m
+index d9387c4..a487da0 100644
+--- a/node_modules/react-native/Libraries/WebSocket/RCTWebSocketModule.m
++++ b/node_modules/react-native/Libraries/WebSocket/RCTWebSocketModule.m
+@@ -165,10 +165,10 @@ - (void)webSocket:(RCTSRWebSocket *)webSocket didFailWithError:(NSError *)error
+   NSNumber *socketID = [webSocket reactTag];
+   _contentHandlers[socketID] = nil;
+   _sockets[socketID] = nil;
+-  [self sendEventWithName:@"websocketFailed" body:@{
+-    @"message": error.localizedDescription,
+-    @"id": socketID
+-  }];
++  NSDictionary *body =
++      @{@"message" : error.localizedDescription ?: @"Undefined, error is nil",
++        @"id" : socketID ?: @(-1)};
++  [self sendEventWithName:@"websocketFailed" body:body];
+ }
+ 
+ - (void)webSocket:(RCTSRWebSocket *)webSocket
 diff --git a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm b/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
 index bd48f44..d243ed0 100644
 --- a/node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm


### PR DESCRIPTION
Bacckport
https://github.com/facebook/react-native/commit/748aa137472d6080427f74bb686c795b925c7d43

Fixes:

~~~
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x129708 __exceptionPreprocess
1  libobjc.A.dylib                0x287a8 objc_exception_throw
2  CoreFoundation                 0x19b9c8 -[__NSCFString characterAtIndex:].cold.1
3  CoreFoundation                 0x1a7a20 -[__NSPlaceholderDictionary initWithCapacity:].cold.1
4  CoreFoundation                 0x164c0 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
5  CoreFoundation                 0x8de0 +[NSDictionary dictionaryWithObjects:forKeys:count:]
6  JitsiMeetSDK                   0x5704b4 -[RCTWebSocketModule webSocket:didFailWithError:] + 168 (RCTWebSocketModule.m:168)
7  JitsiMeetSDK                   0x54a5ec __33-[RCTSRWebSocket _failWithError:]_block_invoke_2 + 622 (RCTSRWebSocket.m:622)
8  libdispatch.dylib              0x2a84 _dispatch_call_block_and_release
9  libdispatch.dylib              0x481c _dispatch_client_callout
10 libdispatch.dylib              0xc004 _dispatch_lane_serial_drain
11 libdispatch.dylib              0xcc00 _dispatch_lane_invoke
12 libdispatch.dylib              0x174bc _dispatch_workloop_worker_thread
13 libsystem_pthread.dylib        0x37a4 _pthread_wqthread
14 libsystem_pthread.dylib        0xa74c start_wqthread
~~~

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
