### PR TITLE
fix(rn,screen-sharing) don't disable button

### DIFF
--- a/react/features/toolbox/components/native/ScreenSharingAndroidButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingAndroidButton.js
@@ -16,11 +16,6 @@ import { toggleScreensharing, isLocalVideoTrackDesktop } from '../../../base/tra
 type Props = AbstractButtonProps & {
 
     /**
-     * True if the button needs to be disabled.
-     */
-    _disabled: boolean,
-
-    /**
      * Whether video is currently muted or not.
      */
     _screensharing: boolean,
@@ -51,16 +46,6 @@ class ScreenSharingAndroidButton extends AbstractButton<Props, *> {
         const enable = !this._isToggled();
 
         this.props.dispatch(toggleScreensharing(enable));
-    }
-
-    /**
-     * Returns a boolean value indicating if this button is disabled or not.
-     *
-     * @protected
-     * @returns {boolean}
-     */
-    _isDisabled() {
-        return this.props._disabled;
     }
 
     /**

--- a/react/features/toolbox/components/native/ScreenSharingButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingButton.js
@@ -3,8 +3,6 @@
 import React from 'react';
 import { Platform } from 'react-native';
 
-import { connect } from '../../../base/redux';
-
 import ScreenSharingAndroidButton from './ScreenSharingAndroidButton.js';
 import ScreenSharingIosButton from './ScreenSharingIosButton.js';
 
@@ -19,22 +17,4 @@ const ScreenSharingButton = props => (
     </>
 );
 
-/**
- * Maps (parts of) the redux state to the associated props for the
- * {@code ScreenSharingButton} component.
- *
- * @param {Object} state - The Redux state.
- * @private
- * @returns {{
- *     _disabled: boolean,
- * }}
- */
-function _mapStateToProps(state): Object {
-    const disabled = state['features/base/audio-only'].enabled;
-
-    return {
-        _disabled: disabled
-    };
-}
-
-export default connect(_mapStateToProps)(ScreenSharingButton);
+export default ScreenSharingButton;

--- a/react/features/toolbox/components/native/ScreenSharingIosButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingIosButton.js
@@ -17,11 +17,6 @@ import { isLocalVideoTrackDesktop } from '../../../base/tracks';
 type Props = AbstractButtonProps & {
 
     /**
-     * True if the button needs to be disabled.
-     */
-    _disabled: boolean,
-
-    /**
      * Whether video is currently muted or not.
      */
     _screensharing: boolean,
@@ -87,16 +82,6 @@ class ScreenSharingIosButton extends AbstractButton<Props, *> {
       const handle = findNodeHandle(this._nativeComponent);
 
       NativeModules.ScreenCapturePickerViewManager.show(handle);
-  }
-
-  /**
-   * Returns a boolean value indicating if this button is disabled or not.
-   *
-   * @protected
-   * @returns {boolean}
-   */
-  _isDisabled() {
-      return this.props._disabled;
   }
 
   /**


### PR DESCRIPTION
Just like the camera mute button, keep it enabled even when in audio-only mode.
Starting to screen share will disable audio-only mode.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
