### PR TITLE
update ljm 1646233686

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1387.0.0+6ddc054c/lib-jitsi-meet.tgz",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1389.0.0+313e0dd3/lib-jitsi-meet.tgz",
         "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -11496,8 +11496,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1387.0.0+6ddc054c/lib-jitsi-meet.tgz",
-      "integrity": "sha512-9PLpOAKlAXtLpXInkna/xIYTRA3X7sCFoZABAE7jR4JqxlA9yon6IKM5TowNKN9BSKHXW0L3IkR588fkdRff2A==",
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1389.0.0+313e0dd3/lib-jitsi-meet.tgz",
+      "integrity": "sha512-+SDQ2xqBg1eO0b6vQCm+Lqxff9M+/SLK5LGg05dFDaZ3ih94yZ9v2qcSfZxD1pu/QPok4ioV48n/FeRFNNRByQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
@@ -28078,8 +28078,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1387.0.0+6ddc054c/lib-jitsi-meet.tgz",
-      "integrity": "sha512-9PLpOAKlAXtLpXInkna/xIYTRA3X7sCFoZABAE7jR4JqxlA9yon6IKM5TowNKN9BSKHXW0L3IkR588fkdRff2A==",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1389.0.0+313e0dd3/lib-jitsi-meet.tgz",
+      "integrity": "sha512-+SDQ2xqBg1eO0b6vQCm+Lqxff9M+/SLK5LGg05dFDaZ3ih94yZ9v2qcSfZxD1pu/QPok4ioV48n/FeRFNNRByQ==",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1387.0.0+6ddc054c/lib-jitsi-meet.tgz",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1389.0.0+313e0dd3/lib-jitsi-meet.tgz",
     "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
- Mobile UI polish (#10982)
- chore(deps) lib-jitsi-meet@latest
- fix: Fixes nil error while processing wrong jwt value. Fixes #10970
- feat: Handles hidden-from-recorder from jwt. (#10973)
- fix(ios) rework RN build workaround
- fix(speaker-stats): labels spearator line fixed and remove footer space
- feat(welcome) updated mobile ui styles
- fix(ios) make sure arm64 sim is not excluded
- chore(deps) react-native-webrtc@1.94.2
- chore(deps) lib-jitsi-meet@latest
- fix(android) initialize the fatal exception handler early
- feat(android) make application more akin to a greenfield RN app
- feat(rn) drop incoming call handling
- fix(toolbox) fixed toolbox safeareaview on mobile
- fix(rn,display-name) don't show display name for local user
- fix(calendar-sync) fixed pull to refresh on Calendar List mobile
- chore(deps) make sure no SSH URLs get generated in package-lock.json
- chore(deps) lib-jitsi-meet@latest
- fix(thumbnails) Revert local tile ratio (#11009)
- fix(mobile-ui) patch for native dialog container, fixed switch track color
- fix(lang) update sv translation
- feat(multi-stream-support) Replace participant connection status logic with track streaming status (#10934)
- fix(mobile-ui) ui fixes
- fix(rn,filmstrip) fix local participant location
- fix(thumbnails, rn) Hide empty indicators container on native (#11019)
- feat(filmstrip) Make filmstrip user resizable (#10884)
- chore(deps) lib-jitsi-meet@latest
- chore(deps) lib-jitsi-meet@latest
- fix(lint) don't check for Flow types on files without the annotation
- fix(facial-recognition) avoid image data conversion
- fix(filmstrip/toolbox) mobile ui adjustments
- fix(ios) fix for building for simulator on M1
- Fix initial volume value if value is 0
- Update main-sv.json
- feat(ios) Add support to the iOS SDK for the Simulator on M1
- fix(i18n) fix some country names
- fix(thumbnail) Fix pinned participant in the resizable filmstrip (#11042)
- feat(screenshare) Allow desktop sharing in audioOnly mode on web.
- feat(filmstrip/toolbox) mobile ui undo changes
- feat: Passing the url to conference mapper (#11013)
- fix(video-devices) Fix video devices not scrollable
- fix(external-api): dismiss lobby notification after handling the knocking participant (#11049)
- feat(filmstrip/toolbox) mobile ui updates (#11051)
- fix(screenshare) Add and then mute the camera track after SS stops instead of not adding the track. This is a follow up for https://github.com/jitsi/lib-jitsi-meet/pull/1944. This is needed to avoid sending a soure-remove followed by a source-add for the same ssrc. This happens when a users mutes camera->starts SS->stops SS->turns on camera on a p2p connection in Unified plan mode. Chrome fails to render the media if the same SSRC is removed and added back to the same m-line.
- chore(deps) lib-jitsi-meet@latest
- fix(lobby-notifications): Prevent lobby notification to remain on scr… (#11054)
- feat(external-api): expose config for breakout rooms (#11055)
- fix(filmstrip) Fix resizable filmstrip (#11025)
- fix: Fixes loading web on mobile browser.
- chore(deps) lib-jitsi-meet@latest
