### PR TITLE
fix(tracks) fix disposing of local tracks

### DIFF
--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -31,6 +31,7 @@ import {
 } from './actionTypes';
 import {
     createLocalTracksA,
+    destroyLocalTracks,
     showNoDataFromSourceVideoError,
     toggleScreensharing,
     trackRemoved,
@@ -217,10 +218,11 @@ StateListenerRegistry.register(
     (conference, { dispatch, getState }, prevConference) => {
         if (prevConference && !conference) {
             // Clear all tracks.
-            const tracks = getState()['features/base/tracks'];
+            const remoteTracks = getState()['features/base/tracks'].filter(t => !t.local);
 
             batch(() => {
-                for (const track of tracks) {
+                dispatch(destroyLocalTracks());
+                for (const track of remoteTracks) {
                     dispatch(trackRemoved(track.jitsiTrack));
                 }
             });


### PR DESCRIPTION
Don't just clear the storage for them, local tracks must be disposed, in order
for RN capturer to be freed for example.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
