### PR TITLE
Add support to the iOS SDK for the Simulator on M1

### DIFF
--- a/ios/scripts/release-sdk.sh
+++ b/ios/scripts/release-sdk.sh
@@ -35,7 +35,6 @@ xcodebuild archive \
     -sdk iphonesimulator \
     -destination='generic/platform=iOS Simulator' \
     -archivePath ios/sdk/out/ios-simulator \
-    VALID_ARCHS=x86_64 \
     ENABLE_BITCODE=NO \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
@@ -46,7 +45,6 @@ xcodebuild archive \
     -sdk iphoneos \
     -destination='generic/platform=iOS' \
     -archivePath ios/sdk/out/ios-device \
-    VALID_ARCHS=arm64 \
     ENABLE_BITCODE=NO \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES


### PR DESCRIPTION
Currently the iOS SDK isn't compiled for Apple Silicon on the simulator, which results in various Rosetta related glitches when running an app on M1 based machines. This PR removes `VALID_ARCHS` on the SDK build script as the standard architectures for both the Simulator and devices are now included in `WebRTC.xcframework` (which I assume was the limiting factor before).

I followed the build [instructions](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-ios-sdk#building-it-yourself) (removing the `VALID_ARCHS` matching this PR) to make a build with Xcode 13.2 and tested the output xcframework on an M1 in a simple project everything worked great. The contents of the `Info.plist` is below to show what is built without `VALID_ARCHS`.

Let me know if you have any questions or would like any changes 👍

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>AvailableLibraries</key>
	<array>
		<dict>
			<key>LibraryIdentifier</key>
			<string>ios-arm64_x86_64-simulator</string>
			<key>LibraryPath</key>
			<string>JitsiMeetSDK.framework</string>
			<key>SupportedArchitectures</key>
			<array>
				<string>arm64</string>
				<string>x86_64</string>
			</array>
			<key>SupportedPlatform</key>
			<string>ios</string>
			<key>SupportedPlatformVariant</key>
			<string>simulator</string>
		</dict>
		<dict>
			<key>LibraryIdentifier</key>
			<string>ios-arm64</string>
			<key>LibraryPath</key>
			<string>JitsiMeetSDK.framework</string>
			<key>SupportedArchitectures</key>
			<array>
				<string>arm64</string>
			</array>
			<key>SupportedPlatform</key>
			<string>ios</string>
		</dict>
	</array>
	<key>CFBundlePackageType</key>
	<string>XFWK</string>
	<key>XCFrameworkFormatVersion</key>
	<string>1.0</string>
</dict>
</plist>
```