### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#c193f0d4335b6ed4810aa07d0c7d6860b814801a",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#51f77cbd51b1ce736fd6eec6f42118aa713c47c4",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12186,11 +12186,6 @@
         "jetify": "bin/jetify"
       }
     },
-    "node_modules/jitsi-meet-logger": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/jitsi-meet-logger.git#4add5bac2e4cea73a05f42b7596ee03c7f7a2567",
-      "integrity": "sha512-1WC//tMrc8lAxfldhEYFxk8EZuHwBcJgy+QDzd9E7ZJCCm5r+aUYshnx69PLwcbf7iLfKPhcuCKz8FOJRpBdXg=="
-    },
     "node_modules/jquery": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
@@ -12494,18 +12489,18 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#c193f0d4335b6ed4810aa07d0c7d6860b814801a",
-      "integrity": "sha512-r2oFXPRnuS7nX0fiM1mu1CoJGZ/c99vB+AHtLye3yEedK4GHIgX3sgYuB4cJtj914UVWqT7geqbUSAJ7LHrzjQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#51f77cbd51b1ce736fd6eec6f42118aa713c47c4",
+      "integrity": "sha512-U5gxxN9ufq/bQ8R/OrbK7LSNESUEBUFxtC5AjMgo3KEj97lJ/DMtjWVmTGIAVa5mi7MwlQt9da5CJmrgG+xDJA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
+        "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
-        "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#v1.0.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",
@@ -29601,11 +29596,6 @@
       "resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.4.tgz",
       "integrity": "sha512-+f/4OLeqY8RAmXnonI1ffeY1DR8kMNJPhv5WMFehchf7U71cjMQVKkOz1n6asz6kfVoAqKNWJz1A/18i18AcXA=="
     },
-    "jitsi-meet-logger": {
-      "version": "git+ssh://git@github.com/jitsi/jitsi-meet-logger.git#4add5bac2e4cea73a05f42b7596ee03c7f7a2567",
-      "integrity": "sha512-1WC//tMrc8lAxfldhEYFxk8EZuHwBcJgy+QDzd9E7ZJCCm5r+aUYshnx69PLwcbf7iLfKPhcuCKz8FOJRpBdXg==",
-      "from": "jitsi-meet-logger@github:jitsi/jitsi-meet-logger#v1.0.0"
-    },
     "jquery": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
@@ -29867,17 +29857,17 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#c193f0d4335b6ed4810aa07d0c7d6860b814801a",
-      "integrity": "sha512-r2oFXPRnuS7nX0fiM1mu1CoJGZ/c99vB+AHtLye3yEedK4GHIgX3sgYuB4cJtj914UVWqT7geqbUSAJ7LHrzjQ==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#c193f0d4335b6ed4810aa07d0c7d6860b814801a",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#51f77cbd51b1ce736fd6eec6f42118aa713c47c4",
+      "integrity": "sha512-U5gxxN9ufq/bQ8R/OrbK7LSNESUEBUFxtC5AjMgo3KEj97lJ/DMtjWVmTGIAVa5mi7MwlQt9da5CJmrgG+xDJA==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#51f77cbd51b1ce736fd6eec6f42118aa713c47c4",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
+        "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
-        "jitsi-meet-logger": "github:jitsi/jitsi-meet-logger#v1.0.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
         "lodash.isequal": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#c193f0d4335b6ed4810aa07d0c7d6860b814801a",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#51f77cbd51b1ce736fd6eec6f42118aa713c47c4",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(e2ee) disable p2p when e2ee is enabled
* fix(e2ee) fix race condition when restarting media sessions
* fix(p2p) fix error if p2p session is stopped while accepting it
* fix(e2ee) removed no longer needed code
* feat: SourceVideoTypeMessage message
* chore(lint) tame the new linter
* chore(deps) update Babel and ESLint to the latest versions
* chore(deps) adapt to logger package rename
* fix(e2ee): fix loading web worker when using a relative path inside a blob for the E2EE context
* * fix(sdp): provide SCTP streams, because the XMPP parser expects them

https://github.com/jitsi/lib-jitsi-meet/compare/c193f0d4335b6ed4810aa07d0c7d6860b814801a...51f77cbd51b1ce736fd6eec6f42118aa713c47c4
