### PR TITLE
fix(rn,settings-drawer) allow for more width

### DIFF
--- a/react/features/mobile/navigation/screenOptions.js
+++ b/react/features/mobile/navigation/screenOptions.js
@@ -93,7 +93,8 @@ export const drawerContentOptions = {
     },
     drawerStyle: {
         backgroundColor: BaseTheme.palette.ui12,
-        width: '54%'
+        maxWidth: 400,
+        width: '75%'
     }
 };
 


### PR DESCRIPTION
I checked other popular apps like Twitter and their drawers take more screen state. With my font size not even "Help center" was visible.

![IMG_4701](https://user-images.githubusercontent.com/317464/150984007-b3169b20-e265-4972-8bcc-24e6bc0faffa.PNG)
![IMG_4700](https://user-images.githubusercontent.com/317464/150984018-75113a8e-8042-4245-8dfc-0ab4abab1282.PNG)

