### PR TITLE
fix(lang) make fr language file format consistent

### DIFF
--- a/lang/main-fr.json
+++ b/lang/main-fr.json
@@ -40,25 +40,25 @@
     "audioOnly": "Bande passante faible"
   },
   "blankPage": {
-     "meetingEnded": "Réunion terminée."
+    "meetingEnded": "Réunion terminée."
   },
   "breakoutRooms": {
     "defaultName": "Salle annexe #{{index}}",
     "mainRoom": "Salle principale",
     "actions": {
-        "add": "Ajouter salle annexe",
-        "autoAssign": "Assigner automatiquement aux salles annexes",
-        "close": "Fermer",
-        "join": "Rejoindre",
-        "leaveBreakoutRoom": "Quitter la salle annexe",
-        "more": "Plus",
-        "remove": "Supprimer",
-        "sendToBreakoutRoom": "Envoyer le participant dans:"
+      "add": "Ajouter salle annexe",
+      "autoAssign": "Assigner automatiquement aux salles annexes",
+      "close": "Fermer",
+      "join": "Rejoindre",
+      "leaveBreakoutRoom": "Quitter la salle annexe",
+      "more": "Plus",
+      "remove": "Supprimer",
+      "sendToBreakoutRoom": "Envoyer le participant dans:"
     },
     "notifications": {
-        "joinedTitle": "Salles annexes",
-        "joined": "Entrée en salle annexe \"{{name}}\"",
-        "joinedMainRoom": "Retour à la salle principalem"
+      "joinedTitle": "Salles annexes",
+      "joined": "Entrée en salle annexe \"{{name}}\"",
+      "joinedMainRoom": "Retour à la salle principalem"
     }
   },
   "calendarSync": {
@@ -245,8 +245,8 @@
     "gracefulShutdown": "Notre service est actuellement en maintenance. Veuillez réessayer plus tard.",
     "grantModeratorDialog": "Êtes-vous sûr de vouloir rendre ce participant modérateur ?",
     "grantModeratorTitle": "Nommer modérateur",
-    "IamHost": "Je suis l'hôte",
     "hideShareAudioHelper": "Ne pas montrer ce dialogue à nouveau",
+    "IamHost": "Je suis l'hôte",
     "incorrectRoomLockPassword": "Mot de passe incorrect",
     "incorrectPassword": "Nom d'utilisateur ou mot de passe incorrect",
     "internalError": "Oups ! Quelque chose s'est mal passée. L'erreur suivante s'est produite : {{error}}",
@@ -262,8 +262,8 @@
     "lockMessage": "Impossible de verrouiller la conférence.",
     "lockRoom": "Ajouter un $t(lockRoomPassword) à la réunion ",
     "lockTitle": "Échec du verrouillage",
-    "login": "Connexion",
     "logoutQuestion": "Voulez-vous vraiment vous déconnecter et arrêter la conférence ?",
+    "login": "Connexion",
     "logoutTitle": "Déconnexion",
     "maxUsersLimitReached": "Le nombre maximal de participants est atteint. Le conférence est complète. Merci de contacter l'organisateur de la réunion ou réessayer plus tard !",
     "maxUsersLimitReachedTitle": "Le nombre maximal de participants est atteint",
@@ -341,7 +341,7 @@
     "sessionRestarted": "L'appel est relancé par la passerelle",
     "Share": "Partager",
     "shareAudio": "Continuer",
-    "shareAudioTitle" : "Comment partager le son",
+    "shareAudioTitle": "Comment partager le son",
     "shareAudioWarningTitle": "Vous devez cesser de partager l'écran avant de partager l'audio",
     "shareAudioWarningH1": "Si vous voulez partager uniquement de l'audio:",
     "shareAudioWarningD1": "vous devez cesser le partage d'écran avant de partager votre son.",
@@ -409,15 +409,15 @@
     "none": "Rien",
     "uploadedImage": "Image téléversée {{index}}",
     "deleteImage": "Supprimer l'image",
-    "image1" : "Plage",
-    "image2" : "Mur blanc neutre",
-    "image3" : "Pièce vide blanche",
-    "image4" : "Lampadaire noir",
-    "image5" : "Montagne",
-    "image6" : "Forêt ",
-    "image7" : "Lever de soleil",
+    "image1": "Plage",
+    "image2": "Mur blanc neutre",
+    "image3": "Pièce vide blanche",
+    "image4": "Lampadaire noir",
+    "image5": "Montagne",
+    "image6": "Forêt ",
+    "image7": "Lever de soleil",
     "desktopShareError": "Impossible de créer le partage de bureau",
-    "desktopShare":"Partage de bureau",
+    "desktopShare": "Partage de bureau",
     "webAssemblyWarning": "WebAssembly non supporté",
     "webAssemblyWarningDescription": "WebAssembly invalidé ou non supporté par ce navigateur",
     "backgroundEffectError": "Erreur dans l'application de l'effet d'arrière-plan."
@@ -447,7 +447,7 @@
     "country": "Pays",
     "dialANumber": "Pour rejoindre votre réunion, composez l'un de ces numéros, puis saisissez le code confidentiel.",
     "dialInConferenceID": "PIN :",
-    "copyNumber":"Copier le numéro",
+    "copyNumber": "Copier le numéro",
     "dialInNotSupported": "Désolé, l'accès par téléphone n'est pas pris en charge pour l'instant.",
     "dialInNumber": "Composer :",
     "dialInSummaryError": "Erreur lors de la récupération des informations de numérotation. Veuillez réessayer plus tard.",
@@ -608,7 +608,7 @@
     "passwordRemovedRemotely": "Le $t(lockRoomPassword) a été supprimé par un autre participant",
     "passwordSetRemotely": "Un $t(lockRoomPassword) a été défini par un autre participant",
     "raisedHand": "{{name}} aimerait prendre la parole.",
-    "raisedHands": "{{participantName}} et {{raisedHands}} autres personnes",    
+    "raisedHands": "{{participantName}} et {{raisedHands}} autres personnes",
     "screenShareNoAudio": " La case Partager l'audio n'a pas été cochée dans l'écran de sélection de la fenêtre.",
     "screenShareNoAudioTitle": "La case Partager l'audio n'a pas été cochée",
     "selfViewTitle": "Vous pouvez toujours rétablir l'affichage de votre propre vidéo dans les paramètres",
@@ -638,7 +638,7 @@
     "moderationToggleDescription": "par {{participantDisplayName}}",
     "raiseHandAction": "Lever la main",
     "reactionSounds": "Bloquer les réactions sonores",
-    "reactionSoundsForAll": "Bloquer les réactions sonores pour tous",    
+    "reactionSoundsForAll": "Bloquer les réactions sonores pour tous",
     "groupTitle": "Notifications",
     "videoUnmuteBlockedTitle": "Rétablissement de la caméra bloqué !",
     "videoUnmuteBlockedDescription": "Le rétablissement de la vidéo a été bloqué temporairement en raison de limites système."
@@ -667,7 +667,7 @@
       "stopVideo": "Couper la vidéo",
       "unblockEveryoneMicCamera": "Débloquer tous les micros et caméras",
       "videoModeration": "Démarrer leur vidéo",
-      "moreModerationControls": "Options de modération supplémentaires"      
+      "moreModerationControls": "Options de modération supplémentaires"
     },
     "search": "Rechercher des participants"
   },
@@ -680,8 +680,8 @@
       "answerPlaceholder": "Option {{index}}",
       "create": "Créer un sondage",
       "cancel": "Annuler",
-      "pollOption" : "Option {{index}}",
-      "pollQuestion" : "Question du sondage",
+      "pollOption": "Option {{index}}",
+      "pollQuestion": "Question du sondage",
       "questionPlaceholder": "Poser une question",
       "removeOption": "Supprimer l'option",
       "send": "Envoyer"
@@ -755,8 +755,8 @@
     "or": "ou",
     "premeeting": "Pré-séance",
     "showScreen": "Activer l'écran de pré-séance",
+    "keyboardShortcuts": "Activer les raccourcis clavier",
     "startWithPhone": "Commencez avec l'audio du téléphone",
-    "keyboardShortcuts" : "Activer les raccourcis clavier",
     "screenSharingError": "Erreur de partage d'écran:",
     "videoOnlyError": "Erreur vidéo:",
     "videoTrackError": "Impossible de créer une piste vidéo.",
@@ -864,7 +864,7 @@
     "sounds": "Sons",
     "speakers": "Haut-parleurs",
     "startAudioMuted": "Tout le monde commence en muet",
-    "startReactionsMuted": "Tout le monde commence avec les réactions sonores bloquées",    
+    "startReactionsMuted": "Tout le monde commence avec les réactions sonores bloquées",
     "startVideoMuted": "Tout le monde commence sans vidéo",
     "talkWhileMuted": "vous parlez en étant muet",
     "title": "Paramètres"
@@ -897,20 +897,20 @@
   },
   "speaker": "Haut-parleur",
   "speakerStats": {
-    "search": "Recherche",
+    "angry": "En colère",
+    "disgusted": "Dégoûté",
+    "fearful": "Effrayé",
+    "happy": "Content",
     "hours": "{{count}}h",
     "minutes": "{{count}}m",
     "name": "Nom",
-    "seconds": "{{count}}s",
-    "speakerStats": "Statistiques de l'interlocuteur",
-    "speakerTime": "Temps de l'interlocuteur",
-    "happy": "Content",
     "neutral": "Indifférent",
     "sad": "Triste",
-    "surprised": "Surpris",
-    "angry": "En colère",
-    "fearful": "Effrayé",
-    "disgusted": "Dégoûté"
+    "search": "Recherche",
+    "seconds": "{{count}}s",
+    "speakerTime": "Temps de l'interlocuteur",
+    "speakerStats": "Statistiques de l'interlocuteur",
+    "surprised": "Surpris"
   },
   "startupoverlay": {
     "policyText": " ",
@@ -1179,13 +1179,13 @@
     "startMeeting": "Démarrer la conférence",
     "terms": "Termes",
     "title": "Système de vidéoconférence sécurisé, riche en fonctionnalités et gratuit",
-    "logo":{
-      "calendar":"Logo Calendar",
-      "microsoftLogo":"Logo Microsoft",
-      "logoDeepLinking":"Logo Jitsi meet",
-      "desktopPreviewThumbnail":"Miniature d'aperçu du bureau",
-      "googleLogo":"Logo Google",
-      "policyLogo":"Logo de la politique"
+    "logo": {
+      "calendar": "Logo Calendar",
+      "microsoftLogo": "Logo Microsoft",
+      "logoDeepLinking": "Logo Jitsi meet",
+      "desktopPreviewThumbnail": "Miniature d'aperçu du bureau",
+      "googleLogo": "Logo Google",
+      "policyLogo": "Logo de la politique"
     }
   },
   "lonelyMeetingExperience": {


### PR DESCRIPTION
CLA already signed in this [PR](https://github.com/jitsi/jitsi-meet/pull/8728#issuecomment-790589534)

this PR does not add or change any message, it only set an uniform format:
- remove trailing whitespaces
- set the ':' separating key and value to a unique form (no space between key and ':' and one space between ':' and value)
- set key order to be the same between International english and localized version
- set an identical indentation for the the file.
Note that I have left the original indentation (2 characters) as it is, while the indent for the international english is 4.
Maybe it was intentional as french is a bit more verbose than english ? or maybe it was for 'historical reasons' ? I don't know so I left it. But I could change to 4 very easily. It would make for a huge diff though.
