### PR TITLE
feat: enable audio settings menu for Firefox

### DIFF
--- a/react/features/toolbox/functions.web.js
+++ b/react/features/toolbox/functions.web.js
@@ -62,7 +62,7 @@ export function isToolboxVisible(state: Object) {
 export function isAudioSettingsButtonDisabled(state: Object) {
 
     return !(hasAvailableDevices(state, 'audioInput')
-          && hasAvailableDevices(state, 'audioOutput'))
+          || hasAvailableDevices(state, 'audioOutput'))
           || state['features/base/config'].startSilent;
 }
 


### PR DESCRIPTION
This small change enables the audio settings menu on the mic button for Firefox > 100. As Firefox 101 finally supports multiple open microphones the audio input settings menu becomes available for these users.