### PR TITLE
refactor(prejoin) use jss instead of sass in CallingDialog

### DIFF
--- a/css/premeeting/_prejoin-dialog.scss
+++ b/css/premeeting/_prejoin-dialog.scss
@@ -165,23 +165,3 @@
         }
     }
 }
-
-.prejoin-dialog-calling {
-    padding: 16px;
-    text-align: center;
-
-    &-header {
-        text-align: right;
-    }
-
-    &-label {
-        font-size: 15px;
-        margin: 8px 0 16px 0;
-    }
-
-    &-number {
-        font-size: 19px;
-        line-height: 28px;
-        margin: 16px 0;
-    }
-}

--- a/react/features/prejoin/components/dialogs/CallingDialog.js
+++ b/react/features/prejoin/components/dialogs/CallingDialog.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { makeStyles } from '@material-ui/styles';
-import clsx from 'clsx';
 import React from 'react';
 
 import { Avatar } from '../../../base/avatar';
@@ -39,7 +38,7 @@ type Props = {
 
 const useStyles = makeStyles(theme => {
     return {
-        root: {
+        callingDialog: {
             padding: theme.spacing(3),
             textAlign: 'center',
 
@@ -49,13 +48,13 @@ const useStyles = makeStyles(theme => {
 
             '& .prejoin-dialog-calling-label': {
                 fontSize: '15px',
-                margin: `${theme.spacing(2)} 0 ${theme.spacing(2)} 0`
+                margin: `${theme.spacing(2)}px 0 ${theme.spacing(3)}px 0`
             },
 
             '& .prejoin-dialog-calling-number': {
                 fontSize: '19px',
                 lineHeight: '28px',
-                margin: `${theme.spacing(3)} 0`
+                margin: `${theme.spacing(3)}px 0`
             }
         }
     };
@@ -72,7 +71,7 @@ function CallingDialog(props: Props) {
     const classes = useStyles();
 
     return (
-        <div className = { clsx('prejoin-dialog-calling', classes.root) }>
+        <div className = { classes.callingDialog }>
             <div className = 'prejoin-dialog-calling-header'>
                 <Icon
                     className = 'prejoin-dialog-icon'

--- a/react/features/prejoin/components/dialogs/CallingDialog.js
+++ b/react/features/prejoin/components/dialogs/CallingDialog.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { makeStyles } from '@material-ui/styles';
+import clsx from 'clsx';
 import React from 'react';
 
 import { Avatar } from '../../../base/avatar';
@@ -35,6 +37,30 @@ type Props = {
     t: Function,
 };
 
+const useStyles = makeStyles(theme => {
+    return {
+        root: {
+            padding: theme.spacing(3),
+            textAlign: 'center',
+
+            '& .prejoin-dialog-calling-header': {
+                textAlign: 'right'
+            },
+
+            '& .prejoin-dialog-calling-label': {
+                fontSize: '15px',
+                margin: `${theme.spacing(2)} 0 ${theme.spacing(2)} 0`
+            },
+
+            '& .prejoin-dialog-calling-number': {
+                fontSize: '19px',
+                lineHeight: '28px',
+                margin: `${theme.spacing(3)} 0`
+            }
+        }
+    };
+});
+
 /**
  * Dialog displayed when the user gets called by the meeting.
  *
@@ -43,9 +69,10 @@ type Props = {
  */
 function CallingDialog(props: Props) {
     const { number, onClose, status, t } = props;
+    const classes = useStyles();
 
     return (
-        <div className = 'prejoin-dialog-calling'>
+        <div className = { clsx('prejoin-dialog-calling', classes.root) }>
             <div className = 'prejoin-dialog-calling-header'>
                 <Icon
                     className = 'prejoin-dialog-icon'


### PR DESCRIPTION
Convert Sass to JSS in `CallingDialog` component.