### PR TITLE
chore(deps): update react-native-webrtc@1.92.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -299,7 +299,7 @@ PODS:
     - react-native-video/Video (= 5.1.1)
   - react-native-video/Video (5.1.1):
     - React-Core
-  - react-native-webrtc (1.92.1):
+  - react-native-webrtc (1.92.2):
     - React-Core
   - react-native-webview (11.0.2):
     - React-Core
@@ -584,7 +584,7 @@ SPEC CHECKSUMS:
   react-native-slider: b733e17fdd31186707146debf1f04b5d94aa1a93
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-video: 1574074179ecaf6a9dd067116c8f31bf9fec15c8
-  react-native-webrtc: 77b969fe6bc5b7c93b455f93a13698812fb8bb4e
+  react-native-webrtc: 41526e4060dac373c18676f866962d4180ee47b9
   react-native-webview: b2542d6fd424bcc3e3b2ec5f854f0abb4ec86c87
   React-RCTActionSheet: bcbc311dc3b47bc8efb2737ff0940239a45789a9
   React-RCTAnimation: 65f61080ce632f6dea23d52e354ffac9948396c6

--- a/package-lock.json
+++ b/package-lock.json
@@ -15201,9 +15201,9 @@
       "integrity": "sha512-iqdJ1KpZbR4XGahgVmaeibB7kDhyMT7wrylINgJaYBY38IAiI0LF32VX1umO4pko6n21YF5I/kSeNQ+OXGqqow=="
     },
     "react-native-webrtc": {
-      "version": "1.92.1",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-1.92.1.tgz",
-      "integrity": "sha512-cbFU1acL9aud/ohk/40jwahSNac4PwBKdmRPgXb9WqaGwxAr4CgSsrBRmruCISMdw0Pec+ZoZtYjXVuHzF51sg==",
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-1.92.2.tgz",
+      "integrity": "sha512-eq8otVRvLBD/kSM53SPymyrI7sq06/qejwhiLQKVlUsxaXTKPf3C5lktXsnw5OGZUmVk7y5rH+8ZJ3k+422t6g==",
       "requires": {
         "base64-js": "^1.1.2",
         "cross-os": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-native-url-polyfill": "1.2.0",
     "react-native-video": "5.1.1",
     "react-native-watch-connectivity": "0.4.3",
-    "react-native-webrtc": "1.92.1",
+    "react-native-webrtc": "1.92.2",
     "react-native-webview": "11.0.2",
     "react-native-youtube-iframe": "2.1.1",
     "react-redux": "7.1.0",


### PR DESCRIPTION
Fixes a crash on Android

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
