### PR TITLE
fix(device-selection):iOS Safari disable previews

### DIFF
--- a/react/features/device-selection/actions.js
+++ b/react/features/device-selection/actions.js
@@ -5,8 +5,6 @@ import {
     setAudioOutputDeviceId,
     setVideoInputDevice
 } from '../base/devices';
-import { isIosMobileBrowser } from '../base/environment/utils';
-import { browser } from '../base/lib-jitsi-meet';
 import { updateSettings } from '../base/settings';
 
 import { getDeviceSelectionDialogProps } from './functions';
@@ -19,16 +17,10 @@ import logger from './logger';
  * @returns {Function}
  */
 export function submitDeviceSelectionTab(newState) {
-    // Always use the new track for mobile Safari because of https://bugs.webkit.org/show_bug.cgi?id=179363#c30. The
-    // old track is stopped by the browser when a new track is created for preview so it needs to be replaced even if
-    // the device selection doesn't change.
-    const replaceTrackAlways = isIosMobileBrowser() && browser.isVersionGreaterThan('15.3');
-
     return (dispatch, getState) => {
         const currentState = getDeviceSelectionDialogProps(getState());
 
-        if ((newState.selectedVideoInputId && (newState.selectedVideoInputId !== currentState.selectedVideoInputId))
-            || replaceTrackAlways) {
+        if (newState.selectedVideoInputId && (newState.selectedVideoInputId !== currentState.selectedVideoInputId)) {
             dispatch(updateSettings({
                 userSelectedCameraDeviceId: newState.selectedVideoInputId,
                 userSelectedCameraDeviceLabel:
@@ -38,8 +30,7 @@ export function submitDeviceSelectionTab(newState) {
             dispatch(setVideoInputDevice(newState.selectedVideoInputId));
         }
 
-        if ((newState.selectedAudioInputId && newState.selectedAudioInputId !== currentState.selectedAudioInputId)
-            || replaceTrackAlways) {
+        if (newState.selectedAudioInputId && newState.selectedAudioInputId !== currentState.selectedAudioInputId) {
             dispatch(updateSettings({
                 userSelectedMicDeviceId: newState.selectedAudioInputId,
                 userSelectedMicDeviceLabel:


### PR DESCRIPTION
On iOS Safari when the tracks for the previews are created the old ones
are auto destroyed which leads many issues like stop sending media while
the devie selectioin is displayed, error messages, etc.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
