### PR TITLE
fix(FIlmstrip): disable default overscrolling

### DIFF
--- a/css/filmstrip/_horizontal_filmstrip.scss
+++ b/css/filmstrip/_horizontal_filmstrip.scss
@@ -63,6 +63,8 @@
     }
 
     .remote-videos {
+        overscroll-behavior: contain;
+
         & > div {
             transition: opacity 1s;
             position: absolute;

--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -15,6 +15,7 @@
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
+        overscroll-behavior: contain;
     }
 
     .filmstrip__videos .videocontainer {

--- a/css/filmstrip/_vertical_filmstrip.scss
+++ b/css/filmstrip/_vertical_filmstrip.scss
@@ -114,6 +114,7 @@
     .remote-videos {
         display: flex;
         transition: height .3s ease-in;
+        overscroll-behavior: contain;
 
         & > div {
             position: absolute;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
With the default overscrolling policy when a user overscroll the
filmstrip the scroll focus is moved to the main window and it looks like
the scroll is not working.