### PR TITLE
Make names in the chat sidebar easier to distinguish

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -297,6 +297,8 @@
     .display-name {
         font-size: 12px;
         font-weight: 600;
+        font-style: italic;
+        color: orange;
         margin-bottom: 5px;
         white-space: nowrap;
         text-overflow: ellipsis;


### PR DESCRIPTION
Partially fixes issue #10906 by using color and italics for names in the chat.

This is a purely theoretical fix (based on experimenting with the browser's inspector), I hope this is in the right place in the code (and that it only needs to be changed in this one place); I have no means to test it in practice, so please ensure it works on your end.

This does not address the other suggestion from ticket #10906 (group back-to-back chats into a single bubble) so if you're interested in that approach too, I would then recommend keeping that ticket open for someone else to implement that part.