### PR TITLE
fix: Fixes emitting conference left event in iframeAPI.

### DIFF
--- a/react/features/breakout-rooms/actions.js
+++ b/react/features/breakout-rooms/actions.js
@@ -233,7 +233,9 @@ export function moveToRoom(roomId?: string) {
             const isVideoMuted = isLocalCameraTrackMuted(localTracks);
 
             try {
-                await APP.conference.leaveRoom(false /* doDisconnect */);
+                // all places we fire notifyConferenceLeft we pass the room name from APP.conference
+                await APP.conference.leaveRoom(false /* doDisconnect */).then(
+                    () => APP.API.notifyConferenceLeft(APP.conference.roomName));
             } catch (error) {
                 logger.warn('APP.conference.leaveRoom() rejected with:', error);
 

--- a/react/features/external-api/middleware.js
+++ b/react/features/external-api/middleware.js
@@ -88,11 +88,12 @@ MiddlewareRegistry.register(store => next => action => {
     case CONFERENCE_JOINED: {
         const state = store.getState();
         const { defaultLocalDisplayName } = state['features/base/config'];
-        const { room } = state['features/base/conference'];
         const { loadableAvatarUrl, name, id } = getLocalParticipant(state);
 
+        // we use APP.conference.roomName as we do not update state['features/base/conference'].room when
+        // moving between rooms in case of breakout rooms and it stays always with the name of the main room
         APP.API.notifyConferenceJoined(
-            room,
+            APP.conference.roomName,
             id,
             {
                 displayName: name,


### PR DESCRIPTION
Moving to breakout room and back in main room do not fire videoConferenceLeft events.
And the videoConferenceJoined was reporting wrong conference name on join.

