### PR TITLE
Fix mobile web toolbox

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1,5 +1,7 @@
 // @flow
 
+import _ from 'lodash';
+
 import { withStyles } from '@material-ui/core/styles';
 import React, { Component } from 'react';
 import { batch } from 'react-redux';
@@ -917,7 +919,7 @@ class Toolbox extends Component<Props> {
         const keys = Object.keys(buttons);
 
         const filtered = [
-            ...order.map(key => buttons[key]),
+            ...order.map(key => _.find(buttons, b => b?.key === key)),
             ...Object.values(buttons).filter((button, index) => !order.includes(keys[index]))
         ].filter(Boolean).filter(({ key, alias = NOT_APPLICABLE }) =>
             isToolbarButtonEnabled(key, _toolbarButtons) || isToolbarButtonEnabled(alias, _toolbarButtons));

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1,8 +1,7 @@
 // @flow
 
-import _ from 'lodash';
-
 import { withStyles } from '@material-ui/core/styles';
+import _ from 'lodash';
 import React, { Component } from 'react';
 import { batch } from 'react-redux';
 
@@ -82,7 +81,12 @@ import {
     setToolbarHovered,
     showToolbox
 } from '../../actions';
-import { THRESHOLDS, NOT_APPLICABLE, NOTIFY_CLICK_MODE } from '../../constants';
+import {
+    THRESHOLDS,
+    THRESHOLDS_MOBILE_WEB,
+    NOT_APPLICABLE,
+    NOTIFY_CLICK_MODE
+} from '../../constants';
 import { isDesktopShareButtonDisabled, isToolboxVisible } from '../../functions';
 import DownloadButton from '../DownloadButton';
 import HangupButton from '../HangupButton';
@@ -904,6 +908,7 @@ class Toolbox extends Component<Props> {
     _getVisibleButtons() {
         const {
             _clientWidth,
+            _isMobile,
             _toolbarButtons
         } = this.props;
 
@@ -912,12 +917,11 @@ class Toolbox extends Component<Props> {
 
         this._setButtonsNotifyClickMode(buttons);
         const isHangupVisible = isToolbarButtonEnabled('hangup', _toolbarButtons);
-        const { order } = THRESHOLDS.find(({ width }) => _clientWidth > width)
-            || THRESHOLDS[THRESHOLDS.length - 1];
+        const thresholds = _isMobile ? THRESHOLDS_MOBILE_WEB : THRESHOLDS;
+        const { order } = thresholds.find(({ width }) => _clientWidth > width)
+            || thresholds[thresholds.length - 1];
         let sliceIndex = order.length + 2;
-
         const keys = Object.keys(buttons);
-
         const filtered = [
             ...order.map(key => _.find(buttons, b => b?.key === key)),
             ...Object.values(buttons).filter((button, index) => !order.includes(keys[index]))

--- a/react/features/toolbox/constants.js
+++ b/react/features/toolbox/constants.js
@@ -4,15 +4,15 @@
 export const THRESHOLDS = [
     {
         width: 520,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants', 'tileview' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane', 'tileview' ]
     },
     {
         width: 470,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane' ]
     },
     {
         width: 420,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'participants' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'participants-pane' ]
     },
     {
         width: 370,

--- a/react/features/toolbox/constants.js
+++ b/react/features/toolbox/constants.js
@@ -16,7 +16,37 @@ export const THRESHOLDS = [
     },
     {
         width: 370,
-        order: [ 'microphone', 'camera', 'chat', 'participants' ]
+        order: [ 'microphone', 'camera', 'chat', 'participants-pane' ]
+    },
+    {
+        width: 225,
+        order: [ 'microphone', 'camera', 'chat' ]
+    },
+    {
+        width: 200,
+        order: [ 'microphone', 'camera' ]
+    }
+];
+
+/**
+ * Thresholds for displaying toolbox buttons on mobile web browsers.
+ */
+export const THRESHOLDS_MOBILE_WEB = [
+    {
+        width: 520,
+        order: [ 'microphone', 'camera', 'chat', 'toggle-camera', 'raisehand', 'participants-pane', 'tileview' ]
+    },
+    {
+        width: 470,
+        order: [ 'microphone', 'camera', 'chat', 'toggle-camera', 'raisehand', 'participants-pane' ]
+    },
+    {
+        width: 420,
+        order: [ 'microphone', 'camera', 'chat', 'toggle-camera', 'participants-pane' ]
+    },
+    {
+        width: 370,
+        order: [ 'microphone', 'camera', 'chat', 'toggle-camera' ]
     },
     {
         width: 225,


### PR DESCRIPTION
Use different thresholds on mobile web to show more relevant buttons.

Before:
<img width="2672" alt="Screenshot 2022-04-14 at 14 22 37" src="https://user-images.githubusercontent.com/317464/163409847-0c406c00-1a74-48a3-873d-0b99e2c0415d.png">

After:
<img width="442" alt="Screenshot 2022-04-14 at 15 46 42" src="https://user-images.githubusercontent.com/317464/163409840-b38ce248-f4f2-42d5-9f7e-d5383258e54a.png">
