### PR TITLE
fix(toolbox) Disable screensharing button on mobile for video sender limit

### DIFF
--- a/react/features/toolbox/components/native/ScreenSharingButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingButton.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { Platform } from 'react-native';
 
 import { connect } from '../../../base/redux';
+import { isDesktopShareButtonDisabled } from '../../functions';
 
 import ScreenSharingAndroidButton from './ScreenSharingAndroidButton.js';
 import ScreenSharingIosButton from './ScreenSharingIosButton.js';
@@ -30,7 +31,7 @@ const ScreenSharingButton = props => (
  * }}
  */
 function _mapStateToProps(state): Object {
-    const disabled = state['features/base/audio-only'].enabled;
+    const disabled = state['features/base/audio-only'].enabled || isDesktopShareButtonDisabled(state);
 
     return {
         _disabled: disabled

--- a/react/features/toolbox/components/web/ShareDesktopButton.js
+++ b/react/features/toolbox/components/web/ShareDesktopButton.js
@@ -5,7 +5,8 @@ import { IconShareDesktop } from '../../../base/icons';
 import JitsiMeetJS from '../../../base/lib-jitsi-meet/_';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
-import { isScreenMediaShared, isScreenVideoShared } from '../../../screen-share';
+import { isScreenVideoShared } from '../../../screen-share';
+import { isDesktopShareButtonDisabled } from '../../functions';
 
 type Props = AbstractButtonProps & {
 
@@ -97,15 +98,8 @@ class ShareDesktopButton extends AbstractButton<Props, *> {
  * @returns {Object}
  */
 const mapStateToProps = state => {
-    const { muted, unmuteBlocked } = state['features/base/media'].video;
-    const videoOrShareInProgress = isScreenMediaShared(state) || !muted;
-
-    // Disable the screenshare button if the video sender limit is reached and there is no video or media share in
-    // progress.
-    let desktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled()
-        && !(unmuteBlocked && !videoOrShareInProgress);
+    let desktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled();
     const { enableFeaturesBasedOnToken } = state['features/base/config'];
-
     let desktopSharingDisabledTooltipKey;
 
     if (enableFeaturesBasedOnToken) {
@@ -114,6 +108,10 @@ const mapStateToProps = state => {
         desktopSharingEnabled = state['features/base/participants'].haveParticipantWithScreenSharingFeature;
         desktopSharingDisabledTooltipKey = 'dialog.shareYourScreenDisabled';
     }
+
+    // Disable the screenshare button if the video sender limit is reached and there is no video or media share in
+    // progress.
+    desktopSharingEnabled = desktopSharingEnabled && !isDesktopShareButtonDisabled(state);
 
     return {
         _desktopSharingDisabledTooltipKey: desktopSharingDisabledTooltipKey,

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -77,7 +77,7 @@ import {
     showToolbox
 } from '../../actions';
 import { THRESHOLDS, NOT_APPLICABLE, DRAWER_MAX_HEIGHT, NOTIFY_CLICK_MODE } from '../../constants';
-import { isToolboxVisible } from '../../functions';
+import { isDesktopShareButtonDisabled, isToolboxVisible } from '../../functions';
 import DownloadButton from '../DownloadButton';
 import HangupButton from '../HangupButton';
 import HelpButton from '../HelpButton';
@@ -122,6 +122,11 @@ type Props = {
      * The {@code JitsiConference} for the current conference.
      */
     _conference: Object,
+
+    /**
+     * Whether or not screensharing button is disabled.
+     */
+    _desktopSharingButtonDisabled: boolean,
 
     /**
      * The tooltip key to use when screensharing is disabled. Or undefined
@@ -537,6 +542,7 @@ class Toolbox extends Component<Props> {
     _doToggleScreenshare() {
         const {
             _backgroundType,
+            _desktopSharingButtonDisabled,
             _desktopSharingEnabled,
             _localVideo,
             _virtualSource,
@@ -558,7 +564,7 @@ class Toolbox extends Component<Props> {
             return;
         }
 
-        if (_desktopSharingEnabled) {
+        if (_desktopSharingEnabled && !_desktopSharingButtonDisabled) {
             dispatch(startScreenShareFlow());
         }
     }
@@ -1059,6 +1065,10 @@ class Toolbox extends Component<Props> {
      * @returns {void}
      */
     _onShortcutToggleScreenshare() {
+        // Ignore the shortcut if the button is disabled.
+        if (this.props._desktopSharingButtonDisabled) {
+            return;
+        }
         sendAnalytics(createShortcutEvent(
                 'toggle.screen.sharing',
                 ACTION_SHORTCUT_TRIGGERED,
@@ -1377,6 +1387,7 @@ function _mapStateToProps(state, ownProps) {
         _clientWidth: clientWidth,
         _conference: conference,
         _desktopSharingEnabled: desktopSharingEnabled,
+        _desktopSharingButtonDisabled: isDesktopShareButtonDisabled(state),
         _desktopSharingDisabledTooltipKey: desktopSharingDisabledTooltipKey,
         _dialog: Boolean(state['features/base/dialog'].component),
         _feedbackConfigured: Boolean(callStatsID),

--- a/react/features/toolbox/functions.native.js
+++ b/react/features/toolbox/functions.native.js
@@ -54,6 +54,19 @@ export function getMovableButtons(width: number): Set<string> {
 }
 
 /**
+ * Indicates if the desktop share button is disabled or not.
+ *
+ * @param {Object} state - The state from the Redux store.
+ * @returns {boolean}
+ */
+export function isDesktopShareButtonDisabled(state: Object) {
+    const { muted, unmuteBlocked } = state['features/base/media'].video;
+    const videoOrShareInProgress = !muted || isLocalVideoTrackDesktop(state);
+
+    return unmuteBlocked && !videoOrShareInProgress;
+}
+
+/**
  * Returns true if the toolbox is visible.
  *
  * @param {Object | Function} stateful - A function or object that can be

--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -1,7 +1,7 @@
 // @flow
-
 import { getToolbarButtons } from '../base/config';
 import { hasAvailableDevices } from '../base/devices';
+import { isScreenMediaShared } from '../screen-share/functions';
 
 import { TOOLBAR_TIMEOUT } from './constants';
 
@@ -64,6 +64,19 @@ export function isAudioSettingsButtonDisabled(state: Object) {
     return !(hasAvailableDevices(state, 'audioInput')
           && hasAvailableDevices(state, 'audioOutput'))
           || state['features/base/config'].startSilent;
+}
+
+/**
+ * Indicates if the desktop share button is disabled or not.
+ *
+ * @param {Object} state - The state from the Redux store.
+ * @returns {boolean}
+ */
+export function isDesktopShareButtonDisabled(state: Object) {
+    const { muted, unmuteBlocked } = state['features/base/media'].video;
+    const videoOrShareInProgress = !muted || isScreenMediaShared(state);
+
+    return unmuteBlocked && !videoOrShareInProgress;
 }
 
 /**


### PR DESCRIPTION
Also, ignore the toggle screenshare shortcut when the video sender limit is reached.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
