### PR TITLE
fix(android) fix incorrect colors on MIUI devices

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,7 @@
 <resources>
-    <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+        <item name="android:forceDarkAllowed">false</item>
         <item name="android:navigationBarColor">@color/colorPrimaryDark</item>
         <item name="android:windowDisablePreview">true</item>
    </style>


### PR DESCRIPTION
They "force" a dark mode but we already have a dark palette, so avoid
the system overriding the base colors.

Before:

![Screenshot_2022-06-03-10-46-45-588_org jitsi meet](https://user-images.githubusercontent.com/317464/171839268-a13fccdc-4d6a-42b1-9c57-0c280c18c291.jpg)

After:

![Screenshot_2022-06-03-12-34-24-008_org jitsi meet](https://user-images.githubusercontent.com/317464/171839259-8e3027e7-4285-4d7d-a56a-bd4932fd5553.jpg)
