### PR TITLE
fix(language) Add lang API option

### DIFF
--- a/config.js
+++ b/config.js
@@ -516,7 +516,7 @@ var config = {
     // Hides the dominant speaker name badge that hovers above the toolbox
     // hideDominantSpeakerBadge: false,
 
-    // Default language for the user interface.
+    // Default language for the user interface. Cannot be overwritten.
     // defaultLanguage: 'en',
 
     // Disables profile and the edit of all fields from the profile settings (display name and email)

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -170,6 +170,7 @@ function changeParticipantNumber(APIInstance, number) {
  * configuration options defined in interface_config.js to be overridden.
  * @param {string} [options.jwt] - The JWT token if needed by jitsi-meet for
  * authentication.
+ * @param {string} [options.lang] - The meeting's language.
  * @param {string} [options.roomName] - The name of the room to join.
  * @returns {string} The URL.
  */
@@ -282,6 +283,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * configuration options defined in interface_config.js to be overridden.
      * @param {string} [options.jwt] - The JWT token if needed by jitsi-meet for
      * authentication.
+     * @param {string} [options.lang] - The meeting's language.
      * @param {string} [options.onload] - The onload function that will listen
      * for iframe onload event.
      * @param {Array<Object>} [options.invitees] - Array of objects containing

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -170,7 +170,7 @@ function changeParticipantNumber(APIInstance, number) {
  * configuration options defined in interface_config.js to be overridden.
  * @param {string} [options.jwt] - The JWT token if needed by jitsi-meet for
  * authentication.
- * @param {string} [options.lang] - The meeting's language.
+ * @param {string} [options.lang] - The meeting's default language.
  * @param {string} [options.roomName] - The name of the room to join.
  * @returns {string} The URL.
  */
@@ -283,7 +283,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * configuration options defined in interface_config.js to be overridden.
      * @param {string} [options.jwt] - The JWT token if needed by jitsi-meet for
      * authentication.
-     * @param {string} [options.lang] - The meeting's language.
+     * @param {string} [options.lang] - The meeting's default language.
      * @param {string} [options.onload] - The onload function that will listen
      * for iframe onload event.
      * @param {Array<Object>} [options.invitees] - Array of objects containing

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -208,7 +208,8 @@ function parseArguments(args) {
             configOverwrite,
             interfaceConfigOverwrite,
             jwt,
-            onload
+            onload,
+            lang
         ] = args;
 
         return {
@@ -219,7 +220,8 @@ function parseArguments(args) {
             configOverwrite,
             interfaceConfigOverwrite,
             jwt,
-            onload
+            onload,
+            lang
         };
     }
     case 'object': // new arguments format
@@ -301,6 +303,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             configOverwrite = {},
             interfaceConfigOverwrite = {},
             jwt = undefined,
+            lang = undefined,
             onload = undefined,
             invitees,
             devices,
@@ -314,6 +317,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             configOverwrite,
             interfaceConfigOverwrite,
             jwt,
+            lang,
             roomName,
             devices,
             userInfo,

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -81,7 +81,6 @@ export default [
     'brandingRoomAlias',
     'debug',
     'debugAudioLevels',
-    'defaultLanguage',
     'defaultLocalDisplayName',
     'defaultRemoteDisplayName',
     'desktopSharingFrameRate',

--- a/react/features/base/util/uri.js
+++ b/react/features/base/util/uri.js
@@ -523,19 +523,25 @@ export function urlObjectToString(o: Object): ?string {
 
     // query/search
 
-    // Web's ExternalAPI jwt
-    const { jwt } = o;
+    // Web's ExternalAPI jwt and lang
+    const { jwt, lang } = o;
+
+    const search = new URLSearchParams(url.search);
 
     if (jwt) {
-        let { search } = url;
+        search.set('jwt', jwt);
+    }
 
-        if (search.indexOf('?jwt=') === -1 && search.indexOf('&jwt=') === -1) {
-            search.startsWith('?') || (search = `?${search}`);
-            search.length === 1 || (search += '&');
-            search += `jwt=${jwt}`;
+    const { defaultLanguage } = o.configOverwrite || {};
 
-            url.search = search;
-        }
+    if (lang || defaultLanguage) {
+        search.set('lang', lang || defaultLanguage);
+    }
+
+    const searchString = search.toString();
+
+    if (searchString) {
+        url.search = `?${searchString}`;
     }
 
     // fragment/hash


### PR DESCRIPTION
- jwt from API overwrites any jwt sent as queryparam
- defaultLanguage from configOverwrite converts to `lang` query param

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
