### PR TITLE
fix: participant join notifications

### DIFF
--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -293,7 +293,7 @@ const _throttledNotifyParticipantLeft = throttle((dispatch: Dispatch<any>, getSt
  * @returns {Function}
  */
 export function showParticipantJoinedNotification(displayName: string) {
-    leftParticipantsNames.push(displayName);
+    joinedParticipantsNames.push(displayName);
 
     return (dispatch: Dispatch<any>, getState: Function) => _throttledNotifyParticipantConnected(dispatch, getState);
 }
@@ -307,7 +307,7 @@ export function showParticipantJoinedNotification(displayName: string) {
  * @returns {Function}
  */
 export function showParticipantLeftNotification(displayName: string) {
-    joinedParticipantsNames.push(displayName);
+    leftParticipantsNames.push(displayName);
 
     return (dispatch: Dispatch<any>, getState: Function) => _throttledNotifyParticipantLeft(dispatch, getState);
 }


### PR DESCRIPTION
Ref: https://github.com/jitsi/jitsi-meet/issues/10610

Wrong arrays were being populated in `showParticipant*Notification` functions, resulting in join notifications never getting triggered.