### PR TITLE
fix(premeeting): Improve pre-meeting responsiveness for screens less 1000px

### DIFF
--- a/css/premeeting/_premeeting-screens.scss
+++ b/css/premeeting/_premeeting-screens.scss
@@ -82,7 +82,7 @@
         flex-direction: column;
         flex-shrink: 0;
         height: 100%;
-        margin: 0 110px;
+        margin: 0 30px;
         padding: 24px 0 16px;
         position: relative;
         width: $prejoinDefaultContentWidth;
@@ -154,7 +154,7 @@
         }
     }
 
-    @media (max-width: 1000px) {
+    @media (max-width: 720px) {
         flex-direction: column-reverse;
 
         .content {


### PR DESCRIPTION
Please see https://github.com/jitsi/jitsi-meet/issues/11027

@saghul I did some tests trying various responsive scenarios and propose to follow 16:9 aspect ratio values, so if there is a breakpoint on 420px then the width breakpoint should be on 720px (HD width).

But that means it requires changing the size of the join panel because the margin is too big if the width is 721px:

<img width="693" alt="Screenshot 2022-02-25 at 14 41 59" src="https://user-images.githubusercontent.com/14282222/155725279-efedcfea-dc07-4eb6-b003-2992c401b090.png">

To avoid that I changed the default panel margin to give more space for video:
 
<img width="766" alt="Screenshot 2022-02-25 at 15 30 02" src="https://user-images.githubusercontent.com/14282222/155732431-d5d595a6-cb7c-4df2-adcd-12e44649e37a.png">

Full size:
<img width="1196" alt="Screenshot 2022-02-25 at 15 30 23" src="https://user-images.githubusercontent.com/14282222/155732481-02546b05-f009-4f7b-ba6f-e123d30635d7.png">

If you have any other suggestions please let me know!
