### PR TITLE
fix(participants-list): Avoid ui moving on input focus

### DIFF
--- a/react/features/participants-pane/components/web/ClearableInput.js
+++ b/react/features/participants-pane/components/web/ClearableInput.js
@@ -72,7 +72,7 @@ const useStyles = makeStyles(theme => {
             padding: '10px 16px',
 
             '&.focused': {
-                border: `3px solid ${theme.palette.field01Focus}`
+                outline: `3px solid ${theme.palette.field01Focus}`
             }
         },
         clearButton: {


### PR DESCRIPTION
When the search input is focused the it is resized because of the border.
![Screenshot 2021-12-08 at 13 55 44](https://user-images.githubusercontent.com/37841821/145204478-44be5f50-c71c-4c5d-b676-6a3013a3d69f.png)
