### PR TITLE
fix(jaas): Get dynamic branding url from config file

### DIFF
--- a/react/features/dynamic-branding/actions.js
+++ b/react/features/dynamic-branding/actions.js
@@ -27,7 +27,7 @@ export function fetchCustomBrandingData() {
         const { customizationReady } = state['features/dynamic-branding'];
 
         if (!customizationReady) {
-            const url = getDynamicBrandingUrl(state);
+            const url = await getDynamicBrandingUrl();
 
             if (url) {
                 try {

--- a/react/features/dynamic-branding/functions.js
+++ b/react/features/dynamic-branding/functions.js
@@ -1,4 +1,5 @@
 // @flow
+import { loadConfig } from '../base/lib-jitsi-meet';
 
 /**
  * Extracts the fqn part from a path, where fqn represents
@@ -17,17 +18,17 @@ export function extractFqnFromPath() {
 /**
  * Returns the url used for fetching dynamic branding.
  *
- * @param {Object} state - The state of the app.
  * @returns {string}
  */
-export function getDynamicBrandingUrl(state: Object) {
-    const { dynamicBrandingUrl } = state['features/base/config'];
+export async function getDynamicBrandingUrl() {
+    const config = await loadConfig(window.location.href);
+    const { dynamicBrandingUrl } = config;
 
     if (dynamicBrandingUrl) {
         return dynamicBrandingUrl;
     }
 
-    const baseUrl = state['features/base/config'].brandingDataUrl;
+    const { brandingDataUrl: baseUrl } = config;
     const fqn = extractFqnFromPath();
 
     if (baseUrl && fqn) {


### PR DESCRIPTION
We make the request for dynamic branding as soon as possible so
at the time of the request the config is not yet added to the store.
In order to fix this we get the the jass brandingDataUrl &
dynamicBrandingUrl directly from the config.
