### PR TITLE
Fix initial volume value if value is 0

### DIFF
--- a/react/features/video-menu/components/web/ParticipantContextMenu.js
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.js
@@ -138,7 +138,7 @@ const ParticipantContextMenu = ({
     const { disableKick, disableGrantModerator } = remoteVideoMenu;
     const { participantsVolume } = useSelector(state => state['features/filmstrip']);
     const _volume = (participant?.local ?? true ? undefined
-        : participant?.id ? participantsVolume[participant?.id] : undefined) || 1;
+        : participant?.id ? participantsVolume[participant?.id] : undefined) ?? 1;
     const isBreakoutRoom = useSelector(isInBreakoutRoom);
 
     const _currentRoomId = useSelector(getCurrentRoomId);


### PR DESCRIPTION
There's a bug if you set someone's volume to 0, next time you open the video menu the slider is set to 1. That's because 0 is considered a falsy value and will default to 1.