### PR TITLE
refactor(premeeting): remove redundant styles from prejoin.scss

### DIFF
--- a/css/premeeting/_prejoin.scss
+++ b/css/premeeting/_prejoin.scss
@@ -23,30 +23,6 @@
         padding: 8px 0;
     }
   
-    &-dropdown-btn {
-        align-items: center;
-        color: #1C2025;
-        cursor: pointer;
-        display: flex;
-        height: 40px;
-        font-size: 15px;
-        line-height: 24px;
-        padding: 0 16px;
-  
-        &:hover {
-            background-color: #DAEBFA;
-        }
-    }
-  
-    &-dropdown-icon {
-        display: inline-block;
-        margin-right: 16px;
-  
-        & > svg {
-            fill:  #1C2025;
-        }
-    }
-  
     &-dropdown-container {
         position: relative;
         width: 100%;


### PR DESCRIPTION
`'prejoin-preview-dropdown-btn'` and `'prejoin-preview-dropdown-icon'` classes are already converted to JSS in `DropdownButton` component.
