### PR TITLE
temporarily pin luajwtjitsi because v3 will intro a breaking change

### DIFF
--- a/debian/jitsi-meet-tokens.postinst
+++ b/debian/jitsi-meet-tokens.postinst
@@ -61,7 +61,7 @@ case "$1" in
                 sed -i '/^\s*--\s*"token_verification"/ s/--\s*//' $PROSODY_HOST_CONFIG
 
                 # Install luajwt
-                if ! luarocks install luajwtjitsi; then
+                if ! luarocks install luajwtjitsi 2.0-0; then
                    echo "Failed to install luajwtjitsi - try installing it manually"
                 fi
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

This pins the version of luajwtjitsi to v2. A PR to the library is currently in the works that will introduce a breaking API change. https://github.com/jitsi/luajwtjitsi/pull/3/ . A follow-on PR will update jitsi-meet to use v3 and revert this change.