### PR TITLE
feat(multi-stream) support mix of plan b and unified plan endpoints 

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2268,7 +2268,7 @@ export default {
 
                 if (fakeScreenshareParticipantId) {
                     APP.store.dispatch(
-                            screenshareParticipantDisplayNameChanged(fakeScreenshareParticipantId, formattedDisplayName)
+                        screenshareParticipantDisplayNameChanged(fakeScreenshareParticipantId, formattedDisplayName)
                     );
                 }
 

--- a/conference.js
+++ b/conference.js
@@ -56,8 +56,7 @@ import {
 } from './react/features/base/conference';
 import {
     getReplaceParticipant,
-    getMultipleVideoSendingSupportFeatureFlag,
-    getSourceNameSignalingFeatureFlag
+    getMultipleVideoSendingSupportFeatureFlag
 } from './react/features/base/config/functions';
 import {
     checkAndNotifyForNewDevice,
@@ -97,7 +96,7 @@ import {
     dominantSpeakerChanged,
     getLocalParticipant,
     getNormalizedDisplayName,
-    getScreenshareParticipantByOwnerId,
+    getFakeScreenshareParticipantByOwnerId,
     localParticipantAudioLevelChanged,
     localParticipantConnectionStatusChanged,
     localParticipantRoleChanged,
@@ -2265,14 +2264,12 @@ export default {
                     name: formattedDisplayName
                 }));
 
-                if (getSourceNameSignalingFeatureFlag(state)) {
-                    const screenshareParticipantId = getScreenshareParticipantByOwnerId(state, id)?.id;
+                const fakeScreenshareParticipantId = getFakeScreenshareParticipantByOwnerId(state, id)?.id;
 
-                    if (screenshareParticipantId) {
-                        APP.store.dispatch(
-                            screenshareParticipantDisplayNameChanged(screenshareParticipantId, formattedDisplayName)
-                        );
-                    }
+                if (fakeScreenshareParticipantId) {
+                    APP.store.dispatch(
+                            screenshareParticipantDisplayNameChanged(fakeScreenshareParticipantId, formattedDisplayName)
+                    );
                 }
 
                 APP.API.notifyDisplayNameChanged(id, {

--- a/conference.js
+++ b/conference.js
@@ -56,7 +56,7 @@ import {
 } from './react/features/base/conference';
 import {
     getReplaceParticipant,
-    getMultipleVideoSupportFeatureFlag,
+    getMultipleVideoSendingSupportFeatureFlag,
     getSourceNameSignalingFeatureFlag
 } from './react/features/base/config/functions';
 import {
@@ -1472,7 +1472,7 @@ export default {
 
                 // In the multi-stream mode, add the track to the conference if there is no existing track, replace it
                 // otherwise.
-                if (getMultipleVideoSupportFeatureFlag(state)) {
+                if (getMultipleVideoSendingSupportFeatureFlag(state)) {
                     const trackAction = oldTrack
                         ? replaceLocalTrack(oldTrack, newTrack, room)
                         : addLocalTrack(newTrack);

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -287,14 +287,17 @@ export default class LargeVideoManager {
 
             const isAudioOnly = APP.conference.isAudioOnly();
 
-            // For Plan B enbdpoints with multi-stream support, display an avatar for the original thumbnail.
-            const planBScreenShare = getMultipleVideoSupportFeatureFlag(state)
+            // Multi-stream is not supported on plan-b endpoints even if its is enabled via config.js. A fake
+            // screenshare tile is still created when a remote endpoint starts screenshare to keep the behavior
+            // consistent and an avatar is displayed on the original participant thumbnail as long as screenshare is in
+            // progress.
+            const legacyScreenshare = getMultipleVideoSupportFeatureFlag(state)
                                         && videoType === VIDEO_TYPE.DESKTOP
                                         && !participant.isFakeScreenShareParticipant;
 
             const showAvatar
                 = isVideoContainer
-                    && ((isAudioOnly && videoType !== VIDEO_TYPE.DESKTOP) || !isVideoRenderable || planBScreenShare);
+                    && ((isAudioOnly && videoType !== VIDEO_TYPE.DESKTOP) || !isVideoRenderable || legacyScreenshare);
 
             let promise;
 

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -9,7 +9,10 @@ import { Provider } from 'react-redux';
 import { createScreenSharingIssueEvent, sendAnalytics } from '../../../react/features/analytics';
 import { Avatar } from '../../../react/features/base/avatar';
 import theme from '../../../react/features/base/components/themes/participantsPaneTheme.json';
-import { getSourceNameSignalingFeatureFlag } from '../../../react/features/base/config';
+import {
+    getMultipleVideoSupportFeatureFlag,
+    getSourceNameSignalingFeatureFlag
+} from '../../../react/features/base/config';
 import { i18next } from '../../../react/features/base/i18n';
 import { JitsiTrackEvents } from '../../../react/features/base/lib-jitsi-meet';
 import { VIDEO_TYPE } from '../../../react/features/base/media';
@@ -283,9 +286,15 @@ export default class LargeVideoManager {
             }
 
             const isAudioOnly = APP.conference.isAudioOnly();
+
+            // For Plan B enbdpoints with multi-stream support, display an avatar for the original thumbnail.
+            const planBScreenShare = getMultipleVideoSupportFeatureFlag(state)
+                                        && videoType === VIDEO_TYPE.DESKTOP
+                                        && !participant.isFakeScreenShareParticipant;
+
             const showAvatar
                 = isVideoContainer
-                    && ((isAudioOnly && videoType !== VIDEO_TYPE.DESKTOP) || !isVideoRenderable);
+                    && ((isAudioOnly && videoType !== VIDEO_TYPE.DESKTOP) || !isVideoRenderable || planBScreenShare);
 
             let promise;
 

--- a/react/features/base/conference/middleware.web.js
+++ b/react/features/base/conference/middleware.web.js
@@ -9,7 +9,7 @@ import {
 import { setScreenAudioShareState, setScreenshareAudioTrack } from '../../screen-share';
 import { AudioMixerEffect } from '../../stream-effects/audio-mixer/AudioMixerEffect';
 import { setAudioOnly } from '../audio-only';
-import { getMultipleVideoSupportFeatureFlag } from '../config/functions.any';
+import { getMultipleVideoSendingSupportFeatureFlag } from '../config/functions.any';
 import { JitsiConferenceErrors, JitsiTrackErrors } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, setScreenshareMuted, VIDEO_TYPE } from '../media';
 import { MiddlewareRegistry } from '../redux';
@@ -51,7 +51,7 @@ MiddlewareRegistry.register(store => next => action => {
         break;
     }
     case TOGGLE_SCREENSHARING: {
-        getMultipleVideoSupportFeatureFlag(getState()) && _toggleScreenSharing(action, store);
+        getMultipleVideoSendingSupportFeatureFlag(getState()) && _toggleScreenSharing(action, store);
 
         break;
     }

--- a/react/features/base/config/functions.any.js
+++ b/react/features/base/config/functions.any.js
@@ -51,15 +51,24 @@ export function getMeetingRegion(state: Object) {
 }
 
 /**
- * Selector used to get the sendMultipleVideoStreams feature flag.
+ * Selector for determining if receiving multiple stream support is enabled.
  *
  * @param {Object} state - The global state.
  * @returns {boolean}
  */
 export function getMultipleVideoSupportFeatureFlag(state: Object) {
     return getFeatureFlag(state, FEATURE_FLAGS.MULTIPLE_VIDEO_STREAMS_SUPPORT)
-        && getSourceNameSignalingFeatureFlag(state)
-        && isUnifiedPlanEnabled(state);
+        && getSourceNameSignalingFeatureFlag(state);
+}
+
+/**
+ * Selector for determining if sending multiple stream support is enabled.
+ *
+ * @param {Object} state - The global state.
+ * @returns {boolean}
+ */
+export function getMultipleVideoSendingSupportFeatureFlag(state: Object) {
+    return getMultipleVideoSupportFeatureFlag(state) && isUnifiedPlanEnabled(state);
 }
 
 /**

--- a/react/features/base/media/middleware.js
+++ b/react/features/base/media/middleware.js
@@ -16,7 +16,7 @@ import { isForceMuted } from '../../participants-pane/functions';
 import { isScreenMediaShared } from '../../screen-share/functions';
 import { SET_AUDIO_ONLY, setAudioOnly } from '../audio-only';
 import { isRoomValid, SET_ROOM } from '../conference';
-import { getMultipleVideoSupportFeatureFlag } from '../config';
+import { getMultipleVideoSendingSupportFeatureFlag } from '../config';
 import { getLocalParticipant } from '../participants';
 import { MiddlewareRegistry } from '../redux';
 import { getPropertyValue } from '../settings';
@@ -192,7 +192,7 @@ function _setAudioOnly({ dispatch, getState }, next, action) {
 
     // Make sure we mute both the desktop and video tracks.
     dispatch(setVideoMuted(audioOnly, MEDIA_TYPE.VIDEO, VIDEO_MUTISM_AUTHORITY.AUDIO_ONLY, ensureVideoTrack));
-    if (getMultipleVideoSupportFeatureFlag(state)) {
+    if (getMultipleVideoSendingSupportFeatureFlag(state)) {
         dispatch(setScreenshareMuted(audioOnly, MEDIA_TYPE.SCREENSHARE, SCREENSHARE_MUTISM_AUTHORITY.AUDIO_ONLY));
     } else if (navigator.product !== 'ReactNative') {
         dispatch(setVideoMuted(audioOnly, MEDIA_TYPE.PRESENTER, VIDEO_MUTISM_AUTHORITY.AUDIO_ONLY, ensureVideoTrack));

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -504,6 +504,35 @@ export function participantMutedUs(participant, track) {
 }
 
 /**
+ * Action to create a fake screen share participant.
+ *
+ * @param {(JitsiLocalTrack|JitsiRemoteTrack)} track - JitsiTrack instance.
+ * @returns {Function}
+ */
+export function createFakeScreenShareParticipant(track) {
+    return (dispatch, getState) => {
+        const state = getState();
+        const participantId = track.getParticipantId();
+        const participant = getParticipantById(state, participantId);
+        const sourceName = track.getSourceName();
+
+        if (!participant.name) {
+            logger.error(`Failed to create a screenshare participant for sourceName: ${sourceName}`);
+
+            return;
+        }
+
+        dispatch(participantJoined({
+            conference: state['features/base/conference'].conference,
+            id: sourceName,
+            isFakeScreenShareParticipant: true,
+            isLocalScreenShare: track.isLocal(),
+            name: participant.name
+        }));
+    };
+}
+
+/**
  * Action to signal that a participant had been kicked.
  *
  * @param {JitsiParticipant} kicker - Information about participant performing the kick.

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -10,7 +10,7 @@ import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag }
 import { JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, shouldRenderVideoTrack } from '../media';
 import { toState } from '../redux';
-import { getTrackByMediaTypeAndParticipant } from '../tracks';
+import { getScreenShareTrack, getTrackByMediaTypeAndParticipant } from '../tracks';
 import { createDeferred } from '../util';
 
 import { JIGASI_PARTICIPANT_ICON, MAX_DISPLAY_NAME_LENGTH, PARTICIPANT_ROLE } from './constants';
@@ -113,7 +113,7 @@ export function getFakeScreenshareParticipantByOwnerId(stateful: Object | Functi
     const state = toState(stateful);
 
     if (getMultipleVideoSupportFeatureFlag(state)) {
-        const track = getTrackByMediaTypeAndParticipant(state['features/base/tracks'], MEDIA_TYPE.SCREENSHARE, id);
+        const track = getScreenShareTrack(state['features/base/tracks'], id);
 
         return getParticipantById(stateful, track?.jitsiTrack.getSourceName());
     }

--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -6,20 +6,15 @@ import type { Store } from 'redux';
 import { i18next } from '../../base/i18n';
 import { isStageFilmstripAvailable } from '../../filmstrip/functions';
 import { GRAVATAR_BASE_URL, isCORSAvatarURL } from '../avatar';
-import { getSourceNameSignalingFeatureFlag } from '../config';
+import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../config';
 import { JitsiParticipantConnectionStatus } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, shouldRenderVideoTrack } from '../media';
 import { toState } from '../redux';
 import { getTrackByMediaTypeAndParticipant } from '../tracks';
 import { createDeferred } from '../util';
 
-import {
-    JIGASI_PARTICIPANT_ICON,
-    MAX_DISPLAY_NAME_LENGTH,
-    PARTICIPANT_ROLE
-} from './constants';
+import { JIGASI_PARTICIPANT_ICON, MAX_DISPLAY_NAME_LENGTH, PARTICIPANT_ROLE } from './constants';
 import { preloadImage } from './preloadImage';
-
 
 /**
  * Temp structures for avatar urls to be checked/preloaded.
@@ -114,12 +109,16 @@ export function getLocalScreenShareParticipant(stateful: Object | Function) {
  * @param {string} id - The owner ID of the screenshare participant to retrieve.
  * @returns {(Participant|undefined)}
  */
-export function getScreenshareParticipantByOwnerId(stateful: Object | Function, id: string) {
-    const track = getTrackByMediaTypeAndParticipant(
-        toState(stateful)['features/base/tracks'], MEDIA_TYPE.SCREENSHARE, id
-    );
+export function getFakeScreenshareParticipantByOwnerId(stateful: Object | Function, id: string) {
+    const state = toState(stateful);
 
-    return getParticipantById(stateful, track?.jitsiTrack.getSourceName());
+    if (getMultipleVideoSupportFeatureFlag(state)) {
+        const track = getTrackByMediaTypeAndParticipant(state['features/base/tracks'], MEDIA_TYPE.SCREENSHARE, id);
+
+        return getParticipantById(stateful, track?.jitsiTrack.getSourceName());
+    }
+
+    return;
 }
 
 /**

--- a/react/features/base/tracks/actionTypes.ts
+++ b/react/features/base/tracks/actionTypes.ts
@@ -108,18 +108,6 @@ export const TRACK_STOPPED = 'TRACK_STOPPED';
 export const TRACK_UPDATED = 'TRACK_UPDATED';
 
 /**
- * The type of redux action dispatched when a screenshare track's muted property were updated.
- *
- * {
- *     type: SCREENSHARE_TRACK_MUTED_UPDATED,
- *     track: Track,
- *     muted: Boolean
- *  
- * }
- */
- export const SCREENSHARE_TRACK_MUTED_UPDATED = 'SCREENSHARE_TRACK_MUTED_UPDATED';
-
-/**
  * The type of redux action dispatched when a local track starts being created
  * via a WebRTC {@code getUserMedia} call. The action's payload includes an
  * extra {@code gumProcess} property which is a {@code Promise} with an extra

--- a/react/features/base/tracks/actions.js
+++ b/react/features/base/tracks/actions.js
@@ -6,7 +6,7 @@ import {
 } from '../../analytics';
 import { NOTIFICATION_TIMEOUT_TYPE, showErrorNotification, showNotification } from '../../notifications';
 import { getCurrentConference } from '../conference';
-import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../config';
+import { getMultipleVideoSendingSupportFeatureFlag, getMultipleVideoSupportFeatureFlag } from '../config';
 import { JitsiTrackErrors, JitsiTrackEvents } from '../lib-jitsi-meet';
 import { createLocalTrack } from '../lib-jitsi-meet/functions';
 import {
@@ -59,7 +59,7 @@ export function addLocalTrack(newTrack) {
         }
 
         const setMuted = newTrack.isVideoTrack()
-            ? getMultipleVideoSupportFeatureFlag(getState())
+            ? getMultipleVideoSendingSupportFeatureFlag(getState())
             && newTrack.getVideoType() === VIDEO_TYPE.DESKTOP
                 ? setScreenshareMuted
                 : setVideoMuted
@@ -370,7 +370,8 @@ function replaceStoredTracks(oldTrack, newTrack) {
             // state. If this is not done, the current mute state of the app will be reflected on the track,
             // not vice-versa.
             const setMuted = newTrack.isVideoTrack()
-                ? getMultipleVideoSupportFeatureFlag(getState()) && newTrack.getVideoType() === VIDEO_TYPE.DESKTOP
+                ? getMultipleVideoSendingSupportFeatureFlag(getState())
+                    && newTrack.getVideoType() === VIDEO_TYPE.DESKTOP
                     ? setScreenshareMuted
                     : setVideoMuted
                 : setAudioMuted;
@@ -417,7 +418,8 @@ export function trackAdded(track) {
 
         // participantId
         const local = track.isLocal();
-        const mediaType = getMultipleVideoSupportFeatureFlag(getState()) && track.getVideoType() === VIDEO_TYPE.DESKTOP
+        const mediaType = getMultipleVideoSendingSupportFeatureFlag(getState())
+            && track.getVideoType() === VIDEO_TYPE.DESKTOP
             ? MEDIA_TYPE.SCREENSHARE
             : track.getType();
         let isReceivingData, noDataFromSourceNotificationInfo, participantId;

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -1,6 +1,9 @@
 /* global APP */
 
-import { getMultipleVideoSendingSupportFeatureFlag } from '../config/functions.any';
+import {
+    getMultipleVideoSendingSupportFeatureFlag,
+    getMultipleVideoSupportFeatureFlag
+} from '../config/functions.any';
 import { isMobileBrowser } from '../environment/utils';
 import JitsiMeetJS, { JitsiTrackErrors, browser } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, VIDEO_TYPE, setAudioMuted } from '../media';
@@ -451,18 +454,44 @@ export function getTrackByMediaTypeAndParticipant(
 }
 
 /**
- * Returns track of given fakeScreenshareParticipantId.
+ * Returns screenshare track of given fakeScreenshareParticipantId.
  *
  * @param {Track[]} tracks - List of all tracks.
  * @param {string} fakeScreenshareParticipantId - Fake Screenshare Participant ID.
  * @returns {(Track|undefined)}
  */
 export function getFakeScreenshareParticipantTrack(tracks, fakeScreenshareParticipantId) {
-    const participantId = getFakeScreenShareParticipantOwnerId(fakeScreenshareParticipantId);
+    const ownderId = getFakeScreenShareParticipantOwnerId(fakeScreenshareParticipantId);
 
+    return getScreenShareTrack(tracks, ownderId);
+}
+
+/**
+ * Returns track source names of given screen share participant ids.
+ *
+ * @param {Object} state - The entire redux state.
+ * @param {string[]} screenShareParticipantIds - Participant ID.
+ * @returns {(string[])}
+ */
+export function getRemoteScreenSharesSourceNames(state, screenShareParticipantIds = []) {
+    const tracks = state['features/base/tracks'];
+
+    return getMultipleVideoSupportFeatureFlag(state)
+        ? screenShareParticipantIds
+        : screenShareParticipantIds.map(id => getScreenShareTrack(tracks, id).jitsiTrack.getSourceName());
+}
+
+/**
+ * Returns screenshare track of given owner ID.
+ *
+ * @param {Track[]} tracks - List of all tracks.
+ * @param {string} ownerId - Screenshare track owner ID.
+ * @returns {(Track|undefined)}
+ */
+export function getScreenShareTrack(tracks, ownerId) {
     return tracks.find(
         t => Boolean(t.jitsiTrack)
-        && t.participantId === participantId
+        && t.participantId === ownerId
         && (t.mediaType === MEDIA_TYPE.SCREENSHARE || t.videoType === VIDEO_TYPE.DESKTOP)
     );
 }

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -1,6 +1,6 @@
 /* global APP */
 
-import { getMultipleVideoSupportFeatureFlag } from '../config/functions.any';
+import { getMultipleVideoSendingSupportFeatureFlag } from '../config/functions.any';
 import { isMobileBrowser } from '../environment/utils';
 import JitsiMeetJS, { JitsiTrackErrors, browser } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, VIDEO_TYPE, setAudioMuted } from '../media';
@@ -607,7 +607,7 @@ export function setTrackMuted(track, muted, state) {
     // browser's 'Stop sharing' button, the local stream is stopped before the inactive stream handler is fired.
     // We still need to proceed here and remove the track from the peerconnection.
     if (track.isMuted() === muted
-        && !(track.getVideoType() === VIDEO_TYPE.DESKTOP && getMultipleVideoSupportFeatureFlag(state))) {
+        && !(track.getVideoType() === VIDEO_TYPE.DESKTOP && getMultipleVideoSendingSupportFeatureFlag(state))) {
         return Promise.resolve();
     }
 

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -426,18 +426,11 @@ export function getVideoTrackByParticipant(
         return;
     }
 
-    let participantId;
-    let mediaType;
-
     if (participant?.isFakeScreenShareParticipant) {
-        participantId = getFakeScreenShareParticipantOwnerId(participant.id);
-        mediaType = MEDIA_TYPE.SCREENSHARE;
-    } else {
-        participantId = participant.id;
-        mediaType = MEDIA_TYPE.VIDEO;
+        return getFakeScreenshareParticipantTrack(tracks, participant.id);
     }
 
-    return getTrackByMediaTypeAndParticipant(tracks, mediaType, participantId);
+    return getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, participant.id);
 }
 
 /**
@@ -467,7 +460,11 @@ export function getTrackByMediaTypeAndParticipant(
 export function getFakeScreenshareParticipantTrack(tracks, fakeScreenshareParticipantId) {
     const participantId = getFakeScreenShareParticipantOwnerId(fakeScreenshareParticipantId);
 
-    return getTrackByMediaTypeAndParticipant(tracks, MEDIA_TYPE.SCREENSHARE, participantId);
+    return tracks.find(
+        t => Boolean(t.jitsiTrack)
+        && t.participantId === participantId
+        && (t.mediaType === MEDIA_TYPE.SCREENSHARE || t.videoType === VIDEO_TYPE.DESKTOP)
+    );
 }
 
 /**

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -24,11 +24,10 @@ import {
     setScreenshareMuted,
     SCREENSHARE_MUTISM_AUTHORITY
 } from '../media';
-import { participantLeft, participantJoined, getParticipantById } from '../participants';
+import { createFakeScreenShareParticipant, participantLeft } from '../participants';
 import { MiddlewareRegistry, StateListenerRegistry } from '../redux';
 
 import {
-    SCREENSHARE_TRACK_MUTED_UPDATED,
     TOGGLE_SCREENSHARING,
     TRACK_ADDED,
     TRACK_MUTE_UNMUTE_FAILED,
@@ -52,7 +51,6 @@ import {
     isUserInteractionRequiredForUnmute,
     setTrackMuted
 } from './functions';
-import logger from './logger';
 
 import './subscriber';
 
@@ -91,7 +89,7 @@ MiddlewareRegistry.register(store => next => action => {
             && !jitsiTrack.isMuted()
             && !skipCreateFakeScreenShareParticipant
         ) {
-            createFakeScreenShareParticipant(store, action);
+            store.dispatch(createFakeScreenShareParticipant(jitsiTrack));
         }
 
         return result;
@@ -102,29 +100,6 @@ MiddlewareRegistry.register(store => next => action => {
         _handleNoDataFromSourceErrors(store, action);
 
         return result;
-    }
-
-    case SCREENSHARE_TRACK_MUTED_UPDATED: {
-        const state = store.getState();
-
-        if (!getSourceNameSignalingFeatureFlag(state)) {
-            return;
-        }
-
-        const { track, muted } = action;
-
-        if (muted) {
-            const conference = getCurrentConference(state);
-            const participantId = track?.jitsiTrack.getSourceName();
-
-            store.dispatch(participantLeft(participantId, conference));
-        }
-
-        if (!muted) {
-            createFakeScreenShareParticipant(store, action);
-        }
-
-        break;
     }
 
     case TRACK_REMOVED: {
@@ -379,32 +354,6 @@ function _handleNoDataFromSourceErrors(store, action) {
 
             dispatch(trackNoDataFromSourceNotificationInfoChanged(jitsiTrack, { timeout }));
         }
-    }
-}
-
-/**
- * Creates a fake participant for screen share using the track's source name as the participant id.
- *
- * @param {Store} store - The redux store in which the specified action is dispatched.
- * @param {Action} action - The redux action dispatched in the specified store.
- * @private
- * @returns {void}
- */
-function createFakeScreenShareParticipant({ dispatch, getState }, { track }) {
-    const state = getState();
-    const participantId = track.jitsiTrack?.getParticipantId?.();
-    const participant = getParticipantById(state, participantId);
-
-    if (participant.name) {
-        dispatch(participantJoined({
-            conference: state['features/base/conference'].conference,
-            id: track.jitsiTrack.getSourceName(),
-            isFakeScreenShareParticipant: true,
-            isLocalScreenShare: track?.jitsiTrack.isLocal(),
-            name: participant.name
-        }));
-    } else {
-        logger.error(`Failed to create a screenshare participant for participantId: ${participantId}`);
     }
 }
 

--- a/react/features/base/tracks/middleware.js
+++ b/react/features/base/tracks/middleware.js
@@ -83,14 +83,9 @@ MiddlewareRegistry.register(store => next => action => {
         // the participant is auto pinned.
         const result = next(action);
 
-        // The TRACK_ADDED action is dispatched when a presenter starts a screenshare. Do not create a local fake
-        // screenshare participant when multiple stream is not enabled.
-        const skipCreateFakeScreenShareParticipant = local && !getMultipleVideoSendingSupportFeatureFlag(state);
-
         if (getMultipleVideoSupportFeatureFlag(state)
             && jitsiTrack.getVideoType() === VIDEO_TYPE.DESKTOP
             && !jitsiTrack.isMuted()
-            && !skipCreateFakeScreenShareParticipant
         ) {
             store.dispatch(createFakeScreenShareParticipant(jitsiTrack));
         }

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 
 import { createScreenSharingIssueEvent, sendAnalytics } from '../../../analytics';
 import { Avatar } from '../../../base/avatar';
-import { getSourceNameSignalingFeatureFlag } from '../../../base/config';
+import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../../../base/config';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { JitsiTrackEvents } from '../../../base/lib-jitsi-meet';
 import { MEDIA_TYPE, VideoTrack } from '../../../base/media';
@@ -1277,6 +1277,7 @@ function _mapStateToProps(state, ownProps): Object {
         _isTestModeEnabled: isTestModeEnabled(state),
         _isVideoPlayable: id && isVideoPlayable(state, id),
         _localFlipX: Boolean(localFlipX),
+        _multipleVideoSupport: getMultipleVideoSupportFeatureFlag(state),
         _participant: participant,
         _raisedHand: hasRaisedHand(participant),
         _stageFilmstripLayout: isStageFilmstripAvailable(state),

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -513,14 +513,23 @@ export function computeDisplayModeFromInput(input: Object) {
         isScreenSharing,
         canPlayEventReceived,
         isRemoteParticipant,
+        multipleVideoSupport,
         stageParticipantsVisible,
         stageFilmstrip,
         tileViewActive
     } = input;
     const adjustedIsVideoPlayable = input.isVideoPlayable && (!isRemoteParticipant || canPlayEventReceived);
 
-    if (isFakeScreenShareParticipant) {
-        return DISPLAY_VIDEO;
+    if (multipleVideoSupport) {
+        // Display video for fake screen share participants in all layouts.
+        if (isFakeScreenShareParticipant) {
+            return DISPLAY_VIDEO;
+        }
+
+        // For Plan B enbdpoints with multi-stream support, display an avatar for the original thumbnail.
+        if (isScreenSharing && isRemoteParticipant) {
+            return DISPLAY_AVATAR;
+        }
     }
 
     if (!tileViewActive && ((isScreenSharing && isRemoteParticipant)
@@ -554,6 +563,7 @@ export function getDisplayModeInput(props: Object, state: Object) {
         _isFakeScreenShareParticipant,
         _isScreenSharing,
         _isVideoPlayable,
+        _multipleVideoSupport,
         _participant,
         _stageParticipantsVisible,
         _videoTrack,
@@ -574,6 +584,7 @@ export function getDisplayModeInput(props: Object, state: Object) {
         isRemoteParticipant: !_participant?.isFakeParticipant && !_participant?.local,
         isScreenSharing: _isScreenSharing,
         isFakeScreenShareParticipant: _isFakeScreenShareParticipant,
+        multipleVideoSupport: _multipleVideoSupport,
         stageParticipantsVisible: _stageParticipantsVisible,
         stageFilmstrip,
         videoStreamMuted: _videoTrack ? _videoTrack.muted : 'no stream'

--- a/react/features/filmstrip/functions.web.js
+++ b/react/features/filmstrip/functions.web.js
@@ -526,8 +526,10 @@ export function computeDisplayModeFromInput(input: Object) {
             return DISPLAY_VIDEO;
         }
 
-        // For Plan B enbdpoints with multi-stream support, display an avatar for the original thumbnail.
-        if (isScreenSharing && isRemoteParticipant) {
+        // Multi-stream is not supported on plan-b endpoints even if its is enabled via config.js. A fake screenshare
+        // tile is still created when a remote endpoint starts screenshare to keep the behavior consistent and an
+        // avatar is displayed on the original participant thumbnail as long as screenshare is in progress.
+        if (isScreenSharing) {
             return DISPLAY_AVATAR;
         }
     }

--- a/react/features/screen-share/actions.js
+++ b/react/features/screen-share/actions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getMultipleVideoSupportFeatureFlag } from '../base/config/functions.any';
+import { getMultipleVideoSendingSupportFeatureFlag } from '../base/config/functions.any';
 import { openDialog } from '../base/dialog/actions';
 import { browser } from '../base/lib-jitsi-meet';
 import { shouldHideShareAudioHelper } from '../base/settings';
@@ -86,7 +86,7 @@ export function startAudioScreenShareFlow() {
         // available for audio screen sharing, namely full window audio.
         // If we're already sharing audio, toggle off.
         if (shouldHideShareAudioHelper(state) || browser.isElectron() || audioOnlySharing) {
-            if (getMultipleVideoSupportFeatureFlag(state)) {
+            if (getMultipleVideoSendingSupportFeatureFlag(state)) {
                 dispatch(toggleScreensharing(!audioOnlySharing, true));
 
                 return;

--- a/react/features/video-layout/subscriber.js
+++ b/react/features/video-layout/subscriber.js
@@ -2,7 +2,7 @@
 
 import debounce from 'lodash/debounce';
 
-import { getSourceNameSignalingFeatureFlag } from '../base/config';
+import { getMultipleVideoSupportFeatureFlag } from '../base/config';
 import { StateListenerRegistry, equals } from '../base/redux';
 import { isFollowMeActive } from '../follow-me';
 
@@ -12,7 +12,7 @@ import { getAutoPinSetting, updateAutoPinnedParticipant } from './functions';
 StateListenerRegistry.register(
     /* selector */ state => state['features/base/participants'].sortedRemoteFakeScreenShareParticipants,
     /* listener */ (sortedRemoteFakeScreenShareParticipants, store) => {
-        if (!getAutoPinSetting() || isFollowMeActive(store) || !getSourceNameSignalingFeatureFlag(store.getState())) {
+        if (!getAutoPinSetting() || isFollowMeActive(store) || !getMultipleVideoSupportFeatureFlag(store.getState())) {
             return;
         }
 
@@ -53,7 +53,7 @@ StateListenerRegistry.register(
         // possible to have screen sharing participant that has already left in the remoteScreenShares array.
         // This can lead to rendering a thumbnails for already left participants since the remoteScreenShares
         // array is used for building the ordered list of remote participants.
-        if (!getAutoPinSetting() || isFollowMeActive(store) || getSourceNameSignalingFeatureFlag(store.getState())) {
+        if (!getAutoPinSetting() || isFollowMeActive(store) || getMultipleVideoSupportFeatureFlag(store.getState())) {
             return;
         }
 

--- a/react/features/video-quality/subscriber.js
+++ b/react/features/video-quality/subscriber.js
@@ -7,7 +7,7 @@ import { getSourceNameSignalingFeatureFlag } from '../base/config';
 import { MEDIA_TYPE } from '../base/media';
 import { getLocalParticipant, getParticipantCount } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
-import { getTrackSourceNameByMediaTypeAndParticipant } from '../base/tracks';
+import { getRemoteScreenSharesSourceNames, getTrackSourceNameByMediaTypeAndParticipant } from '../base/tracks';
 import { reportError } from '../base/util';
 import { getActiveParticipantsIds } from '../filmstrip/functions.web';
 import {
@@ -238,6 +238,8 @@ function _updateReceiverVideoConstraints({ getState }) {
     let receiverConstraints;
 
     if (sourceNameSignaling) {
+        const remoteScreenSharesSourceNames = getRemoteScreenSharesSourceNames(state, remoteScreenShares);
+
         receiverConstraints = {
             constraints: {},
             defaultConstraints: { 'maxHeight': VIDEO_QUALITY_LEVELS.NONE },
@@ -253,7 +255,7 @@ function _updateReceiverVideoConstraints({ getState }) {
             visibleRemoteParticipants.forEach(participantId => {
                 let sourceName;
 
-                if (remoteScreenShares.includes(participantId)) {
+                if (remoteScreenSharesSourceNames.includes(participantId)) {
                     sourceName = participantId;
                 } else {
                     sourceName = getTrackSourceNameByMediaTypeAndParticipant(tracks, MEDIA_TYPE.VIDEO, participantId);
@@ -269,12 +271,11 @@ function _updateReceiverVideoConstraints({ getState }) {
         }
 
         if (localParticipantId !== largeVideoParticipantId) {
-            if (remoteScreenShares.includes(largeVideoParticipantId)) {
+            if (remoteScreenSharesSourceNames.includes(largeVideoParticipantId)) {
                 largeVideoSourceName = largeVideoParticipantId;
             } else {
                 largeVideoSourceName = getTrackSourceNameByMediaTypeAndParticipant(
-                    tracks, MEDIA_TYPE.VIDEO,
-                    largeVideoParticipantId
+                    tracks, MEDIA_TYPE.VIDEO, largeVideoParticipantId
                 );
             }
         }
@@ -290,8 +291,8 @@ function _updateReceiverVideoConstraints({ getState }) {
             });
 
             // Prioritize screenshare in tile view.
-            if (remoteScreenShares?.length) {
-                receiverConstraints.selectedSources = remoteScreenShares;
+            if (remoteScreenSharesSourceNames?.length) {
+                receiverConstraints.selectedSources = remoteScreenSharesSourceNames;
             }
 
         // Stage view.


### PR DESCRIPTION
## Feat
- With multi-stream is enabled, create a fake screen share participant for both plan b and unified plan receiver endpoints. 
  -  If sender is plan b, receivers will see an avatar for the original thumbnail and a fake ss thumbnail 
  -  If sender is unified plan, receivers will see a camera thumbnail and a fake ss thumbnail 
  
## Refactor
- decouple selectors for signaling, receiving and sending multiple streams
- moved createFakeScreenShareParticipant logic outside of tracks/middleware   

## Bug Fixes
- update the selector to find a screenshare track by `mediaType === MEDIA_TYPE.SCREENSHARE` or `videoType === VIDEO_TYPE.DESKTOP` 
