### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6d981ebb6c3a52e9e59538079ca1f24c0744b14d",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#131b9458fe922bceaf661a361cd305fb73a2468b",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12561,8 +12561,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#6d981ebb6c3a52e9e59538079ca1f24c0744b14d",
-      "integrity": "sha512-zQpKZAhE2H5/XlPxtfUF3+9UFmen46Myb9dgLdv/Dtud5jQujxvo6gUH+3asaUKz8Rs6XBr4UwSv+2cXH1ON8A==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#131b9458fe922bceaf661a361cd305fb73a2468b",
+      "integrity": "sha512-Cgy5P2EV2fpVjfc7tB9qcbBD+DNs3e0AP4Ag8d704zClqGgXKe+3LAbUVPEVVd9Zo11xDOusuBUv7IW8B0VeHQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -29988,9 +29988,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#6d981ebb6c3a52e9e59538079ca1f24c0744b14d",
-      "integrity": "sha512-zQpKZAhE2H5/XlPxtfUF3+9UFmen46Myb9dgLdv/Dtud5jQujxvo6gUH+3asaUKz8Rs6XBr4UwSv+2cXH1ON8A==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#6d981ebb6c3a52e9e59538079ca1f24c0744b14d",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#131b9458fe922bceaf661a361cd305fb73a2468b",
+      "integrity": "sha512-Cgy5P2EV2fpVjfc7tB9qcbBD+DNs3e0AP4Ag8d704zClqGgXKe+3LAbUVPEVVd9Zo11xDOusuBUv7IW8B0VeHQ==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#131b9458fe922bceaf661a361cd305fb73a2468b",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6d981ebb6c3a52e9e59538079ca1f24c0744b14d",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#131b9458fe922bceaf661a361cd305fb73a2468b",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* TPC: make the comments more descriptive.
* fix(SignalingLayerImpl): Log an error when only the ssrc owner gets overwritten with a diff ep id.
* fix(TPC): Force reneg when user unmutes the first time. This ensures that the source signaling is sent before the mute state is sent in presence. Jicofo relies on mute state from presence to check if the sender limit has been reached.

https://github.com/jitsi/lib-jitsi-meet/compare/6d981ebb6c3a52e9e59538079ca1f24c0744b14d...131b9458fe922bceaf661a361cd305fb73a2468b

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
