### PR TITLE
fix(breakout-rooms) Improve breakout rooms

### DIFF
--- a/react/features/breakout-rooms/actionTypes.js
+++ b/react/features/breakout-rooms/actionTypes.js
@@ -1,12 +1,17 @@
 // @flow
 
 /**
-  * The type of (redux) action to update the breakout room data.
-  *
-  */
-export const UPDATE_BREAKOUT_ROOMS = 'UPDATE_BREAKOUT_ROOMS';
+ * The type of (redux) action to reset the breakout rooms data.
+ */
+export const _RESET_BREAKOUT_ROOMS = '_RESET_BREAKOUT_ROOMS';
 
 /**
  * The type of (redux) action to update the room counter locally.
  */
 export const _UPDATE_ROOM_COUNTER = '_UPDATE_ROOM_COUNTER';
+
+/**
+  * The type of (redux) action to update the breakout room data.
+  *
+  */
+export const UPDATE_BREAKOUT_ROOMS = 'UPDATE_BREAKOUT_ROOMS';

--- a/react/features/breakout-rooms/actions.js
+++ b/react/features/breakout-rooms/actions.js
@@ -15,7 +15,7 @@ import { setAudioMuted, setVideoMuted } from '../base/media';
 import { getRemoteParticipants } from '../base/participants';
 import { clearNotifications } from '../notifications';
 
-import { _UPDATE_ROOM_COUNTER } from './actionTypes';
+import { _RESET_BREAKOUT_ROOMS, _UPDATE_ROOM_COUNTER } from './actionTypes';
 import { FEATURE_KEY } from './constants';
 import {
     getBreakoutRooms,
@@ -174,6 +174,10 @@ export function moveToRoom(roomId?: string) {
             // $FlowExpectedError
             _roomId.domain = domainParts.join('@');
         }
+
+        dispatch({
+            type: _RESET_BREAKOUT_ROOMS
+        });
 
         if (navigator.product === 'ReactNative') {
             const conference = getCurrentConference(getState);

--- a/react/features/breakout-rooms/components/web/RoomContextMenu.js
+++ b/react/features/breakout-rooms/components/web/RoomContextMenu.js
@@ -56,7 +56,7 @@ export const RoomContextMenu = ({
 
     const onJoinRoom = useCallback(() => {
         sendAnalytics(createBreakoutRoomsEvent('join'));
-        dispatch(moveToRoom(room.id));
+        dispatch(moveToRoom(room.jid));
     }, [ dispatch, room ]);
 
     const onRemoveBreakoutRoom = useCallback(() => {

--- a/react/features/breakout-rooms/components/web/RoomList.js
+++ b/react/features/breakout-rooms/components/web/RoomList.js
@@ -47,7 +47,8 @@ export const RoomList = () => {
                             room = { room }>
                             {!_overflowDrawer && <>
                                 <JoinActionButton room = { room } />
-                                {isLocalModerator && <RoomActionEllipsis onClick = { toggleMenu(room) } />}
+                                {isLocalModerator && !room.isMainRoom
+                                    && <RoomActionEllipsis onClick = { toggleMenu(room) } />}
                             </>}
                         </CollapsibleRoom>
                     </React.Fragment>

--- a/react/features/breakout-rooms/reducer.js
+++ b/react/features/breakout-rooms/reducer.js
@@ -3,6 +3,7 @@
 import { ReducerRegistry } from '../base/redux';
 
 import {
+    _RESET_BREAKOUT_ROOMS,
     _UPDATE_ROOM_COUNTER,
     UPDATE_BREAKOUT_ROOMS
 } from './actionTypes';
@@ -31,6 +32,9 @@ ReducerRegistry.register(FEATURE_KEY, (state = DEFAULT_STATE, action) => {
             roomCounter,
             rooms
         };
+    }
+    case _RESET_BREAKOUT_ROOMS: {
+        return DEFAULT_STATE;
     }
     }
 


### PR DESCRIPTION
Don't show more menu on the main room

Fix join room on mobile web

When moving to room reset breakout rooms state to avoid showing incorrect data before the response from prosody is received
