### PR TITLE
chore(deps) lib-jitsi-meet@latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
+        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#502aaf15b3aeb64b5893306a249b5e10c9eea30c",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -3432,8 +3432,8 @@
     },
     "node_modules/@jitsi/sdp-interop": {
       "version": "1.0.5",
-      "resolved": "git+ssh://git@github.com/jitsi/sdp-interop.git#4669790bb9020cc8f10c1d1f3823c26b08497547",
-      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/sdp-interop.git#3707993863eb6c5b6d66c4a025e9dba193775bfb",
+      "integrity": "sha512-gqp3Pne45vlrLUyBgfTCw58zMflNripWb2Eaj0mF++U5uk2oRoo1/GBZu2C6Z42ExHfHfhFUFR3N8/Ss2LwnVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0",
@@ -12035,14 +12035,14 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#adf2f15d0045747ba609b1fe19c088841717da11",
-      "integrity": "sha512-VqIIMHJLvIgVO5trlDobubGFiXRSu6SMXMehmZHV76gNuJdf31Rs/KParRE2haFpeoNu3WdDQo0qaAuU1sIFqQ==",
+      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#502aaf15b3aeb64b5893306a249b5e10c9eea30c",
+      "integrity": "sha512-Vx5eHAX6GL/r6yGNmG4mnoUqXxOktacBKUkEFlYQ50/TwIHME1fQBOHmwm6oS1/ds2mMMRgFKXyUd7vdm81Lvw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
-        "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
+        "@jitsi/sdp-interop": "github:jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",
@@ -22806,9 +22806,9 @@
       }
     },
     "@jitsi/sdp-interop": {
-      "version": "git+ssh://git@github.com/jitsi/sdp-interop.git#4669790bb9020cc8f10c1d1f3823c26b08497547",
-      "integrity": "sha512-4nqEqJWyRFjHM/riI0DQRNx+mgx277iK0r5LhwVAHDZDBYbLN54vYcfZ6JepcmygQiixa8jet/gLJnikdH9wzQ==",
-      "from": "@jitsi/sdp-interop@github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
+      "version": "git+ssh://git@github.com/jitsi/sdp-interop.git#3707993863eb6c5b6d66c4a025e9dba193775bfb",
+      "integrity": "sha512-gqp3Pne45vlrLUyBgfTCw58zMflNripWb2Eaj0mF++U5uk2oRoo1/GBZu2C6Z42ExHfHfhFUFR3N8/Ss2LwnVw==",
+      "from": "@jitsi/sdp-interop@github:jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
       "requires": {
         "lodash.clonedeep": "4.5.0",
         "sdp-transform": "2.14.1"
@@ -29513,13 +29513,13 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#adf2f15d0045747ba609b1fe19c088841717da11",
-      "integrity": "sha512-VqIIMHJLvIgVO5trlDobubGFiXRSu6SMXMehmZHV76gNuJdf31Rs/KParRE2haFpeoNu3WdDQo0qaAuU1sIFqQ==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
+      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#502aaf15b3aeb64b5893306a249b5e10c9eea30c",
+      "integrity": "sha512-Vx5eHAX6GL/r6yGNmG4mnoUqXxOktacBKUkEFlYQ50/TwIHME1fQBOHmwm6oS1/ds2mMMRgFKXyUd7vdm81Lvw==",
+      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#502aaf15b3aeb64b5893306a249b5e10c9eea30c",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
-        "@jitsi/sdp-interop": "github:jitsi/sdp-interop#4669790bb9020cc8f10c1d1f3823c26b08497547",
+        "@jitsi/sdp-interop": "github:jitsi/sdp-interop#3707993863eb6c5b6d66c4a025e9dba193775bfb",
         "@jitsi/sdp-simulcast": "0.4.0",
         "async": "0.9.0",
         "base64-js": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#adf2f15d0045747ba609b1fe19c088841717da11",
+    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#502aaf15b3aeb64b5893306a249b5e10c9eea30c",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
* fix(logging) Log all the ssrcs present in the source signaling. Since the order of the ssrcs in the json-encoded message is not guaranteed to be in the correct SIM/FID order, log all the ssrcs.
* fix: ensure mucNickname
* ref(JingleSession) Recycle m-lines by rejecting them on source removal.

https://github.com/jitsi/lib-jitsi-meet/compare/adf2f15d0045747ba609b1fe19c088841717da11...502aaf15b3aeb64b5893306a249b5e10c9eea30c

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
