### PR TITLE
update ljm 1639041290

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -163,9 +163,6 @@
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
       }
-    },
-    "github/gajus/eslint-plugin-flowtype": {
-      "extraneous": true
     },
     "node_modules/@amplitude/react-native": {
       "version": "2.3.3",
@@ -12509,8 +12506,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e9e37099a143c06355f9e6868bbcdf20b48583b1",
-      "integrity": "sha512-haNpszEW8gbvcZCtMFzN/nzuU94jC3G4VQnf87/fjX0rL6yEDYlGyoYChFYhqzFGBTJOETKa/SRvYfFDGzfzcw==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
+      "integrity": "sha512-UPQrJjATYSerDZVezRpr+v9OMI94LYwimWyrDUg2Wpr2yfrDnIM90oqn62F9CwsE3QBBBLEZoTUk9K02z2d/Yg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -22871,7 +22868,6 @@
     },
     "@jitsi/sdp-interop": {
       "version": "git+ssh://git@github.com/jitsi/sdp-interop.git#4669790bb9020cc8f10c1d1f3823c26b08497547",
-      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
       "from": "@jitsi/sdp-interop@github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
       "requires": {
         "lodash.clonedeep": "4.5.0",
@@ -29978,9 +29974,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e9e37099a143c06355f9e6868bbcdf20b48583b1",
-      "integrity": "sha512-haNpszEW8gbvcZCtMFzN/nzuU94jC3G4VQnf87/fjX0rL6yEDYlGyoYChFYhqzFGBTJOETKa/SRvYfFDGzfzcw==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
@@ -30010,7 +30005,6 @@
     },
     "libflacjs": {
       "version": "git+ssh://git@github.com/mmig/libflac.js.git#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
-      "integrity": "sha512-7cscxyqMkeUa5PpHOqhIkXgyrmPqxCzYobtXnrnwXFkY5+tvRjwsZqQQ52Z9K4AebDzpNaApK+NVn+gK4CwWUw==",
       "from": "libflacjs@github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d"
     },
     "lines-and-columns": {
@@ -32567,7 +32561,6 @@
     },
     "react-native": {
       "version": "git+ssh://git@github.com/jitsi/react-native.git#891986ec5ecaef65d1c8a7fe472f86cf84fe7551",
-      "integrity": "sha512-VYzZHHsE6JV0igL/UV6i52yNiiWPkHdJIIQmUvKafLs2Np02vMlV05fYtlP6F/tF+BGn/lwZtDIc3VAIv+CxSA==",
       "from": "react-native@github:jitsi/react-native#891986ec5ecaef65d1c8a7fe472f86cf84fe7551",
       "requires": {
         "@babel/runtime": "^7.0.0",
@@ -32635,7 +32628,6 @@
     },
     "react-native-calendar-events": {
       "version": "git+ssh://git@github.com/jitsi/react-native-calendar-events.git#df48ecdc4e1e90c5352f803ddbab1fa7269b74a7",
-      "integrity": "sha512-BDZMAaMdNsuZuzxpT7LpfRDqgFMiXbQfrXXUo55qD49RnbpmtcGKLUMkoqoOU8ywvL9ZQiCqXtymUSGJQhOpCQ==",
       "from": "react-native-calendar-events@github:jitsi/react-native-calendar-events#df48ecdc4e1e90c5352f803ddbab1fa7269b74a7"
     },
     "react-native-callstats": {
@@ -32768,7 +32760,6 @@
     },
     "react-native-sound": {
       "version": "git+ssh://git@github.com/jitsi/react-native-sound.git#3fe5480fce935e888d5089d94a191c7c7e3aa190",
-      "integrity": "sha512-364A1CvMgh5MnzI4iJgg+AqpePO63Jmf1ESvkTlW+VK3S513fM3092+5mupmGO8KIP77PuYpuNjTYpjZukbgkw==",
       "from": "react-native-sound@github:jitsi/react-native-sound#3fe5480fce935e888d5089d94a191c7c7e3aa190"
     },
     "react-native-splash-screen": {
@@ -33341,7 +33332,6 @@
     },
     "rnnoise-wasm": {
       "version": "git+ssh://git@github.com/jitsi/rnnoise-wasm.git#566a16885897704d6e6d67a1d5ac5d39781db2af",
-      "integrity": "sha512-XQgO7DDtjsXzaHU4WiahPrmoU2BmfuT0/0dexNoufSid+fVuTlsXPpZxHq+aSk0/7idvtbO8Xru1khMRv1dPWw==",
       "from": "rnnoise-wasm@github:jitsi/rnnoise-wasm#566a16885897704d6e6d67a1d5ac5d39781db2af"
     },
     "rsvp": {
@@ -34267,7 +34257,6 @@
     },
     "strophejs-plugin-stream-management": {
       "version": "git+ssh://git@github.com/jitsi/strophejs-plugin-stream-management.git#001cf02bef2357234e1ac5d163611b4d60bf2b6a",
-      "integrity": "sha512-ijQSXeEEmGl4dfLx8RcQDCvzg1UPtEArowaCHZr8ITdBOH/X6JxxGzy/DVeMLVSvSy73tH7pGK6iPjBqQajwdQ==",
       "from": "strophejs-plugin-stream-management@github:jitsi/strophejs-plugin-stream-management#001cf02bef2357234e1ac5d163611b4d60bf2b6a"
     },
     "style-loader": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
- fix(rn,remote-video-menu) fix import after refactor
- chore(deps) lib-jitsi-meet@latest
- chore(deps) lib-jitsi-meet@latest
- feat(breakout-rooms) add breakout-rooms
- fix(build) fix make dev with facial recognition worker
- fix(config) fix incorrect option name and whitelist it
- feat(video-quality): Always prioritize SS in tile view.
- fix(lang) update french translation
- fix(lang) update German translation
- fix(lang) update Arabic translation
- fix(lang) update Occitan translation
- fix(lang) update Russian translation
- fix(prejoin) Fix prejoin app
- fix(rn,welcome-page) don't create video track unnecessarily
- fix(Avatar): Display correctly any emoji/special character in a avatar initials
- fix(rn,sdk) remove deprecated color scheme prop
- fix(rn,sdk) drop deprecated option enableWelcomePage
- chore(breakout-rooms) Added analytics (#10421)
- fix(linguistics) Use 'email' instead of 'e-mail'
- feat(ui) updateTheme helper for client branding
- feat(ui) reverted tokens updates
- chore(deps) lib-jitsi-meet@latest
- fix: Updates the default value of rtcstatsEnabled to match the code. (#10425)
- fix(filmstrip) remove border from filmstrip (#10367)
- fix(rn, participants-pane) Show raised hand indicator (#10424)
- feat)rn,sdk) introduce a "ready to close" event
- fix(TileViewButton) fix on mobile
- fix(android) fixes error in BroadcastEvent
- feat(notifications) revisit timeouts and make them configurable
- fix(breakout-rooms) fix error in case main room is no longer available
- fix(breakout-rooms) simplify code
- fix(breakout-rooms) avoid accessing invalid room objects
- fix(breakout-rooms) cleanup code
- fix(lang) update translations for Catalan
- chore(deps) lib-jitsi-meet@latest (#10436)
- feat(load-test): Unmute video.
- fix(lang) update German translation
- chore(rn,deps) react-native-webrtc@1.94.0
- fix(android) set facebook groupId for all react-native dependencies
- fix(config) add transcribingEnabled to whitelist
- chore(deps) lib-jitsi-meet@latest
- fix(breakout-rooms) make sure the default name is monotonically increasing
- feat(conference) UI updates for mobile navigation bar (#10437)
- feat: (speaker-stats) add speaker stats feature to native
- fix(breakout-rooms) Improve breakout rooms
- fix(lang) update Polish translation
- fix(lang) update Polish translation
- feat(branding) added native extension to updateTheme helper
- fix(lint) fix all eslint warnings
- feat(lint) treat warnings as errors
- fix(ios) avoid creating CXProvider objects when CallKit is disabled
- fix(external-api) send AUDIO_MUTED_CHANGED event only when value changed
- feat(rtcstats): send facial expressions to rtcstats-server (#10461)
- fix(breakout-rooms) fix operations when inside a breakout room
- fix(rn,settings) only show "disable call integration" on Android
- fix(breakout-rooms) fix checking if a user is in a room
- feat(config) defaultLocalDisplayName and defaultRemoteDisplayName
- fix(share-video): stop video from the participant list
- feat: Enables muc rate limit for lobby and breakout muc components.
- feat: Add disableBeforeUnloadHandlers option
- chore(deps) lib-jitsi-meet@latest
- fix(conference) remove dead code
- fix(conference) simplify code
- fix(breakout-rooms) disable lobby in breakout rooms
- fix(breakout-rooms) disable recording and live-streaming
- fix(breakout-rooms) fix no video when coming back to main room
- fix: Fixes correct state in lobby screen on wrong password.
- Revert "fix(Prejoin): Make prejoin name noneditable only when taken from jwt"
- feat(conference) Implement audio/video mute disable when sender limit is reached.
- fix(gravatar): Add crossOrigin attribute.
- fix(lang) update German translation
- fix(breakout-rooms) fix when using tenants
- fix(modal) remove dead code
- fix(conference) fix broken dispatch on mobile
- fix(etherpad) fix loading Etherpad on web
- fix(participants) fix unpinning when switching conferences
- New strings translated
- fix(etherpad) fix Etherpad closing when dominant speaker changes
- fix(breakout-rooms) make sure participants in breakout rooms have a display name
- fix(dropbox): OAuth to use postMessage.
- feat: (speaker-stats) fix refresh and minor refactoring
- fix(rn,breakout-rooms) wait for the room to be left
- fix(rn,external-api) remove dead code
- feat(notifications) coalesce participant left and raised hand notifications
- fix(lang) update french translation + fix 2 existing translations
- fix(breakout-rooms) mark function as async
- fix(rn,conference) hide timer until it has started
- chore(deps) lib-jitsi-meet@latest
- feat(tile-view): allow disabling thumbnail enlargement
- chore(deps) lib-jitsi-meet@latest
- fix(rn,navbar) fix invalid boolean check
- feat(breakout-rooms) add notification when joining rooms
- fix(screen-sharing, picture-in-picture) re-enables PIP after stopping screen-share
- feat: (moderate-reaction-sounds) enable moderator to mute reaction sounds
- fix(lang) update German translation
- fix(lang) update french translation
- feat(external-api): enhance recordingLinkAvailable to provide ttl info
- fix(rn,chat): Fix chat and polls title
- fix(breakout-rooms) fix not waiting to leave the room
- fix(breakout,av-moderation): support non-ascii room names
- fix(breakout,av-moderation): support non-ascii tenant names
- fix(media) dispatch the unmute blocked action irrepective of the muted state. This fixes an issue where the user muted by focus is able to unmute themselves even when the sender limit has been reached.
- fix(lang) update Arabic translation
- fix(facial-expressions) load worker as a blob
- fix(lang) update Portuguese translation
- feat(prejoin) Add possibility to hide extra join options buttons (#10434)
- fix(lang) update Traditional Chinese (Taiwan) translation
- fix(lang) update sv translation
- fix(participants-list): Avoid ui moving on input focus
- feat(end-meet-for-all) Trigger notifyReadyToClose event on end meetin… (#10549)
- fix(virtual-backgrounds) fix error if we failed to load the model
- fix(virtual-backgrounds) make error message translatable
- fix(screenshot-capture) Update screenshot capture feature (#10443)
- chore(rn) updates react-native-webrtc
- chore(deps) lib-jitsi-meet@latest
- fix(overflow-drawer) Only use overflow drawer on mobile
- fix(breakout-rooms) fix non-functional context menu
- fix(rn) join conference if started by moderator
- fix(breakout-rooms) cleanup remote tracks when a conference is left
- feat(self-view) Added ability to hide self view
- fix(screenshot-capture) Use feature on web only
- chore(deps) lib-jitsi-meet@latest
