### PR TITLE
feat(external-api): add local subject command

### DIFF
--- a/config.js
+++ b/config.js
@@ -1045,6 +1045,9 @@ var config = {
     // Sets the conference subject
     // subject: 'Conference Subject',
 
+    // Sets the conference local subject
+    // localSubject: 'Conference Local Subject',
+
     // This property is related to the use case when jitsi-meet is used via the IFrame API. When the property is true
     // jitsi-meet will use the local storage of the host page instead of its own. This option is useful if the browser
     // is not persisting the local storage inside the iframe.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -21,6 +21,7 @@ import {
     getCurrentConference,
     sendTones,
     setFollowMe,
+    setLocalSubject,
     setPassword,
     setSubject
 } from '../../react/features/base/conference';
@@ -135,6 +136,10 @@ function initCommands() {
         'display-name': displayName => {
             sendAnalytics(createApiEvent('display.name.changed'));
             APP.conference.changeLocalDisplayName(displayName);
+        },
+        'local-subject': localSubject => {
+            sendAnalytics(createApiEvent('local.subject.changed'));
+            APP.store.dispatch(setLocalSubject(localSubject));
         },
         'mute-everyone': mediaType => {
             const muteMediaType = mediaType ? mediaType : MEDIA_TYPE.AUDIO;

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -38,6 +38,7 @@ const commands = {
     toggleLobby: 'toggle-lobby',
     hangup: 'video-hangup',
     initiatePrivateChat: 'initiate-private-chat',
+    localSubject: 'local-subject',
     kickParticipant: 'kick-participant',
     muteEveryone: 'mute-everyone',
     overwriteConfig: 'overwrite-config',

--- a/react/features/base/conference/actionTypes.js
+++ b/react/features/base/conference/actionTypes.js
@@ -43,6 +43,16 @@ export const CONFERENCE_JOINED = 'CONFERENCE_JOINED';
 export const CONFERENCE_LEFT = 'CONFERENCE_LEFT';
 
 /**
+ * The type of (redux) action, which indicates conference local subject changes.
+ *
+ * {
+ *     type: CONFERENCE_LOCAL_SUBJECT_CHANGED
+ *     subject: string
+ * }
+ */
+ export const CONFERENCE_LOCAL_SUBJECT_CHANGED = 'CONFERENCE_LOCAL_SUBJECT_CHANGED';
+
+ /**
  * The type of (redux) action, which indicates conference subject changes.
  *
  * {

--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -41,6 +41,7 @@ import {
     CONFERENCE_FAILED,
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
+    CONFERENCE_LOCAL_SUBJECT_CHANGED,
     CONFERENCE_SUBJECT_CHANGED,
     CONFERENCE_TIMESTAMP_CHANGED,
     CONFERENCE_UNIQUE_ID_SET,
@@ -792,7 +793,7 @@ export function setStartMutedPolicy(
 }
 
 /**
- * Changing conference subject.
+ * Sets the conference subject.
  *
  * @param {string} subject - The new subject.
  * @returns {void}
@@ -809,5 +810,21 @@ export function setSubject(subject: string) {
                 subject
             });
         }
+    };
+}
+
+/**
+ * Sets the conference local subject.
+ *
+ * @param {string} localSubject - The new local subject.
+ * @returns {{
+ *     type: CONFERENCE_LOCAL_SUBJECT_CHANGED,
+ *     localSubject: string
+ * }}
+ */
+export function setLocalSubject(localSubject: string) {
+    return {
+        type: CONFERENCE_LOCAL_SUBJECT_CHANGED,
+        localSubject
     };
 }

--- a/react/features/base/conference/functions.js
+++ b/react/features/base/conference/functions.js
@@ -180,9 +180,9 @@ export function getConferenceName(stateful: Function | Object): string {
     const state = toState(stateful);
     const { callee } = state['features/base/jwt'];
     const { callDisplayName } = state['features/base/config'];
-    const { pendingSubjectChange, room, subject } = getConferenceState(state);
+    const { localSubject, room, subject } = getConferenceState(state);
 
-    return pendingSubjectChange
+    return localSubject
         || subject
         || callDisplayName
         || (callee && callee.name)

--- a/react/features/base/conference/middleware.any.js
+++ b/react/features/base/conference/middleware.any.js
@@ -39,6 +39,7 @@ import {
     conferenceFailed,
     conferenceWillLeave,
     createConference,
+    setLocalSubject,
     setSubject
 } from './actions';
 import { TRIGGER_READY_TO_CLOSE_REASONS } from './constants';
@@ -484,11 +485,12 @@ function _sendTones({ getState }, next, action) {
  */
 function _setRoom({ dispatch, getState }, next, action) {
     const state = getState();
-    const { subject } = state['features/base/config'];
+    const { localSubject, subject } = state['features/base/config'];
     const { room } = action;
 
     if (room) {
         // Set the stored subject.
+        dispatch(setLocalSubject(localSubject));
         dispatch(setSubject(subject));
     }
 

--- a/react/features/base/conference/reducer.js
+++ b/react/features/base/conference/reducer.js
@@ -10,6 +10,7 @@ import {
     CONFERENCE_FAILED,
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
+    CONFERENCE_LOCAL_SUBJECT_CHANGED,
     CONFERENCE_SUBJECT_CHANGED,
     CONFERENCE_TIMESTAMP_CHANGED,
     CONFERENCE_WILL_JOIN,
@@ -55,6 +56,9 @@ ReducerRegistry.register(
 
         case CONFERENCE_SUBJECT_CHANGED:
             return set(state, 'subject', action.subject);
+
+        case CONFERENCE_LOCAL_SUBJECT_CHANGED:
+            return set(state, 'localSubject', action.localSubject);
 
         case CONFERENCE_TIMESTAMP_CHANGED:
             return set(state, 'conferenceTimestamp', action.conferenceTimestamp);

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -176,6 +176,7 @@ export default [
     'inviteAppName',
     'liveStreamingEnabled',
     'localRecording',
+    'localSubject',
     'maxFullResolutionParticipants',
     'mouseMoveCallbackInterval',
     'notifications',


### PR DESCRIPTION
Extended the external API to support setting a local subject from all participants (regardless of the role).