### PR TITLE
fix(polls): Keep the original height for options when moving it up and down

### DIFF
--- a/react/features/polls/components/web/PollCreate.js
+++ b/react/features/polls/components/web/PollCreate.js
@@ -116,6 +116,13 @@ const PollCreate = (props: AbstractProps) => {
 
     const [ grabbing, setGrabbing ] = useState(null);
 
+    const interchangeHeights = (i, j) => {
+        const h = answerInputs.current[i].scrollHeight;
+
+        answerInputs.current[i].style.height = `${answerInputs.current[j].scrollHeight}px`;
+        answerInputs.current[j].style.height = `${h}px`;
+    };
+
     const onGrab = useCallback((i, ev) => {
         if (ev.button !== 0) {
             return;
@@ -131,6 +138,7 @@ const PollCreate = (props: AbstractProps) => {
     });
     const onMouseOver = useCallback(i => {
         if (grabbing !== null && grabbing !== i) {
+            interchangeHeights(i, grabbing);
             moveAnswer(grabbing, i);
             setGrabbing(i);
         }


### PR DESCRIPTION
Before move
![Screenshot 2021-10-11 at 14 47 11](https://user-images.githubusercontent.com/37841821/136785028-bfe73d5c-9643-4b92-bae3-7f75fcc06aae.png)
After move
![Screenshot 2021-10-11 at 14 47 20](https://user-images.githubusercontent.com/37841821/136785033-f24498d6-77f5-4086-ae51-4fe399c1c780.png)
