### PR TITLE
fix: Disable the 60 second pings to clients3.google.com/generate_204

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@microsoft/microsoft-graph-client": "1.1.0",
         "@react-native-async-storage/async-storage": "1.15.5",
         "@react-native-community/google-signin": "3.0.1",
-        "@react-native-community/netinfo": "4.1.5",
+        "@react-native-community/netinfo": "^6.1.0",
         "@react-native-community/slider": "3.0.3",
         "@react-native-masked-view/masked-view": "0.2.6",
         "@react-navigation/material-top-tabs": "5.3.19",
@@ -4040,9 +4040,9 @@
       }
     },
     "node_modules/@react-native-community/netinfo": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.1.5.tgz",
-      "integrity": "sha512-lagdZr9UiVAccNXYfTEj+aUcPCx9ykbMe9puffeIyF3JsRuMmlu3BjHYx1klUHX7wNRmFNC8qVP0puxUt1sZ0A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-6.1.0.tgz",
+      "integrity": "sha512-SrO+EJYR1FhGqCoKSkvddIKB0waySXapW4inW2IQgpjBYCdCTJyKFLlvZHTVg/3N0vodR4WBGdKraECl9aVS5Q==",
       "peerDependencies": {
         "react-native": ">=0.59"
       }
@@ -25208,9 +25208,9 @@
       "integrity": "sha512-RC9c7ATGdq5IKFqw/h4d8eVTDve8FZxMtsarBHKfP09SrQfEgvOebzVr7YNC+4qs7dFqR+0E2vD7nle1s/dQ3A=="
     },
     "@react-native-community/netinfo": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.1.5.tgz",
-      "integrity": "sha512-lagdZr9UiVAccNXYfTEj+aUcPCx9ykbMe9puffeIyF3JsRuMmlu3BjHYx1klUHX7wNRmFNC8qVP0puxUt1sZ0A=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-6.1.0.tgz",
+      "integrity": "sha512-SrO+EJYR1FhGqCoKSkvddIKB0waySXapW4inW2IQgpjBYCdCTJyKFLlvZHTVg/3N0vodR4WBGdKraECl9aVS5Q=="
     },
     "@react-native-community/slider": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@microsoft/microsoft-graph-client": "1.1.0",
     "@react-native-async-storage/async-storage": "1.15.5",
     "@react-native-community/google-signin": "3.0.1",
-    "@react-native-community/netinfo": "4.1.5",
+    "@react-native-community/netinfo": "^6.1.0",
     "@react-native-community/slider": "3.0.3",
     "@react-native-masked-view/masked-view": "0.2.6",
     "@react-navigation/material-top-tabs": "5.3.19",

--- a/react/features/base/net-info/NetworkInfoService.native.js
+++ b/react/features/base/net-info/NetworkInfoService.native.js
@@ -46,6 +46,11 @@ export default class NetworkInfoService extends EventEmitter {
      * @returns {void}
      */
     start() {
+        NetInfo.configure({
+            // By default iOS SDK pings Google every 60 seconds. Disable that!
+            // https://github.com/jitsi/jitsi-meet/issues/6474
+            reachabilityShouldRun: () => false
+        });
         this._subscription = NetInfo.addEventListener(netInfoState => {
             this.emit(ONLINE_STATE_CHANGED_EVENT, NetworkInfoService._convertNetInfoState(netInfoState));
         });


### PR DESCRIPTION
Especially important if used as JitsiMeet.framework inside other apps.
Using Jitsi Framework should not result in pinging google URLs every
60 seconds.

Closes: #6474