### PR TITLE
feature: patch for muc_owner_allow_kick in prosody 0.12

### DIFF
--- a/resources/prosody-plugins/muc_owner_allow_kick-0.12.patch
+++ b/resources/prosody-plugins/muc_owner_allow_kick-0.12.patch
@@ -1,0 +1,22 @@
+--- muc.lib.lua	2016-10-26 18:26:53.432377291 +0000
++++ muc.lib.lua	2016-10-26 18:41:40.754426072 +0000
+@@ -1582,16 +1582,16 @@
+ 	if event.allowed ~= nil then
+ 		return event.allowed, event.error, event.condition;
+ 	end
++	local occupant_affiliation = self:get_affiliation(occupant.bare_jid);
+ 
+ 	-- Can't do anything to other owners or admins
+-	local occupant_affiliation = self:get_affiliation(occupant.bare_jid);
+-	if occupant_affiliation == "owner" or occupant_affiliation == "admin" then
++	local actor_affiliation = self:get_affiliation(actor);
++	if (occupant_affiliation == "owner" and actor_affiliation ~= "owner") or (occupant_affiliation == "admin" and actor_affiliation ~= "admin" and actor_affiliation ~= "owner") then
+ 		return nil, "cancel", "not-allowed";
+ 	end
+ 
+ 	-- If you are trying to give or take moderator role you need to be an owner or admin
+ 	if occupant.role == "moderator" or role == "moderator" then
+-		local actor_affiliation = self:get_affiliation(actor);
+ 		if actor_affiliation ~= "owner" and actor_affiliation ~= "admin" then
+ 			return nil, "cancel", "not-allowed";
+ 		end


### PR DESCRIPTION
provides a patch to re-enable support for kicking muc owners in the latest prosody release 0.12