### PR TITLE
fix(raised-hand) Preserve raised hand order for active speaker

### DIFF
--- a/react/features/participants-pane/functions.js
+++ b/react/features/participants-pane/functions.js
@@ -225,13 +225,14 @@ export function getSortedParticipantIds(stateful: Object | Function): Array<stri
     }
 
     const dominant = [];
+    const dominantId = dominantSpeaker?.id;
     const local = remoteRaisedHandParticipants.has(id) ? [] : [ id ];
 
-    // Remove dominant speaker.
-    if (dominantSpeaker && dominantSpeaker.id !== id) {
-        remoteRaisedHandParticipants.delete(dominantSpeaker.id);
-        reorderedParticipants.delete(dominantSpeaker.id);
-        dominant.push(dominantSpeaker.id);
+    // In case dominat speaker has raised hand, keep the order in the raised hand queue.
+    // In case they don't have raised hand, goes first in the participants list.
+    if (dominantId && dominantId !== id && !remoteRaisedHandParticipants.has(dominantId)) {
+        reorderedParticipants.delete(dominantId);
+        dominant.push(dominantId);
     }
 
     // Move self and participants with raised hand to the top of the list.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
- fixes:  https://github.com/jitsi/jitsi-meet/issues/10609