### PR TITLE
fix(util) never mark UUID room names as insecure

### DIFF
--- a/react/features/base/util/isInsecureRoomName.js
+++ b/react/features/base/util/isInsecureRoomName.js
@@ -1,6 +1,29 @@
 // @flow
 
+import _ from 'lodash';
+import { NIL, parse as parseUUID } from 'uuid';
 import zxcvbn from 'zxcvbn';
+
+// The null UUID.
+const NIL_UUID = parseUUID(NIL);
+
+/**
+ * Checks if the given string is a valid UUID or not.
+ *
+ * @param {string} str - The string to be checked.
+ * @returns {boolean} - Whether the string is a valid UUID or not.
+ */
+function isValidUUID(str) {
+    let uuid;
+
+    try {
+        uuid = parseUUID(str);
+    } catch (e) {
+        return false;
+    }
+
+    return !_.isEqual(uuid, NIL_UUID);
+}
 
 /**
  * Returns true if the room name is considered a weak (insecure) one.
@@ -9,5 +32,5 @@ import zxcvbn from 'zxcvbn';
  * @returns {boolean}
  */
 export default function isInsecureRoomName(roomName: string = ''): boolean {
-    return zxcvbn(roomName).score < 3;
+    return !isValidUUID(roomName) && zxcvbn(roomName).score < 3;
 }


### PR DESCRIPTION
Except the NIL UUID, that is.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
