### PR TITLE
fix: fixed indentation errors from es-lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ license agreement as either a [corporation](https://jitsi.org/ccla) or an
 in the agreement, unfortunately, we cannot accept your contribution.
 
 ## Creating Pull Requests
-- Make sure your code passes the linter rules beforehand. The linter is executed
-  automatically when committing code.
+- Make sure your code passes the linter rules ("npm run lint") beforehand.
+  The linter is executed automatically when committing code.
 - Perform **one** logical change per pull request.
 - Maintain a clean list of commits, squash them if necessary.
 - Rebase your topic branch on top of the master branch before creating the pull

--- a/modules/keyboardshortcut/keyboardshortcut.js
+++ b/modules/keyboardshortcut/keyboardshortcut.js
@@ -11,7 +11,7 @@ import {
 import { toggleDialog } from '../../react/features/base/dialog';
 import { clickOnVideo } from '../../react/features/filmstrip/actions';
 import { KeyboardShortcutsDialog }
-    from '../../react/features/keyboard-shortcuts';
+from '../../react/features/keyboard-shortcuts';
 import { SpeakerStats } from '../../react/features/speaker-stats';
 
 const logger = Logger.getLogger(__filename);

--- a/react/features/chat/components/native/MessageContainer.js
+++ b/react/features/chat/components/native/MessageContainer.js
@@ -8,7 +8,7 @@ import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 import AbstractMessageContainer, { type Props as AbstractProps }
-    from '../AbstractMessageContainer';
+from '../AbstractMessageContainer';
 
 import ChatMessageGroup from './ChatMessageGroup';
 import styles from './styles';

--- a/react/features/chat/components/web/MessageContainer.js
+++ b/react/features/chat/components/web/MessageContainer.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { MESSAGE_TYPE_REMOTE } from '../../constants';
 import AbstractMessageContainer, { type Props }
-    from '../AbstractMessageContainer';
+from '../AbstractMessageContainer';
 
 import ChatMessageGroup from './ChatMessageGroup';
 

--- a/react/features/conference/components/native/ConferenceNavigationContainer.js
+++ b/react/features/conference/components/native/ConferenceNavigationContainer.js
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import { Chat, ChatAndPolls } from '../../../chat';
 import { SharedDocument } from '../../../etherpad';
 import AddPeopleDialog
-    from '../../../invite/components/add-people-dialog/native/AddPeopleDialog';
+from '../../../invite/components/add-people-dialog/native/AddPeopleDialog';
 import LobbyScreen from '../../../lobby/components/native/LobbyScreen';
 import { ParticipantsPane } from '../../../participants-pane/components/native';
 import { getDisablePolls } from '../../functions';

--- a/react/features/etherpad/components/native/SharedDocument.js
+++ b/react/features/etherpad/components/native/SharedDocument.js
@@ -12,7 +12,7 @@ import { LoadingIndicator } from '../../../base/react';
 import { connect } from '../../../base/redux';
 import { goBack } from '../../../conference/components/native/ConferenceNavigationContainerRef';
 import HeaderNavigationButton
-    from '../../../conference/components/native/HeaderNavigationButton';
+from '../../../conference/components/native/HeaderNavigationButton';
 import { getSharedDocumentUrl } from '../../functions';
 
 import styles, { INDICATOR_COLOR } from './styles';

--- a/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
+++ b/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
@@ -6,7 +6,7 @@ import { translate, translateToHTML } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 
 import AbstractUserMediaPermissionsOverlay, { abstractMapStateToProps }
-    from './AbstractUserMediaPermissionsOverlay';
+from './AbstractUserMediaPermissionsOverlay';
 import OverlayFrame from './OverlayFrame';
 
 declare var interfaceConfig: Object;

--- a/react/features/participants-pane/actions.native.js
+++ b/react/features/participants-pane/actions.native.js
@@ -3,7 +3,7 @@
 import { openDialog } from '../base/dialog';
 import { SharedVideoMenu } from '../video-menu';
 import ConnectionStatusComponent
-    from '../video-menu/components/native/ConnectionStatusComponent';
+from '../video-menu/components/native/ConnectionStatusComponent';
 import RemoteVideoMenu from '../video-menu/components/native/RemoteVideoMenu';
 
 import { SET_VOLUME } from './actionTypes';

--- a/react/features/participants-pane/components/native/ContextMenuMore.js
+++ b/react/features/participants-pane/components/native/ContextMenuMore.js
@@ -26,7 +26,7 @@ import {
 import { MEDIA_TYPE } from '../../../base/media';
 import { getParticipantCount, isEveryoneModerator } from '../../../base/participants';
 import MuteEveryonesVideoDialog
-    from '../../../video-menu/components/native/MuteEveryonesVideoDialog';
+from '../../../video-menu/components/native/MuteEveryonesVideoDialog';
 
 import styles from './styles';
 

--- a/react/features/participants-pane/components/native/ParticipantsPane.js
+++ b/react/features/participants-pane/components/native/ParticipantsPane.js
@@ -12,7 +12,7 @@ import {
     isLocalParticipantModerator
 } from '../../../base/participants';
 import MuteEveryoneDialog
-    from '../../../video-menu/components/native/MuteEveryoneDialog';
+from '../../../video-menu/components/native/MuteEveryoneDialog';
 
 import { ContextMenuMore } from './ContextMenuMore';
 import HorizontalDotsIcon from './HorizontalDotsIcon';

--- a/react/features/participants-pane/components/native/ParticipantsPaneButton.js
+++ b/react/features/participants-pane/components/native/ParticipantsPaneButton.js
@@ -7,7 +7,7 @@ import { IconParticipants } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { navigate }
-    from '../../../conference/components/native/ConferenceNavigationContainerRef';
+from '../../../conference/components/native/ConferenceNavigationContainerRef';
 import { screen } from '../../../conference/components/native/routes';
 
 type Props = AbstractButtonProps & {

--- a/react/features/security/components/security-dialog/native/SecurityDialog.js
+++ b/react/features/security/components/security-dialog/native/SecurityDialog.js
@@ -22,7 +22,7 @@ import { isLocalParticipantModerator } from '../../../../base/participants';
 import { StyleType } from '../../../../base/styles';
 import { toggleLobbyMode } from '../../../../lobby/actions.any';
 import LobbyModeSwitch
-    from '../../../../lobby/components/native/LobbyModeSwitch';
+from '../../../../lobby/components/native/LobbyModeSwitch';
 import { LOCKED_LOCALLY } from '../../../../room-lock';
 import {
     endRoomLockRequest,

--- a/react/features/toolbox/components/web/ToolbarButton.js
+++ b/react/features/toolbox/components/web/ToolbarButton.js
@@ -6,7 +6,7 @@ import { Icon } from '../../../base/icons';
 import { Tooltip } from '../../../base/tooltip';
 import AbstractToolbarButton from '../AbstractToolbarButton';
 import type { Props as AbstractToolbarButtonProps }
-    from '../AbstractToolbarButton';
+from '../AbstractToolbarButton';
 
 /**
  * The type of the React {@code Component} props of {@link ToolbarButton}.

--- a/react/features/video-menu/components/native/BlockAudioVideoDialog.js
+++ b/react/features/video-menu/components/native/BlockAudioVideoDialog.js
@@ -6,7 +6,7 @@ import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import AbstractBlockAudioVideoDialog
-    from '../AbstractBlockAudioVideoDialog';
+from '../AbstractBlockAudioVideoDialog';
 
 /**
  * Dialog to confirm a remote participant kick action.

--- a/react/features/video-menu/components/native/GrantModeratorDialog.js
+++ b/react/features/video-menu/components/native/GrantModeratorDialog.js
@@ -7,7 +7,7 @@ import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import AbstractGrantModeratorDialog, { abstractMapStateToProps }
-    from '../AbstractGrantModeratorDialog';
+from '../AbstractGrantModeratorDialog';
 
 /**
  * Dialog to confirm a remote participant kick action.

--- a/react/features/video-menu/components/native/KickRemoteParticipantDialog.js
+++ b/react/features/video-menu/components/native/KickRemoteParticipantDialog.js
@@ -6,7 +6,7 @@ import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import AbstractKickRemoteParticipantDialog
-    from '../AbstractKickRemoteParticipantDialog';
+from '../AbstractKickRemoteParticipantDialog';
 
 /**
  * Dialog to confirm a remote participant kick action.

--- a/react/features/video-menu/components/native/MuteRemoteParticipantsVideoDialog.js
+++ b/react/features/video-menu/components/native/MuteRemoteParticipantsVideoDialog.js
@@ -6,7 +6,7 @@ import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import AbstractMuteRemoteParticipantsVideoDialog
-    from '../AbstractMuteRemoteParticipantsVideoDialog';
+from '../AbstractMuteRemoteParticipantsVideoDialog';
 
 /**
  * Dialog to confirm a remote participant's video stop action.

--- a/react/features/video-menu/components/web/KickRemoteParticipantDialog.js
+++ b/react/features/video-menu/components/web/KickRemoteParticipantDialog.js
@@ -6,7 +6,7 @@ import { Dialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
 import AbstractKickRemoteParticipantDialog
-    from '../AbstractKickRemoteParticipantDialog';
+from '../AbstractKickRemoteParticipantDialog';
 
 /**
  * Dialog to confirm a remote participant kick action.

--- a/react/features/video-menu/components/web/MuteEveryoneDialog.js
+++ b/react/features/video-menu/components/web/MuteEveryoneDialog.js
@@ -7,7 +7,7 @@ import { translate } from '../../../base/i18n';
 import { Switch } from '../../../base/react';
 import { connect } from '../../../base/redux';
 import AbstractMuteEveryoneDialog, { abstractMapStateToProps, type Props }
-    from '../AbstractMuteEveryoneDialog';
+from '../AbstractMuteEveryoneDialog';
 
 /**
  * A React Component with the contents for a dialog that asks for confirmation

--- a/react/features/video-menu/components/web/MuteEveryonesVideoDialog.js
+++ b/react/features/video-menu/components/web/MuteEveryonesVideoDialog.js
@@ -7,7 +7,7 @@ import { translate } from '../../../base/i18n';
 import { Switch } from '../../../base/react';
 import { connect } from '../../../base/redux';
 import AbstractMuteEveryonesVideoDialog, { abstractMapStateToProps, type Props }
-    from '../AbstractMuteEveryonesVideoDialog';
+from '../AbstractMuteEveryonesVideoDialog';
 
 /**
  * A React Component with the contents for a dialog that asks for confirmation

--- a/react/features/video-menu/components/web/MuteRemoteParticipantsVideoDialog.js
+++ b/react/features/video-menu/components/web/MuteRemoteParticipantsVideoDialog.js
@@ -5,8 +5,8 @@ import React from 'react';
 import { Dialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
-import AbstractMuteRemoteParticipantsVideoDialog
-    from '../AbstractMuteRemoteParticipantsVideoDialog';
+import AbstractMuteRemoteParticipantsVideoDialog from
+'../AbstractMuteRemoteParticipantsVideoDialog';
 
 /**
  * A React Component with the contents for a dialog that asks for confirmation

--- a/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { batch } from 'react-redux';
 
 import ConnectionIndicatorContent from
-    '../../../../features/connection-indicator/components/web/ConnectionIndicatorContent';
+'../../../../features/connection-indicator/components/web/ConnectionIndicatorContent';
 import { isIosMobileBrowser, isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n';
 import { Icon, IconMenuThumb } from '../../../base/icons';

--- a/react/index.native.js
+++ b/react/index.native.js
@@ -9,8 +9,8 @@ import { AppRegistry } from 'react-native';
 
 import { App } from './features/app/components';
 import { _initLogging } from './features/base/logging/functions';
-import JitsiThemePaperProvider
-    from './features/base/ui/components/JitsiThemeProvider';
+import JitsiThemePaperProvider from
+'./features/base/ui/components/JitsiThemeProvider';
 import { IncomingCallApp } from './features/mobile/incoming-call';
 
 declare var __DEV__;


### PR DESCRIPTION
When I run 'npm run lint' locally I get 22 errors complaining about these indentation in the import statements not being correct.