### PR TITLE
fix(breakout-rooms) joining room with hand raised bug

### DIFF
--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -84,6 +84,9 @@ ReducerRegistry.register('features/base/participants', (state = DEFAULT_STATE, a
         const { local } = state;
 
         if (local) {
+            if (action.newValue === 'local' && state.raisedHandsQueue.find(pid => pid.id === local.id)) {
+                state.raisedHandsQueue = state.raisedHandsQueue.filter(pid => pid.id !== local.id);
+            }
             state.local = {
                 ...local,
                 id: action.newValue


### PR DESCRIPTION
Joining a room while hand is raised causes the local raised hand total to be wrong.
This is because when the local participant id changes, the old id is not cleared from the raisedHandQueue.

(CLA is signed.)
