### PR TITLE
fix(context-menu) Don't overwrite hidden prop

### DIFF
--- a/react/features/base/components/context-menu/ContextMenu.js
+++ b/react/features/base/components/context-menu/ContextMenu.js
@@ -148,7 +148,7 @@ const ContextMenu = ({
 
             setIsHidden(false);
         } else {
-            setIsHidden(true);
+            hidden === undefined && setIsHidden(true);
         }
     }, [ entity, offsetTarget, _overflowDrawer ]);
 


### PR DESCRIPTION
Fixes issue where the menu would disappear on dominant speaker change
