### PR TITLE
fix: Restarts jvb after prosody on initial install.

### DIFF
--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -204,6 +204,8 @@ case "$1" in
             fi
         fi
 
+        CERT_ADDED_TO_TRUST="false"
+
         if [ ! -f /var/lib/prosody/$JICOFO_AUTH_DOMAIN.crt ]; then
             # prosodyctl takes care for the permissions
             # echo for using all default values
@@ -220,6 +222,8 @@ case "$1" in
             # store not get re-generated with latest changes
             update-ca-certificates -f
 
+            CERT_ADDED_TO_TRUST="true"
+
             # don't fail on systems with custom config ($PROSODY_HOST_CONFIG is missing)
             if [ -f $PROSODY_HOST_CONFIG ]; then
                 # now let's add the ssl cert for the auth. domain (we use # as a sed delimiter cause filepaths are confused with default / delimiter)
@@ -232,6 +236,11 @@ case "$1" in
 
         if [ "$PROSODY_CONFIG_PRESENT" = "false" ]; then
             invoke-rc.d prosody restart || true
+
+            # In case we had updated the certificates and restarted prosody, let's restart and the bridge if possible
+            if [ -d /run/systemd/system ] && [ "$CERT_ADDED_TO_TRUST" = "true" ]; then
+                systemctl restart jitsi-videobridge2.service >/dev/null || true
+            fi
         fi
     ;;
 


### PR DESCRIPTION
Fixes an issue where on clean install we see:
WARNING: [25] [hostname=localhost id=shard] MucClient.lambda$getConnectAndLoginCallable$7#622: [MucClient id=shard hostname=localhost] error connecting
org.jivesoftware.smack.SmackException$SmackWrappedException: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
