### PR TITLE
Update cloud-api.swagger

### DIFF
--- a/resources/cloud-api.swagger
+++ b/resources/cloud-api.swagger
@@ -138,26 +138,14 @@ definitions:
         type: "boolean"
         description: "Determines if the numbers are available"
       numbers:
-        $ref: "#/definitions/PhoneNumberList"
-
-  PhoneNumberList:
-    description: "List of dial in numbers for the conference."
-    type: "array"
-    items:
-        type: "object"
-        properties:
-          countryCode:
+        type: object
+        additionalProperties:
+          type: "array"
+          items:
             type: "string"
-            description: "ISO 3166-1 country code. Alpha-2 supported."
-          default:
-            type: "boolean"
-            description: "Whether this number is the default one to show. Optional."
-          formattedNumber:
-            type: "string"
-            description: "The formatted telephone number to show."
-          tollFree:
-            type: "boolean"
-            description: "Whether the number is toll free number."
+        example:
+          US: ["+1.123.456.7890"]
+          UK: ["+44.123.456.7890"]
 
 externalDocs:
   description: "Find out more about the Jitsi Cloud API"

--- a/resources/cloud-api.swagger
+++ b/resources/cloud-api.swagger
@@ -85,7 +85,7 @@ paths:
         200:
           description: "successful operation"
           schema:
-            $ref: "#/definitions/PhoneNumberList"
+            $ref: "#/definitions/PhoneNumberListAnswer"
 securityDefinitions:
   token:
     type: "apiKey"
@@ -126,6 +126,19 @@ definitions:
         type: "string"
         format: "JID"
         description: "Full JID for the conference OR boolean false if no conference was found (search by ID)"
+
+  PhoneNumberListAnswer:
+    description: "Answer with Phone number list and additional information"
+    type: "object"
+    properties: 
+      message: 
+        type: "string"
+        description: "General message"
+      numbersEnabled: 
+        type: "boolean"
+        description: "Determines if the numbers are available"
+      numbers:
+        $ref: "#/definitions/PhoneNumberList"
 
   PhoneNumberList:
     description: "List of dial in numbers for the conference."


### PR DESCRIPTION
Update to match with the current implementation

The current implementation seems to have diverged from the swagger document, as most of the conferencemapper implementation out there are somewhat referencing this document I propose to update it. 

See the current in production version: 
```http
GET https://api.jitsi.net/phoneNumberList?conference=test@conference.meet.jit.si

{
  "message": "Phone numbers available.",
  "numbers": {
    "US": ["+1.512.647.1431"],
    "UK": ["+44.203.885.2179"],
    "France": ["+33.1.87.21.0005"],
    "Netherlands": ["+31.85.208.1541"],
    "Spain": ["+34.932.205.409"],
    "Canada": ["+1.437.538.3987"],
    "Australia": ["+61.8.7150.1136"],
    "Brazil": ["+55.21.3500.0112"],
    "Japan": ["+81.3.4510.2372"],
    "Switzerland": ["+41.61.588.0496"]
  },
  "numbersEnabled": true
}

````