### PR TITLE
Added override for webcam

### DIFF
--- a/css/_hide_webcam_override.scss
+++ b/css/_hide_webcam_override.scss
@@ -1,0 +1,3 @@
+.videocontainer.display-avatar-with-name {
+    display: none !important;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -104,5 +104,6 @@ $flagsImagePath: "../images/";
 @import 'plan-limit';
 @import 'polls';
 @import 'notifications';
+@import 'hide_webcam_override';
 
 /* Modules END */


### PR DESCRIPTION
An override to the CSS to ensure the camera tile in the film strip is invisible when we have our camera off.

## Screenshots

### Camera off

<img width="970" alt="image" src="https://user-images.githubusercontent.com/127187/146193120-497d8ba2-5c91-480d-842e-0080ae706844.png">

### Camera on

<img width="625" alt="image" src="https://user-images.githubusercontent.com/127187/146193298-30d17827-9119-44f1-9c30-c79fc04f3b78.png">
