### PR TITLE
fix: broken redirect for url with params when welcome page disable

### DIFF
--- a/react/features/app/getRouteToRender.web.js
+++ b/react/features/app/getRouteToRender.web.js
@@ -80,11 +80,9 @@ function _getWebWelcomePageRoute(state) {
         }
     } else {
         // Web: if the welcome page is disabled, go directly to a random room.
-
-        let href = window.location.href;
-
-        href.endsWith('/') || (href += '/');
-        route.href = href + generateRoomWithoutSeparator();
+        let url = new URL(window.location.href);
+        url.pathname += generateRoomWithoutSeparator();
+        route.href = url.href;
     }
 
     return Promise.resolve(route);

--- a/react/features/app/getRouteToRender.web.js
+++ b/react/features/app/getRouteToRender.web.js
@@ -80,7 +80,8 @@ function _getWebWelcomePageRoute(state) {
         }
     } else {
         // Web: if the welcome page is disabled, go directly to a random room.
-        let url = new URL(window.location.href);
+        const url = new URL(window.location.href);
+
         url.pathname += generateRoomWithoutSeparator();
         route.href = url.href;
     }


### PR DESCRIPTION
When welcome page disabled, random room name is appended to URL -- this is problematic if a url param was provided, in which cases the appended value simply becomes part of the param and the cycle repeats infinitely.

Ref: https://community.jitsi.org/t/infinite-redirects-when-enablewelcomepage-false-and-landing-page-has-url-param/110547

Note: also dropped the `endsWith('/')` check because `URL.pathname` already normalised to `/` when path not provided.