### PR TITLE
Update main-pl.json

### DIFF
--- a/lang/main-pl.json
+++ b/lang/main-pl.json
@@ -901,7 +901,7 @@
             "shareaudio": "Udostępnij audio",
             "sharedvideo": "Przełącz udostępnianie obrazu na YouTube",
             "shareRoom": "Zaproś kogoś",
-            "shareYourScreen": "Przełączanie podziału ekranu",
+            "shareYourScreen": "Przełączanie udostępniania ekranu",
             "shortcuts": "Przełączanie skrótów klawiszowych",
             "show": "Pokaż na scenie",
             "silence": "Cisza",


### PR DESCRIPTION
shareYourScreen : "podział ekranu" means in english "screen partitioning" but "screen sharing" means "udostępniać ekran". That is the correct translation.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
