### PR TITLE
implemented auto-mute setting and automute improvements

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -937,6 +937,7 @@
         "startReactionsMuted": "Mute reaction sounds for everyone",
         "startVideoMuted": "Everyone starts hidden",
         "talkWhileMuted": "Talk while muted",
+        "disableAutoMute": "Auto-Mute",
         "title": "Settings"
     },
     "settingsView": {
@@ -959,6 +960,7 @@
         "showAdvanced": "Show advanced settings",
         "startWithAudioMuted": "Start with audio muted",
         "startWithVideoMuted": "Start with video muted",
+        "disableAutoMute": "Disable Auto-Mute on Youtube playback.",
         "version": "Version"
     },
     "share": {

--- a/react/features/base/settings/functions.any.js
+++ b/react/features/base/settings/functions.any.js
@@ -277,3 +277,13 @@ export function shouldHideSelfView(state: Object) {
 export function getHideSelfView(state: Object) {
     return state['features/base/config'].disableSelfView || state['features/base/settings'].disableSelfView;
 }
+
+/**
+ * Gets the AutoMute setting for the youtube video share.
+ *
+ * @param {Object} state - Redux state.
+ * @returns {boolean}
+ */
+ export function getAutoMute(state: Object) {
+    return state['features/base/settings'].disableAutoMute;
+}

--- a/react/features/base/settings/reducer.js
+++ b/react/features/base/settings/reducer.js
@@ -22,6 +22,7 @@ const DEFAULT_STATE = {
     disableCrashReporting: undefined,
     disableP2P: undefined,
     disableSelfView: false,
+    disableAutoMute: false,
     displayName: undefined,
     email: undefined,
     localFlipX: true,

--- a/react/features/settings/actions.js
+++ b/react/features/settings/actions.js
@@ -116,6 +116,10 @@ export function submitMoreTab(newState: Object): Function {
         if (newState.hideSelfView !== currentState.hideSelfView) {
             dispatch(updateSettings({ disableSelfView: newState.hideSelfView }));
         }
+
+        if (newState.disableAutoMute !== currentState.disableAutoMute) {
+            dispatch(updateSettings({ disableAutoMute: newState.disableAutoMute }));
+        }
     };
 }
 

--- a/react/features/settings/components/web/MoreTab.js
+++ b/react/features/settings/components/web/MoreTab.js
@@ -13,6 +13,8 @@ import { translate } from '../../../base/i18n';
 import TouchmoveHack from '../../../chat/components/web/TouchmoveHack';
 import { SS_DEFAULT_FRAME_RATE } from '../../constants';
 
+const _disableAutoMute = "automute-disable"
+
 /**
  * The type of the React {@code Component} props of {@link MoreTab}.
  */
@@ -86,6 +88,11 @@ export type Props = {
     hideSelfView: boolean,
 
     /**
+     * boolean to disable mic auto mute when sharing a Youtube video
+     */
+    disableAutoMute: boolean,
+
+    /**
      * Invoked to obtain translated strings.
      */
     t: Function
@@ -136,6 +143,7 @@ class MoreTab extends AbstractDialogTab<Props, State> {
         this._onShowPrejoinPageChanged = this._onShowPrejoinPageChanged.bind(this);
         this._onKeyboardShortcutEnableChanged = this._onKeyboardShortcutEnableChanged.bind(this);
         this._onHideSelfViewChanged = this._onHideSelfViewChanged.bind(this);
+        this._ondisableAutoMuteChanged = this._ondisableAutoMuteChanged.bind(this);
     }
 
     /**
@@ -277,6 +285,21 @@ class MoreTab extends AbstractDialogTab<Props, State> {
         super._onChange({ hideSelfView: checked });
     }
 
+    _ondisableAutoMuteChanged: (Object) => void;
+
+    /**
+     * Callback invoked to select if the user
+     * should be automuted during youtube video playback.
+     *
+     * @param {Object} e - The key event to handle.
+     *
+     * @returns {void}
+     */
+    _ondisableAutoMuteChanged({ target: { checked } }) {
+        super._onChange({ disableAutoMute: checked });
+    }
+
+
     /**
      * Returns the React Element for the desktop share frame rate dropdown.
      *
@@ -379,6 +402,33 @@ class MoreTab extends AbstractDialogTab<Props, State> {
             </div>
         );
     }
+
+
+    /**
+     * Returns the React Element for Automute settings.
+     *
+     * @private
+     * @returns {ReactElement}
+     */
+     _renderdisableAutoMuteCheckbox() {
+        const { disableAutoMute, t} = this.props;
+
+        return (
+            <div
+                className = 'settings-sub-pane-element'
+                key = 'disableAutoMute'>
+                <h2 className = 'mock-atlaskit-label'>
+                    { t('settings.disableAutoMute') }
+                </h2>
+                <Checkbox
+                    isChecked = { disableAutoMute }
+                    label = { t('settingsView.disableAutoMute') }
+                    name = 'disable-auto-mute'
+                    onChange = { this._ondisableAutoMuteChanged } />
+            </div>
+        );
+    }
+
 
     /**
      * Returns the menu item for changing displayed language.
@@ -515,7 +565,7 @@ class MoreTab extends AbstractDialogTab<Props, State> {
      * @returns {ReactElement}
      */
     _renderSettingsLeft() {
-        const { disableHideSelfView, showNotificationsSettings, showPrejoinSettings } = this.props;
+        const { disableHideSelfView, showNotificationsSettings, showPrejoinSettings} = this.props;
 
         return (
             <div
@@ -525,6 +575,7 @@ class MoreTab extends AbstractDialogTab<Props, State> {
                 { showNotificationsSettings && this._renderNotificationsSettings() }
                 { this._renderKeyboardShortcutCheckbox() }
                 { !disableHideSelfView && this._renderSelfViewCheckbox() }
+                { this._renderdisableAutoMuteCheckbox() }
             </div>
         );
     }

--- a/react/features/settings/components/web/SettingsDialog.js
+++ b/react/features/settings/components/web/SettingsDialog.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 
 import { getAvailableDevices } from '../../../base/devices';
 import { DialogWithTabs, hideDialog } from '../../../base/dialog';
-import { connect } from '../../../base/redux';
+import { connect, toState } from '../../../base/redux';
 import { isCalendarEnabled } from '../../../calendar-sync';
 import {
     DeviceSelection,
@@ -144,7 +144,7 @@ function _mapStateToProps(state) {
     const moderatorTabProps = getModeratorTabProps(state);
     const { showModeratorSettings } = moderatorTabProps;
     const { showLanguageSettings, showNotificationsSettings, showPrejoinSettings } = moreTabProps;
-    const showMoreTab = showLanguageSettings || showNotificationsSettings || showPrejoinSettings;
+    const showMoreTab = showLanguageSettings || showNotificationsSettings || showPrejoinSettings || disableAutoMute;
     const showProfileSettings
         = configuredTabs.includes('profile') && !state['features/base/config'].disableProfile;
     const showCalendarSettings
@@ -200,10 +200,10 @@ function _mapStateToProps(state) {
 
                 return {
                     ...newProps,
-                    followMeEnabled: tabState?.followMeEnabled,
-                    startAudioMuted: tabState?.startAudioMuted,
-                    startVideoMuted: tabState?.startVideoMuted,
-                    startReactionsMuted: tabState?.startReactionsMuted
+                    followMeEnabled: tabState.followMeEnabled,
+                    startAudioMuted: tabState.startAudioMuted,
+                    startVideoMuted: tabState.startVideoMuted,
+                    startReactionsMuted: tabState.startReactionsMuted
                 };
             },
             styles: 'settings-pane moderator-pane',
@@ -242,11 +242,12 @@ function _mapStateToProps(state) {
 
                 return {
                     ...newProps,
-                    currentFramerate: tabState?.currentFramerate,
-                    currentLanguage: tabState?.currentLanguage,
-                    hideSelfView: tabState?.hideSelfView,
-                    showPrejoinPage: tabState?.showPrejoinPage,
-                    enabledNotifications: tabState?.enabledNotifications
+                    currentFramerate: tabState.currentFramerate,
+                    currentLanguage: tabState.currentLanguage,
+                    hideSelfView: tabState.hideSelfView,
+                    showPrejoinPage: tabState.showPrejoinPage,
+                    enabledNotifications: tabState.enabledNotifications,
+                    disableAutoMute: tabState.disableAutoMute,
                 };
             },
             styles: 'settings-pane more-pane',

--- a/react/features/settings/functions.js
+++ b/react/features/settings/functions.js
@@ -12,6 +12,7 @@ import { toState } from '../base/redux';
 import { getHideSelfView } from '../base/settings';
 import { parseStandardURIString } from '../base/util';
 import { isFollowMeActive } from '../follow-me';
+import { getAutoMute } from '../base/settings';
 import { isReactionsEnabled } from '../reactions/functions.any';
 
 import { SS_DEFAULT_FRAME_RATE, SS_SUPPORTED_FRAMERATES } from './constants';
@@ -115,7 +116,6 @@ export function getMoreTabProps(stateful: Object | Function) {
     const language = i18next.language || DEFAULT_LANGUAGE;
     const configuredTabs = interfaceConfig.SETTINGS_SECTIONS || [];
     const enabledNotifications = getNotificationsMap(stateful);
-
     // when self view is controlled by the config we hide the settings
     const { disableSelfView, disableSelfViewSettings } = state['features/base/config'];
 
@@ -130,7 +130,8 @@ export function getMoreTabProps(stateful: Object | Function) {
         enabledNotifications,
         showNotificationsSettings: Object.keys(enabledNotifications).length > 0,
         showPrejoinPage: !state['features/base/settings'].userSelectedSkipPrejoin,
-        showPrejoinSettings: state['features/base/config'].prejoinConfig?.enabled
+        showPrejoinSettings: state['features/base/config'].prejoinConfig?.enabled,
+        disableAutoMute: getAutoMute(state)
     };
 }
 

--- a/react/features/shared-video/components/web/YoutubeVideoManager.js
+++ b/react/features/shared-video/components/web/YoutubeVideoManager.js
@@ -152,6 +152,8 @@ class YoutubeVideoManager extends AbstractVideoManager {
             this.onPlay();
         } else if (event.data === YouTube.PlayerState.PAUSED) {
             this.onPause();
+        } else if (event.data === YouTube.PlayerState.ENDED) {
+            this.onEnd();
         }
     };
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

The auto-mute feature is handy for bigger groups. However it is rather unwelcome when you want to watch a video with a few friends from whom you want to hear some reaction.

Therefore I added a simple opt-out button on the more settings tab to disable this feature.

![image](https://user-images.githubusercontent.com/72016555/160980819-7b8de34b-2192-41a9-a355-abb3408e53ae.png)

Additionally, I implemented auto-unmute when the video pauses and/or ends.
For this I simply reused the Auto-mute function in reverse on pause and video-end.
