### PR TITLE
feat(external-api): enhance recordingLinkAvailable to provide ttl info

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1470,12 +1470,14 @@ class API {
      * available.
      *
      * @param {string} link - The recording download link.
+     * @param {number} ttl - The recording download link time to live.
      * @returns {void}
      */
-    notifyRecordingLinkAvailable(link: string) {
+    notifyRecordingLinkAvailable(link: string, ttl: number) {
         this._sendEvent({
             name: 'recording-link-available',
-            link
+            link,
+            ttl
         });
     }
 

--- a/react/features/recording/actions.any.js
+++ b/react/features/recording/actions.any.js
@@ -198,10 +198,11 @@ export function showStartedRecordingNotification(
                 const tenant = getVpaasTenant(state);
 
                 try {
-                    const link = await getRecordingLink(recordingSharingUrl, sessionId, region, tenant);
+                    const response = await getRecordingLink(recordingSharingUrl, sessionId, region, tenant);
+                    const { url: link, urlExpirationTimeMillis: ttl } = response;
 
                     if (typeof APP === 'object') {
-                        APP.API.notifyRecordingLinkAvailable(link);
+                        APP.API.notifyRecordingLinkAvailable(link, ttl);
                     }
 
                     // add the option to copy recording link

--- a/react/features/recording/functions.js
+++ b/react/features/recording/functions.js
@@ -65,7 +65,7 @@ export async function getRecordingLink(url: string, recordingSessionId: string, 
     });
     const json = await res.json();
 
-    return res.ok ? json.url : Promise.reject(json);
+    return res.ok ? json : Promise.reject(json);
 }
 
 /**


### PR DESCRIPTION
Added time to live param for the `recordingLinkAvailable` event. 
