### PR TITLE
fix(prejoin) fix incorrect alignment of alternative join options

### DIFF
--- a/css/premeeting/_prejoin.scss
+++ b/css/premeeting/_prejoin.scss
@@ -21,7 +21,6 @@
 .prejoin-preview {
     &-dropdown-btns {
         padding: 8px 0;
-        width: calc(100% - 48px);
     }
   
     &-dropdown-btn {
@@ -59,8 +58,6 @@
             background: #fff;
             padding: 0;
             position: absolute !important;
-            top: 48px !important;
-            transform: none !important;
             width: 100%;
         }
     }


### PR DESCRIPTION
remove styles that break the inline dialog's position management on mobile devices

Before
<img width="420" alt="Screenshot 2021-10-21 at 07 06 21" src="https://user-images.githubusercontent.com/1556279/138209832-31baf9e1-063a-4297-bc4c-82006eec0fc2.png">


After
<img width="378" alt="Screenshot 2021-10-21 at 07 05 48" src="https://user-images.githubusercontent.com/1556279/138209840-3f217a1c-d9b7-4e5e-8ed5-ffb1d1ee9f8d.png">

