### PR TITLE
fix(avatar): add ZWNJ between initials of letter avatars

### DIFF
--- a/react/features/base/avatar/functions.js
+++ b/react/features/base/avatar/functions.js
@@ -68,7 +68,9 @@ export function getInitials(s: ?string) {
     const initialsBasis = _.split(s, '@')[0];
     const [ firstWord, secondWord ] = initialsBasis.split(wordSplitRegex).filter(Boolean);
 
-    return getFirstGraphemeUpper(firstWord) + getFirstGraphemeUpper(secondWord);
+    // Add ZWNJ to separate the initials in languages like Arabic or Persian.
+    return `${getFirstGraphemeUpper(firstWord)}\u200c${getFirstGraphemeUpper(secondWord)}`;
+
 }
 
 /**


### PR DESCRIPTION
Some languages have a separate representation for characters based on their context, placement in a word. The form of a character may be different if it is an isolated character, an initial character, a medial character, or a final character. See this [link](https://en.wikipedia.org/wiki/Persian_alphabet#Overview_table) showing different forms of a Persian character based on its context.

Usually for initials, the isolated form is displayed. This pull request adds a zero-width non-joiner between the initials, so the isolated form is rendered.