### PR TITLE
fix(screenshare) Add and then mute the camera track after SS stops instead of not adding the track.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1612,32 +1612,29 @@ export default {
 
         APP.store.dispatch(setScreenAudioShareState(false));
 
-        if (didHaveVideo && !ignoreDidHaveVideo) {
-            promise = promise.then(() => createLocalTracksF({ devices: [ 'video' ] }))
-                .then(([ stream ]) => {
-                    logger.debug(`_turnScreenSharingOff using ${stream} for useVideoStream`);
+        promise = promise.then(() => createLocalTracksF({ devices: [ 'video' ] }))
+            .then(([ stream ]) => {
+                logger.debug(`_turnScreenSharingOff using ${stream} for useVideoStream`);
 
-                    return this.useVideoStream(stream);
-                })
-                .catch(error => {
-                    logger.error('failed to switch back to local video', error);
+                return this.useVideoStream(stream);
+            })
+            .catch(error => {
+                logger.error('failed to switch back to local video', error);
 
-                    return this.useVideoStream(null).then(() =>
+                return this.useVideoStream(null).then(() =>
 
-                        // Still fail with the original err
-                        Promise.reject(error)
-                    );
-                });
-        } else {
-            promise = promise.then(() => {
-                logger.debug('_turnScreenSharingOff using null for useVideoStream');
-
-                return this.useVideoStream(null);
+                    // Still fail with the original err
+                    Promise.reject(error)
+                );
             });
-        }
 
         return promise.then(
             () => {
+                // Mute the video if camera video needs to be ignored or if video was muted before switching to screen
+                // share.
+                if (ignoreDidHaveVideo || !didHaveVideo) {
+                    APP.store.dispatch(setVideoMuted(true, MEDIA_TYPE.VIDEO));
+                }
                 this.videoSwitchInProgress = false;
                 sendAnalytics(createScreenSharingEvent('stopped',
                     duration === 0 ? null : duration));


### PR DESCRIPTION
This is a follow up for https://github.com/jitsi/lib-jitsi-meet/pull/1944. This is needed to avoid sending a soure-remove followed by a source-add for the same ssrc. This happens when a users mutes camera->starts SS->stops SS->turns on camera on a p2p connection in Unified plan mode. Chrome fails to render the media if the same SSRC is removed and added back to the same m-line.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
