### PR TITLE
fix(reponsive-ui): Fix self view when remote videos disabled

### DIFF
--- a/css/filmstrip/_vertical_filmstrip_overrides.scss
+++ b/css/filmstrip/_vertical_filmstrip_overrides.scss
@@ -84,10 +84,6 @@
         margin-bottom: 3px;
         margin-left: $remoteVideoMenuIconMargin;
     }
-
-    .self-view-mobile-portrait video {
-        object-fit: contain;
-    }
 }
 
 /**
@@ -115,12 +111,4 @@
         transition: 1.2s ease-in-out;
         transition-delay: 0.1s;
     }
-}
-
-/**
- * Overrides for self view when in portrait mode on mobile.
- * This is done in order to keep the aspect ratio.
- */
-.vertical-filmstrip .self-view-mobile-portrait #localVideo_container {
-    object-fit: contain;
 }


### PR DESCRIPTION
Self view will be shown in portrait mode on mobile web but only when remote videos
are disabled.

![Screenshot 2021-10-19 at 14 26 27](https://user-images.githubusercontent.com/37841821/137900469-8ffd0c6d-e2c1-4e74-b46f-bd1b9784d447.png)

