### PR TITLE
fix(speaker-stats): responsiveness of facial expressions

### DIFF
--- a/react/features/speaker-stats/components/AbstractSpeakerStatsList.js
+++ b/react/features/speaker-stats/components/AbstractSpeakerStatsList.js
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getLocalParticipant } from '../../base/participants';
 import { initUpdateStats } from '../actions';
 import {
+    REDUCE_EXPRESSIONS_THRESHOLD,
     SPEAKER_STATS_RELOAD_INTERVAL
 } from '../constants';
 
@@ -94,7 +95,7 @@ const abstractSpeakerStatsList = (speakerStatsItem: Function): Function[] => {
             props.facialExpressions = statsModel.getFacialExpressions();
         }
         props.showFacialExpressions = enableFacialRecognition;
-        props.reduceExpressions = clientWidth < 750;
+        props.reduceExpressions = clientWidth < REDUCE_EXPRESSIONS_THRESHOLD;
         props.displayName = statsModel.getDisplayName() || defaultRemoteDisplayName;
         props.t = t;
 

--- a/react/features/speaker-stats/components/AbstractSpeakerStatsList.js
+++ b/react/features/speaker-stats/components/AbstractSpeakerStatsList.js
@@ -22,6 +22,7 @@ const abstractSpeakerStatsList = (speakerStatsItem: Function): Function[] => {
     const conference = useSelector(state => state['features/base/conference'].conference);
     const speakerStats = useSelector(state => state['features/speaker-stats'].stats);
     const localParticipant = useSelector(getLocalParticipant);
+    const { clientWidth } = useSelector(state => state['features/base/responsive-ui']);
     const { defaultRemoteDisplayName, enableFacialRecognition } = useSelector(
         state => state['features/base/config']) || {};
     const { facialExpressions: localFacialExpressions } = useSelector(
@@ -93,6 +94,7 @@ const abstractSpeakerStatsList = (speakerStatsItem: Function): Function[] => {
             props.facialExpressions = statsModel.getFacialExpressions();
         }
         props.showFacialExpressions = enableFacialRecognition;
+        props.reduceExpressions = clientWidth < 750;
         props.displayName = statsModel.getDisplayName() || defaultRemoteDisplayName;
         props.t = t;
 

--- a/react/features/speaker-stats/constants.js
+++ b/react/features/speaker-stats/constants.js
@@ -1,1 +1,6 @@
+/**
+ * The with of the client at witch the facial expressions will be reduced to only 4.
+ */
+export const REDUCE_EXPRESSIONS_THRESHOLD = 750;
+
 export const SPEAKER_STATS_RELOAD_INTERVAL = 1000;


### PR DESCRIPTION
Fix the responsiveness of facial expressions in speaker stats. Show only 4 expressions when client width is less than 750px.

Before
![Screenshot 2021-12-20 at 09 40 38](https://user-images.githubusercontent.com/57035818/146730770-d9bfd969-7b50-42c9-83f7-be256a6d9a0d.png)


Now
![Screenshot 2021-12-20 at 09 42 01](https://user-images.githubusercontent.com/57035818/146730813-0900ac2e-0675-4c47-baa0-05b10615d027.png)

