### PR TITLE
feat(external-api) add data-channel-open event

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1034,6 +1034,15 @@ class API {
     }
 
     /**
+     * Notify external application that the data channel has been opened.
+     *
+     * @returns {void}
+     */
+    notifyDataChannelOpened() {
+        this._sendEvent({ name: 'data-channel-opened' });
+    }
+
+    /**
      * Notify external application (if API is enabled) that we are ready to be
      * closed.
      *

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -80,6 +80,7 @@ const events = {
     'camera-error': 'cameraError',
     'chat-updated': 'chatUpdated',
     'content-sharing-participants-changed': 'contentSharingParticipantsChanged',
+    'data-channel-opened': 'dataChannelOpened',
     'device-list-changed': 'deviceListChanged',
     'display-name-change': 'displayNameChange',
     'email-change': 'emailChange',

--- a/react/features/external-api/middleware.js
+++ b/react/features/external-api/middleware.js
@@ -3,6 +3,7 @@
 import {
     CONFERENCE_FAILED,
     CONFERENCE_JOINED,
+    DATA_CHANNEL_OPENED,
     KICKED_OUT
 } from '../base/conference';
 import { NOTIFY_CAMERA_ERROR, NOTIFY_MIC_ERROR } from '../base/devices';
@@ -102,6 +103,10 @@ MiddlewareRegistry.register(store => next => action => {
         );
         break;
     }
+
+    case DATA_CHANNEL_OPENED:
+        APP.API.notifyDataChannelOpened();
+        break;
 
     case DOMINANT_SPEAKER_CHANGED:
         APP.API.notifyDominantSpeakerChanged(action.participant.id);


### PR DESCRIPTION
Signals that the bridge channel is open. It may take a few ms to get established
after the conference join, so applications might be interested in using it once
ready.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
