### PR TITLE
feat(build) use lib-jitsi-meet release tarballs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e6779627b712db1be3489aa75695a03f9aa4b0be",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/1340/lib-jitsi-meet-0.0.0.tgz",
         "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -12030,9 +12030,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e6779627b712db1be3489aa75695a03f9aa4b0be",
-      "integrity": "sha512-ux4CbEx0ikDtGn8sK0Q4ufUYDzwTGLJ0ak1byVRRsF7X4dQvJHBm56II6ud+2oiIJn3H1wmGks917Q83pxu8sw==",
-      "hasInstallScript": true,
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/1340/lib-jitsi-meet-0.0.0.tgz",
+      "integrity": "sha512-YkljH0xUFlOu/hP6QPK3AfXgHGwqXDvyM8hZ2fiBCeiZ6YUdjOdHxJLqm9xDBIW2ROrxybBJUCyvZvk0Ek+vWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
@@ -29176,9 +29175,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "git+ssh://git@github.com/jitsi/lib-jitsi-meet.git#e6779627b712db1be3489aa75695a03f9aa4b0be",
-      "integrity": "sha512-ux4CbEx0ikDtGn8sK0Q4ufUYDzwTGLJ0ak1byVRRsF7X4dQvJHBm56II6ud+2oiIJn3H1wmGks917Q83pxu8sw==",
-      "from": "lib-jitsi-meet@github:jitsi/lib-jitsi-meet#e6779627b712db1be3489aa75695a03f9aa4b0be",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/1340/lib-jitsi-meet-0.0.0.tgz",
+      "integrity": "sha512-YkljH0xUFlOu/hP6QPK3AfXgHGwqXDvyM8hZ2fiBCeiZ6YUdjOdHxJLqm9xDBIW2ROrxybBJUCyvZvk0Ek+vWA==",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "github:jitsi/lib-jitsi-meet#e6779627b712db1be3489aa75695a03f9aa4b0be",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/1340/lib-jitsi-meet-0.0.0.tgz",
     "libflacjs": "github:mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
This has 2 benefits:

a) it no longer needs to be built at install time, thus making builds faster

before:

real	0m46.865s
user	1m3.938s
sys	0m22.478s

after:

real	0m27.828s
user	0m25.582s
sys	0m21.699s

b) integrity errors go away since they are not computed over a locally
generated tarball

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
