### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#75d3106544afca8c0ab6223f6899a28f6b60be4b",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#012c38769d216a97fcfc36d057103f44984a172c",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12842,8 +12842,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#75d3106544afca8c0ab6223f6899a28f6b60be4b",
-      "integrity": "sha512-aIGBi0Klp0PKxl2r4JMi5+4n8CXas15P1qa2fOUxFRcIzauaN/GWsnWWCX86VEDKkgxYWWZD0H6fJd3j5DDHaw==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#012c38769d216a97fcfc36d057103f44984a172c",
+      "integrity": "sha512-4DUEju/Ru7+FqdYsE/adQTcKLeBQ1lwYyuce7GEUd4xmX49AR1y0HQPTbvKu5XMoflqHKmHGf9xHLEZsH2Ywlw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -31949,9 +31949,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#75d3106544afca8c0ab6223f6899a28f6b60be4b",
-      "integrity": "sha512-aIGBi0Klp0PKxl2r4JMi5+4n8CXas15P1qa2fOUxFRcIzauaN/GWsnWWCX86VEDKkgxYWWZD0H6fJd3j5DDHaw==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#75d3106544afca8c0ab6223f6899a28f6b60be4b",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#012c38769d216a97fcfc36d057103f44984a172c",
+      "integrity": "sha512-4DUEju/Ru7+FqdYsE/adQTcKLeBQ1lwYyuce7GEUd4xmX49AR1y0HQPTbvKu5XMoflqHKmHGf9xHLEZsH2Ywlw==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#012c38769d216a97fcfc36d057103f44984a172c",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#75d3106544afca8c0ab6223f6899a28f6b60be4b",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#012c38769d216a97fcfc36d057103f44984a172c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* ref(JingleSessionPC) Do not renegotiate on every local source change. Instead rely on the 'negotiationneeded' event fired by the browser for JVB connection. This makes local source changes faster even if the modification queue is backed up.

https://github.com/jitsi/lib-jitsi-meet/compare/75d3106544afca8c0ab6223f6899a28f6b60be4b...012c38769d216a97fcfc36d057103f44984a172c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
