### PR TITLE
fix(chat) Fix iOS web chat

### DIFF
--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -199,7 +199,6 @@ class Chat extends AbstractChat<Props> {
                     <ChatInput
                         onResize = { this._onChatInputResize }
                         onSend = { this._onSendMessage } />
-                    <KeyboardAvoider />
                 </div>
             </>
         );


### PR DESCRIPTION
Fixes: on iOS web the chat input would move from the bottom when the keyboard was open

