### PR TITLE
Fix ios pip resizing and positioning

### DIFF
--- a/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
+++ b/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
@@ -177,7 +177,6 @@ public class PiPViewCoordinator {
     open func configureExitPiPButton(target: Any,
                                      action: Selector) -> UIButton {
         let buttonImage = UIImage.init(named: "image-resize",
-                // Need to get image from original coordinator code.
                 in: Bundle(for: type(of: self)),
                 compatibleWith: nil)
         let button = UIButton(type: .custom)

--- a/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
+++ b/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
@@ -67,6 +67,11 @@ public class PiPViewCoordinator {
         self.view = view
         // Required because otherwise the view will not rotate correctly.
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        // Otherwise the enter/exit pip animation looks odd
+        // when pip window is bottom left, top left or top right,
+        // because the jitsi view content does not animate, but jumps to the new size immediately.
+        view.clipsToBounds = true
     }
 
     /// Configure the view to be always on top of all the contents


### PR DESCRIPTION
This PR fixes a bug where `JitsiMeetView` would not rotate on device rotation correctly on iOS, when `PiPViewCoordinator` was used.
This also led to the issue that the PiP window, when minimized, would move off-screen when the device was rotated.
In addition to that, the PiP window now stays at the position where the user has put it after device rotation and after exiting and entering PiP mode.

To recreate the bug(s), just run the PiP sample app: https://github.com/jitsi/jitsi-meet-sdk-samples/tree/master/ios/swift-pip/JitsiSDKTest,
However, don't forget to update to the newest SDK version.

**One issue remains:**
The content of `JitsiMeetView` does not animate when entering/existing the PiP mode. I had to clip it so that animations from bottom left, top left and top right would not look glitchy.
I could not find out why the content does not scale like the wrapping view does, unfortunately.
All hints regarding this are welcomed.

Before you go on reviewing this PR, please bear in mind that I am not an iOS developer and this is my first iOS PR ever. However, I needed this to work for a Flutter plugin I am working on at the moment, and it works!
Any tips, suggestions and most of all best practices are very welcomed.

