### PR TITLE
fix(prejoin):Disable device selection on iosSafari

### DIFF
--- a/react/features/device-selection/functions.js
+++ b/react/features/device-selection/functions.js
@@ -49,7 +49,7 @@ export function getDeviceSelectionDialogProps(stateful: Object | Function) {
     // conference and this is not supported, when we open device selection on
     // welcome page changing input devices will not be a problem
     // on welcome page we also show only what we have saved as user selected devices
-    if (!conference) {
+    if (!conference && !isMobileSafari) {
         disableAudioInputChange = false;
         disableVideoInputSelect = false;
         selectedAudioInputId = userSelectedMic;


### PR DESCRIPTION
It seems that showing the device selection dialog on ios Safari will
leads to not working audio. This is temporary fix until we find out
better solution.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
