### PR TITLE
fix(avatar) Center phone icon in participants pane avatars

### DIFF
--- a/react/features/base/avatar/components/web/StatelessAvatar.js
+++ b/react/features/base/avatar/components/web/StatelessAvatar.js
@@ -59,6 +59,7 @@ const styles = () => {
             color: 'rgba(255, 255, 255, 1)',
             fontWeight: '100',
             objectFit: 'cover',
+            textAlign: 'center',
 
             '&.avatar-small': {
                 height: '28px !important',


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/11474153/165459226-2d657e2a-7bfc-4cbc-bcce-bfac9ec4f54e.png)

After
![image](https://user-images.githubusercontent.com/11474153/165459242-268bb6e1-30fb-44d3-87d1-baa368fe2fdd.png)

