### PR TITLE
fix(multi-stream) RN Add listeners for track streaming status updates on large-video.

### DIFF
--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -248,7 +248,8 @@ class Thumbnail extends PureComponent<Props> {
                     { !tileView && _pinned && <PinnedIndicator />}
                     { renderModeratorIndicator && !_isVirtualScreenshare && <ModeratorIndicator />}
                     { !tileView && ((isScreenShare && !_isMultiStreamSupportEnabled) || _isVirtualScreenshare)
-                        && <ScreenShareIndicator />
+                        && <ScreenShareIndicator /> /* Do not show screensharing indicator on the local camera
+                        thumbnail when a virtual SS participant tile is created for local screenshare */
                     }
                 </Container>
                 {

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -213,6 +213,7 @@ class Thumbnail extends PureComponent<Props> {
     _renderIndicators() {
         const {
             _audioMuted: audioMuted,
+            _isMultiStreamSupportEnabled,
             _isScreenShare: isScreenShare,
             _isVirtualScreenshare,
             _isFakeParticipant,
@@ -246,7 +247,7 @@ class Thumbnail extends PureComponent<Props> {
                     { audioMuted && !_isVirtualScreenshare && <AudioMutedIndicator /> }
                     { !tileView && _pinned && <PinnedIndicator />}
                     { renderModeratorIndicator && !_isVirtualScreenshare && <ModeratorIndicator />}
-                    { !tileView && (isScreenShare || _isVirtualScreenshare)
+                    { !tileView && ((isScreenShare && !_isMultiStreamSupportEnabled) || _isVirtualScreenshare)
                         && <ScreenShareIndicator />
                     }
                 </Container>


### PR DESCRIPTION
Fixes an issue where video on large-video is not being rendered when there is no filmstrip, i.e., there is only 1 remote participant in the call with source-name signaling enabled. Also do not show the screensharing indicator on the camera thumbnail when a virtual SS tile is created for the local screenshare.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
