### PR TITLE
fix(rn,filmstrip) fix local participant location

### DIFF
--- a/react/features/filmstrip/components/native/Filmstrip.js
+++ b/react/features/filmstrip/components/native/Filmstrip.js
@@ -237,8 +237,15 @@ class Filmstrip extends PureComponent<Props> {
             ? width / (thumbnailWidth + (2 * margin))
             : height / (thumbnailHeight + (2 * margin))
         );
-        const participants = this._separateLocalThumbnail || _disableSelfView
-            ? _participants : [ _localParticipantId, ..._participants ];
+        let participants;
+
+        if (this._separateLocalThumbnail || _disableSelfView) {
+            participants = _participants;
+        } else if (isNarrowAspectRatio) {
+            participants = [ ..._participants, _localParticipantId ];
+        } else {
+            participants = [ _localParticipantId, ..._participants ];
+        }
 
         return (
             <SafeAreaView style = { filmstripStyle }>


### PR DESCRIPTION
This applies to android only, where we don't separate the local
thumbnail.

In portrait mode the local thumbnail needs to be on the right, aka the
last one. In landscape mode it needs to be on top, aka the first.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
