### PR TITLE
fix(thumbnails, rn) Hide empty indicators container on native

### DIFF
--- a/react/features/display-name/components/native/DisplayNameLabel.js
+++ b/react/features/display-name/components/native/DisplayNameLabel.js
@@ -69,12 +69,12 @@ class DisplayNameLabel extends Component<Props> {
  * }}
  */
 function _mapStateToProps(state: Object, ownProps: Props) {
-    const { participantId } = ownProps;
+    const { participantId, contained } = ownProps;
     const participant = getParticipantById(state, participantId);
 
     return {
         _participantName: getParticipantDisplayName(state, participantId),
-        _render: participant && !participant?.local && !participant?.isFakeParticipant
+        _render: participant && (!participant?.local || contained) && !participant?.isFakeParticipant
     };
 }
 

--- a/react/features/display-name/components/native/styles.js
+++ b/react/features/display-name/components/native/styles.js
@@ -12,8 +12,8 @@ export default {
     },
 
     displayNamePadding: {
-        paddingHorizontal: BaseTheme.spacing[2],
-        paddingVertical: BaseTheme.spacing[1]
+        padding: BaseTheme.spacing[1],
+        paddingRight: 6
     },
 
     displayNameText: {

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -224,8 +224,10 @@ class Thumbnail extends PureComponent<Props> {
             indicators.push(<Container
                 key = 'bottom-indicators'
                 style = { styles.thumbnailIndicatorContainer }>
-                { audioMuted && <AudioMutedIndicator /> }
-                { renderModeratorIndicator && <ModeratorIndicator />}
+                <Container style = { (audioMuted || renderModeratorIndicator) && styles.bottomIndicatorsContainer }>
+                    { audioMuted && <AudioMutedIndicator /> }
+                    { renderModeratorIndicator && <ModeratorIndicator />}
+                </Container>
                 {
                     renderDisplayName && <DisplayNameLabel
                         contained = { true }

--- a/react/features/filmstrip/components/native/styles.js
+++ b/react/features/filmstrip/components/native/styles.js
@@ -134,7 +134,13 @@ export default {
         position: 'absolute',
         maxWidth: '95%',
         overflow: 'hidden',
-        ...indicatorContainer
+        ...indicatorContainer,
+        padding: 0
+    },
+
+    bottomIndicatorsContainer: {
+        padding: 2,
+        flexDirection: 'row'
     },
 
     thumbnailTopIndicatorContainer: {


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 13 - 2022-02-24 at 14 00 32](https://user-images.githubusercontent.com/11474153/155520079-92710957-009b-48c7-86c1-35e27da92f04.png)
![Simulator Screen Shot - iPhone 13 - 2022-02-24 at 14 00 26](https://user-images.githubusercontent.com/11474153/155520084-59b20898-74d4-4613-a3e9-135bb4b6403c.png)

