### PR TITLE
fix(webpack): ignore optional canvas dependency in resemblejs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -295,6 +295,10 @@ module.exports = (_env, argv) => {
                 ...config.plugins,
                 ...getBundleAnalyzerPlugin(analyzeBundle, 'app'),
                 new webpack.IgnorePlugin({
+                    resourceRegExp: /^canvas$/,
+                    contextRegExp: /resemblejs$/
+                }),
+                new webpack.IgnorePlugin({
                     resourceRegExp: /^\.\/locale$/,
                     contextRegExp: /moment$/
                 }),


### PR DESCRIPTION
Skipping node-canvas dependency in resemblejs as it [fails in certain environments](https://github.com/rsmbl/Resemble.js#nodejs).
The reference states

> If you are using Resemble.js for in-browser analysis only, you can skip the node-canvas dependency.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
