### PR TITLE
feat: Drops nginx dependency for turnserver config.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,5 +54,5 @@ Package: jitsi-meet-turnserver
 Architecture: all
 Breaks: apache2
 Pre-Depends: jitsi-meet-web-config
-Depends: ${misc:Depends}, nginx (>= 1.13.10) | nginx-full (>= 1.13.10) | nginx-extras (>= 1.13.10), jitsi-meet-prosody, coturn, dnsutils
+Depends: ${misc:Depends}, jitsi-meet-prosody, coturn, dnsutils
 Description: Configures coturn to be used with Jitsi Meet

--- a/debian/jitsi-meet-turnserver.postinst
+++ b/debian/jitsi-meet-turnserver.postinst
@@ -33,7 +33,6 @@ case "$1" in
         JVB_HOSTNAME=$(echo "$RET" | xargs echo -n)
 
         TURN_CONFIG="/etc/turnserver.conf"
-        NGINX_CONFIG="/etc/nginx/sites-available/$JVB_HOSTNAME.conf"
         JITSI_MEET_CONFIG="/etc/jitsi/meet/$JVB_HOSTNAME-config.js"
 
         # if there was a turn config backup it so we can configure
@@ -49,19 +48,6 @@ case "$1" in
             if [[ -f $TURN_CONFIG ]] && grep -q "jitsi-meet coturn config" "$TURN_CONFIG" ; then
                 rm -f $TURN_CONFIG
             fi
-        fi
-
-        # this detect only old installations with no nginx
-        db_get jitsi-meet/jvb-serve || true
-        if [ ! -f $NGINX_CONFIG -o "$RET" = "true" ] ; then
-            # nothing to do
-            echo "------------------------------------------------"
-            echo ""
-            echo "turnserver not configured"
-            echo ""
-            echo "------------------------------------------------"
-            db_stop
-            exit 0
         fi
 
         if [[ -f $TURN_CONFIG ]] ; then
@@ -117,7 +103,7 @@ denied-peer-ip=240.0.0.0-255.255.255.255" >> $TURN_CONFIG
         sed -i "s/jitsi-meet.example.com/$JVB_HOSTNAME/g" $TURN_CONFIG
         sed -i "s/__turnSecret__/$TURN_SECRET/g" $TURN_CONFIG
 
-        # SSL for nginx
+        # SSL settings
         db_get jitsi-meet/cert-choice
         CERT_CHOICE="$RET"
 

--- a/debian/jitsi-meet-turnserver.postrm
+++ b/debian/jitsi-meet-turnserver.postrm
@@ -23,26 +23,12 @@ set -e
 
 
 case "$1" in
-    remove)
-        if [ -x "/etc/init.d/nginx" ]; then
-            invoke-rc.d nginx reload || true
-        fi
-        if [ -x "/etc/init.d/apache2" ]; then
-            invoke-rc.d apache2 reload || true
-        fi
-    ;;
     purge)
         rm -rf /etc/turnserver.conf
-        if [ -x "/etc/init.d/nginx" ]; then
-            invoke-rc.d nginx reload || true
-        fi
-        if [ -x "/etc/init.d/apache2" ]; then
-            invoke-rc.d apache2 reload || true
-        fi
         # Clear the debconf variable
         db_purge
     ;;
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
 
     *)


### PR DESCRIPTION
We used to multiplex the ports in nginx, but we dropped that at some point, so now coturn is on its own listening and nginx dependency is no longer needed. Our turnserver config can be used with nginx | apache2.
