### PR TITLE
fix(participants-pane) search value to not be cleared when closing pane

### DIFF
--- a/react/features/participants-pane/components/web/MeetingParticipants.js
+++ b/react/features/participants-pane/components/web/MeetingParticipants.js
@@ -107,7 +107,8 @@ function MeetingParticipants({
             {showInviteButton && <InviteButton />}
             <ClearableInput
                 onChange = { setSearchString }
-                placeholder = { t('participantsPane.search') } />
+                placeholder = { t('participantsPane.search') }
+                value = { searchString } />
             <div>
                 <MeetingParticipantItems
                     askUnmuteText = { askUnmuteText }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Fix for search value to no be cleared after participants pane is closed
