### PR TITLE
Increase the visibility of 404 error message

### DIFF
--- a/css/404.scss
+++ b/css/404.scss
@@ -4,7 +4,8 @@
     text-align: center;
 
     h2 {
-        font-size: 36px;
+        font-size: 48px;
+        color : #f2f2f2;
     }
 
     &__message {


### PR DESCRIPTION
Changed the font-size and color of the h2 element of the 404 error page so that it can look more vibrant and stand out.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Old look:

<img width="452" alt="image" src="https://user-images.githubusercontent.com/75029064/157817302-29b7b324-4e9d-4da0-80df-eb6e10473174.png">

New look:

<img width="476" alt="image" src="https://user-images.githubusercontent.com/75029064/157817388-01cbfd5f-d539-4e43-ae5f-e451d6106e6a.png">


