### PR TITLE
fix: removed platformColor  from styles

### DIFF
--- a/react/features/video-menu/components/native/styles.js
+++ b/react/features/video-menu/components/native/styles.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { PlatformColor } from 'react-native';
-
 import {
     MD_FONT_SIZE,
     MD_ITEM_HEIGHT,
@@ -72,8 +70,7 @@ export default createStyleSheet({
     },
 
     dividerDialog: {
-        // eslint-disable-next-line new-cap
-        backgroundColor: PlatformColor('separator'),
+        backgroundColor: BaseTheme.palette.dividerColor,
         marginBottom: BaseTheme.spacing[3]
     },
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->


Using PlatformColor makes the app crash in react-native because it cant find any color with the name "separator", it seems that it's the only place where is used so I changed it to a constant color and now it works, i don't know if am missing something more here since I am still new to the codebase.

The error refers to the following color:

<img width="298" alt="Screenshot 2022-03-20 at 19 18 40" src="https://user-images.githubusercontent.com/54106114/159176772-d9b66ffb-405f-4426-ba33-fd724353e754.png">

Here are some videos of the process
Tested on Samsung galaxy s10 plus & samsung galaxy note 20 ultra ( on prod app and in debubbing)

### Video of the error
https://user-images.githubusercontent.com/54106114/159176879-c0441aab-3e2f-4c25-b8b7-ab1300f3ecb8.mp4
### Video after fix
https://user-images.githubusercontent.com/54106114/159176884-e37fd93d-d188-4ce2-b850-ccc535345513.mp4





