### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12530,8 +12530,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#53b96016893088824621ceacc721e6ba912bdb99",
-      "integrity": "sha512-O6V6kAWvIQtuJwZiI+AmPnAkfSnFAe76rwKaEkf9Li5VwFJPTNa7VNjzlhABrhSokTpYewlrHJURcZ68rr8BNQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#adf2f15d0045747ba609b1fe19c088841717da11",
+      "integrity": "sha512-VqIIMHJLvIgVO5trlDobubGFiXRSu6SMXMehmZHV76gNuJdf31Rs/KParRE2haFpeoNu3WdDQo0qaAuU1sIFqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -30374,9 +30374,9 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#53b96016893088824621ceacc721e6ba912bdb99",
-      "integrity": "sha512-O6V6kAWvIQtuJwZiI+AmPnAkfSnFAe76rwKaEkf9Li5VwFJPTNa7VNjzlhABrhSokTpYewlrHJURcZ68rr8BNQ==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#adf2f15d0045747ba609b1fe19c088841717da11",
+      "integrity": "sha512-VqIIMHJLvIgVO5trlDobubGFiXRSu6SMXMehmZHV76gNuJdf31Rs/KParRE2haFpeoNu3WdDQo0qaAuU1sIFqQ==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#53b96016893088824621ceacc721e6ba912bdb99",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(TPC): Implode the simulcast group only after toUnifiedPlan conversion. This fixes a regression introduced by the previous commit.

https://github.com/jitsi/lib-jitsi-meet/compare/53b96016893088824621ceacc721e6ba912bdb99...adf2f15d0045747ba609b1fe19c088841717da11

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
