### PR TITLE
fix: volume slider min width so not squashed when lonely

### DIFF
--- a/react/features/video-menu/components/web/VolumeSlider.js
+++ b/react/features/video-menu/components/web/VolumeSlider.js
@@ -52,6 +52,7 @@ const styles = theme => {
     return {
         container: {
             minHeight: '40px',
+            minWidth: '120px',
             width: '100%',
             boxSizing: 'border-box',
             cursor: 'pointer',

--- a/react/features/video-menu/components/web/VolumeSlider.js
+++ b/react/features/video-menu/components/web/VolumeSlider.js
@@ -52,7 +52,7 @@ const styles = theme => {
     return {
         container: {
             minHeight: '40px',
-            minWidth: '120px',
+            minWidth: '180px',
             width: '100%',
             boxSizing: 'border-box',
             cursor: 'pointer',


### PR DESCRIPTION
Volume slider currently takes the width of the popup menu on remove video. This is a problem in the case of non-moderator users when chat feature is disabled -- there are no other menu items to push out the width and slider ends up unusably small.

See: https://community.jitsi.org/t/squashed-volume-slider-for-non-moderator-if-chat-disabled/110275?u=shawn

This PR addresses this by ensuring volume slider has a minimum width.