### PR TITLE
fix(breakout,av-moderation): support non-ascii tenant and room names

### DIFF
--- a/resources/prosody-plugins/mod_jitsi_session.lua
+++ b/resources/prosody-plugins/mod_jitsi_session.lua
@@ -3,6 +3,7 @@
 module:set_global();
 
 local formdecode = require "util.http".formdecode;
+local urlencode = require "util.http".urlencode;
 
 -- Extract the following parameters from the URL and set them in the session:
 -- * previd: for session resumption
@@ -18,7 +19,7 @@ function init_session(event)
         session.previd = query and params.previd or nil;
 
         -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = params.room;
+        session.jitsi_web_query_room = urlencode(params.room);
         session.jitsi_web_query_prefix = params.prefix or "";
     end
 end

--- a/resources/prosody-plugins/mod_jitsi_session.lua
+++ b/resources/prosody-plugins/mod_jitsi_session.lua
@@ -20,7 +20,7 @@ function init_session(event)
 
         -- The room name and optional prefix from the web query
         session.jitsi_web_query_room = urlencode(params.room);
-        session.jitsi_web_query_prefix = params.prefix or "";
+        session.jitsi_web_query_prefix = urlencode(params.prefix) or "";
     end
 end
 


### PR DESCRIPTION
rooms are created in prosody in their urlencoded form, eg täst
becomes t%c3%a4st@conference.jitsi.example.org

As local params = formdecode(query) contains an urldecode, we
need to reencode the room name so that the room can be found in
prosody.

Closes: #10525
Signed-off-by: Christoph Settgast <csett86@web.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
