### PR TITLE
fix(stage-filmstrip) Fix issues

### DIFF
--- a/react/features/filmstrip/actionTypes.ts
+++ b/react/features/filmstrip/actionTypes.ts
@@ -170,3 +170,13 @@ export const SET_STAGE_PARTICIPANTS = 'SET_STAGE_PARTICIPANTS';
  * }
  */
 export const SET_MAX_STAGE_PARTICIPANTS = 'SET_MAX_STAGE_PARTICIPANTS';
+
+
+/**
+ * The type of Redux action which toggles the pin state of stage participants.
+ * {
+ *     type: TOGGLE_PIN_STAGE_PARTICIPANT,
+ *     participantId: String
+ * }
+ */
+export const TOGGLE_PIN_STAGE_PARTICIPANT = 'TOGGLE_PIN_STAGE_PARTICIPANT';

--- a/react/features/filmstrip/actions.web.js
+++ b/react/features/filmstrip/actions.web.js
@@ -23,7 +23,8 @@ import {
     SET_USER_IS_RESIZING,
     SET_VERTICAL_VIEW_DIMENSIONS,
     SET_VOLUME,
-    SET_MAX_STAGE_PARTICIPANTS
+    SET_MAX_STAGE_PARTICIPANTS,
+    TOGGLE_PIN_STAGE_PARTICIPANT
 } from './actionTypes';
 import {
     HORIZONTAL_FILMSTRIP_MARGIN,
@@ -447,5 +448,18 @@ export function setMaxStageParticipants(maxParticipants) {
     return {
         type: SET_MAX_STAGE_PARTICIPANTS,
         maxParticipants
+    };
+}
+
+/**
+ * Toggles the pin state of the given participant.
+ *
+ * @param {string} participantId - The id of the participant to be toggled.
+ * @returns {Object}
+ */
+export function togglePinStageParticipant(participantId) {
+    return {
+        type: TOGGLE_PIN_STAGE_PARTICIPANT,
+        participantId
     };
 }

--- a/react/features/filmstrip/components/web/ThumbnailWrapper.js
+++ b/react/features/filmstrip/components/web/ThumbnailWrapper.js
@@ -148,7 +148,8 @@ function _mapStateToProps(state, ownProps) {
     const sourceNameSignalingEnabled = getSourceNameSignalingFeatureFlag(state);
     const _verticalViewGrid = showGridInVerticalView(state);
     const stageFilmstrip = ownProps.data?.stageFilmstrip;
-    const remoteParticipants = stageFilmstrip ? activeParticipants : remote;
+    const sortedActiveParticipants = activeParticipants.sort();
+    const remoteParticipants = stageFilmstrip ? sortedActiveParticipants : remote;
     const remoteParticipantsLength = remoteParticipants.length;
     const localId = getLocalParticipant(state).id;
 

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -498,6 +498,7 @@ export function computeDisplayModeFromInput(input: Object) {
         isScreenSharing,
         canPlayEventReceived,
         isRemoteParticipant,
+        stageParticipantsVisible,
         tileViewActive
     } = input;
     const adjustedIsVideoPlayable = input.isVideoPlayable && (!isRemoteParticipant || canPlayEventReceived);
@@ -506,7 +507,8 @@ export function computeDisplayModeFromInput(input: Object) {
         return DISPLAY_VIDEO;
     }
 
-    if (!tileViewActive && ((isScreenSharing && isRemoteParticipant) || isActiveParticipant)) {
+    if (!tileViewActive && ((isScreenSharing && isRemoteParticipant)
+        || (stageParticipantsVisible && isActiveParticipant))) {
         return DISPLAY_AVATAR;
     } else if (isCurrentlyOnLargeVideo && !tileViewActive) {
         // Display name is always and only displayed when user is on the stage
@@ -537,6 +539,7 @@ export function getDisplayModeInput(props: Object, state: Object) {
         _isScreenSharing,
         _isVideoPlayable,
         _participant,
+        _stageParticipantsVisible,
         _videoTrack
     } = props;
     const tileViewActive = _currentLayout === LAYOUTS.TILE_VIEW;
@@ -554,6 +557,7 @@ export function getDisplayModeInput(props: Object, state: Object) {
         isRemoteParticipant: !_participant?.isFakeParticipant && !_participant?.local,
         isScreenSharing: _isScreenSharing,
         isFakeScreenShareParticipant: _isFakeScreenShareParticipant,
+        stageParticipantsVisible: _stageParticipantsVisible,
         videoStreamMuted: _videoTrack ? _videoTrack.muted : 'no stream'
     };
 }
@@ -674,7 +678,7 @@ export function getActiveParticipantsIds(state) {
  * Gets the ids of the active participants.
  *
  * @param {Object} state - Redux state.
- * @returns {Array<string>}
+ * @returns {Array<Object>}
  */
 export function getPinnedActiveParticipants(state) {
     const { activeParticipants } = state['features/filmstrip'];
@@ -686,16 +690,18 @@ export function getPinnedActiveParticipants(state) {
  * Get whether or not the stage filmstrip should be displayed.
  *
  * @param {Object} state - Redux state.
+ * @param {number} minParticipantCount - The min number of participants for the stage filmstrip
+ * to be displayed.
  * @returns {boolean}
  */
-export function shouldDisplayStageFilmstrip(state) {
+export function shouldDisplayStageFilmstrip(state, minParticipantCount = 2) {
     const { activeParticipants } = state['features/filmstrip'];
     const { remoteScreenShares } = state['features/video-layout'];
     const currentLayout = getCurrentLayout(state);
     const sharedVideo = isSharingStatus(state['features/shared-video']?.status);
 
     return isStageFilmstripEnabled(state) && remoteScreenShares.length === 0 && !sharedVideo
-        && activeParticipants.length > 1 && currentLayout === LAYOUTS.VERTICAL_FILMSTRIP_VIEW;
+        && activeParticipants.length >= minParticipantCount && currentLayout === LAYOUTS.VERTICAL_FILMSTRIP_VIEW;
 }
 
 /**

--- a/react/features/video-menu/components/web/TogglePinToStageButton.js
+++ b/react/features/video-menu/components/web/TogglePinToStageButton.js
@@ -6,8 +6,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import ContextMenuItem from '../../../base/components/context-menu/ContextMenuItem';
 import { IconPinParticipant, IconUnpin } from '../../../base/icons';
-import { addStageParticipant, removeStageParticipant } from '../../../filmstrip/actions.web';
-import { getActiveParticipantsIds } from '../../../filmstrip/functions';
+import { togglePinStageParticipant } from '../../../filmstrip/actions.web';
+import { getPinnedActiveParticipants } from '../../../filmstrip/functions.web';
 
 type Props = {
 
@@ -35,11 +35,10 @@ type Props = {
 const TogglePinToStageButton = ({ className, noIcon = false, onClick, participantID }: Props) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
-    const isActive = Boolean(useSelector(getActiveParticipantsIds).find(p => p === participantID));
+    const isActive = Boolean(useSelector(getPinnedActiveParticipants)
+        .find(p => p.participantId === participantID));
     const _onClick = useCallback(() => {
-        dispatch(isActive
-            ? removeStageParticipant(participantID)
-            : addStageParticipant(participantID, true));
+        dispatch(togglePinStageParticipant(participantID));
         onClick && onClick();
     }, [ participantID, isActive ]);
 


### PR DESCRIPTION
Fix dominant speaker not removed on leave
Fix video not shown in vertical filmstrip when a remote screensharing was on
Refactor pin/ unpin. Add click to unpin
Remove from stage on unpin, except dominant (just change pin state)
Fix local shows video on both stage and vertical filmstrip
Don't reorder on stage based on queue (sort all by id)
