### PR TITLE
fix(media) Deprecate startScreenSharing config option for web browsers.

### DIFF
--- a/config.js
+++ b/config.js
@@ -236,7 +236,11 @@ var config = {
     //     max: 5
     // },
 
-    // Try to start calls with screen-sharing instead of camera video.
+    // This option has been deprecated since it is no longer supported as per the w3c spec.
+    // https://w3c.github.io/mediacapture-screen-share/#dom-mediadevices-getdisplaymedia. If the user has not
+    // interacted with the webpage before the getDisplayMedia call, the promise will be rejected by the browser. This
+    // has already been implemented in Firefox and Safari and will be implemented in Chrome soon.
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1198918
     // startScreenSharing: false,
 
     // Recording


### PR DESCRIPTION
This is no longer supported as per the w3c spec for getDisplayMedia.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
