### PR TITLE
fix(lang) fix default language selection

### DIFF
--- a/react/features/base/i18n/i18next.js
+++ b/react/features/base/i18n/i18next.js
@@ -15,8 +15,6 @@ import languageDetector from './languageDetector';
 /**
  * The available/supported languages.
  *
- * XXX The element at index zero is the default language.
- *
  * @public
  * @type {Array<string>}
  */
@@ -25,12 +23,12 @@ export const LANGUAGES: Array<string> = Object.keys(LANGUAGES_RESOURCES);
 /**
  * The default language.
  *
- * XXX The element at index zero of {@link LANGUAGES} is the default language.
+ * English is the default language.
  *
  * @public
  * @type {string} The default language.
  */
-export const DEFAULT_LANGUAGE = LANGUAGES[0];
+export const DEFAULT_LANGUAGE = 'en';
 
 /**
  * The options to initialize i18next with.


### PR DESCRIPTION
[0] introduced sorted language keys, but we had the assumption that the
first one meant to indicate the default language.

Break that assumption and be explicit about English being the default
language.

[0]: https://github.com/jitsi/jitsi-meet/commit/7fe319d965e4514c96a8eac2b7f520e974b47515

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
