### PR TITLE
fix(multi-stream) only create fake screenshare participants when mult…

### DIFF
--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -6,7 +6,7 @@ import {
 } from '../../analytics';
 import { NOTIFICATION_TIMEOUT_TYPE, showErrorNotification, showNotification } from '../../notifications';
 import { getCurrentConference } from '../conference';
-import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../config';
+import { getMultipleVideoSupportFeatureFlag } from '../config';
 import { JitsiTrackErrors, JitsiTrackEvents, createLocalTrack } from '../lib-jitsi-meet';
 import {
     CAMERA_FACING_MODE,
@@ -397,7 +397,7 @@ export function trackAdded(track) {
         track.on(
             JitsiTrackEvents.TRACK_MUTE_CHANGED,
         () => {
-            if (getSourceNameSignalingFeatureFlag(getState()) && track.getVideoType() === VIDEO_TYPE.DESKTOP) {
+            if (getMultipleVideoSupportFeatureFlag(getState()) && track.getVideoType() === VIDEO_TYPE.DESKTOP) {
                 dispatch(screenshareTrackMutedChanged(track));
             }
             dispatch(trackMutedChanged(track));

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -8,7 +8,7 @@ import { shouldShowModeratedNotification } from '../../av-moderation/functions';
 import { hideNotification, isModerationNotificationDisplayed } from '../../notifications';
 import { isPrejoinPageVisible } from '../../prejoin/functions';
 import { getCurrentConference } from '../conference/functions';
-import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../config';
+import { getMultipleVideoSupportFeatureFlag } from '../config';
 import { getAvailableDevices } from '../devices/actions';
 import {
     CAMERA_FACING_MODE,
@@ -75,7 +75,7 @@ MiddlewareRegistry.register(store => next => action => {
             store.dispatch(getAvailableDevices());
         }
 
-        if (getSourceNameSignalingFeatureFlag(store.getState())
+        if (getMultipleVideoSupportFeatureFlag(store.getState())
             && action.track.jitsiTrack.videoType === VIDEO_TYPE.DESKTOP
             && !action.track.jitsiTrack.isMuted()
         ) {
@@ -95,7 +95,7 @@ MiddlewareRegistry.register(store => next => action => {
     case SCREENSHARE_TRACK_MUTED_UPDATED: {
         const state = store.getState();
 
-        if (!getSourceNameSignalingFeatureFlag(state)) {
+        if (!getMultipleVideoSupportFeatureFlag(state)) {
             return;
         }
 
@@ -118,7 +118,7 @@ MiddlewareRegistry.register(store => next => action => {
     case TRACK_REMOVED: {
         const state = store.getState();
 
-        if (getSourceNameSignalingFeatureFlag(state) && action.track.jitsiTrack.videoType === VIDEO_TYPE.DESKTOP) {
+        if (getMultipleVideoSupportFeatureFlag(state) && action.track.jitsiTrack.videoType === VIDEO_TYPE.DESKTOP) {
             const conference = getCurrentConference(state);
             const participantId = action.track.jitsiTrack.getSourceName();
 


### PR DESCRIPTION
…iple video support is enabled

Create a fake screenshare participant when multiple video support is enabled instead of only when source name is on.