### PR TITLE
fix(popper): resolve @atlaskit/popper to an unbuggy version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -758,12 +758,12 @@
       }
     },
     "node_modules/@atlaskit/popper": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/popper/-/popper-5.2.2.tgz",
-      "integrity": "sha512-gCP/hVAcIPk5VAQLB9Dm+rUSlUPD9MuA4See6sWo0LVzEq+g0GbKHI0iFeNVRwSTR4ImO2LanqHyWwcrPxqZuw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@atlaskit/popper/-/popper-5.0.4.tgz",
+      "integrity": "sha512-HBZUi8me48JEdfVri95oAZ0dOOfxcJD6pRoV40HGpHvW8cVxxvGrwQILEzTYKjhmfgHxniagz9ry2sD1XlHPcg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@popperjs/core": "^2.9.1",
+        "@popperjs/core": "^2.4.2",
         "react-popper": "^2.2.3"
       },
       "peerDependencies": {
@@ -3780,9 +3780,9 @@
       "dev": true
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -19929,12 +19929,12 @@
       }
     },
     "@atlaskit/popper": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@atlaskit/popper/-/popper-5.2.2.tgz",
-      "integrity": "sha512-gCP/hVAcIPk5VAQLB9Dm+rUSlUPD9MuA4See6sWo0LVzEq+g0GbKHI0iFeNVRwSTR4ImO2LanqHyWwcrPxqZuw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@atlaskit/popper/-/popper-5.0.4.tgz",
+      "integrity": "sha512-HBZUi8me48JEdfVri95oAZ0dOOfxcJD6pRoV40HGpHvW8cVxxvGrwQILEzTYKjhmfgHxniagz9ry2sD1XlHPcg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@popperjs/core": "^2.9.1",
+        "@popperjs/core": "^2.4.2",
         "react-popper": "^2.2.3"
       }
     },
@@ -22076,9 +22076,9 @@
       "dev": true
     },
     "@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
     },
     "@react-native-async-storage/async-storage": {
       "version": "1.15.14",


### PR DESCRIPTION
If you open participants pane and then click on the overflow button, the inline dialog is displayed at the wrong position.

<img width="1511" alt="misplaced overflow menu" src="https://user-images.githubusercontent.com/45701680/156415290-5cb8836a-4c5c-4eaf-b845-d03d25bb11e1.png">

If we resolve `@popperjs/core` to `2.6.0` `2.11.2`, this bug will be fixed.
