### PR TITLE
update ljm 1649325751

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1411.0.0+6d8060a4/lib-jitsi-meet.tgz",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1412.0.0+832d7d35/lib-jitsi-meet.tgz",
         "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.1",
@@ -11795,8 +11795,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1411.0.0+6d8060a4/lib-jitsi-meet.tgz",
-      "integrity": "sha512-LrWpNHbXFLIuRFq9ygon1xuW+1Tac3qpSBp3O4QF03TR+DQpjSkvjYlXY/gw/2PK/Dgc2hXkvq6JvAudAHEJjA==",
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1412.0.0+832d7d35/lib-jitsi-meet.tgz",
+      "integrity": "sha512-QffTLTXyI7RAauRUULOtNlMWDU4XursMcREj6gFQTsYJ4A64rgNaJfd/G8sya7mRLrrj9jJ4yeLVfMQL/q11xg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
@@ -28795,8 +28795,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1411.0.0+6d8060a4/lib-jitsi-meet.tgz",
-      "integrity": "sha512-LrWpNHbXFLIuRFq9ygon1xuW+1Tac3qpSBp3O4QF03TR+DQpjSkvjYlXY/gw/2PK/Dgc2hXkvq6JvAudAHEJjA==",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1412.0.0+832d7d35/lib-jitsi-meet.tgz",
+      "integrity": "sha512-QffTLTXyI7RAauRUULOtNlMWDU4XursMcREj6gFQTsYJ4A64rgNaJfd/G8sya7mRLrrj9jJ4yeLVfMQL/q11xg==",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1411.0.0+6d8060a4/lib-jitsi-meet.tgz",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1412.0.0+832d7d35/lib-jitsi-meet.tgz",
     "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.1",


### PR DESCRIPTION
- fix(rn,remote-video-menu) fix import after refactor
- chore(deps) lib-jitsi-meet@latest
- chore(deps) lib-jitsi-meet@latest
- feat(breakout-rooms) add breakout-rooms
- fix(build) fix make dev with facial recognition worker
- fix(config) fix incorrect option name and whitelist it
- feat(video-quality): Always prioritize SS in tile view.
- fix(lang) update french translation
- fix(lang) update German translation
- fix(lang) update Arabic translation
- fix(lang) update Occitan translation
- fix(lang) update Russian translation
- fix(prejoin) Fix prejoin app
- fix(rn,welcome-page) don't create video track unnecessarily
- fix(Avatar): Display correctly any emoji/special character in a avatar initials
- fix(rn,sdk) remove deprecated color scheme prop
- fix(rn,sdk) drop deprecated option enableWelcomePage
- chore(breakout-rooms) Added analytics (#10421)
- fix(linguistics) Use 'email' instead of 'e-mail'
- feat(ui) updateTheme helper for client branding
- feat(ui) reverted tokens updates
- chore(deps) lib-jitsi-meet@latest
- fix: Updates the default value of rtcstatsEnabled to match the code. (#10425)
- fix(filmstrip) remove border from filmstrip (#10367)
- fix(rn, participants-pane) Show raised hand indicator (#10424)
- feat)rn,sdk) introduce a "ready to close" event
- fix(TileViewButton) fix on mobile
- fix(android) fixes error in BroadcastEvent
- feat(notifications) revisit timeouts and make them configurable
- fix(breakout-rooms) fix error in case main room is no longer available
- fix(breakout-rooms) simplify code
- fix(breakout-rooms) avoid accessing invalid room objects
- fix(breakout-rooms) cleanup code
- fix(lang) update translations for Catalan
- chore(deps) lib-jitsi-meet@latest (#10436)
- feat(load-test): Unmute video.
- fix(lang) update German translation
- chore(rn,deps) react-native-webrtc@1.94.0
- fix(android) set facebook groupId for all react-native dependencies
- fix(config) add transcribingEnabled to whitelist
- chore(deps) lib-jitsi-meet@latest
- fix(breakout-rooms) make sure the default name is monotonically increasing
- feat(conference) UI updates for mobile navigation bar (#10437)
- feat: (speaker-stats) add speaker stats feature to native
- fix(breakout-rooms) Improve breakout rooms
- fix(lang) update Polish translation
- fix(lang) update Polish translation
- feat(branding) added native extension to updateTheme helper
- fix(lint) fix all eslint warnings
- feat(lint) treat warnings as errors
- fix(ios) avoid creating CXProvider objects when CallKit is disabled
- fix(external-api) send AUDIO_MUTED_CHANGED event only when value changed
- feat(rtcstats): send facial expressions to rtcstats-server (#10461)
- fix(breakout-rooms) fix operations when inside a breakout room
- fix(rn,settings) only show "disable call integration" on Android
- fix(breakout-rooms) fix checking if a user is in a room
- feat(config) defaultLocalDisplayName and defaultRemoteDisplayName
- fix(share-video): stop video from the participant list
- feat: Enables muc rate limit for lobby and breakout muc components.
- feat: Add disableBeforeUnloadHandlers option
- chore(deps) lib-jitsi-meet@latest
- fix(conference) remove dead code
- fix(conference) simplify code
- fix(breakout-rooms) disable lobby in breakout rooms
- fix(breakout-rooms) disable recording and live-streaming
- fix(breakout-rooms) fix no video when coming back to main room
- fix: Fixes correct state in lobby screen on wrong password.
- Revert "fix(Prejoin): Make prejoin name noneditable only when taken from jwt"
- feat(conference) Implement audio/video mute disable when sender limit is reached.
- fix(gravatar): Add crossOrigin attribute.
- fix(lang) update German translation
- fix(breakout-rooms) fix when using tenants
- fix(modal) remove dead code
- fix(conference) fix broken dispatch on mobile
- fix(etherpad) fix loading Etherpad on web
- fix(participants) fix unpinning when switching conferences
- New strings translated
- fix(etherpad) fix Etherpad closing when dominant speaker changes
- fix(breakout-rooms) make sure participants in breakout rooms have a display name
- fix(dropbox): OAuth to use postMessage.
- feat: (speaker-stats) fix refresh and minor refactoring
- fix(rn,breakout-rooms) wait for the room to be left
- fix(rn,external-api) remove dead code
- feat(notifications) coalesce participant left and raised hand notifications
- fix(lang) update french translation + fix 2 existing translations
- fix(breakout-rooms) mark function as async
- fix(rn,conference) hide timer until it has started
- chore(deps) lib-jitsi-meet@latest
- feat(tile-view): allow disabling thumbnail enlargement
- chore(deps) lib-jitsi-meet@latest
- fix(rn,navbar) fix invalid boolean check
- feat(breakout-rooms) add notification when joining rooms
- fix(screen-sharing, picture-in-picture) re-enables PIP after stopping screen-share
- feat: (moderate-reaction-sounds) enable moderator to mute reaction sounds
- fix(lang) update German translation
- fix(lang) update french translation
- feat(external-api): enhance recordingLinkAvailable to provide ttl info
- fix(rn,chat): Fix chat and polls title
- fix(breakout-rooms) fix not waiting to leave the room
- fix(breakout,av-moderation): support non-ascii room names
- fix(breakout,av-moderation): support non-ascii tenant names
- fix(media) dispatch the unmute blocked action irrepective of the muted state. This fixes an issue where the user muted by focus is able to unmute themselves even when the sender limit has been reached.
- fix(lang) update Arabic translation
- fix(facial-expressions) load worker as a blob
- fix(lang) update Portuguese translation
- feat(prejoin) Add possibility to hide extra join options buttons (#10434)
- fix(lang) update Traditional Chinese (Taiwan) translation
- fix(lang) update sv translation
- fix(participants-list): Avoid ui moving on input focus
- feat(end-meet-for-all) Trigger notifyReadyToClose event on end meetin… (#10549)
- fix(virtual-backgrounds) fix error if we failed to load the model
- fix(virtual-backgrounds) make error message translatable
- fix(screenshot-capture) Update screenshot capture feature (#10443)
- chore(rn) updates react-native-webrtc
- chore(deps) lib-jitsi-meet@latest
- fix(overflow-drawer) Only use overflow drawer on mobile
- fix(breakout-rooms) fix non-functional context menu
- fix(rn) join conference if started by moderator
- fix(breakout-rooms) cleanup remote tracks when a conference is left
- feat(self-view) Added ability to hide self view
- fix(screenshot-capture) Use feature on web only
- fix(android) fix NoClassDefFoundError for Landroid/graphics/ColorSpace
- chore(deps) lib-jitsi-meet@latest (#10566)
- fix(browser-compatibility) hide launch in web for unsupported mobile browsers (#10569)
- fix(notifications) Create web middleware (#10568)
- fix(lang) update Catalan translation
- feat(chat) keyboard covering input on android fix
- feat(tracks) Clean up the track if a source addition is rejected. (#10562)
- fix(breakout-rooms) cleanup local tracks when a conference is left.
- fix(shortcuts) Ignore keyboard shortcuts when the button are disabled.
- fix(notifications) Adjust the timeout for unmute blocked notifications.
- chore(rn,versions) bump app and sdk versions
- fix(rn,breakout-rooms) fix not rendering display names
- fix(disableSelfView) Fix issue with remote participant video (#10582)
- fix(tracks) fix disposing of local tracks
- fix(rn,breakout-rooms) create desired local tracks when joining rooms
- fix(breakout-rooms) ensure we use the same media types when joining
- typo fix
- feat(index.html): Add fonts.html SSI.
- feat(security) created SecurityOptions React Navigation screen (#10509)
- chore(deps) lib-jitsi-meet@latest
- feat(media) Disable desktopshare when the video sender limit is reached.
- chore(deps) lib-jitsi-meet@latest
- fix(lang) update German translation
- fix(rn) fix broken mobile build
- feat(i18n): Allow label rewrite via advanced branding
- fix(Polls): Calculate vote percentage based on total number of votes
- fix(overflow-menu) Pin reactions on menu bottom on mobile web (#10599)
- fix(speaker-stats): prevent search from closing when enter pressed and from keeping previous state (#10597)
- feat(profile-settings): Hide email field under profile settings
- fix: Fixes disable moderation sounds in meeting. (#10604)
- fix(Avatar): Fix initials when avatar contains multiple special characters
- fix(Prejoin): Allow changing 'Enable pre meeting screen' option while prejoin screen visible
- fix(config.js) Added missing participant left notification key.
- fix(overflow-menu) Use fixed height only on drawer (#10612)
- fix: Respects disable reactions moderation flag for popups.
- fix: Use default remote display name in speaker stats when one is missing.
- fix(lang) update Dutch translations
- feat(thumbnail) Video thumbnails redesign and refactor (#10351)
- fix(lang) update Portuguese translation
- chore(deps) lib-jitsi-meet@latest
- Fix default values for hideConferenceSubject/-Timer
- fix: participant join notifications
- fix: Fixes destroying main room when breakout rooms are enabled.
- fix(tile-view) fix screensharing size in self view (#10634)
- fix: Fixes emitting conference left event in iframeAPI.
- fix(lang) update Spanish translation
- Self view refactor (#10620)
- feat: Update video receiver constraints to use source names (#10527)
- fix(breakout-rooms): Adds a check for missing room.
- feat(external-api): add local subject command (#10636)
- fix(breakout-rooms): close option shown to non-moderators (#10648)
- feat(chat/settings) - add ephemeral chat notifications with user settings support (#10617)
- fix(theme) Update colors (#10649)
- fix(lang) updated Arabic translation
- fix(breakout-rooms): Fix polls usage.
- feat(Avatar): CORS mode support.
- fix(rn, recording) adds _toggleScreenshotCapture function to AbstractStartRecordingDialog
- fix(rn, tileview) Add SafeAreaView to Tile View (#10642)
- feat(raise-hand) Update raised hand design (#10651)
- fix(speaker-stats): responsiveness of facial expressions (#10664)
- feat(config): add flag to hide the participant display name (#10650)
- fix(thumbnail) Update tile resizing constraints (#10645)
- fix(prejoin) Consider user selection for prejoin only on mount
- feat(conference-info) Updated title bar (#10670)
- feat(facial-expressions): send facial expressions to webhook endpoint (#10585)
- fix(participants-pane) Make search work with breakout rooms (#10668)
- fix(base) fixed text going out of share meeting container
- fix: Generates correct join error for lobby.  (#10673)
- fix: Fixes showing user region.
- feat: Drop unused constants.
- feat: Adds id to chat messages internal state.
- feat: Adds internal action for editing chat messages.
- feat: Edits messages display name on breakout info received. Fixes #10671.
- feat: Skips notifications for messages from history (the messages on join).
- Update main-nl.json
- fix(lang) updated Russian translation
- fix(lang) update french translation
- Update main-ar.json
- [i18n] Update for Polish (#10643)
- Add Dutch translations Participants Pane and Chat/Polls
- chore(deps) lib-jitsi-meet@latest
- Added translation of toolbar icons (#10563)
- fix: Add ipv6 networks to coturn's deny list.
- fix(lang) make fr language file format consistent
- fix(title-bar) Updated animation duration (#10688)
- fix: Fixes muted state for moderators when login (secure-domain).
- fix(breakout-rooms): Adds few nil checks in lua code.
- fix(lang) update Occitan translation
- fix(lang) update German translation
- fix(participants-pane) fix search value clear when closing pane
- feat(toolbar-button-clicked) Enhance toolbar buttons with notify click
- fix(aot) Let jitsi-meet-electron-sdk do the close (#10679)
- fix(lang) update Portuguese Translation
- fix(lang) update French translation
- fix(rn, recording) adds _toggleScreenshotCapture function to AbstractStopRecordingDialog
- fix(polls) use medium timeout for poll notifications
- fix(lang) update Catalan translation
- feat(virtual-backgrounds) use new Open Source model
- fix(lang) update Portuguese translation
- chore(deps) @react-native-async-storage/async-storage @ 1.15.14
- chore(deps) @amplitude/react-native @ 2.7.0
- chore(deps) @react-native-google-signin/google-signin @ 7.0.4
- chore(deps) @react-native-community/netinfo @ 7.1.7
- chore(deps) @react-native-community/slider @ 4.1.12
- chore(deps) react-native-background-timer @ 2.4.1
- chore(deps) react-native-calendar-events @ 2.2.0
- chore(deps) react-native-callstats @ 3.73.7
- chore(deps) react-native-collapsible @ 1.6.0
- chore(deps) react-native-default-preference @ latest
- chore(deps) react-native-device-info @ 8.4.8
- chore(deps) react-native-get-random-values @ 1.7.2
- chore(deps) react-native-performance @ 2.1.0
- chore(deps) react-native-sound @ 0.11.1
- chore(deps) react-native-splash-screen @ 3.3.0
- chore(deps) react-native-svg-transformer @ 1.0.0
- chore(deps) react-native-url-polyfill @ 1.3.0
- chore(deps) react-native-video @ 5.2.0
- chore(deps) react-native-watch-connectivity @ 1.0.4
- chore(deps) react-native-webview @ 11.15.0
- chore(deps) react-native-youtube-iframe @ 2.2.1
- fix(rn,android) adjust changed package names
- fix(toolbox) Disable screensharing button on mobile for video sender limit. Also, ignore the toggle screenshare shortcut when the video sender limit is reached.
- fix(rn,audio) fix playback after API change
- update react-native-paper to 4.11.1
- feat(participants-pane) hide admit all if knocking part < 2
- fix(rn, web) await initialisation before dispatching appWillMount
- feat(filmstrip) fixed context menus for thumbnail
- feat(conference) centered header navigation button
- feat(participants-pane) updated styles for add breakout and invite buttons
- fix: Fixes startWithAudioMuted on quickly moving away from pre-join screen.
- fix: Fixes start A/V muted received by focus in case of slow gUM.
- chore(deps) lib-jitsi-meet@latest
- fix(thresholds) adjust thresholds for smaller width integrations (#10749)
- fix(disableSelfView) Config overwrites settings (#10750)
- fix: still show menu to toggle self view if disableLocalVideoFlip (#10751)
- chore(deps) lib-jitsi-meet@latest
- feat(rn) update React Native to version 0.63
- fix(lint) tame Flow
- fix(rn,welcome) use native driver for opacity animation
- chore(deps,rn) update navigation librarries to their latest versions
- fix(jaas) log settings error
- chore(deps, rn) update react-native-webview
- fix(android) disables windows preview
- fix(android) restore executable flag on gradlew
- Persian translations (#10765)
- fix(rn) await for the promise in the _init object
- fix(toolbox) hide volume meter when audio levels are disabled
- feat: Updates reload reason.
- chore(deps) lib-jitsi-meet@latest
- fix(build) exit with error if any CSS step fails
- fix(thumbnail) Fix screenshare indicator (#10774)
- fix(config) Update comment for disableTileEnlargement (#10779)
- fix(thumbnail) Fixed screensharing indicator tooltip (#10780)
- fix(filmstrip) don't display filmstrip toggle in Jibri
- Revert "fix(Polls): Calculate vote percentage based on total number of votes" (#10781)
- fix(lang) update German translation
- feat(participants-pane) separated participants into collapsible lists
- feat(participants-pane) added style comments
- feat(title-bar) Updated title bar (#10752)
- fix(raised-hand) Preserve raised hand order for active speaker
- feat(rn,overflow-menu) remove duplicated buttons from overflow menu
- chore(rn,versions) bump app and sdk versions
- fix(breakout-rooms) joining room with hand raised bug Joining a room while hand is raised caused the local raised hand total to be wrong. This is because when the local participant id changes, the old id is not cleared from the raisedHandQueue.
- chore(translates) Merge main-es.json into main-esUS.json
- feat(filmstrip) Updated filmstrip design (#10791)
- lang fix syntax errors
- lang: Typo in lang pl
- fix(virtual-background): Prevent buttons repositioning on click action.
- ci: check language jsons if valid json
- fix(iframeAPI): startShareVideo command.
- lang: sort json keys
- chore(deps) lib-jitsi-meet@latest
- fix: Add min width to volume slider (#10808)
- chore(deps) lib-jitsi-meet@latest
- Fix Japanese translations
- lang: fix(lang) update Japanese translation
- fix(rn, conference): dispatch auth status changed in base/conference
- fix(rn) remove no longer needed hack
- fix(video-quality) fix not registering reducer on mobile
- feat(rn) update React Native to version 0.66
- feat(lint) drop Flow
- feat(rn,build) drop confusing commands
- fix(lang) fix default language selection
- ci: ensure that lang files stay sorted
- feat(lobby,notifications) refactor lobby notifications
- fix(ios) fix build with Xcode 13
- fix(screen-capture): disable.
- fix(raised-hand) lower raised hand by local audio level changes when participant is dominant
- fix(rn,build) fix use of "bare" relative path
- chore(deps) npm audit fix
- chore(deps) webpack-dev-server@4.7.3
- chore(deps) drop jsonlint
- fix(android) drop jcenter
- fix(screenshot-capture) Add initial state (#10827)
- fix(security-dialog) fix form event propagation after migrating to React 17
- fix(lang) update french translation
- chore(cleanup) delete dead code
- fix(lang) update Occitan translation
- feat(shared-video): show  invalid URL error.
- feat(lobby) removed native lobby enable/disable dialogs
- feat(ts) introduce TypeScript
- fix(build) remove double slashes
- feat(rn) use the TSC generated lib-jitsi-meet bundle
- fix(config): use hide display name flag for dominant speaker (#10839)
- feat(rn,app) unified navigators
- fix(rn,settings-drawer) allow for more width
- chore(deps) run npm audit fix
- fix(rn,navigation) fix navigating back to the welcome page
- feat(notification-button-testid): Add testid to notification buttons.
- feat(notification-button-testid): Add testid to notification buttons.
- fix(media) Deprecate startScreenSharing config option for web browsers. This is no longer supported as per the w3c spec for getDisplayMedia.
- fix: broken redirect for url with params when welcome page disable
- fix lint errors
- fix(lang, shared-video): Reference to YouTube
- feat(build) use lib-jitsi-meet release tarballs
- fix(tools) adapt update-ljm.sh to new ljm release mode
- chore(deps) lib-jitsi-meet@latest
- fix(notifications): support html descriptions
- fix(overflow-menu) hide "more moderation controls" option if moderator settings tab disabled
- fix(lang) update Japanese translation
- fix(screenshot-capture) Add initial call for region selection (#10818)
- fix(thumbnails) Change local thumbnail aspect ratio (#10861)
- fix(iAmRecorder): middleware bug
- fix(screenshot-capture) Updated feature (#10865)
- fix(lang) update Dutch translation
- feat(disableSelfView) Toggle self view on native (#10871)
- fix(lang) update Spanish translation
- feat(config) add ability to hide dominant speaker badge
- fix(util) never mark UUID room names as insecure
- fix: Fixes #10796 authentication in conference. (#10848)
- chore(deps) microsoft-graph-client@3.0.1
- fix(calendar-sync) remove unneeded function
- fix(lang) update Dutch translation
- fix(lang) update Dutch translation
- fix(config) document missing notification
- fix(title-bar) Fix native titlebar (#10882)
- fix: Restarts jvb after prosody on initial install.
- fix(lang) update Arabic translation
- feat(app) fix navigation from external link
- feat(welcome) blur room name input onListContainerPress
- feat(speaker-stats) new design for web and mobile
- feat(tileView): Display 3 participants in 1 row
- fix(thumbnail): mouse enter is not triggered
- feat(notifications) reset same type notification timeout
- feat(dialog) added react-native-dialog dep and updated ConfirmDialog
- feat(external-api) notify conference joined with room type flag
- fix(lang) update sq translation
- fix(facial-expressions): set screen size in worker and add constants for worker message types (#10678)
- feat(dialog) removed native CustomDialog
- fix(app) fix member count to filter out hidden participants
- feat(dialog) new native InputDialog
- feat(external-api) expose breakout rooms actions
- feat(external-api) add commands to open/close the participants pane
- feat(dialog) updated LoginDialog
- chore: update face-api (#10912)
- fix(toolbox) never show the toolbox for recorders
- fix(shared-video) use more space on recorders
- chore(deps) lib-jitsi-meet@latest. fix(ProxyConnection) set signaling layer by @saghul in #1862 fix: Fixes version while building. by @damencho in #1866 feat(multi-stream-support)Add support for multiple local and remote tracks/mediaType. by @jallamsetty1 in #1861 fix: Add private message handler for breakout_rooms by @steve-vsee in #1867 fix(JingleSessionPC) Do not force track removal at pc level on user leave. by @jallamsetty1 in #1869 feat(multi-stream-support) Handle SDP munging for multiple local/remote streams per ep. by @jallamsetty1 in #1868
- feat(toolbox) removed unused BetaTag component and styles
- fix(load-test) update package-lock.json to npm8
- fix(lang) update Dutch translation
- feat(dialog) change description text color
- chore(deps): bump simple-get from 3.1.0 to 3.1.1
- feat(dialog) start recording/live stream screens, new AlertDialog
- feat(dialog) refinaments
- fix(dialog) fixed translations
- chore(deps) lib-jitsi-meet@latest
- fix(lang) update french translation
- chore(deps) lib-jitsi-meet@latest
- fix: Fixes script with correct commit message.
- fix: Fixes reconnecting on pre-join screen in case of max users error.
- fix(lang) update German translation
- feat(navigation) two actions screen header buttons ui updates
- chore(deps): bump follow-redirects from 1.14.7 to 1.14.8
- feat(thumbnails, rn) Native thumbnails redesign (#10954)
- fix(breakout-rooms) close room before removing it (#10956)
- fix(video-quality-label) Open dialog also on audio-only mode (#10957)
- fix(breakout-rooms) Hide non-working options inside breakout rooms (#10959)
- chore(deps) update react-native-dialog
- chore(deps) lib-jitsi-meet@latest
- fix(context-menu) Add max height (#10965)
- fix: Fixes param in spanish translation.
- chore(deps) lib-jitsi-meet@latest
- Mobile UI polish (#10982)
- chore(deps) lib-jitsi-meet@latest
- fix: Fixes nil error while processing wrong jwt value. Fixes #10970
- feat: Handles hidden-from-recorder from jwt. (#10973)
- fix(ios) rework RN build workaround
- fix(speaker-stats): labels spearator line fixed and remove footer space
- feat(welcome) updated mobile ui styles
- fix(ios) make sure arm64 sim is not excluded
- chore(deps) react-native-webrtc@1.94.2
- chore(deps) lib-jitsi-meet@latest
- fix(android) initialize the fatal exception handler early
- feat(android) make application more akin to a greenfield RN app
- feat(rn) drop incoming call handling
- fix(toolbox) fixed toolbox safeareaview on mobile
- fix(rn,display-name) don't show display name for local user
- fix(calendar-sync) fixed pull to refresh on Calendar List mobile
- chore(deps) make sure no SSH URLs get generated in package-lock.json
- chore(deps) lib-jitsi-meet@latest
- fix(thumbnails) Revert local tile ratio (#11009)
- fix(mobile-ui) patch for native dialog container, fixed switch track color
- fix(lang) update sv translation
- feat(multi-stream-support) Replace participant connection status logic with track streaming status (#10934)
- fix(mobile-ui) ui fixes
- fix(rn,filmstrip) fix local participant location
- fix(thumbnails, rn) Hide empty indicators container on native (#11019)
- feat(filmstrip) Make filmstrip user resizable (#10884)
- chore(deps) lib-jitsi-meet@latest
- chore(deps) lib-jitsi-meet@latest
- fix(lint) don't check for Flow types on files without the annotation
- fix(facial-recognition) avoid image data conversion
- fix(filmstrip/toolbox) mobile ui adjustments
- fix(ios) fix for building for simulator on M1
- Fix initial volume value if value is 0
- Update main-sv.json
- feat(ios) Add support to the iOS SDK for the Simulator on M1
- fix(i18n) fix some country names
- fix(thumbnail) Fix pinned participant in the resizable filmstrip (#11042)
- feat(screenshare) Allow desktop sharing in audioOnly mode on web.
- feat(filmstrip/toolbox) mobile ui undo changes
- feat: Passing the url to conference mapper (#11013)
- fix(video-devices) Fix video devices not scrollable
- fix(external-api): dismiss lobby notification after handling the knocking participant (#11049)
- feat(filmstrip/toolbox) mobile ui updates (#11051)
- fix(screenshare) Add and then mute the camera track after SS stops instead of not adding the track. This is a follow up for https://github.com/jitsi/lib-jitsi-meet/pull/1944. This is needed to avoid sending a soure-remove followed by a source-add for the same ssrc. This happens when a users mutes camera->starts SS->stops SS->turns on camera on a p2p connection in Unified plan mode. Chrome fails to render the media if the same SSRC is removed and added back to the same m-line.
- chore(deps) lib-jitsi-meet@latest
- fix(lobby-notifications): Prevent lobby notification to remain on scr… (#11054)
- feat(external-api): expose config for breakout rooms (#11055)
- fix(filmstrip) Fix resizable filmstrip (#11025)
- fix: Fixes loading web on mobile browser.
- chore(deps) lib-jitsi-meet@latest
- fix(WaitForOwnerDialog) simplify code
- Enable polls for breakout rooms by default.
- fix(receiver constraints): source name not found
- fix: Fixes recording dialog web rendering.
- fix(dynamic-branding): Extract fqn from public meeting
- fix(popper): resolve @atlaskit/popper to an unbuggy version
- fix(premeeting): Improve pre-meeting responsiveness for screens less than 1000px
- feat: Lobby chat (#10847)
- fix(rn,dialogs,auth) fix not showing authentication dialogs
- fix(dominant-label) Fix dominant speaker stage view label (#11071)
- feat(face-centering) implement centering of faces in a video
- fix(video-layout):Screenshares not updated on time
- fix(lang) update German translation
- fix(conference) Disable audio-only mode when user switches to screenshare. Make the behavior consistent with enabling camera when the user is audio-only mode. Also fixes an issue where the screenshare preview doesn't appear if it is enabled while the user is in audio-only mode.
- feat(salesforce) - link resources to the current session (#10992)
- feat(display-name) remove DisplayNameLabel web
- deps(rn) react-native-webrtc@1.98.0
- chore(rn,versions) bump app versions
- fix(language) Add lang API option
- feat(recording) mobile and web ui updates
- fix(dynamic-branding) fix permissions screen not accounting for custom backgrounds (#11097)
- fix: Updates token verification hooks priority. (#11105)
- fix(screensharing) Fix screensharing container width (#11089)
- fix(prejoin) Fix layout on reduced height
- fix(letsencrypt) avoid using hardcoded path
- fix(lang) update Arabic translation
- feat(gif) Added GIF support (GIPHY integration) (#11021)
- Fix broken link in README.md to the handbook
- fix(lang) update Portuguese translation
- feat(toolbar) add flag for autohiding while chat open (#11104)
- feat(recording) allow highlighting meeting recording moments (#10981)
- fix(filmstrip) Fix resizable filmstrip with shared video (#11124)
- fix: Hides ask to unmute when av mod is disabled. Fixes #11057.
- fix: Hides ask to unmute when participant is audio unmuted.
- feat(remote-participant-menu) Enhance remote participant menu:
- fix(highlight) fix allowing disabled button to execute handler (#11128)
- refactor(keyboard-shortcuts) use jss instead of scss
- chore: remove unused modal ids constants (#11036)
- refactor(avatar) use jss instead of scss (#11037)
- refactor(prejoin) use jss instead of sass in DeviceStatus (#11116)
- refactor(speaker-stats) use jss instead of sass in SpeakerStats (#11121)
- fix(lang) update Arabic translation
- refactor(prejoin) use jss instead of sass in CallingDialog (#11117)
- refactor(premeeting): use jss instead of sass in ConnectionStatus (#11115)
- refactor(participnats-pane) move participant-avatar to commmonStyles (#11120)
- refactor(prejoin) use jss instead of sass in DialInDialog (#11122)
- fix(screenshot-capture): send remote participant id instead of jid (#11132)
- fix(lang) update french translation
- add(screenshot-capture): local participants id to participants array in metadata (#11134)
- feat(tile-view): Optimize grid dimnsions.
- fix(resizable-filmstrip): grid view paddings.
- chore(deps) lib-jitsi-meet@latest
- feat(multi-stream-support) Add screenshare as a second video track to the call.
- fix(config) add missing notify.hostAskedUnmute
- chore(deps) lib-jitsi-meet@latest
- feat(filmstrip): Don't reorder in small meetings.
- feature: patch for muc_owner_allow_kick in prosody 0.12 (#11142)
- fix(premeeting): call hooks before any conditional block in ConnectionStatus (#11136)
- Revert "deps(rn) react-native-webrtc@1.98.0"
- fix(premeeting): fix undefined breakpoint in media query (#11148)
- fix(resziable-filmstrip) Update video constraints on filmstrip resize (#11150)
- fix(salesforce): send link notes and default to empty string (#11160)
- fix(video-constraints) Fix calculations (#11161)
- feat: Use same recommendedBrowsers page for IE and browsers marked in interface_config.js (#10923)
- fix(ios,build) use epoch seconds for build number
- fix(mobile/navigations) added LoadConfigOverlay to RootNavigator (#11067)
- fix(css) remove no longer used AUI classes
- fix(config): add missing toolbar button config (#11165)
- fix(highlight) display option to start recording (#11146)
- fix(recording) fix incorrect condition for recording notification message (#11167)
- add(highlights): mobile flow (#11168)
- patch(react-native-dialog)- replaced PlatformColor with hardcoded colors on Android
- fix(highlight) fix notifications not disappearing (#11183)
- fix: removed platformColor  from styles
- task: mod_muc_password_whitelist prosody module (#11184)
- chore(deps) lib-jitsi-meet@latest
- fix(shared-video): Can't click controls issue
- refactor(premeeting): remove redundant styles from prejoin.scss (#11151)
- fix(settings-dialog) Fix crash (#11191)
- fix(mobile/navigation/sdk) - simplified check for sdk
- fix(mobile,navigation) remove end meeting page
- fix(chat) Fix iOS web chat (#11193)
- Update config.js with new e2eping properties. (#11195)
- chore(deps) lib-jitsi-meet@latest
- feat(external-api) Add grantModerator command (#11199)
- chore(deps) lib-jitsi-meet@latest
- fix(mobile/navigation) - fixed bottom color glitch
- fix(lobby) display the entire message in the reject notification
- fix(overlay) fix not showing the correct gUM helper text
- conf(nginx) add keepalive via upstream groups
- feat(reservations) add integration with mod_muc_max_occupants
- fix(rn,recording) fix start button not being enabled
- feat(participants/native) - updated container styles
- fix(lang) update Dutch translation
- fix(facial-expressions): base url for models (#11218)
- fix(highlight) implement custom notification for highlight start recording (#11217)
- fix(highlight) set highlight button visibility based on record button… (#11215)
- Increase the visibility of 404 error message (#11108)
- fix(rn,recording) fix recording dialog state not updating
- chore(deps) lib-jitsi-meet@latest
- fix(lang): update french translation
- fix(face-centering) fix face centering on browsers with no offscreencanvas support (#11234)
- fix(debian) support installing the prosody-0.12 upstream package
- fix(redux) fix not working with Redux Devtools
- feat: Adds a hint for cors headers in default prosody config.
- feat(stage) Add stage filmstrip (multiple participants on stage) (#11145)
- refactor(settings): use jss instead of css (#11149)
- refactor(dialog): use jss instead of sass for mute-dialog style (#11154)
- refactor: move chat component outside of videoconference_page (#11138)
- refactor(virtual-background): use jss instead of sass (#11152)
- refactor(connection-stats): use jss instead of sass in ConnectionStatsTable (#11156)
- fix(rn) Fix native after stage filmstrip merge (#11247)
- feat(participants/native) - fix joining breakout room
- fix(android,back-button) rework back button handling on Android
- fix(settings-dialog) Add back CSS classes used by tests
- fix(rn,lobby) fix lobby not showing up on subsequent tries
- fix(video-layout) fix incorrect import of isStageFilmstripEnabled
- fix(background-alpha) Fix setting background opacity
- Revert "fix(screenshare) Add and then mute the camera track after SS stops instead of not adding the track." This workaround is not needed anymore since P2P is disabled between plan-b and unified-plan clients. Fixes https://github.com/jitsi/jitsi-meet/issues/11131
- feat: Updates external-services.lua to latest.
- Add missing key to Persian lang file
- chore(deps): bump node-forge from 1.2.1 to 1.3.0
- fix(context-menu) Don't overwrite hidden prop (#11265)
- fix(gif) Keep showing GIF on hover (#11266)
- feat(gif, rn) Added GIPHY integration on native (#11236)
- fix(notifications) Change moderation notifications to medium (#11262)
- chore(deps) lib-jitsi-meet@latest
- Update Portuguese translation
- feat(ios) enable Dropbox recording
- fix(ios) cycle in dependancies with Xcode 13.3
- chore(deps): bump plist from 3.0.4 to 3.0.5
- chore(deps): bump ansi-regex from 4.1.0 to 4.1.1
- chore(deps): bump ansi-regex from 3.0.0 to 3.0.1 in /resources/load-test
- chore(deps): bump minimist from 1.2.5 to 1.2.6
- fix(thumbnails) Fix recalculate tile dimensions on client resize (#11267)
- feat(rn, thumbnail) Updated indicators on native (#11280)
- fix(ci) make the "dirty git tree" CI failure clearer
- fix(salesforce) use salesforce only in the main room (#11245)
- chore(deps) lib-jitsi-meet@latest (#11284)
- feat(android) use JitsiMeetView instead of JitsiMeetFragment
- fix(large-video) Show the pinned participant on large-video when stage filmstrip is disabled. Fixes an issue where a non-screenshare participant cannot be pinned on stage with filmstrip on stage feature disabled.
- Fixes for highlights mobile (#11209)
- Pushes e2e pings to rtcstats (#11270)
- feat(polls/web) fixed issue with duplicating value to next input on keypress
- feat(multi-stream) Update config.js.
- fix(lang): update french translation
- fix(lang) updated Arabic translation
- fix(highlights) allow highlighting moments if recording is running (#11301)
- ref(AOT) Change buttons to not use abstract classes (#11302)
- feat(participants-pane/native) adjusted styles for participants container
- fix(filmstrip) Fix resizing on chat toggle (#11305)
- feat(face-landmarks) merge face expressions and face centering (#11283)
- chore(rn,versions) bump app and sdk versions
- chore(deps) update react-native-webrtc to 1.100.0
- feat(multi-stream) Add fake participant tile for screen share.
- feat(multi-stream) Whitelist config flags for multi-stream.
- fix(conference) Do not add audio track from screenshare to redux. In audio-only screenshare mode when there is no local audio track from mic present, do not add the audio track from screenshare to redux. Adding the track to redux will sync the track mute state to that of /base/media and show that the mic is unmuted even when that is not the case. Fixes https://github.com/jitsi/jitsi-meet/issues/10706.
- chore(deps) lib-jitsi-meet@latest
- chore(deps) npm audit fix
- ref(overflow-menu) Use ContextMenu component (#11282)
- fix(follow-me) Make follow me work with stage filmstrip (#11306)
- fix(lang) update Russian translation
- fix(multi-stream) support screenshare tile in stage filmstrip
- fix(lang) update Portuguese Translation
- fix: leaking listeners while waiting on auth dialog (#11288)
- ref(face-landmarks) refactor namings (#11307)
- fix: Adds undefined check to avoid error.
- feat(stage-filmstrip) Added user configurable max (#11324)
- fix(rn,polyfills) remove no longer needed polyfill
- chore(deps) react-native-reanimated@1.13.4
- feat(rn,deps) update React Native to 0.67
- fix(rn) remove no longer needed hack
- feat(conference/native) - hide label in one to one meeting
- chore(deps) lib-jitsi-meet@latest
