### PR TITLE
fix(conference) Disable audio-only mode when user switches to screenshare

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -27,6 +27,7 @@ import {
 } from './react/features/app/actions';
 import { showModeratedNotification } from './react/features/av-moderation/actions';
 import { shouldShowModeratedNotification } from './react/features/av-moderation/functions';
+import { setAudioOnly } from './react/features/base/audio-only';
 import {
     AVATAR_URL_COMMAND,
     EMAIL_COMMAND,
@@ -1677,6 +1678,9 @@ export default {
             return Promise.reject('Cannot toggle screen sharing: not supported.');
         }
 
+        if (this.isAudioOnly()) {
+            APP.store.dispatch(setAudioOnly(false));
+        }
         if (toggle) {
             try {
                 await this._switchToScreenSharing(options);
@@ -1938,11 +1942,13 @@ export default {
                     // api.
                     if (localAudio) {
                         this._mixerEffect = new AudioMixerEffect(this._desktopAudioStream);
-
+                        logger.debug(`_switchToScreenSharing is mixing ${this._desktopAudioStream} and ${localAudio}`
+                        + ' as a single audio stream');
                         await localAudio.setEffect(this._mixerEffect);
                     } else {
                         // If no local stream is present ( i.e. no input audio devices) we use the screen share audio
                         // stream as we would use a regular stream.
+                        logger.debug(`_switchToScreenSharing is using ${this._desktopAudioStream} for useAudioStream`);
                         await this.useAudioStream(this._desktopAudioStream);
 
                     }


### PR DESCRIPTION
Make the behavior consistent with enabling camera when the user is audio-only mode. Also fixes an issue where the screenshare preview doesn't appear if it is enabled while the user is in audio-only mode.
Follow-up PR for https://github.com/jitsi/jitsi-meet/pull/11033

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
