### PR TITLE
fix(multi-stream) only create local ss particpant with multi-stream e…

### DIFF
--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -69,15 +69,23 @@ declare var APP: Object;
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
     case TRACK_ADDED: {
+        const state = store.getState();
+        const { jitsiTrack, local } = action.track;
+
         // The devices list needs to be refreshed when no initial video permissions
         // were granted and a local video track is added by umuting the video.
-        if (action.track.local) {
+        if (local) {
             store.dispatch(getAvailableDevices());
         }
 
-        if (getSourceNameSignalingFeatureFlag(store.getState())
-            && action.track.jitsiTrack.videoType === VIDEO_TYPE.DESKTOP
-            && !action.track.jitsiTrack.isMuted()
+        // The TRACK_ADDED action is dispatched when a presenter starts a screenshare. Do not create a local fake
+        // screenshare participant when multiple stream is not enabled.
+        const skipCreateFakeScreenShareParticipant = local && !getMultipleVideoSupportFeatureFlag(state);
+
+        if (getSourceNameSignalingFeatureFlag(state)
+            && jitsiTrack.getVideoType() === VIDEO_TYPE.DESKTOP
+            && !jitsiTrack.isMuted()
+            && !skipCreateFakeScreenShareParticipant
         ) {
             createFakeScreenShareParticipant(store, action);
         }


### PR DESCRIPTION
…nabled

w/ source name and w/o multi stream:
- As a presenter - we will not create a second screenshare tile.
- As a participant - it should still create a second tile if the remote endpoint has multi-stream enabled and sends a second video stream for SS
