### PR TITLE
fix(breakout-rooms) fix checking if a user is in a room

### DIFF
--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -263,9 +263,11 @@ function on_message(event)
         -- Check if the participant is in any breakout room.
         for breakout_room_jid in pairs(room._data.breakout_rooms or {}) do
             local breakout_room = breakout_rooms_muc_service.get_room_from_jid(breakout_room_jid);
-            occupant = breakout_room:get_occupant_by_real_jid(from);
-            if occupant then
-                break;
+            if breakout_room then
+                occupant = breakout_room:get_occupant_by_real_jid(from);
+                if occupant then
+                    break;
+                end
             end
         end
         if not occupant then


### PR DESCRIPTION
Breakout rooms are just reserved UUIDs, they need not exist as actual MUCs,
until a participant joins. Thus, take this into account when checking if a
participant is in a room.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
