### PR TITLE
fix(rn, conference): dispatch authStatusChanged in base/conference

### DIFF
--- a/react/features/base/conference/actions.js
+++ b/react/features/base/conference/actions.js
@@ -96,6 +96,9 @@ function _addConferenceListeners(conference, dispatch, state) {
     // Dispatches into features/base/conference follow:
 
     conference.on(
+        JitsiConferenceEvents.AUTH_STATUS_CHANGED,
+        (authEnabled, authLogin) => dispatch(authStatusChanged(authEnabled, authLogin)));
+    conference.on(
         JitsiConferenceEvents.CONFERENCE_FAILED,
         (...args) => dispatch(conferenceFailed(conference, ...args)));
     conference.on(


### PR DESCRIPTION
Dispatching the authStatusChanged action in base/conference (in addition to conference.js for web clients).