### PR TITLE
feat: config to hide dominant speaker badge

### DIFF
--- a/config.js
+++ b/config.js
@@ -506,7 +506,10 @@ var config = {
     // defaultRemoteDisplayName: 'Fellow Jitster',
 
     // Hides the display name from the participant thumbnail
-    // hideDisplayName: false
+    // hideDisplayName: false,
+
+    // Hides the dominant speaker name badge that hovers above the toolbox
+    // hideDominantSpeakerBadge: false,
 
     // Default language for the user interface.
     // defaultLanguage: 'en',

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -162,6 +162,7 @@ export default [
     'hiddenPremeetingButtons',
     'hideConferenceSubject',
     'hideDisplayName',
+    'hideDominantSpeakerBadge',
     'hideRecordingLabel',
     'hideParticipantsStats',
     'hideConferenceTimer',

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -238,7 +238,7 @@ class Conference extends AbstractConference<Props, *> {
                         <Filmstrip />
                     </div>
 
-                    { _showPrejoin || _showLobby || <Toolbox showDominantSpeakerName = { true } /> }
+                    { _showPrejoin || _showLobby || <Toolbox /> }
                     <Chat />
 
                     {_notificationsVisible && (_overflowDrawer

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -221,6 +221,11 @@ type Props = {
     _sharingVideo: boolean,
 
     /**
+     * Whether or not to show dominant speaker badge.
+     */
+    _showDominantSpeakerBadge: boolean,
+
+    /**
      * Whether or not the tile view is enabled.
      */
     _tileViewEnabled: boolean,
@@ -249,11 +254,6 @@ type Props = {
      * Invoked to active other features of the app.
      */
     dispatch: Function,
-
-    /**
-     * If the dominant speaker name should be displayed or not.
-     */
-    showDominantSpeakerName?: boolean,
 
     /**
      * Invoked to obtain translated strings.
@@ -1258,8 +1258,8 @@ class Toolbox extends Component<Props> {
             _overflowMenuVisible,
             _reactionsEnabled,
             _toolbarButtons,
+            _showDominantSpeakerBadge,
             classes,
-            showDominantSpeakerName,
             t
         } = this.props;
 
@@ -1278,7 +1278,7 @@ class Toolbox extends Component<Props> {
                         onMouseOver: this._onMouseOver
                     }) }>
 
-                    { showDominantSpeakerName && <DominantSpeakerName /> }
+                    { _showDominantSpeakerBadge && <DominantSpeakerName /> }
 
                     <div className = 'toolbox-content-items'>
                         {mainMenuButtons.map(({ Content, key, ...rest }) => Content !== Separator && (
@@ -1349,6 +1349,7 @@ function _mapStateToProps(state, ownProps) {
         callStatsID,
         disableProfile,
         enableFeaturesBasedOnToken,
+        hideDominantSpeakerBadge,
         buttonsWithNotifyClick
     } = state['features/base/config'];
     const {
@@ -1404,6 +1405,7 @@ function _mapStateToProps(state, ownProps) {
         _raisedHand: hasRaisedHand(localParticipant),
         _reactionsEnabled: isReactionsEnabled(state),
         _screenSharing: isScreenVideoShared(state),
+        _showDominantSpeakerBadge: !hideDominantSpeakerBadge,
         _tileViewEnabled: shouldDisplayTileView(state),
         _toolbarButtons: toolbarButtons,
         _virtualSource: state['features/virtual-background'].virtualSource,


### PR DESCRIPTION
This introduces a new `hideDominantSpeakerBadge` config var which hides the dominant speaker badge that floats above the toolbar. This offers users an option to not have the badge cover screenshare which still retaining names in the video thumbnails.

Ref: https://community.jitsi.org/t/screen-sharing-display-name/110658
