### PR TITLE
fix(lastN) fix last N getting stuck on 1

### DIFF
--- a/react/features/base/lastn/middleware.js
+++ b/react/features/base/lastn/middleware.js
@@ -49,15 +49,14 @@ const _updateLastN = debounce(({ dispatch, getState }) => {
     const { appState } = state['features/background'] || {};
     const { enabled: filmStripEnabled } = state['features/filmstrip'];
     const config = state['features/base/config'];
-    const { lastNLimits, lastN } = state['features/base/lastn'];
+    const { lastNLimits } = state['features/base/lastn'];
     const participantCount = getParticipantCount(state);
 
-    // Select the lastN value based on the following preference order.
-    // 1. The last-n value in redux.
-    // 2. The last-n value from 'startLastN' if it is specified in config.js
-    // 3. The last-n value from 'channelLastN' if specified in config.js.
-    // 4. -1 as the default value.
-    let lastNSelected = lastN || (config.startLastN ?? (config.channelLastN ?? -1));
+    // Select the (initial) lastN value based on the following preference order.
+    // 1. The last-n value from 'startLastN' if it is specified in config.js
+    // 2. The last-n value from 'channelLastN' if specified in config.js.
+    // 3. -1 as the default value.
+    let lastNSelected = config.startLastN ?? (config.channelLastN ?? -1);
 
     // Apply last N limit based on the # of participants and config settings.
     const limitedLastN = limitLastN(participantCount, lastNLimits);


### PR DESCRIPTION
If last N goes down to 1 it will be stuck there since it's > 0 and will
be our `lastNSelected`. When limits are applied we'll take the minimum,
so it will end up being 1.

Once can end up in last N being 1 by several means, the more obvious one
by entering Picture-in-Picture mode on mobile.

Fix it by not using the previous last N value for the current
calculation, at all.

Fixes: https://github.com/jitsi/jitsi-meet/issues/10257
Closes: https://github.com/jitsi/jitsi-meet/pull/10491

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
