### PR TITLE
feat: Adding viirtual backgrounds from config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -1055,6 +1055,10 @@ var config = {
     // Disables using screensharing as virtual background.
     // disableScreensharingVirtualBackground: false,
 
+    // A list of images that can be used as video backgrounds.
+    // When this field is present, the default images will be replaced with those provided.
+    // virtualBackgrounds: ['https://example.com/img.jpg'],
+
     // Sets the background transparency level. '0' is fully transparent, '1' is opaque.
     // backgroundAlpha: 1,
 

--- a/react/features/virtual-background/components/VirtualBackgroundDialog.js
+++ b/react/features/virtual-background/components/VirtualBackgroundDialog.js
@@ -91,12 +91,13 @@ const onError = event => {
  */
 function _mapStateToProps(state): Object {
     const { localFlipX } = state['features/base/settings'];
+    const brandingImages = state['features/base/config'].virtualBackgrounds;
     const dynamicBrandingImages = state['features/dynamic-branding'].virtualBackgrounds;
-    const hasBrandingImages = Boolean(dynamicBrandingImages.length);
+    const hasBrandingImages = Boolean(dynamicBrandingImages.length) || Boolean(brandingImages.length);
 
     return {
         _localFlipX: Boolean(localFlipX),
-        _images: (hasBrandingImages && dynamicBrandingImages) || IMAGES,
+        _images: (hasBrandingImages && dynamicBrandingImages || brandingImages) || IMAGES,
         _virtualBackground: state['features/virtual-background'],
         _selectedThumbnail: state['features/virtual-background'].selectedThumbnail,
         _showUploadButton: !(hasBrandingImages || state['features/base/config'].disableAddingBackgroundImages),

--- a/react/features/virtual-background/components/VirtualBackgroundDialog.js
+++ b/react/features/virtual-background/components/VirtualBackgroundDialog.js
@@ -97,7 +97,7 @@ function _mapStateToProps(state): Object {
 
     return {
         _localFlipX: Boolean(localFlipX),
-        _images: (hasBrandingImages && dynamicBrandingImages || brandingImages) || IMAGES,
+        _images: (hasBrandingImages && dynamicBrandingImages) || (hasBrandingImages && brandingImages) || IMAGES,
         _virtualBackground: state['features/virtual-background'],
         _selectedThumbnail: state['features/virtual-background'].selectedThumbnail,
         _showUploadButton: !(hasBrandingImages || state['features/base/config'].disableAddingBackgroundImages),


### PR DESCRIPTION
Currently the only way to add brandingVirtualBackgrounds is by using the  dynamicBrandingUrl this requires to create and endpoint somewhere that responses with a json with the virutalBackgrounds.

This merge request allows the virtualBackgrounds to be configured by the config.js. Should give the option to provide easier /quicker config for virtualBackgroundsImages.
