### PR TITLE
fix(large-video) Call play() whenever a new stream is attached to large-video

### DIFF
--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -495,6 +495,10 @@ export class VideoContainer extends LargeContainer {
 
         stream.attach(this.$video[0]);
 
+        // Ensure large video gets play() called on it when a new stream is attached to it. This is necessary in the
+        // case of Safari as autoplay doesn't kick-in automatically on Safari 15 and newer versions.
+        browser.isWebKitBased() && this.$video[0].play();
+
         const flipX = stream.isLocal() && this.localFlipX && !this.isScreenSharing();
 
         this.$video.css({


### PR DESCRIPTION
This fixes an issue on Safari 15 (and newer versions) where black video is rendered sometimes whenever a new stream is attached to the large video container.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
