### PR TITLE
fix(screenshare) use selector for getting screenshare owner display name

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -298,10 +298,9 @@ export function getParticipantDisplayName(stateful: Object | Function, id: strin
  * @returns {string}
  */
 export function getScreenshareParticipantDisplayName(stateful: Object | Function, id: string) {
-    const owner = getParticipantById(stateful, getVirtualScreenshareParticipantOwnerId(id));
-    const name = owner.name;
+    const ownerDisplayName = getParticipantDisplayName(stateful, getVirtualScreenshareParticipantOwnerId(id));
 
-    return i18next.t('screenshareDisplayName', { name });
+    return i18next.t('screenshareDisplayName', { name: ownerDisplayName });
 }
 
 /**


### PR DESCRIPTION
## Description of bug
With multi-stream support, when a presenter that is still screen sharing leaves a conference, they will see a `Cannot read properties of undefined (reading 'name')` error in the logs. This is a race condition where the local screenshare participant hasn't been removed yet by the state listener.

## Fix
Use the `getParticipantDisplayName` selector, which also handles defaults, for getting the owner's name to always ensure there is a value.  This also handles the corner case when a presenter edits their name to "" while screen sharing. 

