### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#42c675249aeef632aaf169e0544eeba240f7f962",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#111e50c38ac0d4000a8187af8a651050b6b33084",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -10766,12 +10766,12 @@
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
-      "version": "0.5.1",
+      "version": "0.5.5",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -10948,7 +10948,7 @@
       }
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
-      "version": "1.2.0",
+      "version": "1.2.5",
       "inBundle": true,
       "license": "MIT",
       "optional": true
@@ -13018,8 +13018,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#42c675249aeef632aaf169e0544eeba240f7f962",
-      "integrity": "sha512-n9SUvINfAh47orcLkC1y6DzN792gvLWgPls+p5m8s44gpUfTRjKYK5Nu4utu1GNQ6A39sUFkcFJgRoQ51M1aUQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#111e50c38ac0d4000a8187af8a651050b6b33084",
+      "integrity": "sha512-2L0Bie+Sf9bDe6dz24DevKA18mMfNs4sonVT0WTf/nRGcOkILHwZpq9symlfeX1eV255aEJoTCFffMbNnYRFkQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30525,11 +30525,11 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.5",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -30657,7 +30657,7 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.5",
               "bundled": true,
               "optional": true
             }
@@ -32282,9 +32282,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#42c675249aeef632aaf169e0544eeba240f7f962",
-      "integrity": "sha512-n9SUvINfAh47orcLkC1y6DzN792gvLWgPls+p5m8s44gpUfTRjKYK5Nu4utu1GNQ6A39sUFkcFJgRoQ51M1aUQ==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#42c675249aeef632aaf169e0544eeba240f7f962",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#111e50c38ac0d4000a8187af8a651050b6b33084",
+      "integrity": "sha512-2L0Bie+Sf9bDe6dz24DevKA18mMfNs4sonVT0WTf/nRGcOkILHwZpq9symlfeX1eV255aEJoTCFffMbNnYRFkQ==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#111e50c38ac0d4000a8187af8a651050b6b33084",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#42c675249aeef632aaf169e0544eeba240f7f962",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#111e50c38ac0d4000a8187af8a651050b6b33084",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* ref(JitsiConference) Remove remote tracks from conf before reneg is done. We do not have to wait for the removal of the ssrcs from the remote description for removing the remote tracks associated with a participant that left the call. This speeds up removal of the participant from call even if the JingleSession modification queue is backed up.
* faet(SDP): Add test for jingle JSON format.

https://github.com/jitsi/lib-jitsi-meet/compare/42c675249aeef632aaf169e0544eeba240f7f962...111e50c38ac0d4000a8187af8a651050b6b33084

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
