### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6b3d3d278362a7a30afe112c7f98200f7b209bfd",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -10258,12 +10258,12 @@
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
-      "version": "0.5.1",
+      "version": "0.5.5",
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -10440,7 +10440,7 @@
       }
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
-      "version": "1.2.0",
+      "version": "1.2.5",
       "inBundle": true,
       "license": "MIT",
       "optional": true
@@ -12509,8 +12509,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6",
-      "integrity": "sha512-4zJDXH/kASJxv/W6ihfNAGJALPLltb0o37kQEhhIYwyFGrAxRePO3+ST5OrjaPG11eUu2XTaCAbqlUDHtWJXtA==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#6b3d3d278362a7a30afe112c7f98200f7b209bfd",
+      "integrity": "sha512-2mFMVg0woLvENjvEVXI4hL1LHFvxEPKI1aPQPaHMGm3dqh4tG0t4dbJyUpWSHeuRs6KvTKmicU67dzQ5Sk5B6g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -28238,11 +28238,11 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.5",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -28370,7 +28370,7 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.0",
+              "version": "1.2.5",
               "bundled": true,
               "optional": true
             }
@@ -29978,9 +29978,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6",
-      "integrity": "sha512-4zJDXH/kASJxv/W6ihfNAGJALPLltb0o37kQEhhIYwyFGrAxRePO3+ST5OrjaPG11eUu2XTaCAbqlUDHtWJXtA==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#6b3d3d278362a7a30afe112c7f98200f7b209bfd",
+      "integrity": "sha512-2mFMVg0woLvENjvEVXI4hL1LHFvxEPKI1aPQPaHMGm3dqh4tG0t4dbJyUpWSHeuRs6KvTKmicU67dzQ5Sk5B6g==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#6b3d3d278362a7a30afe112c7f98200f7b209bfd",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#6b3d3d278362a7a30afe112c7f98200f7b209bfd",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* feat: Handle disableBeforeUnloadHandlers option.
* feat(conference) Implement audio/video mute disable when sender limit is reached. Jicofo sends a presence when the audio/video sender limit is reaced in the conference. The client can then proceed to disable the audio and video mute buttons when this occurs.

https://github.com/jitsi/lib-jitsi-meet/compare/f4f7db2e5f4c815a2c5e1bc4de44f0e16e1d27a6...6b3d3d278362a7a30afe112c7f98200f7b209bfd
