### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#55a03ac1b52f85dcbd9bfe339690ad88436ac029",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12530,8 +12530,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#55a03ac1b52f85dcbd9bfe339690ad88436ac029",
-      "integrity": "sha512-0ZNhG4ZPzcH+2R7K5xa5tSNVK8CKrKVCGP/bjr07XtiV3pcY65OWI2mH+QzlMIMDOXqgqQtry9RHv4vmzy5pIg==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#53b96016893088824621ceacc721e6ba912bdb99",
+      "integrity": "sha512-O6V6kAWvIQtuJwZiI+AmPnAkfSnFAe76rwKaEkf9Li5VwFJPTNa7VNjzlhABrhSokTpYewlrHJURcZ68rr8BNQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30374,9 +30374,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#55a03ac1b52f85dcbd9bfe339690ad88436ac029",
-      "integrity": "sha512-0ZNhG4ZPzcH+2R7K5xa5tSNVK8CKrKVCGP/bjr07XtiV3pcY65OWI2mH+QzlMIMDOXqgqQtry9RHv4vmzy5pIg==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#55a03ac1b52f85dcbd9bfe339690ad88436ac029",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#53b96016893088824621ceacc721e6ba912bdb99",
+      "integrity": "sha512-O6V6kAWvIQtuJwZiI+AmPnAkfSnFAe76rwKaEkf9Li5VwFJPTNa7VNjzlhABrhSokTpYewlrHJURcZ68rr8BNQ==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#55a03ac1b52f85dcbd9bfe339690ad88436ac029",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* ref(TPC) Cleanup and fix formating.
* ref(TPC) Remove an unnecessary toUnified sdp conversion. sLD is called immediately after createOffer/createAnswer, therefore the desc provided by createOffer/createAnswer can be directly passed to sLD without the need for converting it to unified plan format. This also fixes a warning seen on the browser console that says 'The description does not look like plan-b'.
* fix(tpc) extend ulpfec workaround to all versions
* fix: check if chrome version > 95 instead
* Fix issue number for rtx ulpfec workaround
* fix(tpc) disable ulpfec on chrome 97

https://github.com/jitsi/lib-jitsi-meet/compare/55a03ac1b52f85dcbd9bfe339690ad88436ac029...53b96016893088824621ceacc721e6ba912bdb99

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
