### PR TITLE
Displaying Room name properly

### DIFF
--- a/resources/prosody-plugins/mod_muc_census.lua
+++ b/resources/prosody-plugins/mod_muc_census.lua
@@ -55,7 +55,7 @@ function handle_get_room_census(event)
                 participant_count = 0
             end
             table.insert(room_data, {
-                room_name = room.jid;
+                room_name = jid.node(room.jid);
                 participants = participant_count;
                 created_time = room.created_timestamp;
             });


### PR DESCRIPTION
instead of showing long muc name it's better to show just simple room name.
e.g
```

 {
"room_census": [
{
"created_time": 1633998331000,
"participants": 1,
"room_name": "room1@conference.meet.example.com"
}

]
}
```

to 
```
{
"room_census": [
{
"created_time": 1633998331000,
"participants": 1,
"room_name": "room1"
}
]
}
```

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
