### PR TITLE
fix(ios,broadcast-extension) remove unused import

### DIFF
--- a/ios/app/broadcast-extension/SampleHandler.swift
+++ b/ios/app/broadcast-extension/SampleHandler.swift
@@ -15,7 +15,6 @@
  */
 
 import ReplayKit
-import JitsiMeetSDK
 
 private enum Constants {
     // the App Group ID value that the app and the broadcast extension targets are setup with. It differs for each app.


### PR DESCRIPTION
It creates a compilation warning because it forces linking with the SDK.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
