### PR TITLE
fix(rn,conference) fix unmute when "everyone starts muted" is set

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -135,8 +135,11 @@ function _addConferenceListeners(conference, dispatch, state) {
 
             // Remove the tracks from peerconnection as well.
             for (const track of localTracks) {
-                if ((audioMuted && track.jitsiTrack.getType() === MEDIA_TYPE.AUDIO)
-                    || (videoMuted && track.jitsiTrack.getType() === MEDIA_TYPE.VIDEO)) {
+                const trackType = track.jitsiTrack.getType();
+
+                // Do not remove the audio track on RN. Starting with iOS 15 it will fail to unmute otherwise.
+                if ((audioMuted && trackType === MEDIA_TYPE.AUDIO && navigator.product !== 'ReactNative')
+                        || (videoMuted && trackType === MEDIA_TYPE.VIDEO)) {
                     dispatch(replaceLocalTrack(track.jitsiTrack, null, conference));
                 }
             }


### PR DESCRIPTION
Since iOS 15 we really need the audio stream to exist, so make sure we don't
destroy it even when "everyone starts muted" is set, we'll just mute it.

Fixes: https://github.com/jitsi/jitsi-meet/issues/10053

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
