### PR TITLE
fix(share-video): stop video from the participant list

### DIFF
--- a/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
@@ -34,6 +34,7 @@ import { sendParticipantToRoom } from '../../../breakout-rooms/actions';
 import { getBreakoutRooms, getCurrentRoomId } from '../../../breakout-rooms/functions';
 import { openChatById } from '../../../chat/actions';
 import { setVolume } from '../../../filmstrip/actions.web';
+import { stopSharedVideo } from '../../../shared-video/actions.any';
 import { GrantModeratorDialog, KickRemoteParticipantDialog, MuteEveryoneDialog } from '../../../video-menu';
 import { VolumeSlider } from '../../../video-menu/components/web';
 import MuteRemoteParticipantsVideoDialog from '../../../video-menu/components/web/MuteRemoteParticipantsVideoDialog';
@@ -250,9 +251,10 @@ class MeetingParticipantContextMenu extends Component<Props> {
      * @returns {void}
      */
     _onStopSharedVideo() {
-        const { dispatch } = this.props;
+        const { dispatch, onSelect } = this.props;
 
-        dispatch(this._onStopSharedVideo());
+        onSelect(true);
+        dispatch(stopSharedVideo());
     }
 
     _onMuteEveryoneElse: () => void;


### PR DESCRIPTION
Added a fix to enable stopping the video from the participant list and dismissing the meeting participant context menu (noticed that keeping the participant list open and sharing again would leave the context menu in a funny enabled state without the possibility of actually displaying the portal).