### PR TITLE
fix(raised-hand): lower raised hand by local audio level changes when participant is dominant

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -90,6 +90,7 @@ import {
     dominantSpeakerChanged,
     getLocalParticipant,
     getNormalizedDisplayName,
+    localParticipantAudioLevelChanged,
     localParticipantConnectionStatusChanged,
     localParticipantRoleChanged,
     participantConnectionStatusChanged,
@@ -2127,6 +2128,10 @@ export default {
         room.on(JitsiConferenceEvents.TRACK_AUDIO_LEVEL_CHANGED, (id, lvl) => {
             const localAudio = getLocalJitsiAudioTrack(APP.store.getState());
             let newLvl = lvl;
+
+            if (this.isLocalId(id)) {
+                APP.store.dispatch(localParticipantAudioLevelChanged(lvl));
+            }
 
             if (this.isLocalId(id) && localAudio?.isMuted()) {
                 newLvl = 0;

--- a/react/features/base/participants/actionTypes.js
+++ b/react/features/base/participants/actionTypes.js
@@ -192,3 +192,12 @@ export const LOCAL_PARTICIPANT_RAISE_HAND = 'LOCAL_PARTICIPANT_RAISE_HAND';
  * }
  */
 export const RAISE_HAND_UPDATED = 'RAISE_HAND_UPDATED';
+
+/**
+ * The type of Redux action which notifies that the local participant has changed the audio levels.
+ * {
+ *     type: LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED
+ *     level: number
+ * }
+ */
+export const LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED = 'LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED'

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -7,6 +7,7 @@ import {
     HIDDEN_PARTICIPANT_LEFT,
     GRANT_MODERATOR,
     KICK_PARTICIPANT,
+    LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED,
     LOCAL_PARTICIPANT_RAISE_HAND,
     MUTE_REMOTE_PARTICIPANT,
     PARTICIPANT_ID_CHANGED,
@@ -590,5 +591,21 @@ export function raiseHandUpdateQueue(participant) {
     return {
         type: RAISE_HAND_UPDATED,
         participant
+    };
+}
+
+/**
+ * Notifies if the local participant audio level has changed.
+ *
+ * @param {number} level - The audio level.
+ * @returns {{
+ *      type: LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED,
+ *      level: number
+ * }}
+ */
+export function localParticipantAudioLevelChanged(level) {
+    return {
+        type: LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED,
+        level
     };
 }

--- a/react/features/base/participants/constants.js
+++ b/react/features/base/participants/constants.js
@@ -76,4 +76,4 @@ export const PARTICIPANT_ROLE = {
  *
  * @type {string}
  */
-export const LOWER_HAND_AUDIO_LEVEL = 0.6;
+export const LOWER_HAND_AUDIO_LEVEL = 0.2;

--- a/react/features/base/participants/constants.js
+++ b/react/features/base/participants/constants.js
@@ -70,3 +70,10 @@ export const PARTICIPANT_ROLE = {
     NONE: 'none',
     PARTICIPANT: 'participant'
 };
+
+/**
+ * The audio level at which the hand will be lowered if raised.
+ *
+ * @type {string}
+ */
+export const LOWER_HAND_AUDIO_LEVEL = 0.6;

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -28,9 +28,9 @@ import { MiddlewareRegistry, StateListenerRegistry } from '../redux';
 import { playSound, registerSound, unregisterSound } from '../sounds';
 
 import {
-    DOMINANT_SPEAKER_CHANGED,
     GRANT_MODERATOR,
     KICK_PARTICIPANT,
+    LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED,
     LOCAL_PARTICIPANT_RAISE_HAND,
     MUTE_REMOTE_PARTICIPANT,
     PARTICIPANT_DISPLAY_NAME_CHANGED,
@@ -92,17 +92,13 @@ MiddlewareRegistry.register(store => next => action => {
         store.dispatch(localParticipantIdChanged(action.conference.myUserId()));
         break;
 
-    case DOMINANT_SPEAKER_CHANGED: {
-        // Lower hand through xmpp when local participant becomes dominant speaker.
-        const { id } = action.participant;
+    case LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED: {
         const state = store.getState();
         const participant = getLocalParticipant(state);
-        const isLocal = participant && participant.id === id;
 
-        if (isLocal && hasRaisedHand(participant) && !getDisableRemoveRaisedHandOnFocus(state)) {
+        if (action.level > 0.009 && hasRaisedHand(participant) && !getDisableRemoveRaisedHandOnFocus(state)) {
             store.dispatch(raiseHand(false));
         }
-
         break;
     }
 


### PR DESCRIPTION
Add LOCAL_PARTICIPANT_AUDIO_LEVEL_CHANGED action and lower hand when the audio level is higher than a given value instead of lowering when the local participant becomes the dominant speaker.
