### PR TITLE
fix(speaker-stats): Fix stats search position on narrow screens

### DIFF
--- a/react/features/speaker-stats/components/SpeakerStatsSearch.js
+++ b/react/features/speaker-stats/components/SpeakerStatsSearch.js
@@ -9,12 +9,18 @@ import { useSelector } from 'react-redux';
 import { getFieldValue } from '../../base/react';
 import { isSpeakerStatsSearchDisabled } from '../functions';
 
-const useStyles = makeStyles(() => {
+const useStyles = makeStyles(theme => {
     return {
         speakerStatsSearch: {
             position: 'absolute',
             right: '80px',
-            top: '8px'
+            top: '8px',
+
+            [theme.breakpoints.down('400')]: {
+                left: 20,
+                right: 0,
+                top: 42
+            }
         }
     };
 });


### PR DESCRIPTION
Before:
![Screenshot 2021-11-17 at 09 47 34](https://user-images.githubusercontent.com/37841821/142157855-503f5e18-020d-4ba0-9b1e-1c4056b2651e.png)


After:
![Screenshot 2021-11-17 at 09 46 04](https://user-images.githubusercontent.com/37841821/142157895-e3669658-8a54-4113-b90c-beb9876e8fa5.png)
