### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ var subdir = '<!--# echo var="subdir" default="" -->';
 var subdomain = '<!--# echo var="subdomain" default="" -->';
 
 if (subdomain) {
-    subdomain = subdomain.substr(0, subdomain.length - 1).split('.')
+    subdomain = subdomain.slice(0, -1).split('.')
         .join('_')
         .toLowerCase() + '.';
 }

--- a/index.html
+++ b/index.html
@@ -106,9 +106,9 @@
                         if (hashIdx === -1) {
                             href += separator + "rCounter=1";
                         } else {
-                            var hashPart = href.substr(hashIdx);
+                            var hashPart = href.slice(hashIdx);
 
-                            href = href.substr(0, hashIdx)
+                            href = href.slice(0, hashIdx)
                                 + separator + "rCounter=1" + hashPart;
                         }
                     } else {

--- a/react/features/app/actions.native.ts
+++ b/react/features/app/actions.native.ts
@@ -66,7 +66,7 @@ export function appNavigate(uri?: string, options: IReloadNowOptions = {}) {
                 // setters in order to reduce the risks of inconsistent state.
                 location.hostname = defaultLocation.hostname;
                 location.pathname
-                    = defaultLocation.pathname + location.pathname.substr(1);
+                    = defaultLocation.pathname + location.pathname.slice(1);
                 location.port = defaultLocation.port;
                 location.protocol = defaultLocation.protocol;
             } else {

--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -52,7 +52,7 @@ export function appNavigate(uri?: string) {
                 // setters in order to reduce the risks of inconsistent state.
                 location.hostname = defaultLocation.hostname;
                 location.pathname
-                    = defaultLocation.pathname + location.pathname.substr(1);
+                    = defaultLocation.pathname + location.pathname.slice(1);
                 location.port = defaultLocation.port;
                 location.protocol = defaultLocation.protocol;
             } else {

--- a/react/features/base/config/actions.ts
+++ b/react/features/base/config/actions.ts
@@ -134,7 +134,7 @@ export function setConfig(config: IConfig = {}) {
                     contextRoot
                 } = parseURIString(locationURL?.href);
 
-                bosh = `${protocol}//${host}${contextRoot || '/'}${bosh.substr(1)}`;
+                bosh = `${protocol}//${host}${contextRoot || '/'}${bosh.slice(1)}`;
             }
             config.bosh = bosh;
         }

--- a/react/features/base/connection/functions.ts
+++ b/react/features/base/connection/functions.ts
@@ -21,7 +21,7 @@ export function getCurrentConferenceUrl(stateful: IStateful) {
     }
 
     // Check if the URL doesn't end with a slash
-    if (currentUrl && currentUrl.substr(-1) === '/') {
+    if (currentUrl && currentUrl.slice(-1) === '/') {
         currentUrl = undefined;
     }
 

--- a/react/features/base/devices/functions.web.ts
+++ b/react/features/base/devices/functions.web.ts
@@ -261,7 +261,7 @@ export function formatDeviceLabel(label: string) {
     const ix = formattedLabel.lastIndexOf('(');
 
     if (ix !== -1) {
-        formattedLabel = formattedLabel.substr(0, ix);
+        formattedLabel = formattedLabel.slice(0, ix);
     }
 
     return formattedLabel;

--- a/react/features/base/util/parseURLParams.ts
+++ b/react/features/base/util/parseURLParams.ts
@@ -35,7 +35,7 @@ export function parseURLParams(
     }
     const paramStr = source === 'search' ? url.search : url.hash;
     const params: any = {};
-    const paramParts = paramStr?.substr(1).split('&') || [];
+    const paramParts = paramStr?.slice(1).split('&') || [];
 
     // Detect and ignore hash params for hash routers.
     if (source === 'hash' && paramParts.length === 1) {

--- a/react/features/deep-linking/functions.ts
+++ b/react/features/deep-linking/functions.ts
@@ -36,7 +36,7 @@ export function generateDeepLinkingURL(state: IReduxState) {
     // https://developer.chrome.com/multidevice/android/intents
     if (Platform.OS === 'android') {
         // https://meet.jit.si/foo -> meet.jit.si/foo
-        const url = href.replace(regex, '').substr(2);
+        const url = href.replace(regex, '').slice(2);
 
         return `intent://${url}#Intent;scheme=${appScheme};package=${appPackage};end`;
     }

--- a/react/features/dynamic-branding/components/native/BrandingImageBackground.tsx
+++ b/react/features/dynamic-branding/components/native/BrandingImageBackground.tsx
@@ -19,7 +19,7 @@ interface IProps {
  * @returns {ReactElement}
  */
 const BrandingImageBackground: React.FC<IProps> = ({ uri }: IProps) => {
-    const imageType = uri?.substr(uri.lastIndexOf('/') + 1);
+    const imageType = uri?.slice(uri.lastIndexOf('/') + 1);
     const imgSrc = uri ? uri : undefined;
 
     let backgroundImage;

--- a/react/features/gifs/function.any.ts
+++ b/react/features/gifs/function.any.ts
@@ -75,7 +75,7 @@ export function isGifMessage(message: string) {
 export function getGifUrl(gif?: { data?: { embed_url: string; }; embed_url?: string; }, proxyUrl?: string) {
     const embedUrl = gif?.embed_url || gif?.data?.embed_url || '';
     const idx = embedUrl.lastIndexOf('/');
-    const id = embedUrl.substr(idx + 1);
+    const id = embedUrl.slice(idx + 1);
 
     if (proxyUrl) {
         return `${proxyUrl}gifs/id/${id}`;

--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -160,7 +160,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
      */
     _animateRoomNameChanging(word: string) {
         let animateTimeoutId;
-        const roomPlaceholder = this.state.roomPlaceholder + word.substr(0, 1);
+        const roomPlaceholder = this.state.roomPlaceholder + word.slice(0, 1);
 
         if (word.length > 1) {
             animateTimeoutId


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.