### PR TITLE
fix(Polls): Fix polls pane on Firefox

### DIFF
--- a/css/_polls.scss
+++ b/css/_polls.scss
@@ -236,7 +236,7 @@ ol.poll-result-list {
 
 
 .polls-pane-content {
-    height: calc(100% - 102px);
+    height: 100%;
     position: relative;
 }
 
@@ -306,6 +306,10 @@ ol.poll-result-list {
     color: #FFF;
     border-radius: 6px;
     padding: 10px 16px;
+}
+
+#polls-panel {
+    height: calc(100% - 102px);
 }
 
 .poll-container {


### PR DESCRIPTION
On Firefox the create button is not visible.
Having a poll with long question/options breaks the UI.

Before:
![Screenshot 2021-11-01 at 14 10 08](https://user-images.githubusercontent.com/37841821/139669708-3463c1e0-a46e-44b9-b1b8-8de70c052c10.png)

After:
![Screenshot 2021-11-01 at 14 13 02](https://user-images.githubusercontent.com/37841821/139669744-ae8b2001-aff4-4504-8c87-448879ed8c7f.png)

