### PR TITLE
fix(device-selection) Enable device selection on mobile Safari.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "jquery-i18next": "1.2.1",
         "js-md5": "0.6.1",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1419.0.0+607646a1/lib-jitsi-meet.tgz",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1422.0.0+cf22aa36/lib-jitsi-meet.tgz",
         "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
         "lodash": "4.17.21",
         "moment": "2.29.2",
@@ -6017,9 +6017,9 @@
       }
     },
     "node_modules/async": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-      "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -11796,15 +11796,15 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1419.0.0+607646a1/lib-jitsi-meet.tgz",
-      "integrity": "sha512-aiz6NJPganDbSodJBGJ9PNX2HOgGiVhnQEDhKDi6vxiApIRBwribdgax0bdmWvZsGO9D6doATsPzffUSeq/KxQ==",
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1422.0.0+cf22aa36/lib-jitsi-meet.tgz",
+      "integrity": "sha512-Ot//JoQPLnyuATkge/Klk5Cml2hocuatRO2BxiQQl7SM3YBMFPaagnv7ShUD19qmhCLnojfwWUw5OAHJszqnbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
-        "async": "0.9.0",
+        "async": "3.2.3",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
         "lodash.clonedeep": "4.5.0",
@@ -24419,9 +24419,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-      "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -28899,14 +28899,14 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1419.0.0+607646a1/lib-jitsi-meet.tgz",
-      "integrity": "sha512-aiz6NJPganDbSodJBGJ9PNX2HOgGiVhnQEDhKDi6vxiApIRBwribdgax0bdmWvZsGO9D6doATsPzffUSeq/KxQ==",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1422.0.0+cf22aa36/lib-jitsi-meet.tgz",
+      "integrity": "sha512-Ot//JoQPLnyuATkge/Klk5Cml2hocuatRO2BxiQQl7SM3YBMFPaagnv7ShUD19qmhCLnojfwWUw5OAHJszqnbA==",
       "requires": {
         "@jitsi/js-utils": "2.0.0",
         "@jitsi/logger": "2.0.0",
         "@jitsi/sdp-interop": "https://git@github.com/jitsi/sdp-interop#3d49eb4aa26863a3f8d32d7581cdb4321244266b",
         "@jitsi/sdp-simulcast": "0.4.0",
-        "async": "0.9.0",
+        "async": "3.2.3",
         "base64-js": "1.3.1",
         "current-executing-script": "0.1.3",
         "lodash.clonedeep": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "jquery-i18next": "1.2.1",
     "js-md5": "0.6.1",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1419.0.0+607646a1/lib-jitsi-meet.tgz",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v1422.0.0+cf22aa36/lib-jitsi-meet.tgz",
     "libflacjs": "https://git@github.com/mmig/libflac.js#93d37e7f811f01cf7d8b6a603e38bd3c3810907d",
     "lodash": "4.17.21",
     "moment": "2.29.2",

--- a/react/features/device-selection/functions.js
+++ b/react/features/device-selection/functions.js
@@ -13,7 +13,6 @@ import {
     setAudioOutputDevice,
     setVideoInputDeviceAndUpdateSettings
 } from '../base/devices';
-import { isIosMobileBrowser } from '../base/environment/utils';
 import JitsiMeetJS from '../base/lib-jitsi-meet';
 import { toState } from '../base/redux';
 import {
@@ -34,22 +33,21 @@ export function getDeviceSelectionDialogProps(stateful: Object | Function) {
     const settings = state['features/base/settings'];
     const { conference } = state['features/base/conference'];
     const { permissions } = state['features/base/devices'];
-    const isMobileSafari = isIosMobileBrowser();
     const cameraChangeSupported = JitsiMeetJS.mediaDevices.isDeviceChangeAvailable('input');
     const speakerChangeSupported = JitsiMeetJS.mediaDevices.isDeviceChangeAvailable('output');
     const userSelectedCamera = getUserSelectedCameraDeviceId(state);
     const userSelectedMic = getUserSelectedMicDeviceId(state);
     let disableAudioInputChange = !JitsiMeetJS.mediaDevices.isMultipleAudioInputSupported();
     let disableVideoInputSelect = !cameraChangeSupported;
-    let selectedAudioInputId = isMobileSafari ? userSelectedMic : settings.micDeviceId;
+    let selectedAudioInputId = settings.micDeviceId;
     let selectedAudioOutputId = getAudioOutputDeviceId();
-    let selectedVideoInputId = isMobileSafari ? userSelectedCamera : settings.cameraDeviceId;
+    let selectedVideoInputId = settings.cameraDeviceId;
 
     // audio input change will be a problem only when we are in a
     // conference and this is not supported, when we open device selection on
     // welcome page changing input devices will not be a problem
     // on welcome page we also show only what we have saved as user selected devices
-    if (!conference && !isMobileSafari) {
+    if (!conference) {
         disableAudioInputChange = false;
         disableVideoInputSelect = false;
         selectedAudioInputId = userSelectedMic;


### PR DESCRIPTION
With https://bugs.webkit.org/show_bug.cgi?id=179363 being fixed, we should now be able to switch between devices in call. Also, before the webkit fix, we were able to continue to use the old track when a new track was created for preview in device settings before joining the call. This doesn't work anymore after the fix. Therefore, always replace the track in redux even if the selected device hasn't changed. Depends on https://github.com/jitsi/lib-jitsi-meet/pull/1993.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
