### PR TITLE
fix(lobby): return to welcome screen when rejected

### DIFF
--- a/react/features/conference/actions.web.js
+++ b/react/features/conference/actions.web.js
@@ -2,8 +2,10 @@
 
 import type { Dispatch } from 'redux';
 
+import { maybeRedirectToWelcomePage } from '../app/actions';
 import { getParticipantDisplayName } from '../base/participants';
 import {
+    NOTIFICATION_TIMEOUT,
     NOTIFICATION_TIMEOUT_TYPE,
     NOTIFICATION_TYPE,
     showNotification
@@ -36,5 +38,7 @@ export function notifyKickedOut(participant: Object, _: ?Function) { // eslint-d
             titleKey: 'dialog.kickTitle',
             titleArguments: args
         }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
+
+        setTimeout(() => dispatch(maybeRedirectToWelcomePage()), NOTIFICATION_TIMEOUT.LONG);
     };
 }

--- a/react/features/lobby/middleware.js
+++ b/react/features/lobby/middleware.js
@@ -19,6 +19,7 @@ import { approveKnockingParticipant, rejectKnockingParticipant } from '../lobby/
 import {
     LOBBY_NOTIFICATION_ID,
     NOTIFICATION_ICON,
+    NOTIFICATION_TIMEOUT,
     NOTIFICATION_TIMEOUT_TYPE,
     NOTIFICATION_TYPE,
     hideNotification,
@@ -30,6 +31,7 @@ import { shouldAutoKnock } from '../prejoin/functions';
 
 import { KNOCKING_PARTICIPANT_ARRIVED_OR_UPDATED, KNOCKING_PARTICIPANT_LEFT } from './actionTypes';
 import {
+    cancelKnocking,
     hideLobbyScreen,
     knockingParticipantLeft,
     openLobbyScreen,
@@ -311,6 +313,8 @@ function _conferenceFailed({ dispatch, getState }, next, action) {
                 descriptionKey: 'lobby.joinRejectedMessage'
             }, NOTIFICATION_TIMEOUT_TYPE.LONG)
         );
+
+        setTimeout(() => dispatch(cancelKnocking()), NOTIFICATION_TIMEOUT.LONG);
     }
 
     return next(action);

--- a/react/features/mobile/navigation/middleware.js
+++ b/react/features/mobile/navigation/middleware.js
@@ -1,5 +1,6 @@
 import { appNavigate } from '../../app/actions';
 import { CONFERENCE_FAILED } from '../../base/conference/actionTypes';
+import { AlertDialog, openDialog } from '../../base/dialog';
 import { JitsiConferenceErrors } from '../../base/lib-jitsi-meet';
 import { MiddlewareRegistry } from '../../base/redux';
 
@@ -29,7 +30,12 @@ function _conferenceFailed({ dispatch }, next, action) {
     // We need to cover the case where knocking participant
     // is rejected from entering the conference
     if (error.name === JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED) {
-        dispatch(appNavigate(undefined));
+        dispatch(openDialog(AlertDialog, {
+            contentKey: {
+                key: 'lobby.joinRejectedMessage'
+            },
+            onSubmit: () => dispatch(appNavigate(undefined))
+        }));
     }
 
     return next(action);


### PR DESCRIPTION
If a participant is rejected from the lobby, they end up in a room seemingly alone. This change would send them back to the Welcome screen after a timeout.