### PR TITLE
fix(rn,navigation) fix navigating back to the welcome page

### DIFF
--- a/react/features/mobile/navigation/middleware.js
+++ b/react/features/mobile/navigation/middleware.js
@@ -38,7 +38,7 @@ function _setRoom(store, next, action) {
 
     if (!oldRoom && newRoom) {
         navigateRoot(screen.conference.root);
-    } else if (oldRoom && !newRoom) {
+    } else if (!newRoom) {
         navigateRoot(screen.root);
     }
 


### PR DESCRIPTION
The CONFERENCE_WILL_LEAVE reducer in base/conference wipes the state so
we cannot rely on the old room value.

We may want to revisit this in the future.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
