### PR TITLE
fix(av-moderation) use a consistent UID for ask to unmute notifications

### DIFF
--- a/react/features/av-moderation/constants.js
+++ b/react/features/av-moderation/constants.js
@@ -18,6 +18,7 @@ export const MEDIA_TYPE_TO_PENDING_STORE_KEY: {[key: MediaType]: string} = {
     [MEDIA_TYPE.VIDEO]: 'pendingVideo'
 };
 
+export const ASKED_TO_UNMUTE_NOTIFICATION_ID = 'asked-to-unmute';
 export const ASKED_TO_UNMUTE_SOUND_ID = 'ASKED_TO_UNMUTE_SOUND';
 
 export const AUDIO_MODERATION_NOTIFICATION_ID = 'audio-moderation';

--- a/react/features/av-moderation/middleware.js
+++ b/react/features/av-moderation/middleware.js
@@ -48,7 +48,9 @@ import {
     participantRejected
 } from './actions';
 import {
-    ASKED_TO_UNMUTE_SOUND_ID, AUDIO_MODERATION_NOTIFICATION_ID,
+    ASKED_TO_UNMUTE_NOTIFICATION_ID,
+    ASKED_TO_UNMUTE_SOUND_ID,
+    AUDIO_MODERATION_NOTIFICATION_ID,
     CS_MODERATION_NOTIFICATION_ID,
     VIDEO_MODERATION_NOTIFICATION_ID
 } from './constants';
@@ -222,7 +224,8 @@ StateListenerRegistry.register(
                         titleKey: 'notify.hostAskedUnmute',
                         sticky: true,
                         customActionNameKey: [ 'notify.unmute' ],
-                        customActionHandler: [ () => dispatch(muteLocal(false, MEDIA_TYPE.AUDIO)) ]
+                        customActionHandler: [ () => dispatch(muteLocal(false, MEDIA_TYPE.AUDIO)) ],
+                        uid: ASKED_TO_UNMUTE_NOTIFICATION_ID
                     }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
                     dispatch(playSound(ASKED_TO_UNMUTE_SOUND_ID));
                 }


### PR DESCRIPTION
This way only one will be shown at a time.
<img width="2032" alt="Screenshot 2022-05-06 at 09 20 40" src="https://user-images.githubusercontent.com/317464/167087089-bcecf768-dda6-4957-854d-b69b83b5026b.png">

