### PR TITLE
fix(rn,dialogs,auth) fix not showing authentication dialogs

### DIFF
--- a/react/features/authentication/components/native/LoginDialog.js
+++ b/react/features/authentication/components/native/LoginDialog.js
@@ -45,6 +45,11 @@ type Props = {
     _error: Object,
 
     /**
+     * Extra handler for cancel functionality.
+     */
+    _onCancel: Function,
+
+    /**
      * The progress in the floating range between 0 and 1 of the authenticating
      * and upgrading the role of the local participant/user.
      */
@@ -63,7 +68,12 @@ type Props = {
     /**
      * Invoked to obtain translated strings.
      */
-    t: Function
+    t: Function,
+
+    /**
+     * Override the default visibility.
+     */
+    visible: boolean
 };
 
 /**
@@ -110,6 +120,10 @@ type State = {
  * of the configuration parameters.
  */
 class LoginDialog extends Component<Props, State> {
+    static defaultProps = {
+        visible: true
+    };
+
     /**
      * Initializes a new LoginDialog instance.
      *
@@ -140,13 +154,14 @@ class LoginDialog extends Component<Props, State> {
     render() {
         const {
             _connecting: connecting,
-            t
+            t,
+            visible
         } = this.props;
 
         return (
             <View>
                 <Dialog.Container
-                    visible = { true }>
+                    visible = { visible }>
                     <Dialog.Title>
                         { t('dialog.login') }
                     </Dialog.Title>
@@ -280,7 +295,10 @@ class LoginDialog extends Component<Props, State> {
      * @returns {void}
      */
     _onCancel() {
-        this.props.dispatch(cancelLogin());
+        const { _onCancel, dispatch } = this.props;
+
+        _onCancel && _onCancel();
+        dispatch(cancelLogin());
     }
 
     _onLogin: () => void;

--- a/react/features/authentication/components/native/WaitForOwnerDialog.js
+++ b/react/features/authentication/components/native/WaitForOwnerDialog.js
@@ -6,7 +6,9 @@ import type { Dispatch } from 'redux';
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { connect } from '../../../base/redux';
-import { openLoginDialog, cancelWaitForOwner } from '../../actions.native';
+import { cancelWaitForOwner } from '../../actions.native';
+
+import LoginDialog from './LoginDialog';
 
 /**
  * The type of the React {@code Component} props of {@link WaitForOwnerDialog}.
@@ -40,9 +42,14 @@ class WaitForOwnerDialog extends Component<Props> {
     constructor(props) {
         super(props);
 
+        this.state = {
+            showLoginDialog: false
+        };
+
         // Bind event handlers so they are only bound once per instance.
         this._onCancel = this._onCancel.bind(this);
         this._onLogin = this._onLogin.bind(this);
+        this._onLoginDialogCancel = this._onLoginDialogCancel.bind(this);
     }
 
     /**
@@ -58,7 +65,12 @@ class WaitForOwnerDialog extends Component<Props> {
                 confirmLabel = 'dialog.IamHost'
                 descriptionKey = 'dialog.WaitForHostMsg'
                 onCancel = { this._onCancel }
-                onSubmit = { this._onLogin } />
+                onSubmit = { this._onLogin }>
+                <LoginDialog
+                    // eslint-disable-next-line react/jsx-handler-names
+                    _onCancel = { this._onLoginDialogCancel }
+                    visible = { this.state.showLoginDialog } />
+            </ConfirmDialog>
         );
     }
 
@@ -83,7 +95,17 @@ class WaitForOwnerDialog extends Component<Props> {
      * @returns {void}
      */
     _onLogin() {
-        this.props.dispatch(openLoginDialog());
+        this.setState({ showLoginDialog: true });
+    }
+
+    /**
+     * Called when the nested login dialog is cancelled.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onLoginDialogCancel() {
+        this.setState({ showLoginDialog: false });
     }
 }
 

--- a/react/features/authentication/middleware.native.js
+++ b/react/features/authentication/middleware.native.js
@@ -62,13 +62,14 @@ MiddlewareRegistry.register(store => next => action => {
             // Go back to the app's entry point.
             _hideLoginDialog(store);
 
-            const { authRequired, conference } = getState()['features/base/conference'];
+            const state = getState();
+            const { authRequired, conference } = state['features/base/conference'];
+            const { passwordRequired } = state['features/base/connection'];
 
             // Only end the meeting if we are not already inside and trying to upgrade.
-            if (authRequired && !conference) {
-                // FIXME Like cancelWaitForOwner, dispatch conferenceLeft to notify
-                // the external-api.
-
+            // NOTE: Despite it's confusing name, `passwordRequired` implies an XMPP
+            // connection auth error.
+            if ((passwordRequired || authRequired) && !conference) {
                 dispatch(appNavigate(undefined));
             }
         }


### PR DESCRIPTION
1) Fix not being able to show multiple dialogs at once in iOS
2) Fix cancelling the login dialog when XMPP auth is enabled without
   guest support

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
