### PR TITLE
fix(conference) Do not add audio track from screenshare to redux.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1633,7 +1633,8 @@ export default {
         // In case there was no local audio when screen sharing was started the fact that we set the audio stream to
         // null will take care of the desktop audio stream cleanup.
         } else if (this._desktopAudioStream) {
-            await this.useAudioStream(null);
+            await room.replaceTrack(this._desktopAudioStream, null);
+            this._desktopAudioStream.dispose();
             this._desktopAudioStream = undefined;
         }
 
@@ -1976,9 +1977,9 @@ export default {
                     } else {
                         // If no local stream is present ( i.e. no input audio devices) we use the screen share audio
                         // stream as we would use a regular stream.
-                        logger.debug(`_switchToScreenSharing is using ${this._desktopAudioStream} for useAudioStream`);
-                        await this.useAudioStream(this._desktopAudioStream);
-
+                        logger.debug(`_switchToScreenSharing is using ${this._desktopAudioStream} for replacing it as`
+                        + ' the only audio track on the conference');
+                        await room.replaceTrack(null, this._desktopAudioStream);
                     }
                     APP.store.dispatch(setScreenAudioShareState(true));
                 }


### PR DESCRIPTION
In audio-only screenshare mode when there is no local audio track from mic present, do not add the audio track from screenshare to redux. Adding the track to redux will sync the track mute state to that of /base/media and show that the mic is unmuted even when that is not the case. Fixes https://github.com/jitsi/jitsi-meet/issues/10706.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
