### PR TITLE
feat(polls/web) fixed issue with duplicating value to next input on keypress

### DIFF
--- a/react/features/polls/components/web/PollCreate.js
+++ b/react/features/polls/components/web/PollCreate.js
@@ -60,6 +60,18 @@ const PollCreate = (props: AbstractProps) => {
     }, [ lastFocus ]);
 
     const checkModifiers = useCallback(ev => {
+        // Composition events used to add accents to characters
+        // despite their absence from standard US keyboards,
+        // to build up logograms of many Asian languages
+        // from their base components or categories and so on.
+        if (ev.isComposing || ev.keyCode === 229) {
+            // keyCode 229 means that user pressed some button,
+            // but input method is still processing that.
+            // This is a standard behavior for some input methods
+            // like entering japanese or сhinese hieroglyphs.
+            return true;
+        }
+
         // Because this isn't done automatically on MacOS
         if (ev.key === 'Enter' && ev.metaKey) {
             ev.preventDefault();
@@ -90,7 +102,11 @@ const PollCreate = (props: AbstractProps) => {
         }
 
         if (ev.key === 'Enter') {
-            addAnswer(i + 1);
+            // We add a new option input
+            // only if we are on the last option input
+            if (i === answers.length - 1) {
+                addAnswer(i + 1);
+            }
             requestFocus(i + 1);
             ev.preventDefault();
         } else if (ev.key === 'Backspace' && ev.target.value === '' && answers.length > 1) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

On enter, input value doesn't get duplicated and added to the next input.
We only add a new option input, if we are on the last option input.

Fix for https://github.com/jitsi/brave-tracker/issues/78