### PR TITLE
fix: still show menu to toggle self view if disableLocalVideoFlip

### DIFF
--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.js
@@ -173,10 +173,10 @@ class LocalVideoMenuTriggerButton extends Component<Props> {
                     hidden = { false }
                     inDrawer = { _overflowDrawer }>
                     <ContextMenuItemGroup>
-                        {_showLocalVideoFlipButton &&
-                            < FlipLocalVideoButton
-                                className = {_overflowDrawer ? classes.flipText : ''}
-                                onClick = {hidePopover} />
+                        { _showLocalVideoFlipButton
+                            && <FlipLocalVideoButton
+                                className = { _overflowDrawer ? classes.flipText : '' }
+                                onClick = { hidePopover } />
                         }
                         { _showHideSelfViewButton
                             && <HideSelfViewVideoButton

--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.js
@@ -173,9 +173,11 @@ class LocalVideoMenuTriggerButton extends Component<Props> {
                     hidden = { false }
                     inDrawer = { _overflowDrawer }>
                     <ContextMenuItemGroup>
-                        <FlipLocalVideoButton
-                            className = { _overflowDrawer ? classes.flipText : '' }
-                            onClick = { hidePopover } />
+                        {_showLocalVideoFlipButton &&
+                            < FlipLocalVideoButton
+                                className = {_overflowDrawer ? classes.flipText : ''}
+                                onClick = {hidePopover} />
+                        }
                         { _showHideSelfViewButton
                             && <HideSelfViewVideoButton
                                 className = { _overflowDrawer ? classes.flipText : '' }
@@ -189,7 +191,7 @@ class LocalVideoMenuTriggerButton extends Component<Props> {
             );
 
         return (
-            isMobileBrowser() || _showLocalVideoFlipButton
+            isMobileBrowser() || _showLocalVideoFlipButton || _showHideSelfViewButton
                 ? <Popover
                     content = { content }
                     id = 'local-video-menu-trigger'


### PR DESCRIPTION
**Issue being addressed:**

When `disableLocalVideoFlip=true` three-dot menu in thumbnail is completely hidden even though the "Hide self view" item is still relevant.

Related community post: https://community.jitsi.org/t/couple-of-issues-with-hide-self-view/108960/12?u=shawn

