### PR TITLE
fix(android) fix crash when starting foreground service

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
@@ -51,11 +51,20 @@ public class JitsiMeetOngoingConferenceService extends Service
         intent.setAction(Action.START.getName());
 
         ComponentName componentName;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            componentName = context.startForegroundService(intent);
-        } else {
-            componentName = context.startService(intent);
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                componentName = context.startForegroundService(intent);
+            } else {
+                componentName = context.startService(intent);
+            }
+        } catch (RuntimeException e) {
+            // Avoid crashing due to ForegroundServiceStartNotAllowedException (API level 31).
+            // See: https://developer.android.com/guide/components/foreground-services#background-start-restrictions
+            JitsiMeetLogger.w(TAG + " Ongoing conference service not started", e);
+            return;
         }
+
         if (componentName == null) {
             JitsiMeetLogger.w(TAG + " Ongoing conference service not started");
         }


### PR DESCRIPTION
If we attempt to start it while in the background we'll get a crash. A
more elegant fix would be to wait until the app transitions to the
foreground to start it, but the crash is hurting us now.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
