### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e566291864046cadba2ef0af7fc2e31b513e3b4b",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e6b330186fbf667d1f8a7fa48410772cd2526e9d",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -13018,8 +13018,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e566291864046cadba2ef0af7fc2e31b513e3b4b",
-      "integrity": "sha512-2Iypvb1wZ2WeBwdmUngr+RQz8IGJTJsez/GgLYiSdRq3jnOUEozIhaXW+Jz4pHQ4+/ga3J59P2X7uMJp3yXg3A==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e6b330186fbf667d1f8a7fa48410772cd2526e9d",
+      "integrity": "sha512-9dGkPk5cvhIeo9USMH9vqXk0dgbfF5rmhFFu8Zrr0I93HxmHd7hWdnwlTaOuSQc6E0q/NZTOxGn3TStNp5VN7Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -32282,9 +32282,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e566291864046cadba2ef0af7fc2e31b513e3b4b",
-      "integrity": "sha512-2Iypvb1wZ2WeBwdmUngr+RQz8IGJTJsez/GgLYiSdRq3jnOUEozIhaXW+Jz4pHQ4+/ga3J59P2X7uMJp3yXg3A==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#e566291864046cadba2ef0af7fc2e31b513e3b4b",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e6b330186fbf667d1f8a7fa48410772cd2526e9d",
+      "integrity": "sha512-9dGkPk5cvhIeo9USMH9vqXk0dgbfF5rmhFFu8Zrr0I93HxmHd7hWdnwlTaOuSQc6E0q/NZTOxGn3TStNp5VN7Q==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#e6b330186fbf667d1f8a7fa48410772cd2526e9d",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e566291864046cadba2ef0af7fc2e31b513e3b4b",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e6b330186fbf667d1f8a7fa48410772cd2526e9d",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(presence) Send presence on mute state change.
* fix(TPC) change the tranceiver dir to recvonly when track is removed. This fixes occasional failures of MuteTest.MuteAfterJoinCanShareAndUnmute torture test and also the case on Safari where user stopping the screenshare doesn't stop showing the screensharing indication on the thumbnail.
* fix: Avoid sending two presences if start muted and then screen share.
* feat: use source names in presence
* ref: move SignalingLayer to the conference
* feat: Delays deployment info stats till we get update from backend.

https://github.com/jitsi/lib-jitsi-meet/compare/e566291864046cadba2ef0af7fc2e31b513e3b4b...e6b330186fbf667d1f8a7fa48410772cd2526e9d

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
