### PR TITLE
fix(highlight) display option to start recording

### DIFF
--- a/react/features/recording/actions.any.js
+++ b/react/features/recording/actions.any.js
@@ -132,14 +132,13 @@ export function highlightMeetingMoment() {
     return async (dispatch: Function, getState: Function) => {
         dispatch(setHighlightMomentButtonState(true));
 
-        try {
-            await sendMeetingHighlight(getState());
+        const success = await sendMeetingHighlight(getState());
+
+        if (success) {
             dispatch(showNotification({
                 descriptionKey: 'recording.highlightMomentSucessDescription',
                 titleKey: 'recording.highlightMomentSuccess'
             }));
-        } catch (err) {
-            logger.error('Could not highlight meeting moment', err);
         }
 
         dispatch(setHighlightMomentButtonState(false));

--- a/react/features/recording/components/Recording/AbstractHighlightButton.js
+++ b/react/features/recording/components/Recording/AbstractHighlightButton.js
@@ -1,10 +1,20 @@
 // @flow
 
 import { Component } from 'react';
+import { batch } from 'react-redux';
 
 import { getActiveSession, isHighlightMeetingMomentDisabled } from '../..';
+import { openDialog } from '../../../base/dialog';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import {
+    hideNotification,
+    NOTIFICATION_TIMEOUT_TYPE,
+    NOTIFICATION_TYPE,
+    showNotification
+} from '../../../notifications';
 import { highlightMeetingMoment } from '../../actions.any';
+import { StartRecordingDialog } from '../../components';
+import { PROMPT_RECORDING_NOTIFICATION_ID } from '../../constants';
 
 export type Props = {
 
@@ -45,7 +55,21 @@ export default class AbstractHighlightButton<P: Props> extends Component<P> {
     _onClick() {
         const { _disabled, dispatch } = this.props;
 
-        if (!_disabled) {
+        if (_disabled) {
+            dispatch(showNotification({
+                descriptionKey: 'recording.highlightMomentDisabled',
+                titleKey: 'recording.highlightMoment',
+                uid: PROMPT_RECORDING_NOTIFICATION_ID,
+                customActionNameKey: [ 'localRecording.start' ],
+                customActionHandler: [ () => {
+                    batch(() => {
+                        dispatch(hideNotification(PROMPT_RECORDING_NOTIFICATION_ID));
+                        dispatch(openDialog(StartRecordingDialog));
+                    });
+                } ],
+                appearance: NOTIFICATION_TYPE.NORMAL
+            }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+        } else {
             dispatch(highlightMeetingMoment());
         }
     }

--- a/react/features/recording/constants.js
+++ b/react/features/recording/constants.js
@@ -18,6 +18,13 @@ export const LIVE_STREAMING_OFF_SOUND_ID = 'LIVE_STREAMING_OFF_SOUND';
 export const LIVE_STREAMING_ON_SOUND_ID = 'LIVE_STREAMING_ON_SOUND';
 
 /**
+ * The identifier of the prompt to start recording notification.
+ *
+ * @type {string}
+ */
+export const PROMPT_RECORDING_NOTIFICATION_ID = 'PROMPT_RECORDING_NOTIFICATION_ID';
+
+/**
  * The identifier of the sound to be played when a recording session is stopped.
  *
  * @type {string}


### PR DESCRIPTION
Fix incorrect handling of error case when highlighting moments
Allow users to start recording when trying to highlight while recording not started

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
