### PR TITLE
fix(lint) remove warning in eslint-plugin-react

### DIFF
--- a/react/.eslintrc.js
+++ b/react/.eslintrc.js
@@ -9,5 +9,10 @@ module.exports = {
     'rules': {
         // XXX remove this eventually.
         'react/jsx-indent-props': 0
+    },
+    'settings': {
+        'react': {
+            'version': 'detect'
+        }
     }
 };


### PR DESCRIPTION
Fixes: Warning: React version not specified in eslint-plugin-react settings.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
