### PR TITLE
fix(auth) fix WaitForOwnerDialog not vanishing

### DIFF
--- a/react/features/authentication/middleware.web.js
+++ b/react/features/authentication/middleware.web.js
@@ -83,9 +83,7 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case CONFERENCE_JOINED:
-        if (_isWaitingForOwner(store)) {
-            store.dispatch(stopWaitForOwner());
-        }
+        store.dispatch(stopWaitForOwner());
         store.dispatch(hideLoginDialog());
         break;
 


### PR DESCRIPTION
Since all the auth logic is not ported to React on the web,
`_isWaitingForOwner` will always return `false` because the
`waitForOwner()` action is not (yet) used there.

THis fix always tries to hide the dialog no matter what, which is not a
Bad Thing to do anyway.

There is a related bug remaining, however: if one pressed "I am the
host" and then cancel, it doesn't goo back to the previous dialog, but
it completely kils the meeting. This is a compromise we'll have to live
with for a bit longer.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
