### PR TITLE
Make the toolbox appear above the filmstrip

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -123,7 +123,7 @@ $reloadZ: 20;
 $poweredByZ: 100;
 $ringingZ: 300;
 $sideToolbarContainerZ: 200;
-$toolbarZ: 250;
+$toolbarZ: 252;
 $drawerZ: 351;
 $tooltipsZ: 401;
 $dropdownMaskZ: 900;


### PR DESCRIPTION
Fixes #10116 

This makes sure that all menus within the toolbox appear above the filmstrip so that they remain visible and can be interacted with.