### PR TITLE
fix(rn) join conference if started by moderator

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -501,7 +501,7 @@ export function checkIfCanJoin() {
         const { authRequired, password }
             = getState()['features/base/conference'];
 
-        const replaceParticipant = getReplaceParticipant(APP.store.getState());
+        const replaceParticipant = getReplaceParticipant(getState());
 
         authRequired && dispatch(_conferenceWillJoin(authRequired));
         authRequired && authRequired.join(password, replaceParticipant);


### PR DESCRIPTION
Issue was that APP is not defined at this place on mobile,
thus this raising ReferenceError which caused the waitForOwner to break

Closes: #10211

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
