### PR TITLE
feat: Update video receiver constraints to use source names

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,11 @@ var config = {
     // Connection
     //
 
+    flags: {
+        // Enables source names in the signaling.
+        // sourceNameSignaling: false,
+    },
+
     hosts: {
         // XMPP domain.
         domain: 'jitsi-meet.example.com',

--- a/config.js
+++ b/config.js
@@ -4,11 +4,6 @@ var config = {
     // Connection
     //
 
-    flags: {
-        // Enables source names in the signaling.
-        // sourceNameSignaling: false,
-    },
-
     hosts: {
         // XMPP domain.
         domain: 'jitsi-meet.example.com',
@@ -77,6 +72,12 @@ var config = {
         // This takes a value between 0 and 100 which determines the probability for
         // the callstats to be enabled.
         // callStatsThreshold: 5 // enable callstats for 5% of the users.
+    },
+
+    // Feature Flags.
+    flags: {
+        // Enables source names in the signaling.
+        // sourceNameSignaling: false,
     },
 
     // Disables moderator indicators.

--- a/react/features/base/config/constants.js
+++ b/react/features/base/config/constants.js
@@ -56,3 +56,14 @@ export const PREMEETING_BUTTONS = [ 'microphone', 'camera', 'select-background',
   * The toolbar buttons to show on 3rdParty prejoin screen.
   */
 export const THIRD_PARTY_PREJOIN_BUTTONS = [ 'microphone', 'camera', 'select-background' ];
+
+
+/**
+ * The set of feature flags.
+ *
+ * @enum {string}
+ */
+
+export const FEATURE_FLAGS = {
+    SOURCE_NAME_SIGNALING: 'sourceNameSignaling'
+};

--- a/react/features/base/config/functions.any.js
+++ b/react/features/base/config/functions.any.js
@@ -50,13 +50,13 @@ export function getMeetingRegion(state: Object) {
 }
 
 /**
- * Selector used to get feature flags.
+ * Selector used to get a feature flag.
  *
  * @param {Object} state - The global state.
  * @param {string} featureFlag - The name of the feature flag.
  * @returns {boolean}
  */
-export function getFeatureFlags(state: Object, featureFlag) {
+export function getFeatureFlag(state: Object, featureFlag) {
     const featureFlags = state['features/base/config']?.flags || {};
 
     return Boolean(featureFlags[featureFlag]);

--- a/react/features/base/config/functions.any.js
+++ b/react/features/base/config/functions.any.js
@@ -50,6 +50,19 @@ export function getMeetingRegion(state: Object) {
 }
 
 /**
+ * Selector used to get feature flags.
+ *
+ * @param {Object} state - The global state.
+ * @param {string} featureFlag - The name of the feature flag.
+ * @returns {boolean}
+ */
+export function getFeatureFlags(state: Object, featureFlag) {
+    const featureFlags = state['features/base/config']?.flags || {};
+
+    return Boolean(featureFlags[featureFlag]);
+}
+
+/**
  * Selector used to get the disableRemoveRaisedHandOnFocus.
  *
  * @param {Object} state - The global state.

--- a/react/features/base/config/functions.any.js
+++ b/react/features/base/config/functions.any.js
@@ -56,7 +56,7 @@ export function getMeetingRegion(state: Object) {
  * @param {string} featureFlag - The name of the feature flag.
  * @returns {boolean}
  */
-export function getFeatureFlag(state: Object, featureFlag) {
+export function getFeatureFlag(state: Object, featureFlag: string) {
     const featureFlags = state['features/base/config']?.flags || {};
 
     return Boolean(featureFlags[featureFlag]);

--- a/react/features/base/config/functions.any.js
+++ b/react/features/base/config/functions.any.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import { parseURLParams } from '../util';
 
 import CONFIG_WHITELIST from './configWhitelist';
-import { _CONFIG_STORE_PREFIX } from './constants';
+import { _CONFIG_STORE_PREFIX, FEATURE_FLAGS } from './constants';
 import INTERFACE_CONFIG_WHITELIST from './interfaceConfigWhitelist';
 import logger from './logger';
 
@@ -47,6 +47,16 @@ export function createFakeConfig(baseURL: string) {
  */
 export function getMeetingRegion(state: Object) {
     return state['features/base/config']?.deploymentInfo?.region || '';
+}
+
+/**
+ * Selector used to get the sourceNameSignaling feature flag.
+ *
+ * @param {Object} state - The global state.
+ * @returns {boolean}
+ */
+export function getSourceNameSignalingFeatureFlag(state: Object) {
+    return getFeatureFlag(state, FEATURE_FLAGS.SOURCE_NAME_SIGNALING);
 }
 
 /**

--- a/react/features/base/config/index.js
+++ b/react/features/base/config/index.js
@@ -1,4 +1,5 @@
 export * from './actions';
 export * from './actionTypes';
 export { default as CONFIG_WHITELIST } from './configWhitelist';
+export * from './constants';
 export * from './functions';

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -400,6 +400,25 @@ export function getTrackByMediaTypeAndParticipant(
 }
 
 /**
+ * Returns track source name of specified media type for specified participant id.
+ *
+ * @param {Track[]} tracks - List of all tracks.
+ * @param {MEDIA_TYPE} mediaType - Media type.
+ * @param {string} participantId - Participant ID.
+ * @returns {(string|undefined)}
+ */
+export function getTrackSourceNameByMediaTypeAndParticipant(
+        tracks,
+        mediaType,
+        participantId) {
+    const track = tracks.find(
+    t => Boolean(t.jitsiTrack) && t.participantId === participantId && t.mediaType === mediaType
+    );
+
+    return track?.jitsiTrack?.getSourceName();
+}
+
+/**
  * Returns the track if any which corresponds to a specific instance
  * of JitsiLocalTrack or JitsiRemoteTrack.
  *

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -411,9 +411,10 @@ export function getTrackSourceNameByMediaTypeAndParticipant(
         tracks,
         mediaType,
         participantId) {
-    const track = tracks.find(
-    t => Boolean(t.jitsiTrack) && t.participantId === participantId && t.mediaType === mediaType
-    );
+    const track = getTrackByMediaTypeAndParticipant(
+        tracks,
+        mediaType,
+        participantId);
 
     return track?.jitsiTrack?.getSourceName();
 }

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -6,7 +6,7 @@ import { _handleParticipantError } from '../base/conference';
 import { MEDIA_TYPE } from '../base/media';
 import { getParticipantCount } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
-import { getTrackByMediaTypeAndParticipant } from '../base/tracks';
+import { getTrackSourceNameByMediaTypeAndParticipant } from '../base/tracks';
 import { reportError } from '../base/util';
 import { shouldDisplayTileView } from '../video-layout';
 
@@ -211,8 +211,7 @@ function _updateReceiverVideoConstraints({ getState }) {
 
         if (visibleRemoteParticipants?.size) {
             visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].reduce((acc, participantId) => {
-                const track = getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, participantId);
-                const sourceName = track?.jitsiTrack?.getSourceName?.();
+                const sourceName = getTrackSourceNameByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, participantId);
 
                 if (sourceName) {
                     acc.push(sourceName);
@@ -222,10 +221,10 @@ function _updateReceiverVideoConstraints({ getState }) {
             }, []);
         }
 
-        const largeVideoSourceName = getTrackByMediaTypeAndParticipant(
+        const largeVideoSourceName = getTrackSourceNameByMediaTypeAndParticipant(
             tracks, MEDIA_TYPE.VIDEO,
             largeVideoParticipantId
-        )?.jitsiTrack?.getSourceName?.();
+        );
 
         // Tile view.
         if (shouldDisplayTileView(state)) {
@@ -239,11 +238,9 @@ function _updateReceiverVideoConstraints({ getState }) {
 
             // Prioritize screenshare in tile view.
             if (remoteScreenShares?.length) {
-                const remoteScreenSharesSourceNames = remoteScreenShares.map(remoteScreenShare => {
-                    const track = getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, remoteScreenShare);
-
-                    return track?.jitsiTrack?.getSourceName?.();
-                });
+                const remoteScreenSharesSourceNames = remoteScreenShares.map(remoteScreenShare =>
+                    getTrackSourceNameByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, remoteScreenShare)
+                );
 
                 receiverConstraints.selectedSources = remoteScreenSharesSourceNames;
             }

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -245,7 +245,12 @@ function _updateReceiverVideoConstraints({ getState }) {
             });
 
             // Prioritize screenshare in tile view.
-            remoteScreenShares?.length && (receiverConstraints.selectedSources = remoteScreenShares);
+            if (remoteScreenShares?.length) {
+                const remoteScreenSharesSourceNames = remoteScreenShares.map(remoteScreenShare =>
+                    participantIdToTrackSourceName[remoteScreenShare]);
+
+                receiverConstraints.selectedSources = remoteScreenSharesSourceNames;
+            }
 
         // Stage view.
         } else {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -203,7 +203,7 @@ function _updateReceiverVideoConstraints({ getState }) {
         constraints: {},
         defaultConstraints: { 'maxHeight': VIDEO_QUALITY_LEVELS.NONE },
         lastN,
-        ...sourceNameSignaling ? { prioritizedSources: [] } : { onStageEndpoints: [] },
+        ...sourceNameSignaling ? { onStageSources: [] } : { onStageEndpoints: [] },
         ...sourceNameSignaling ? { selectedSources: [] } : { selectedEndpoints: [] }
     };
 
@@ -263,7 +263,7 @@ function _updateReceiverVideoConstraints({ getState }) {
 
             if (largeVideoSourceName) {
                 receiverConstraints.constraints[largeVideoSourceName] = { 'maxHeight': maxFrameHeight };
-                receiverConstraints.prioritizedSources = [ largeVideoSourceName ];
+                receiverConstraints.onStageSources = [ largeVideoSourceName ];
             }
         }
 

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -3,7 +3,7 @@
 import debounce from 'lodash/debounce';
 
 import { _handleParticipantError } from '../base/conference';
-import { FEATURE_FLAGS, getFeatureFlag } from '../base/config';
+import { getSourceNameSignalingFeatureFlag } from '../base/config';
 import { MEDIA_TYPE } from '../base/media';
 import { getLocalParticipant, getParticipantCount } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
@@ -197,7 +197,7 @@ function _updateReceiverVideoConstraints({ getState }) {
     const { remoteScreenShares } = state['features/video-layout'];
     const { visibleRemoteParticipants } = state['features/filmstrip'];
     const tracks = state['features/base/tracks'];
-    const sourceNameSignaling = getFeatureFlag(state, FEATURE_FLAGS.SOURCE_NAME_SIGNALING);
+    const sourceNameSignaling = getSourceNameSignalingFeatureFlag(state);
     const localParticipantId = getLocalParticipant(state).id;
 
     const receiverConstraints = {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -208,19 +208,17 @@ function _updateReceiverVideoConstraints({ getState }) {
     };
 
     if (sourceNameSignaling) {
-        let visibleRemoteTrackSourceNames = [];
+        const visibleRemoteTrackSourceNames = [];
         let largeVideoSourceName;
 
         if (visibleRemoteParticipants?.size) {
-            visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].reduce((acc, participantId) => {
+            visibleRemoteParticipants.forEach(participantId => {
                 const sourceName = getTrackSourceNameByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, participantId);
 
                 if (sourceName) {
-                    acc.push(sourceName);
+                    visibleRemoteTrackSourceNames.push(sourceName);
                 }
-
-                return acc;
-            }, []);
+            });
         }
 
         if (localParticipantId !== largeVideoParticipantId) {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -223,8 +223,13 @@ function _updateReceiverVideoConstraints({ getState }) {
         let visibleRemoteTrackSourceNames;
 
         if (visibleRemoteParticipants?.size) {
-            visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].map(participantId =>
-                participantIdToTrackSourceName[participantId]);
+            visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].reduce((acc, participantId) => {
+                if (participantIdToTrackSourceName[participantId]) {
+                    acc.push(participantIdToTrackSourceName[participantId]);
+                }
+
+                return acc;
+            }, []);
         }
 
         const largeVideoSourceName = participantIdToTrackSourceName[largeVideoParticipantId];

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -204,12 +204,8 @@ function _updateReceiverVideoConstraints({ getState }) {
         ...sourceNameSignaling ? { selectedSources: [] } : { selectedEndpoints: [] }
     };
 
-    let largeVideoSourceName;
-    let participantIdToTrackSourceName;
-    let visibleRemoteTrackSourceNames;
-
     if (sourceNameSignaling) {
-        participantIdToTrackSourceName = tracks.reduce((acc, { jitsiTrack, participantId }) => {
+        const participantIdToTrackSourceName = tracks.reduce((acc, { jitsiTrack, participantId }) => {
             const local = jitsiTrack.isLocal();
             const isVideo = jitsiTrack && jitsiTrack.type === 'video';
 
@@ -224,12 +220,14 @@ function _updateReceiverVideoConstraints({ getState }) {
             return acc;
         }, {});
 
+        let visibleRemoteTrackSourceNames;
+
         if (visibleRemoteParticipants?.size) {
             visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].map(participantId =>
                 participantIdToTrackSourceName[participantId]);
         }
 
-        largeVideoSourceName = participantIdToTrackSourceName[largeVideoParticipantId];
+        const largeVideoSourceName = participantIdToTrackSourceName[largeVideoParticipantId];
 
         // Tile view.
         if (shouldDisplayTileView(state)) {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -3,7 +3,7 @@
 import debounce from 'lodash/debounce';
 
 import { _handleParticipantError } from '../base/conference';
-import { FEATURE_FLAGS, getFeatureFlags } from '../base/config';
+import { FEATURE_FLAGS, getFeatureFlag } from '../base/config';
 import { MEDIA_TYPE } from '../base/media';
 import { getLocalParticipant, getParticipantCount } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
@@ -197,7 +197,7 @@ function _updateReceiverVideoConstraints({ getState }) {
     const { remoteScreenShares } = state['features/video-layout'];
     const { visibleRemoteParticipants } = state['features/filmstrip'];
     const tracks = state['features/base/tracks'];
-    const sourceNameSignaling = getFeatureFlags(state, FEATURE_FLAGS.SOURCE_NAME_SIGNALING);
+    const sourceNameSignaling = getFeatureFlag(state, FEATURE_FLAGS.SOURCE_NAME_SIGNALING);
     const localParticipantId = getLocalParticipant(state).id;
 
     const receiverConstraints = {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -3,8 +3,9 @@
 import debounce from 'lodash/debounce';
 
 import { _handleParticipantError } from '../base/conference';
+import { FEATURE_FLAGS, getFeatureFlags } from '../base/config';
 import { MEDIA_TYPE } from '../base/media';
-import { getParticipantCount } from '../base/participants';
+import { getLocalParticipant, getParticipantCount } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
 import { getTrackSourceNameByMediaTypeAndParticipant } from '../base/tracks';
 import { reportError } from '../base/util';
@@ -195,9 +196,9 @@ function _updateReceiverVideoConstraints({ getState }) {
     const maxFrameHeight = Math.min(maxReceiverVideoQuality, preferredVideoQuality);
     const { remoteScreenShares } = state['features/video-layout'];
     const { visibleRemoteParticipants } = state['features/filmstrip'];
-    const { flags: { sourceNameSignaling } } = state['features/base/config'];
-    const { local: { id: localParticipantId } } = state['features/base/participants'];
     const tracks = state['features/base/tracks'];
+    const sourceNameSignaling = getFeatureFlags(state, FEATURE_FLAGS.SOURCE_NAME_SIGNALING);
+    const localParticipantId = getLocalParticipant(state).id;
 
     const receiverConstraints = {
         constraints: {},

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -196,6 +196,7 @@ function _updateReceiverVideoConstraints({ getState }) {
     const { remoteScreenShares } = state['features/video-layout'];
     const { visibleRemoteParticipants } = state['features/filmstrip'];
     const { flags: { sourceNameSignaling } } = state['features/base/config'];
+    const { local: { id: localParticipantId } } = state['features/base/participants'];
     const tracks = state['features/base/tracks'];
 
     const receiverConstraints = {
@@ -208,6 +209,7 @@ function _updateReceiverVideoConstraints({ getState }) {
 
     if (sourceNameSignaling) {
         let visibleRemoteTrackSourceNames;
+        let largeVideoSourceName;
 
         if (visibleRemoteParticipants?.size) {
             visibleRemoteTrackSourceNames = [ ...visibleRemoteParticipants ].reduce((acc, participantId) => {
@@ -221,10 +223,12 @@ function _updateReceiverVideoConstraints({ getState }) {
             }, []);
         }
 
-        const largeVideoSourceName = getTrackSourceNameByMediaTypeAndParticipant(
-            tracks, MEDIA_TYPE.VIDEO,
-            largeVideoParticipantId
-        );
+        if (localParticipantId !== largeVideoParticipantId) {
+            largeVideoSourceName = getTrackSourceNameByMediaTypeAndParticipant(
+                tracks, MEDIA_TYPE.VIDEO,
+                largeVideoParticipantId
+            );
+        }
 
         // Tile view.
         if (shouldDisplayTileView(state)) {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -208,7 +208,7 @@ function _updateReceiverVideoConstraints({ getState }) {
     };
 
     if (sourceNameSignaling) {
-        let visibleRemoteTrackSourceNames;
+        let visibleRemoteTrackSourceNames = [];
         let largeVideoSourceName;
 
         if (visibleRemoteParticipants?.size) {

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -238,11 +238,11 @@ function _updateReceiverVideoConstraints({ getState }) {
 
             // Prioritize screenshare in tile view.
             if (remoteScreenShares?.length) {
-                const remoteScreenSharesSourceNames = remoteScreenShares.map(remoteScreenShare =>
+                const remoteScreenShareSourceNames = remoteScreenShares.map(remoteScreenShare =>
                     getTrackSourceNameByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, remoteScreenShare)
                 );
 
-                receiverConstraints.selectedSources = remoteScreenSharesSourceNames;
+                receiverConstraints.selectedSources = remoteScreenShareSourceNames;
             }
 
         // Stage view.


### PR DESCRIPTION
Adjust the `setReceiverConstraints` method to ensure formats are not being mixed and the new sources format is only used when the `sourceNameSignaling` feature flag is enabled. 

Related PR: https://github.com/jitsi/lib-jitsi-meet/pull/1813