### PR TITLE
fix(speaker-stats): labels spearator line fixed and remove footer space

### DIFF
--- a/react/features/speaker-stats/components/web/SpeakerStats.js
+++ b/react/features/speaker-stats/components/web/SpeakerStats.js
@@ -20,11 +20,17 @@ import SpeakerStatsSearch from './SpeakerStatsSearch';
 
 const useStyles = makeStyles(theme => {
     return {
+        footer: {
+            display: 'none !important'
+        },
+        labelsContainer: {
+            position: 'relative'
+        },
         separator: {
             position: 'absolute',
-            width: '100%',
+            width: 'calc(100% + 48px)',
             height: 1,
-            left: 0,
+            left: -24,
             backgroundColor: theme.palette.border02
         },
         searchSwitchContainer: {
@@ -74,6 +80,7 @@ const SpeakerStats = () => {
     return (
         <Dialog
             cancelKey = 'dialog.close'
+            classes = {{ footer: classes.footer }}
             hideCancelButton = { true }
             submitDisabled = { true }
             titleKey = 'speakerStats.speakerStats'
@@ -100,11 +107,11 @@ const SpeakerStats = () => {
                     }
                 </div>
                 { displayLabels && (
-                    <>
+                    <div className = { classes.labelsContainer }>
                         <SpeakerStatsLabels
                             showFacialExpressions = { showFacialExpressions ?? false } />
                         <div className = { classes.separator } />
-                    </>
+                    </div>
                 )}
                 <SpeakerStatsList />
             </div>

--- a/react/features/speaker-stats/components/web/SpeakerStatsList.js
+++ b/react/features/speaker-stats/components/web/SpeakerStatsList.js
@@ -11,7 +11,8 @@ import SpeakerStatsItem from './SpeakerStatsItem';
 const useStyles = makeStyles(theme => {
     return {
         list: {
-            marginTop: `${theme.spacing(3)}px`
+            marginTop: `${theme.spacing(3)}px`,
+            marginBottom: `${theme.spacing(3)}px`
         },
         item: {
             height: `${theme.spacing(7)}px`,


### PR DESCRIPTION
Fix separator line when the list of participants overflows and remove footer space

Before
<img width="400" alt="Screenshot 2022-02-17 at 16 49 11" src="https://user-images.githubusercontent.com/57035818/154509226-74bd3467-8e57-4e24-8a5d-9e937e2f59f4.png">

After
<img width="402" alt="Screenshot 2022-02-17 at 16 51 36" src="https://user-images.githubusercontent.com/57035818/154509584-283286e9-83a6-41bf-855d-42980397e5e9.png">

