### PR TITLE
fix(ios) Fixes RCTBridge not being released when JitsiMeet is trying to destroy its bridge on some OS versions

### DIFF
--- a/ios/sdk/src/JitsiMeet.m
+++ b/ios/sdk/src/JitsiMeet.m
@@ -127,6 +127,7 @@
 }
 
 - (void)destroyReactNativeBridge {
+    [_bridgeWrapper invalidate];
     _bridgeWrapper = nil;
 }
 

--- a/ios/sdk/src/RCTBridgeWrapper.h
+++ b/ios/sdk/src/RCTBridgeWrapper.h
@@ -34,4 +34,6 @@
 
 @property (nonatomic, readonly, strong)  RCTBridge *bridge;
 
+- (void)invalidate;
+
 @end

--- a/ios/sdk/src/RCTBridgeWrapper.m
+++ b/ios/sdk/src/RCTBridgeWrapper.m
@@ -33,6 +33,10 @@
     return self;
 }
 
+- (void)invalidate {
+    [_bridge invalidate];
+}
+
 #pragma mark helper methods for getting the packager URL
 
 #if DEBUG


### PR DESCRIPTION
On iOS versions prior to 15.0, when the react native bridge is being manually managed through the `instantiateReactNativeBridge` and `destroyReactNativeBridge` methods on `JitsiMeet`, the `RCTBridgeWrapper` instance (together with `RCTBridge`, the JS processing thread and the `JSContext` instance) is not being released.

The JS processing thread has an `autoreleasepool` (see `RCTCxxBridge::runRunLoop`) which doesn't drain itself during the lifetime of the thread, keeping autoreleased references to `RCTBridge` and its delegate: `RCTBridgeWrapper`. Bridge invalidation normally happens in its `dealloc` method, but since the autorelease pool keeps the object alive, this won't take place without manually invalidation.

For this reason, I've added the internal `invalidate` method to the `RCTBridgeWrapper` and call it from `destroyReactNativeBridge`. This ensures the bridge and all the JS resources are cleaned.

This leak instruments screenshot shows how references to `RCTBridgeWrapper` are not being released by the pool on iOS 14:
<img width="1792" alt="RunLoop Autorelease on iOS 14" src="https://user-images.githubusercontent.com/57091410/137272880-d87f4662-ac01-4f19-8b68-e3331588a167.png">

On iOS 15, the screenshot below shows that the pool drains its references correctly:
<img width="1792" alt="RunLoop Autorelease on iOS 15" src="https://user-images.githubusercontent.com/57091410/137272991-b17aad9d-0532-4e38-885d-0060a00c00ba.png">

I'm not sure what causes the underlying difference in behavior, if it's from the React framework or not. The provided workaround doesn't address this underlying issue.
