### PR TITLE
fix(TileViewButton) fix on mobile

### DIFF
--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -71,7 +71,7 @@ class TileViewButton<P: Props> extends AbstractButton<P, *> {
         logger.debug(`Tile view ${value ? 'enable' : 'disable'}`);
         batch(() => {
             dispatch(setTileView(value));
-            dispatch(setOverflowMenuVisible(false));
+            navigator.product !== 'ReactNative' && dispatch(setOverflowMenuVisible(false));
         });
 
     }


### PR DESCRIPTION
`setOverflowMenuVisible` doesn't exist on mobile.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
