### PR TITLE
fix(analytics) Fix analytics event names

### DIFF
--- a/react/features/analytics/AnalyticsEvents.js
+++ b/react/features/analytics/AnalyticsEvents.js
@@ -143,7 +143,6 @@ export function createCalendarClickedEvent(eventName, attributes = {}) {
 export function createCalendarSelectedEvent(attributes = {}) {
     return {
         action: 'selected',
-        actionSubject: 'calendar.selected',
         attributes,
         source: 'calendar',
         type: TYPE_UI
@@ -159,8 +158,8 @@ export function createCalendarSelectedEvent(attributes = {}) {
  */
 export function createCalendarConnectedEvent(attributes = {}) {
     return {
-        action: 'calendar.connected',
-        actionSubject: 'calendar.connected',
+        action: 'connected',
+        actionSubject: 'calendar',
         attributes
     };
 }
@@ -212,7 +211,6 @@ export function createChromeExtensionBannerEvent(installPressed, attributes = {}
 export function createRecentSelectedEvent(attributes = {}) {
     return {
         action: 'selected',
-        actionSubject: 'recent.list.selected',
         attributes,
         source: 'recent.list',
         type: TYPE_UI
@@ -533,12 +531,11 @@ export function createRejoinedEvent({ url, lastConferenceDuration, timeSinceLeft
 export function createRemoteMuteConfirmedEvent(participantId, mediaType) {
     return {
         action: 'clicked',
-        actionSubject: 'remote.mute.dialog.confirm.button',
         attributes: {
             'participant_id': participantId,
             'media_type': mediaType
         },
-        source: 'remote.mute.dialog',
+        source: 'remote.mute.button',
         type: TYPE_UI
     };
 }
@@ -583,21 +580,6 @@ export function createRTCStatsTraceCloseEvent(closeEvent) {
 }
 
 /**
- * Creates an event indicating that an action related to video blur
- * occurred (e.g. It was started or stopped).
- *
- * @param {string} action - The action which occurred.
- * @returns {Object} The event in a format suitable for sending via
- * sendAnalytics.
- */
-export function createVideoBlurEvent(action) {
-    return {
-        action,
-        actionSubject: 'video.blur'
-    };
-}
-
-/**
  * Creates an event indicating that an action related to screen sharing
  * occurred (e.g. It was started or stopped).
  *
@@ -627,26 +609,6 @@ export function createScreenSharingIssueEvent(attributes) {
         action: 'screen.sharing.issue',
         attributes
     };
-}
-
-/**
- * The local participant failed to send a "selected endpoint" message to the
- * bridge.
- *
- * @param {Error} error - The error which caused the failure.
- * @returns {Object} The event in a format suitable for sending via
- * sendAnalytics.
- */
-export function createSelectParticipantFailedEvent(error) {
-    const event = {
-        action: 'select.participant.failed'
-    };
-
-    if (error) {
-        event.error = error.toString();
-    }
-
-    return event;
 }
 
 /**
@@ -686,7 +648,6 @@ export function createShortcutEvent(
         attributes = {}) {
     return {
         action,
-        actionSubject: 'keyboard.shortcut',
         actionSubjectId: shortcut,
         attributes,
         source: 'keyboard.shortcut',
@@ -822,24 +783,6 @@ export function createToolbarEvent(buttonName, attributes = {}) {
 }
 
 /**
- * Creates an event associated with reactions.
- *
- * @param {string} action - Event action.
- * @param {string} name - Event name.
- * @param {string} source - Event source.
- * @returns {Object} The event in a format suitable for sending via
- * sendAnalytics.
- */
-function createReactionEvent(action, name, source) {
-    return {
-        action,
-        actionSubject: name,
-        source: `reaction.${source}`,
-        type: TYPE_UI
-    };
-}
-
-/**
  * Creates an event associated with a reaction button being clicked/pressed.
  *
  * @param {string} buttonName - The identifier of the reaction button which was
@@ -848,7 +791,13 @@ function createReactionEvent(action, name, source) {
  * sendAnalytics.
  */
 export function createReactionMenuEvent(buttonName) {
-    return createReactionEvent('clicked', buttonName, 'button');
+    return {
+        action: 'clicked',
+        actionSubject: 'button',
+        source: 'reaction',
+        buttonName,
+        type: TYPE_UI
+    };
 }
 
 /**
@@ -858,7 +807,12 @@ export function createReactionMenuEvent(buttonName) {
  * sendAnalytics.
  */
 export function createReactionSoundsDisabledEvent() {
-    return createReactionEvent('disabled', 'sounds', 'settings');
+    return {
+        action: 'disabled',
+        actionSubject: 'sounds',
+        source: 'reaction.settings',
+        type: TYPE_UI
+    };
 }
 
 /**
@@ -925,6 +879,6 @@ export function createWelcomePageEvent(action, actionSubject, attributes = {}) {
  */
 export function createScreensharingCaptureTakenEvent() {
     return {
-        action: 'screen.sharing.capture'
+        action: 'screen.sharing.capture.taken'
     };
 }

--- a/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
+++ b/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
@@ -87,7 +87,7 @@ class AddMeetingUrlButton extends Component<Props> {
     _onClick() {
         const { calendarId, dispatch, eventId } = this.props;
 
-        sendAnalytics(createCalendarClickedEvent('calendar.add.url'));
+        sendAnalytics(createCalendarClickedEvent('add.url'));
 
         dispatch(updateCalendarEvent(eventId, calendarId));
     }

--- a/react/features/calendar-sync/components/CalendarList.web.js
+++ b/react/features/calendar-sync/components/CalendarList.web.js
@@ -221,7 +221,7 @@ class CalendarList extends AbstractPage<Props> {
      * @returns {void}
      */
     _onOpenSettings() {
-        sendAnalytics(createCalendarClickedEvent('calendar.connect'));
+        sendAnalytics(createCalendarClickedEvent('connect'));
 
         this.props.dispatch(openSettingsDialog(SETTINGS_TABS.CALENDAR));
     }

--- a/react/features/calendar-sync/components/CalendarListContent.native.js
+++ b/react/features/calendar-sync/components/CalendarListContent.native.js
@@ -117,7 +117,7 @@ class CalendarListContent extends Component<Props> {
      * associated with this action.
      * @returns {void}
      */
-    _onPress(url, analyticsEventName = 'calendar.meeting.tile') {
+    _onPress(url, analyticsEventName = 'meeting.tile') {
         sendAnalytics(createCalendarClickedEvent(analyticsEventName));
 
         this.props.dispatch(appNavigate(url));

--- a/react/features/calendar-sync/components/CalendarListContent.web.js
+++ b/react/features/calendar-sync/components/CalendarListContent.web.js
@@ -109,7 +109,7 @@ class CalendarListContent extends Component<Props> {
     _onJoinPress(event, url) {
         event.stopPropagation();
 
-        this._onPress(url, 'calendar.meeting.join');
+        this._onPress(url, 'meeting.join');
     }
 
     _onPress: (string, ?string) => Function;
@@ -123,7 +123,7 @@ class CalendarListContent extends Component<Props> {
      * associated with this action.
      * @returns {void}
      */
-    _onPress(url, analyticsEventName = 'calendar.meeting.tile') {
+    _onPress(url, analyticsEventName = 'meeting.tile') {
         sendAnalytics(createCalendarClickedEvent(analyticsEventName));
 
         this.props.dispatch(appNavigate(url));

--- a/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.js
@@ -142,11 +142,11 @@ function AddPeopleDialog({
      */
     useEffect(() => {
         sendAnalytics(createInviteDialogEvent(
-            'invite.dialog.opened', 'dialog'));
+            'opened', 'dialog'));
 
         return () => {
             sendAnalytics(createInviteDialogEvent(
-                'invite.dialog.closed', 'dialog'));
+                'closed', 'dialog'));
         };
     }, []);
 

--- a/react/features/recent-list/components/AbstractRecentList.js
+++ b/react/features/recent-list/components/AbstractRecentList.js
@@ -102,7 +102,7 @@ export default class AbstractRecentList<P: Props> extends AbstractPage<P> {
     _onPress(url) {
         const { dispatch } = this.props;
 
-        sendAnalytics(createRecentClickedEvent('recent.meeting.tile'));
+        sendAnalytics(createRecentClickedEvent('meeting.tile'));
 
         dispatch(appNavigate(url));
     }

--- a/react/features/video-menu/components/AbstractMuteVideoButton.js
+++ b/react/features/video-menu/components/AbstractMuteVideoButton.js
@@ -56,7 +56,7 @@ export default class AbstractMuteVideoButton extends AbstractButton<Props, *> {
         const { dispatch, participantID } = this.props;
 
         sendAnalytics(createRemoteVideoMenuButtonEvent(
-            'mute.button',
+            'video.mute.button',
             {
                 'participant_id': participantID
             }));


### PR DESCRIPTION
Fixed analytics where event names had duplicated words (eg. calendar.calendar.selected.selected)

Group reaction buttons analytics into one event

Removed unused code
