### PR TITLE
fix(tile-view) fix screensharing size in self view

### DIFF
--- a/css/filmstrip/_tile_view.scss
+++ b/css/filmstrip/_tile_view.scss
@@ -99,19 +99,6 @@
                 display: block;
                 margin: 2px;
             }
-
-            video {
-                object-fit: contain;
-            }
-
-            /**
-            * Max-width corresponding to the ASPECT_RATIO_BREAKPOINT from features/filmstrip/constants.
-            */
-            @media only screen and (max-width: 500px) {
-                video {
-                    object-fit: cover;
-                }
-            }
         }
     }
 }

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -479,17 +479,18 @@ class Thumbnail extends Component<Props, State> {
         }
 
         let videoStyles = null;
+        const doNotStretchVideo = (_height < 320 && tileViewActive)
+            || _disableTileEnlargement
+            || _isScreenSharing;
 
-        if (!_isScreenSharing) {
-            if (canPlayEventReceived || _participant.local) {
-                videoStyles = {
-                    objectFit: (_height < 320 && tileViewActive) || _disableTileEnlargement ? 'contain' : 'cover'
-                };
-            } else {
-                videoStyles = {
-                    display: 'none'
-                };
-            }
+        if (canPlayEventReceived || _participant.local) {
+            videoStyles = {
+                objectFit: doNotStretchVideo ? 'contain' : 'cover'
+            };
+        } else {
+            videoStyles = {
+                display: 'none'
+            };
         }
 
         styles = {


### PR DESCRIPTION
clean-up overriden css for tileview video tags

Before:
<img width="1670" alt="Screenshot 2021-12-16 at 12 18 52" src="https://user-images.githubusercontent.com/1556279/146354907-00e703fa-b4ee-49a3-879a-1f4808cbda35.png">

After
<img width="1675" alt="Screenshot 2021-12-16 at 12 16 27" src="https://user-images.githubusercontent.com/1556279/146355013-fa95023d-a7f5-4dfd-89dc-a64a55dbcb55.png">



