### PR TITLE
fix(ios) disable QuickType bar on iOS15 when not using autocorrect

### DIFF
--- a/react/features/authentication/components/native/LoginDialog.js
+++ b/react/features/authentication/components/native/LoginDialog.js
@@ -167,6 +167,7 @@ class LoginDialog extends Component<Props, State> {
                         onChangeText = { this._onUsernameChange }
                         placeholder = { 'user@domain.com' }
                         placeholderTextColor = { PLACEHOLDER_COLOR }
+                        spellCheck = { false }
                         style = { _dialogStyles.field }
                         underlineColorAndroid = { FIELD_UNDERLINE }
                         value = { this.state.username } />

--- a/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
@@ -200,6 +200,7 @@ class AddPeopleDialog extends AbstractAddPeopleDialog<Props, State> {
                         }
                         placeholderTextColor = { ColorPalette.lightGrey }
                         ref = { this._setFieldRef }
+                        spellCheck = { false }
                         style = { styles.searchField }
                         value = { this.state.fieldValue } />
                     { this._renderClearButton() }

--- a/react/features/settings/components/native/SettingsView.js
+++ b/react/features/settings/components/native/SettingsView.js
@@ -170,6 +170,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
                             mode = 'outlined'
                             onChangeText = { this._onChangeDisplayName }
                             placeholder = 'John Doe'
+                            spellCheck = { false }
                             style = { styles.textInputContainer }
                             textContentType = { 'name' } // iOS only
                             theme = {{
@@ -188,6 +189,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
                             mode = 'outlined'
                             onChangeText = { this._onChangeEmail }
                             placeholder = 'email@example.com'
+                            spellCheck = { false }
                             style = { styles.textInputContainer }
                             textContentType = { 'emailAddress' } // iOS only
                             theme = {{
@@ -212,6 +214,7 @@ class SettingsView extends AbstractSettingsView<Props, State> {
                             onBlur = { this._onBlurServerURL }
                             onChangeText = { this._onChangeServerURL }
                             placeholder = { this.props._serverURL }
+                            spellCheck = { false }
                             style = { styles.textInputContainer }
                             textContentType = { 'URL' } // iOS only
                             theme = {{

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -311,6 +311,7 @@ class WelcomePage extends AbstractWelcomePage {
                                 placeholder = { this.state.roomPlaceholder }
                                 placeholderTextColor = { PLACEHOLDER_TEXT_COLOR }
                                 returnKeyType = { 'go' }
+                                spellCheck = { false }
                                 style = { styles.textInput }
                                 underlineColorAndroid = 'transparent'
                                 value = { this.state.room } />


### PR DESCRIPTION
See:
https://reactnative.dev/blog/2021/09/01/preparing-your-app-for-iOS-15-and-android-12#quicktype-bar

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
