### PR TITLE
fix: Skips clearing tracks on conference failed.

### DIFF
--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -318,9 +318,10 @@ MiddlewareRegistry.register(store => next => action => {
 StateListenerRegistry.register(
     state => getCurrentConference(state),
     (conference, { dispatch, getState }, prevConference) => {
+        const { authRequired, error } = getState()['features/base/conference'];
 
         // conference keep flipping while we are authenticating, skip clearing while we are in that process
-        if (prevConference && !conference && !getState()['features/base/conference'].authRequired) {
+        if (prevConference && !conference && !authRequired && !error) {
 
             // Clear all tracks.
             const remoteTracks = getState()['features/base/tracks'].filter(t => !t.local);


### PR DESCRIPTION
In case of conference failed as max number of occupants reached, we should skip clearing the local tracks to keep state of pre-join screen. Otherwise, on join we will join muted even though on prejoin screen it was unmuted on the initial attempt.

