### PR TITLE
fix(rn,display-name) don't show display name for lcoal user

### DIFF
--- a/react/features/display-name/components/native/DisplayNameLabel.js
+++ b/react/features/display-name/components/native/DisplayNameLabel.js
@@ -71,18 +71,10 @@ class DisplayNameLabel extends Component<Props> {
 function _mapStateToProps(state: Object, ownProps: Props) {
     const { participantId } = ownProps;
     const participant = getParticipantById(state, participantId);
-    const isFakeParticipant = participant && participant.isFakeParticipant;
-
-    // Currently we only render the display name if it's not the local
-    // participant and there is no video rendered for
-    // them.
-    const _render = Boolean(participantId)
-        && !isFakeParticipant;
 
     return {
-        _participantName:
-            getParticipantDisplayName(state, participantId),
-        _render
+        _participantName: getParticipantDisplayName(state, participantId),
+        _render: participant && !participant?.local && !participant?.isFakeParticipant
     };
 }
 


### PR DESCRIPTION
In large view. This aligns the behavior with the web.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
