### PR TITLE
fix: Fixes kick when allowners is enabled.

### DIFF
--- a/resources/prosody-plugins/mod_muc_allowners.lua
+++ b/resources/prosody-plugins/mod_muc_allowners.lua
@@ -170,8 +170,8 @@ function filter_admin_set_query(event)
         return nil;
     end
 
-    -- any revoking is disabled
-    if _aff ~= 'owner' then
+    -- any revoking is disabled, everyone should be owners
+    if _aff == 'none' or _aff == 'outcast' or _aff == 'member' then
         origin.send(st.error_reply(stanza, "auth", "forbidden"));
         return true;
     end


### PR DESCRIPTION
Broken after ab18fa7 which disallows the kick as the affiliation attribute is missing in kick iq that is sent.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
