### PR TITLE
fix(thresholds) adjust thresholds for smaller width integrations

### DIFF
--- a/react/features/toolbox/constants.js
+++ b/react/features/toolbox/constants.js
@@ -19,11 +19,11 @@ export const THRESHOLDS = [
         order: [ 'microphone', 'camera', 'chat', 'participants' ]
     },
     {
-        width: 320,
+        width: 225,
         order: [ 'microphone', 'camera', 'chat' ]
     },
     {
-        width: 270,
+        width: 200,
         order: [ 'microphone', 'camera' ]
     }
 ];


### PR DESCRIPTION
allows chat button to be displayed when there should be enough space for it

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
