### PR TITLE
fix(responsive-ui): Make modal full screen & fix prejoin layout on mobile landscape

### DIFF
--- a/css/_atlaskit_overrides.scss
+++ b/css/_atlaskit_overrides.scss
@@ -103,3 +103,20 @@ div.Tooltip {
     line-height: 14px;
     padding: 8px;
 }
+
+// make modal full screen on landscape orientation
+@media (max-height: 420px) {
+    .atlaskit-portal {
+        .css-1oc7v0j {
+            height: 100%;
+            padding: 0;
+            max-width: 100%;
+            top: 0;
+            width: 100%;
+
+            &> div {
+                height: 100%;
+            }
+        }
+    }
+}

--- a/css/premeeting/_premeeting-screens.scss
+++ b/css/premeeting/_premeeting-screens.scss
@@ -170,6 +170,19 @@
         }
     }
 
+    // mobile phone landscape
+    @media (max-height: 420px) {
+        flex-direction: row;
+
+        div.content {
+            padding: 16px 16px 0 16px;
+        }
+
+        .con-status {
+            display: none;
+        }
+    }
+
     @media (max-width: 400px) {
         .content {
             padding: 16px;


### PR DESCRIPTION
Before:

![Screenshot 2021-11-16 at 11 08 14](https://user-images.githubusercontent.com/37841821/141956187-dbb2db47-b82b-41b5-b4c0-7a5705cefce0.png)
![Screenshot 2021-11-16 at 11 08 28](https://user-images.githubusercontent.com/37841821/141956188-be48499b-3336-4e1b-af47-f52b4d2244c1.png)


After:

![Screenshot 2021-11-16 at 10 32 41](https://user-images.githubusercontent.com/37841821/141956233-da17740f-1299-469a-9a58-c11b9609e8c2.png)
![Screenshot 2021-11-16 at 11 04 32](https://user-images.githubusercontent.com/37841821/141956237-c473dded-eb9a-44ef-9db8-31257aadd878.png)
