### PR TITLE
fix(video-layout) fix usage of disableTileView

### DIFF
--- a/react/features/video-layout/functions.any.js
+++ b/react/features/video-layout/functions.any.js
@@ -60,15 +60,6 @@ export function getCurrentLayout(state: Object) {
  * @returns {boolean} True if tile view should be displayed.
  */
 export function shouldDisplayTileView(state: Object = {}) {
-    const participantCount = getParticipantCount(state);
-
-    const tileViewEnabledFeatureFlag = getFeatureFlag(state, TILE_VIEW_ENABLED, true);
-    const { disableTileView } = state['features/base/config'];
-
-    if (disableTileView || !tileViewEnabledFeatureFlag) {
-        return false;
-    }
-
     const { tileViewEnabled } = state['features/video-layout'];
 
     if (tileViewEnabled !== undefined) {
@@ -77,6 +68,14 @@ export function shouldDisplayTileView(state: Object = {}) {
         return tileViewEnabled;
     }
 
+    const tileViewEnabledFeatureFlag = getFeatureFlag(state, TILE_VIEW_ENABLED, true);
+    const { disableTileView } = state['features/base/config'];
+
+    if (disableTileView || !tileViewEnabledFeatureFlag) {
+        return false;
+    }
+
+    const participantCount = getParticipantCount(state);
     const { iAmRecorder } = state['features/base/config'];
 
     // None tile view mode is easier to calculate (no need for many negations), so we do


### PR DESCRIPTION
The documented behavior is that it would disable auto-switching to it,
but users would still be available to toggle it.

This change restores that behavior. If the user has selected a layout
that will be preferred before cheching for this setting.

Ref: https://community.jitsi.org/t/how-to-disable-titleview/115093

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
