### PR TITLE
feat: Updates reload reason.

### DIFF
--- a/react/features/overlay/components/AbstractPageReloadOverlay.js
+++ b/react/features/overlay/components/AbstractPageReloadOverlay.js
@@ -288,11 +288,27 @@ export function abstractMapStateToProps(state: Object) {
     const { error: connectionError } = state['features/base/connection'];
     const { fatalError } = state['features/overlay'];
 
+    let reason = fatalError && (fatalError.message || fatalError.name);
+
+    if (!reason) {
+        const { error: conferenceError } = state['features/base/conference'];
+
+        if (conferenceError) {
+            reason = `error.conference.${conferenceError.name}`;
+        } else if (configError) {
+            reason = `error.config.${configError.name}`;
+        } else if (connectionError) {
+            reason = `error.connection.${connectionError.name}`;
+        } else {
+            logger.error('No reload reason defined!');
+        }
+    }
+
     return {
         details: fatalError && fatalError.details,
         error: fatalError,
         isNetworkFailure:
             fatalError === configError || fatalError === connectionError,
-        reason: fatalError && (fatalError.message || fatalError.name)
+        reason
     };
 }

--- a/react/features/overlay/overlays.web.js
+++ b/react/features/overlay/overlays.web.js
@@ -7,8 +7,6 @@ import {
     UserMediaPermissionsOverlay
 } from './components/web';
 
-declare var interfaceConfig: Object;
-
 /**
  * Returns the list of available platform specific overlays.
  *


### PR DESCRIPTION
When there is no reload reason defined, try to extract something from the errors that caused it.

