### PR TITLE
fix(premeeting) Detach premeeting toolbar buttons visibility

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -1430,14 +1430,7 @@ function _mapStateToProps(state, ownProps) {
         }
     }
 
-    let { toolbarButtons } = ownProps;
-    const stateToolbarButtons = getToolbarButtons(state);
-
-    if (toolbarButtons) {
-        toolbarButtons = toolbarButtons.filter(name => isToolbarButtonEnabled(name, stateToolbarButtons));
-    } else {
-        toolbarButtons = stateToolbarButtons;
-    }
+    const toolbarButtons = ownProps.toolbarButtons || getToolbarButtons(state);
 
     return {
         _backgroundType: state['features/virtual-background'].backgroundType,


### PR DESCRIPTION
- if hiddenPremeetingButtons is undefined, toolbarButtons overwrite decides what buttons to show
- if hiddenPremeetingButtons is empty array, all buttons are show on premeeting screen regardless of toolbarButtons
- if hiddenPremeetingButtons hides some buttons, only those buttons will be hidden regardless of toolbarButtons overwrite

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
