### PR TITLE
fix(recent-list) do not store room when inside an iframe

### DIFF
--- a/config.js
+++ b/config.js
@@ -1009,7 +1009,8 @@ var config = {
     // Disables all invite functions from the app (share, invite, dial out...etc)
     // disableInviteFunctions: true,
 
-    // Disables storing the room name to the recents list
+    // Disables storing the room name to the recents list. When in an iframe this is ignored and
+    // the room is never stored in the recents list.
     // doNotStoreRoom: true,
 
     // Deployment specific URLs.

--- a/react/features/analytics/functions.js
+++ b/react/features/analytics/functions.js
@@ -12,6 +12,7 @@ import JitsiMeetJS, {
 } from '../base/lib-jitsi-meet';
 import { isAnalyticsEnabled } from '../base/lib-jitsi-meet/functions';
 import { getJitsiMeetGlobalNS, loadScript, parseURIString } from '../base/util';
+import { inIframe } from '../base/util/iframeUtils';
 
 import { AmplitudeHandler, MatomoHandler } from './handlers';
 import logger from './logger';
@@ -218,24 +219,6 @@ export function initAnalytics({ getState }: { getState: Function }, handlers: Ar
                 });
             }
         });
-    }
-}
-
-/**
- * Checks whether we are loaded in iframe.
- *
- * @returns {boolean} Returns {@code true} if loaded in iframe.
- * @private
- */
-export function inIframe() {
-    if (navigator.product === 'ReactNative') {
-        return false;
-    }
-
-    try {
-        return window.self !== window.top;
-    } catch (e) {
-        return true;
     }
 }
 

--- a/react/features/base/jitsi-local-storage/setup.web.js
+++ b/react/features/base/jitsi-local-storage/setup.web.js
@@ -4,6 +4,7 @@ import Bourne from '@hapi/bourne';
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
 
 import { browser } from '../lib-jitsi-meet';
+import { inIframe } from '../util/iframeUtils';
 import { parseURLParams } from '../util/parseURLParams';
 
 import logger from './logger';
@@ -11,19 +12,6 @@ import logger from './logger';
 declare var APP: Object;
 declare var config: Object;
 
-/**
- * Checks whether we are loaded in an iframe.
- *
- * @returns {boolean} Returns {@code true} if loaded in iframe.
- * @private
- */
-function _inIframe() {
-    try {
-        return window.self !== window.top;
-    } catch (e) {
-        return true;
-    }
-}
 
 /**
  * Handles changes of the fake local storage.
@@ -55,7 +43,7 @@ function shouldUseHostPageLocalStorage(urlParams) {
         return true;
     }
 
-    if (browser.isWebKitBased() && _inIframe()) {
+    if (browser.isWebKitBased() && inIframe()) {
         // WebKit browsers don't persist local storage for third-party iframes.
 
         return true;

--- a/react/features/base/util/iframeUtils.ts
+++ b/react/features/base/util/iframeUtils.ts
@@ -1,0 +1,16 @@
+/**
+ * Checks whether we are loaded in iframe.
+ *
+ * @returns Whether the current page is loaded in an iframe.
+ */
+export function inIframe(): boolean {
+    if (navigator.product === 'ReactNative') {
+        return false;
+    }
+
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
+    }
+}

--- a/react/features/recent-list/middleware.js
+++ b/react/features/recent-list/middleware.js
@@ -9,6 +9,7 @@ import {
 import { addKnownDomains } from '../base/known-domains';
 import { MiddlewareRegistry } from '../base/redux';
 import { parseURIString } from '../base/util';
+import { inIframe } from '../base/util/iframeUtils';
 
 import { _storeCurrentConference, _updateConferenceDuration } from './actions';
 import { isRecentListEnabled } from './functions';
@@ -88,7 +89,7 @@ function _appWillMount({ dispatch, getState }, next, action) {
 function _conferenceWillLeave({ dispatch, getState }, next, action) {
     const { doNotStoreRoom } = getState()['features/base/config'];
 
-    if (!doNotStoreRoom) {
+    if (!doNotStoreRoom && !inIframe()) {
         let locationURL;
 
         /**
@@ -128,7 +129,7 @@ function _conferenceWillLeave({ dispatch, getState }, next, action) {
 function _setRoom({ dispatch, getState }, next, action) {
     const { doNotStoreRoom } = getState()['features/base/config'];
 
-    if (!doNotStoreRoom && action.room) {
+    if (!doNotStoreRoom && !inIframe() && action.room) {
         const { locationURL } = getState()['features/base/connection'];
 
         if (locationURL) {


### PR DESCRIPTION
Due to local storage limitations we might end up making the URL huge
when we save the state there. Avoid the issue at the root by never
storing URLs in that case.

Closes: https://github.com/jitsi/jitsi-meet/issues/11567

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
