### PR TITLE
Use SHA-256 as the webpack hash function

### DIFF
--- a/resources/load-test/webpack.config.js
+++ b/resources/load-test/webpack.config.js
@@ -94,7 +94,8 @@ const config = {
         filename: `[name]${minimize ? '.min' : ''}.js`,
         path: `${__dirname}/libs`,
         publicPath: 'load-test/libs/',
-        sourceMapFilename: `[name].${minimize ? 'min' : 'js'}.map`
+        sourceMapFilename: `[name].${minimize ? 'min' : 'js'}.map`,
+        hashFunction: 'sha256'
     },
     plugins: [
         analyzeBundle

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -203,7 +203,8 @@ function getConfig(options = {}) {
             filename: `[name]${minimize ? '.min' : ''}.js`,
             path: `${__dirname}/build`,
             publicPath: '/libs/',
-            sourceMapFilename: `[name].${minimize ? 'min' : 'js'}.map`
+            sourceMapFilename: `[name].${minimize ? 'min' : 'js'}.map`,
+            hashFunction: 'sha256'
         },
         plugins: [
             detectCircularDeps


### PR DESCRIPTION
Webpack [defaults to MD4](https://webpack.js.org/configuration/output/#outputhashfunction) as the output hash function. MD4 was [moved to the legacy provider](https://www.openssl.org/news/changelog.html#openssl-30) in OpenSSL 3.0 and is not available by default. As a result, webpack fails to run on any system with OpenSSL 3.0 or later.

This patch sets the hash function explicitly to SHA-256 which fixes the webpack build on such systems. SHA-256 is chosen as a reasonable modern default.

An alternative solution would be to upgrade to webpack v5.54.0 or later and use webpack's future default hash function xxhash64, which doesn't depend on OpenSSL and is also faster than SHA-256.

Related: jitsi/lib-jitsi-meet#1743
