### PR TITLE
fix(multi-stream) Do not show join notifications for SS tiles.

### DIFF
--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -210,14 +210,22 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case PARTICIPANT_JOINED: {
-        _maybePlaySounds(store, action);
+        const { isFakeScreenShareParticipant } = action.participant;
+
+        // Do not play sounds when a fake participant tile is created for screenshare.
+        !isFakeScreenShareParticipant && _maybePlaySounds(store, action);
 
         return _participantJoinedOrUpdated(store, next, action);
     }
 
-    case PARTICIPANT_LEFT:
-        _maybePlaySounds(store, action);
+    case PARTICIPANT_LEFT: {
+        const { isFakeScreenShareParticipant } = action.participant;
+
+        // Do not play sounds when a tile for screenshare is removed.
+        !isFakeScreenShareParticipant && _maybePlaySounds(store, action);
+
         break;
+    }
 
     case PARTICIPANT_UPDATED:
         return _participantJoinedOrUpdated(store, next, action);

--- a/react/features/notifications/middleware.js
+++ b/react/features/notifications/middleware.js
@@ -128,7 +128,12 @@ MiddlewareRegistry.register(store => next => action => {
         const { participant: p } = action;
         const { conference } = state['features/base/conference'];
 
-        if (conference && !p.local && !joinLeaveNotificationsDisabled() && !p.isReplacing) {
+        // Do not display notifications for the fake screenshare tiles.
+        if (conference
+            && !p.local
+            && !p.isFakeScreenShareParticipant
+            && !joinLeaveNotificationsDisabled()
+            && !p.isReplacing) {
             dispatch(showParticipantJoinedNotification(
                 getParticipantDisplayName(state, p.id)
             ));
@@ -143,7 +148,11 @@ MiddlewareRegistry.register(store => next => action => {
                 action.participant.id
             );
 
-            if (participant && !participant.local && !action.participant.isReplaced) {
+            // Do not display notifications for the fake screenshare tiles.
+            if (participant
+                && !participant.local
+                && !participant.isFakeScreenShareParticipant
+                && !action.participant.isReplaced) {
                 dispatch(showParticipantLeftNotification(
                     getParticipantDisplayName(state, participant.id)
                 ));


### PR DESCRIPTION
Do not show join notifications or play sounds when the fake participant tile for Screenshare is added or removed with multi-steam mode.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
