### PR TITLE
feat(multi-stream-support) Support track streaming status

### DIFF
--- a/react/features/base/lib-jitsi-meet/index.js
+++ b/react/features/base/lib-jitsi-meet/index.js
@@ -19,6 +19,7 @@ export const JitsiE2ePingEvents = JitsiMeetJS.events.e2eping;
 export const JitsiMediaDevicesEvents = JitsiMeetJS.events.mediaDevices;
 export const JitsiParticipantConnectionStatus
     = JitsiMeetJS.constants.participantConnectionStatus;
+export const JitsiTrackStreamingStatus = JitsiMeetJS.constants.trackStreamingStatus;
 export const JitsiRecordingConstants = JitsiMeetJS.constants.recording;
 export const JitsiSIPVideoGWStatus = JitsiMeetJS.constants.sipVideoGW;
 export const JitsiTrackErrors = JitsiMeetJS.errors.track;

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -554,6 +554,26 @@ export function trackVideoTypeChanged(track, videoType) {
 }
 
 /**
+ * Create an action for when track streaming status changes.
+ *
+ * @param {(JitsiRemoteTrack)} track - JitsiTrack instance.
+ * @param {string} streamingStatus - The new streaming status of the track.
+ * @returns {{
+ *     type: TRACK_UPDATED,
+ *     track: Track
+ * }}
+ */
+export function trackStreamingStatusChanged(track, streamingStatus) {
+    return {
+        type: TRACK_UPDATED,
+        track: {
+            jitsiTrack: track,
+            streamingStatus
+        }
+    };
+}
+
+/**
  * Signals passed tracks to be added.
  *
  * @param {(JitsiLocalTrack|JitsiRemoteTrack)[]} tracks - List of tracks.

--- a/react/features/connection-indicator/components/web/ConnectionIndicatorIcon.js
+++ b/react/features/connection-indicator/components/web/ConnectionIndicatorIcon.js
@@ -1,0 +1,110 @@
+// @flow
+
+import clsx from 'clsx';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { getSourceNameSignalingFeatureFlag } from '../../../base/config';
+import { Icon, IconConnectionActive, IconConnectionInactive } from '../../../base/icons';
+import { JitsiTrackEvents } from '../../../base/lib-jitsi-meet';
+import { trackStreamingStatusChanged } from '../../../base/tracks';
+
+type Props = {
+
+    /**
+     * An object containing the CSS classes.
+     */
+    classes: Object,
+
+    /**
+     * A CSS class that interprets the current connection status as a color.
+     */
+    colorClass: string,
+
+    /**
+     * Disable/enable inactive indicator.
+     */
+     connectionIndicatorInactiveDisabled: boolean,
+
+    /**
+     * JitsiTrack instance.
+     */
+    track: Object,
+
+    /**
+     * Whether or not the connection status is inactive.
+     */
+    isConnectionStatusInactive: boolean,
+
+    /**
+     * Whether or not the connection status is interrupted.
+     */
+    isConnectionStatusInterrupted: boolean,
+}
+
+export const ConnectionIndicatorIcon = ({
+    classes,
+    colorClass,
+    connectionIndicatorInactiveDisabled,
+    isConnectionStatusInactive,
+    isConnectionStatusInterrupted,
+    track
+}: Props) => {
+    const sourceNameSignalingEnabled = useSelector(state => getSourceNameSignalingFeatureFlag(state));
+    const dispatch = useDispatch();
+    const sourceName = track?.jitsiTrack?.getSourceName?.();
+
+    const handleTrackStreamingStatusChanged = streamingStatus => {
+        dispatch(trackStreamingStatusChanged(track.jitsiTrack, streamingStatus));
+    };
+
+    useEffect(() => {
+        if (track && !track.local && sourceNameSignalingEnabled) {
+            track.jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, handleTrackStreamingStatusChanged);
+
+            dispatch(trackStreamingStatusChanged(track.jitsiTrack, track.jitsiTrack.getTrackStreamingStatus?.()));
+        }
+
+        return () => {
+            if (track && !track.local && sourceNameSignalingEnabled) {
+                track.jitsiTrack.off(
+                    JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
+                    handleTrackStreamingStatusChanged
+                );
+
+                dispatch(trackStreamingStatusChanged(track.jitsiTrack, track.jitsiTrack.getTrackStreamingStatus?.()));
+            }
+        };
+    }, [ sourceName ]);
+
+    if (isConnectionStatusInactive) {
+        if (connectionIndicatorInactiveDisabled) {
+            return null;
+        }
+
+        return (
+            <span className = 'connection_ninja'>
+                <Icon
+                    className = { clsx(classes.icon, classes.inactiveIcon, colorClass) }
+                    size = { 24 }
+                    src = { IconConnectionInactive } />
+            </span>
+        );
+    }
+
+    let emptyIconWrapperClassName = 'connection_empty';
+
+    if (isConnectionStatusInterrupted) {
+        // emptyIconWrapperClassName is used by the torture tests to identify lost connection status handling.
+        emptyIconWrapperClassName = 'connection_lost';
+    }
+
+    return (
+        <span className = { emptyIconWrapperClassName }>
+            <Icon
+                className = { clsx(classes.icon, colorClass) }
+                size = { 12 }
+                src = { IconConnectionActive } />
+        </span>
+    );
+};

--- a/react/features/connection-indicator/functions.js
+++ b/react/features/connection-indicator/functions.js
@@ -1,0 +1,73 @@
+import { JitsiParticipantConnectionStatus, JitsiTrackStreamingStatus } from '../base/lib-jitsi-meet';
+
+/**
+ * Checks if the passed track's streaming status is active.
+ *
+ * @param {Object} videoTrack - Track reference.
+ * @returns {boolean} - Is streaming status active.
+ */
+export function isTrackStreamingStatusActive(videoTrack) {
+    const streamingStatus = videoTrack?.streamingStatus;
+
+    return streamingStatus === JitsiTrackStreamingStatus.ACTIVE;
+}
+
+/**
+ * Checks if the passed track's streaming status is inactive.
+ *
+ * @param {Object} videoTrack - Track reference.
+ * @returns {boolean} - Is streaming status inactive.
+ */
+export function isTrackStreamingStatusInactive(videoTrack) {
+    const streamingStatus = videoTrack?.streamingStatus;
+
+    return streamingStatus === JitsiTrackStreamingStatus.INACTIVE;
+}
+
+/**
+ * Checks if the passed track's streaming status is interrupted.
+ *
+ * @param {Object} videoTrack - Track reference.
+ * @returns {boolean} - Is streaming status interrupted.
+ */
+export function isTrackStreamingStatusInterrupted(videoTrack) {
+    const streamingStatus = videoTrack?.streamingStatus;
+
+    return streamingStatus === JitsiTrackStreamingStatus.INTERRUPTED;
+}
+
+/**
+ * Checks if the passed participant's connecton status is active.
+ *
+ * @param {Object} participant - Participant reference.
+ * @returns {boolean} - Is connection status active.
+ */
+export function isParticipantConnectionStatusActive(participant) {
+    const connectionStatus = participant?.connectionStatus;
+
+    return connectionStatus === JitsiParticipantConnectionStatus.ACTIVE;
+}
+
+/**
+ * Checks if the passed participant's connecton status is inactive.
+ *
+ * @param {Object} participant - Participant reference.
+ * @returns {boolean} - Is connection status inactive.
+ */
+export function isParticipantConnectionStatusInactive(participant) {
+    const connectionStatus = participant?.connectionStatus;
+
+    return connectionStatus === JitsiParticipantConnectionStatus.INACTIVE;
+}
+
+/**
+ * Checks if the passed participant's connecton status is interrupted.
+ *
+ * @param {Object} participant - Participant reference.
+ * @returns {boolean} - Is connection status interrupted.
+ */
+export function isParticipantConnectionStatusInterrupted(participant) {
+    const connectionStatus = participant?.connectionStatus;
+
+    return connectionStatus === JitsiParticipantConnectionStatus.INTERRUPTED;
+}


### PR DESCRIPTION
Start listening to the `TRACK_STREAMING_STATUS_CHANGED` event introduced in https://github.com/jitsi/lib-jitsi-meet/pull/1855. This implementation still assumes only one video track per participant. 

High level objectives:
- Handle the `init` and `dispose` logic for `TrackStreamingStatus` when a connection icon is rendered. This is an optimization to help the performance in large conferences.
- Replace the participant connection status logic with track streaming status throughout the code base. Ensure backwards compatibility when the feature flag is disabled and feature parity when enabled.
- Add `streamingStatus` property to the Track data model in the redux store and add code to update this new property.  


