### PR TITLE
Fix Japanese translations

### DIFF
--- a/lang/main-ja.json
+++ b/lang/main-ja.json
@@ -243,7 +243,7 @@
         "lockMessage": "ミーティングをロックできませんでした。",
         "lockRoom": "ミーティング $t(lockRoomPasswordUppercase) を追加",
         "lockTitle": "ロックに失敗しました",
-        "login": "Log住所in",
+        "login": "ログイン",
         "logoutQuestion": "ログアウトしてミーティングを停止してもよろしいですか?",
         "logoutTitle": "ログアウト",
         "maxUsersLimitReached": "参加者数が上限に達しました。このミーティングは満員です。ミーティングの主催者にお問い合わせするか、後でもう一度お試しください!",


### PR DESCRIPTION
"Log住所in" is "Log-MailingAddress-in" in Japanese. So fix it.