### PR TITLE
fix(ios,build) use epoch seconds for build number

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -71,7 +71,7 @@ platform :ios do
 
     # Inrement the build number by 1
     increment_build_number(
-      build_number: latest_testflight_build_number + 1,
+      build_number: Time.now.to_i,
       xcodeproj: "app/app.xcodeproj"
     )
 


### PR DESCRIPTION
Avoids conflicts when a build is rejected by Apple since Fastlane cannot
detect it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
