### PR TITLE
fix(audio-only) Do not create a new track for audio-only changes.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2617,7 +2617,8 @@ export default {
                         track => track.jitsiTrack
                             && track.jitsiTrack.getType() === 'video'));
 
-            if (!isTrackInRedux) {
+
+            if (isTrackInRedux) {
                 this.muteVideo(audioOnly);
             }
 


### PR DESCRIPTION
Now that screenshare is permitted when a user is in audio-only mode, do not create a new video track if it doesn't exist when audio-only mode is automatically disabled. New track creation should only be prompted by user action such as camera unmute or start screenshare. Fixes https://github.com/jitsi/jitsi-meet/issues/11460.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
