### PR TITLE
fix(shared-video): Can't click controls

### DIFF
--- a/react/features/display-name/components/web/DominantSpeakerName.js
+++ b/react/features/display-name/components/web/DominantSpeakerName.js
@@ -22,6 +22,7 @@ const useStyles = makeStyles(theme => {
             justifyContent: 'center',
             marginBottom: theme.spacing(7),
             transition: 'margin-bottom 0.3s',
+            pointerEvents: 'none',
             position: 'absolute',
             bottom: 0,
             left: 0,


### PR DESCRIPTION
The Dominant speaker name badge was overlaping the shared video
controls  (audio level, play/pause, etc).

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
