### PR TITLE
fix(thumbnail) Update tile resizing constraints

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -6,6 +6,10 @@
 * {
     -webkit-user-select: none;
     user-select: none;
+
+    // Firefox only
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, .5) transparent;
 }
 
 input,

--- a/react/features/filmstrip/actions.web.js
+++ b/react/features/filmstrip/actions.web.js
@@ -39,7 +39,7 @@ export function setTileViewDimensions(dimensions: Object) {
     return (dispatch: Dispatch<any>, getState: Function) => {
         const state = getState();
         const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
-        const { disableResponsiveTiles } = state['features/base/config'];
+        const { disableResponsiveTiles, disableTileEnlargement } = state['features/base/config'];
         const {
             height,
             width
@@ -47,7 +47,8 @@ export function setTileViewDimensions(dimensions: Object) {
             ...dimensions,
             clientWidth,
             clientHeight,
-            disableResponsiveTiles
+            disableResponsiveTiles,
+            disableTileEnlargement
         });
         const { columns, rows } = dimensions;
         const thumbnailsTotalHeight = rows * (TILE_VERTICAL_MARGIN + height);

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -454,12 +454,17 @@ class Thumbnail extends Component<Props, State> {
             _isHidden,
             _isScreenSharing,
             _participant,
+            _videoTrack,
             _width,
             horizontalOffset,
             style
         } = this.props;
 
+
         const tileViewActive = _currentLayout === LAYOUTS.TILE_VIEW;
+        const jitsiVideoTrack = _videoTrack?.jitsiTrack;
+        const track = jitsiVideoTrack?.track;
+        const isPortraitVideo = ((track && track.getSettings()?.aspectRatio) || 1) < 1;
 
         let styles: {
             avatar: Object,
@@ -479,7 +484,7 @@ class Thumbnail extends Component<Props, State> {
         }
 
         let videoStyles = null;
-        const doNotStretchVideo = (_height < 320 && tileViewActive)
+        const doNotStretchVideo = (isPortraitVideo && tileViewActive)
             || _disableTileEnlargement
             || _isScreenSharing;
 

--- a/react/features/filmstrip/constants.js
+++ b/react/features/filmstrip/constants.js
@@ -47,6 +47,21 @@ export const TWO_COLUMN_BREAKPOINT = 1000;
 export const ASPECT_RATIO_BREAKPOINT = 500;
 
 /**
+ * Minimum height of tile for small screens.
+ */
+export const TILE_MIN_HEIGHT_SMALL = 150;
+
+/**
+ * Minimum height of tile for large screens.
+ */
+export const TILE_MIN_HEIGHT_LARGE = 200;
+
+/**
+ * Aspect ratio for portrait tiles. (height / width).
+ */
+export const TILE_PORTRAIT_ASPECT_RATIO = 1.3;
+
+/**
  * The default number of columns for tile view.
  */
 export const DEFAULT_MAX_COLUMNS = 5;


### PR DESCRIPTION
disableTileEnlargement config now uses old behavior (small tiles, not just small video in the tiles)
Update Firefox scrollbar style to match WebKit
Show more rows when height allows it instead of stretching a fixed number of rows, but make sure we always try to fill the whole viewport
Added constraints for how narrow portrait tiles can be and how wide landscape tiles can be
The video should cover the whole tile in tile view unless disableTileEnlargement is set or video is portrait
Added min height in px for tiles
