### PR TITLE
fix(toolbox): prevents filmstrip scrolling.

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -29,6 +29,7 @@
     right: 0;
     transition: bottom .3s ease-in;
     width: 100%;
+    pointer-events: none;
 
 
     &.visible {


### PR DESCRIPTION
The toolbox container with is 100% and when displayed prevents filmstrip
scrolling for the whole width of the screen.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
