### PR TITLE
fix(breakout-rooms) fix non-functional context menu

### DIFF
--- a/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
@@ -306,8 +306,9 @@ class MeetingParticipantContextMenu extends Component<Props> {
      */
     _onSendToRoom(room: Object) {
         return () => {
-            const { _participant, dispatch } = this.props;
+            const { _participant, dispatch, onSelect } = this.props;
 
+            onSelect(true);
             sendAnalytics(createBreakoutRoomsEvent('send.participant.to.room'));
             dispatch(sendParticipantToRoom(_participant.id, room.id));
         };


### PR DESCRIPTION
Close the menu after sending a participant to a breakout room, that will detach
the context menu from the current participant and it will work properly when
they join back.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
