### PR TITLE
fix(build) exit with error if any CSS step fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ deploy-facial-expressions:
 
 deploy-css:
 	$(NODE_SASS) $(STYLES_MAIN) $(STYLES_BUNDLE) && \
-	$(CLEANCSS) --skip-rebase $(STYLES_BUNDLE) > $(STYLES_DESTINATION) ; \
+	$(CLEANCSS) --skip-rebase $(STYLES_BUNDLE) > $(STYLES_DESTINATION) && \
 	rm $(STYLES_BUNDLE)
 
 deploy-local:


### PR DESCRIPTION
Before:

~~~
$ make deploy-css
./node_modules/.bin/sass css/main.scss css/all.bundle.css && \
        ./node_modules/.bin/cleancss --skip-rebase css/all.bundle.css > css/all.css ; \
        rm css/all.bundle.css
Error: Can't find stylesheet to import.
   ╷
78 │ @import 'filmstrip/vertical_filmstrip_overrides2';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  css/main.scss 78:9  root stylesheet
$
(exitcode is 0)
~~~

After:

~~~
$ make deploy-css
./node_modules/.bin/sass css/main.scss css/all.bundle.css && \
        ./node_modules/.bin/cleancss --skip-rebase css/all.bundle.css > css/all.css && \
        rm css/all.bundle.css
Error: Can't find stylesheet to import.
   ╷
78 │ @import 'filmstrip/vertical_filmstrip_overrides2';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  css/main.scss 78:9  root stylesheet
make: *** [deploy-css] Error 65
$
(exitcode is != 0)
~~~

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
