### PR TITLE
feat(notifications) add ability to disable specific notifications

### DIFF
--- a/config.js
+++ b/config.js
@@ -1344,6 +1344,9 @@ var config = {
     //     'transcribing.failedToStart' // shown when transcribing fails to start
     // ],
 
+    // List of notifications to be disabled. Works in tandem with the above setting.
+    // disabledNotifications: [],
+
     // Prevent the filmstrip from autohiding when screen width is under a certain threshold
     // disableFilmstripAutohiding: false,
 

--- a/react/features/base/config/configWhitelist.js
+++ b/react/features/base/config/configWhitelist.js
@@ -94,6 +94,7 @@ export default [
     'disableBeforeUnloadHandlers',
     'disableChatSmileys',
     'disableDeepLinking',
+    'disabledNotifications',
     'disabledSounds',
     'disableFilmstripAutohiding',
     'disableInitialGUM',

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -109,10 +109,12 @@ export function showErrorNotification(props: Object, type: ?string) {
  */
 export function showNotification(props: Object = {}, type: ?string) {
     return function(dispatch: Function, getState: Function) {
-        const { notifications, notificationTimeouts } = getState()['features/base/config'];
+        const { disabledNotifications = [], notifications, notificationTimeouts } = getState()['features/base/config'];
         const enabledFlag = getFeatureFlag(getState(), NOTIFICATIONS_ENABLED, true);
 
         const shouldDisplay = enabledFlag
+            && !(disabledNotifications.includes(props.descriptionKey)
+                || disabledNotifications.includes(props.titleKey))
             && (!notifications
                 || notifications.includes(props.descriptionKey)
                 || notifications.includes(props.titleKey));


### PR DESCRIPTION
This works together with the broader "notifications" config option. One
might choose to leave the existing option unespecified *thus allowing
all notifications) and then use this new one to be explicit about which
ones to disable.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
