### PR TITLE
feat: Use same recommendedBrowsers page for IE and browsers marked in interface_config.js

### DIFF
--- a/react/features/unsupported-browser/components/DefaultUnsupportedDesktopBrowser.js
+++ b/react/features/unsupported-browser/components/DefaultUnsupportedDesktopBrowser.js
@@ -2,37 +2,22 @@
 
 import React, { Component } from 'react';
 
-import { isBrowsersOptimal } from '../../base/environment';
-import { translate } from '../../base/i18n';
-
-import { CHROME, FIREFOX } from './browserLinks';
-
-/**
- * The namespace of the CSS styles of UnsupportedDesktopBrowser.
- *
- * @private
- * @type {string}
- */
-const _SNS = 'unsupported-desktop-browser';
-
-/**
- * The type of the React {@code Component} props of
- * {@link JaasUnsupportedDesktopBrowser}.
- */
-type Props = {
-
-    /**
-     * The function to translate human-readable text.
-     */
-    t: Function
-};
-
 /**
  * React component representing unsupported browser page.
  *
- * @class UnsupportedDesktopBrowser
+ * @class DefaultUnsupportedDesktopBrowser
  */
-class JaasUnsupportedDesktopBrowser extends Component<Props> {
+class DefaultUnsupportedDesktopBrowser extends Component {
+
+    /**
+     * Redirects to the static recommended browsers page that is also used for IE.
+     *
+     * @returns {void}
+     */
+    componentDidMount() {
+        window.location.href = '/static/recommendedBrowsers.html';
+    }
+
     /**
      * Renders the component.
      *
@@ -40,34 +25,9 @@ class JaasUnsupportedDesktopBrowser extends Component<Props> {
      */
     render() {
         return (
-            <div className = { _SNS }>
-                <h2 className = { `${_SNS}__title` }>
-                    It looks like you're using a browser we don't support.
-                </h2>
-                <p className = { `${_SNS}__description` }>
-                    Please try again with the latest version of&nbsp;
-                    <a
-                        className = { `${_SNS}__link` }
-                        href = { CHROME } >Chrome</a>&nbsp;
-                    {
-                        this._showFirefox() && <>or <a
-                            className = { `${_SNS}__link` }
-                            href = { FIREFOX }>Firefox</a></>
-                    }
-                </p>
-            </div>
+            <div />
         );
-    }
-
-    /**
-     * Returns whether or not a link to download Firefox is displayed.
-     *
-     * @private
-     * @returns {boolean}
-     */
-    _showFirefox() {
-        return isBrowsersOptimal('firefox');
     }
 }
 
-export default translate(JaasUnsupportedDesktopBrowser);
+export default DefaultUnsupportedDesktopBrowser;


### PR DESCRIPTION
Reason:
- This is easier overridable than then embedded react page
- Consistenty between IE and other unsupported browsers

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
