### PR TITLE
fix: Fixes displaying country names which has multiple names listed.

### DIFF
--- a/react/features/invite/components/dial-in-summary/web/NumbersList.js
+++ b/react/features/invite/components/dial-in-summary/web/NumbersList.js
@@ -66,9 +66,20 @@ class NumbersList extends Component<Props> {
                 (resultNumbers, number) => {
                     // The i18n-iso-countries package insists on upper case.
                     const countryCode = number.countryCode.toUpperCase();
-                    const countryName = countryCode === 'SIP'
-                        ? t('info.sip')
-                        : t(`countries:countries.${countryCode}`);
+
+                    let countryName;
+
+                    if (countryCode === 'SIP') {
+                        countryName = t('info.sip');
+                    } else {
+                        countryName = t(`countries:countries.${countryCode}`);
+
+                        // Some countries have multiple names as US ['United States of America', 'USA']
+                        // choose the first one if that is the case
+                        if (!countryName) {
+                            countryName = t(`countries:countries.${countryCode}.0`);
+                        }
+                    }
 
                     if (resultNumbers[countryName]) {
                         resultNumbers[countryName].push(number);


### PR DESCRIPTION
Some countries have multiple names listed in i18n-iso-countries, like US -> ['United States of America', 'USA'].

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
