### PR TITLE
lang: fix(lang) update Japanese translation

### DIFF
--- a/lang/main-ja.json
+++ b/lang/main-ja.json
@@ -638,7 +638,7 @@
         "joinMeeting": "ミーティングに参加",
         "joinWithoutAudio": "音声なしで参加",
         "linkCopied": "リンクをクリップボードにコピーしました",
-        "lookGood": "マイクが正常に動作していないようです",
+        "lookGood": "マイクは正常に動作しています",
         "or": "または",
         "premeeting": "プレミーティング",
         "screenSharingError": "画面共有のエラー:",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

There is a discrepancy between the meaning of English and the meaning of Japanese about "lookGood".

"lookGood" represents a good condition.
However, "マイクが正常に動作していないようです" represents a bad condition in Japanese.
In Japanese, "マイクは正常に動作しています" represents a good condition.