### PR TITLE
fix(lang): logout question asks to stop the conference

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -288,7 +288,7 @@
         "lockRoom": "Add meeting $t(lockRoomPassword)",
         "lockTitle": "Lock failed",
         "login": "Login",
-        "logoutQuestion": "Are you sure you want to logout and stop the conference?",
+        "logoutQuestion": "Are you sure you want to logout and leave the conference?",
         "logoutTitle": "Logout",
         "maxUsersLimitReached": "The limit for maximum number of participants has been reached. The conference is full. Please contact the meeting owner or try again later!",
         "maxUsersLimitReachedTitle": "Maximum participants limit reached",


### PR DESCRIPTION
A minor wording change to prevent confusion: On logout one is asked whether to stop the conference but the conference is only left by the participant.
