### PR TITLE
feat: Fix display name in prejoin stealing focus.

### DIFF
--- a/react/features/base/conference/middleware.web.js
+++ b/react/features/base/conference/middleware.web.js
@@ -44,9 +44,14 @@ MiddlewareRegistry.register(store => next => action => {
         break;
     }
     case CONFERENCE_FAILED: {
-        enableForcedReload
-            && action.error?.name === JitsiConferenceErrors.CONFERENCE_RESTARTED
-            && dispatch(setSkipPrejoinOnReload(true));
+        const errorName = action.error?.name;
+
+        if (errorName === JitsiConferenceErrors.MEMBERS_ONLY_ERROR
+            || errorName === JitsiConferenceErrors.PASSWORD_REQUIRED) {
+            dispatch(setPrejoinPageVisibility(false));
+        } else if (enableForcedReload && errorName === JitsiConferenceErrors.CONFERENCE_RESTARTED) {
+            dispatch(setSkipPrejoinOnReload(true));
+        }
 
         break;
     }


### PR DESCRIPTION
When there is a password and lobby enabled, participants cannot enter password as the display name is stealing the focus.
When there is just password set the same field steals the focus from the password prompt.

