### PR TITLE
fix(premeeting): fix undefined breakpoint in media query

### DIFF
--- a/react/features/base/premeeting/components/web/ConnectionStatus.js
+++ b/react/features/base/premeeting/components/web/ConnectionStatus.js
@@ -44,7 +44,7 @@ const useStyles = makeStyles(theme => {
                 width: '100%'
             },
 
-            [theme.breakpoints.down('720')]: {
+            '@media (max-width: 720px)': {
                 margin: `${theme.spacing(4)} auto`,
                 position: 'fixed',
                 top: 0,


### PR DESCRIPTION
`720` value is not defined in the `theme.breakpoints`.