### PR TITLE
update ljm 1639041974

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12509,8 +12509,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e9e37099a143c06355f9e6868bbcdf20b48583b1",
-      "integrity": "sha512-haNpszEW8gbvcZCtMFzN/nzuU94jC3G4VQnf87/fjX0rL6yEDYlGyoYChFYhqzFGBTJOETKa/SRvYfFDGzfzcw==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
+      "integrity": "sha512-UPQrJjATYSerDZVezRpr+v9OMI94LYwimWyrDUg2Wpr2yfrDnIM90oqn62F9CwsE3QBBBLEZoTUk9K02z2d/Yg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -29978,9 +29978,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e9e37099a143c06355f9e6868bbcdf20b48583b1",
-      "integrity": "sha512-haNpszEW8gbvcZCtMFzN/nzuU94jC3G4VQnf87/fjX0rL6yEDYlGyoYChFYhqzFGBTJOETKa/SRvYfFDGzfzcw==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
+      "integrity": "sha512-UPQrJjATYSerDZVezRpr+v9OMI94LYwimWyrDUg2Wpr2yfrDnIM90oqn62F9CwsE3QBBBLEZoTUk9K02z2d/Yg==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e9e37099a143c06355f9e6868bbcdf20b48583b1",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#161da84ac045afd8ac8eed9168bd708dc0cbedb1",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
- fix(rn,remote-video-menu) fix import after refactor
- chore(deps) lib-jitsi-meet@latest
- chore(deps) lib-jitsi-meet@latest
- feat(breakout-rooms) add breakout-rooms
- fix(build) fix make dev with facial recognition worker
- fix(config) fix incorrect option name and whitelist it
- feat(video-quality): Always prioritize SS in tile view.
- fix(lang) update french translation
- fix(lang) update German translation
- fix(lang) update Arabic translation
- fix(lang) update Occitan translation
- fix(lang) update Russian translation
- fix(prejoin) Fix prejoin app
- fix(rn,welcome-page) don't create video track unnecessarily
- fix(Avatar): Display correctly any emoji/special character in a avatar initials
- fix(rn,sdk) remove deprecated color scheme prop
- fix(rn,sdk) drop deprecated option enableWelcomePage
- chore(breakout-rooms) Added analytics (#10421)
- fix(linguistics) Use 'email' instead of 'e-mail'
- feat(ui) updateTheme helper for client branding
- feat(ui) reverted tokens updates
- chore(deps) lib-jitsi-meet@latest
- fix: Updates the default value of rtcstatsEnabled to match the code. (#10425)
- fix(filmstrip) remove border from filmstrip (#10367)
- fix(rn, participants-pane) Show raised hand indicator (#10424)
- feat)rn,sdk) introduce a "ready to close" event
- fix(TileViewButton) fix on mobile
- fix(android) fixes error in BroadcastEvent
- feat(notifications) revisit timeouts and make them configurable
- fix(breakout-rooms) fix error in case main room is no longer available
- fix(breakout-rooms) simplify code
- fix(breakout-rooms) avoid accessing invalid room objects
- fix(breakout-rooms) cleanup code
- fix(lang) update translations for Catalan
- chore(deps) lib-jitsi-meet@latest (#10436)
- feat(load-test): Unmute video.
- fix(lang) update German translation
- chore(rn,deps) react-native-webrtc@1.94.0
- fix(android) set facebook groupId for all react-native dependencies
- fix(config) add transcribingEnabled to whitelist
- chore(deps) lib-jitsi-meet@latest
- fix(breakout-rooms) make sure the default name is monotonically increasing
- feat(conference) UI updates for mobile navigation bar (#10437)
- feat: (speaker-stats) add speaker stats feature to native
- fix(breakout-rooms) Improve breakout rooms
- fix(lang) update Polish translation
- fix(lang) update Polish translation
- feat(branding) added native extension to updateTheme helper
- fix(lint) fix all eslint warnings
- feat(lint) treat warnings as errors
- fix(ios) avoid creating CXProvider objects when CallKit is disabled
- fix(external-api) send AUDIO_MUTED_CHANGED event only when value changed
- feat(rtcstats): send facial expressions to rtcstats-server (#10461)
- fix(breakout-rooms) fix operations when inside a breakout room
- fix(rn,settings) only show "disable call integration" on Android
- fix(breakout-rooms) fix checking if a user is in a room
- feat(config) defaultLocalDisplayName and defaultRemoteDisplayName
- fix(share-video): stop video from the participant list
- feat: Enables muc rate limit for lobby and breakout muc components.
- feat: Add disableBeforeUnloadHandlers option
- chore(deps) lib-jitsi-meet@latest
- fix(conference) remove dead code
- fix(conference) simplify code
- fix(breakout-rooms) disable lobby in breakout rooms
- fix(breakout-rooms) disable recording and live-streaming
- fix(breakout-rooms) fix no video when coming back to main room
- fix: Fixes correct state in lobby screen on wrong password.
- Revert "fix(Prejoin): Make prejoin name noneditable only when taken from jwt"
- feat(conference) Implement audio/video mute disable when sender limit is reached.
- fix(gravatar): Add crossOrigin attribute.
- fix(lang) update German translation
- fix(breakout-rooms) fix when using tenants
- fix(modal) remove dead code
- fix(conference) fix broken dispatch on mobile
- fix(etherpad) fix loading Etherpad on web
- fix(participants) fix unpinning when switching conferences
- New strings translated
- fix(etherpad) fix Etherpad closing when dominant speaker changes
- fix(breakout-rooms) make sure participants in breakout rooms have a display name
- fix(dropbox): OAuth to use postMessage.
- feat: (speaker-stats) fix refresh and minor refactoring
- fix(rn,breakout-rooms) wait for the room to be left
- fix(rn,external-api) remove dead code
- feat(notifications) coalesce participant left and raised hand notifications
- fix(lang) update french translation + fix 2 existing translations
- fix(breakout-rooms) mark function as async
- fix(rn,conference) hide timer until it has started
- chore(deps) lib-jitsi-meet@latest
- feat(tile-view): allow disabling thumbnail enlargement
- chore(deps) lib-jitsi-meet@latest
- fix(rn,navbar) fix invalid boolean check
- feat(breakout-rooms) add notification when joining rooms
- fix(screen-sharing, picture-in-picture) re-enables PIP after stopping screen-share
- feat: (moderate-reaction-sounds) enable moderator to mute reaction sounds
- fix(lang) update German translation
- fix(lang) update french translation
- feat(external-api): enhance recordingLinkAvailable to provide ttl info
- fix(rn,chat): Fix chat and polls title
- fix(breakout-rooms) fix not waiting to leave the room
- fix(breakout,av-moderation): support non-ascii room names
- fix(breakout,av-moderation): support non-ascii tenant names
- fix(media) dispatch the unmute blocked action irrepective of the muted state. This fixes an issue where the user muted by focus is able to unmute themselves even when the sender limit has been reached.
- fix(lang) update Arabic translation
- fix(facial-expressions) load worker as a blob
- fix(lang) update Portuguese translation
- feat(prejoin) Add possibility to hide extra join options buttons (#10434)
- fix(lang) update Traditional Chinese (Taiwan) translation
- fix(lang) update sv translation
- fix(participants-list): Avoid ui moving on input focus
- feat(end-meet-for-all) Trigger notifyReadyToClose event on end meetin… (#10549)
- fix(virtual-backgrounds) fix error if we failed to load the model
- fix(virtual-backgrounds) make error message translatable
- fix(screenshot-capture) Update screenshot capture feature (#10443)
- chore(rn) updates react-native-webrtc
- chore(deps) lib-jitsi-meet@latest
- fix(overflow-drawer) Only use overflow drawer on mobile
- fix(breakout-rooms) fix non-functional context menu
- fix(rn) join conference if started by moderator
- fix(breakout-rooms) cleanup remote tracks when a conference is left
- feat(self-view) Added ability to hide self view
- fix(screenshot-capture) Use feature on web only
- chore(deps) lib-jitsi-meet@latest
