### PR TITLE
fix(breakout-rooms) close room before removing it

### DIFF
--- a/react/features/breakout-rooms/actions.js
+++ b/react/features/breakout-rooms/actions.js
@@ -33,7 +33,8 @@ import { _RESET_BREAKOUT_ROOMS, _UPDATE_ROOM_COUNTER } from './actionTypes';
 import { FEATURE_KEY } from './constants';
 import {
     getBreakoutRooms,
-    getMainRoom
+    getMainRoom,
+    getRoomByJid
 } from './functions';
 import logger from './logger';
 
@@ -97,6 +98,17 @@ export function closeBreakoutRoom(roomId: string) {
 export function removeBreakoutRoom(breakoutRoomJid: string) {
     return (dispatch: Dispatch<any>, getState: Function) => {
         sendAnalytics(createBreakoutRoomsEvent('remove'));
+        const room = getRoomByJid(getState, breakoutRoomJid);
+
+        if (!room) {
+            logger.error('The room to remove was not found.');
+
+            return;
+        }
+
+        if (Object.keys(room.participants).length > 0) {
+            dispatch(closeBreakoutRoom(room.id));
+        }
 
         // $FlowExpectedError
         getCurrentConference(getState)?.getBreakoutRooms()

--- a/react/features/breakout-rooms/functions.js
+++ b/react/features/breakout-rooms/functions.js
@@ -30,6 +30,20 @@ export const getMainRoom = (stateful: Function | Object) => {
 };
 
 /**
+ * Returns the room by Jid.
+ *
+ * @param {Function|Object} stateful - The redux store, the redux
+ * {@code getState} function, or the redux state itself.
+ * @param {string} roomJid - The jid of the room.
+ * @returns {Object|undefined} The main room object, or undefined.
+ */
+export const getRoomByJid = (stateful: Function | Object, roomJid: string): Object => {
+    const rooms = getBreakoutRooms(stateful);
+
+    return _.find(rooms, (room: Object) => room.jid === roomJid);
+};
+
+/**
  * Returns the id of the current room.
  *
  * @param {Function|Object} stateful - The redux store, the redux


### PR DESCRIPTION
This change is needed for the external api, as the current UI doesn't allow removing a room that has participants in it.
