### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#bdfbb82087ce2a9336157da35e739fb4b250ed66",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#a1c966058c0c0e721ba72e5d170919db3ab02fdf",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12567,8 +12567,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#bdfbb82087ce2a9336157da35e739fb4b250ed66",
-      "integrity": "sha512-DqdQ/b/l7gzVplV2UkdwUDwFzST6yEj0oB+MFEIQAobhj/bIm/QjLjhPnu8EBKXFtUegma/WsX4jSBK+6U3RzQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#a1c966058c0c0e721ba72e5d170919db3ab02fdf",
+      "integrity": "sha512-eWcJWRgpNH/IoBn41E3Cxu+306x0AveQo1TuZ6QiFYzpA1JLBqjMC44Rt+TB0WSnf7+6s/cqNfcgjbiOLLVGyg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -29999,9 +29999,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#bdfbb82087ce2a9336157da35e739fb4b250ed66",
-      "integrity": "sha512-DqdQ/b/l7gzVplV2UkdwUDwFzST6yEj0oB+MFEIQAobhj/bIm/QjLjhPnu8EBKXFtUegma/WsX4jSBK+6U3RzQ==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#bdfbb82087ce2a9336157da35e739fb4b250ed66",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#a1c966058c0c0e721ba72e5d170919db3ab02fdf",
+      "integrity": "sha512-eWcJWRgpNH/IoBn41E3Cxu+306x0AveQo1TuZ6QiFYzpA1JLBqjMC44Rt+TB0WSnf7+6s/cqNfcgjbiOLLVGyg==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#a1c966058c0c0e721ba72e5d170919db3ab02fdf",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#bdfbb82087ce2a9336157da35e739fb4b250ed66",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#a1c966058c0c0e721ba72e5d170919db3ab02fdf",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): Select 1 as the default scale factor for p2p. This fixes an issue where a user is not able to unmute their video if the MediaStreamTrack associated with the camera stream returns a null value for the track height.
* Save track source name to JitsiRemoteTrack

https://github.com/jitsi/lib-jitsi-meet/compare/bdfbb82087ce2a9336157da35e739fb4b250ed66...a1c966058c0c0e721ba72e5d170919db3ab02fdf

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
