### PR TITLE
feat(settings): add option to mute lobby knocking sounds

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -944,6 +944,7 @@
         "name": "Name",
         "noDevice": "None",
         "participantJoined": "Participant Joined",
+        "participantKnocking": "Participant entered lobby",
         "participantLeft": "Participant Left",
         "playSounds": "Play sound on",
         "reactions": "Meeting reactions",

--- a/react/features/base/settings/reducer.js
+++ b/react/features/base/settings/reducer.js
@@ -30,6 +30,7 @@ const DEFAULT_STATE = {
     hideShareAudioHelper: false,
     soundsIncomingMessage: true,
     soundsParticipantJoined: true,
+    soundsParticipantKnocking: true,
     soundsParticipantLeft: true,
     soundsTalkWhileMuted: true,
     soundsReactions: true,

--- a/react/features/lobby/middleware.js
+++ b/react/features/lobby/middleware.js
@@ -96,6 +96,8 @@ StateListenerRegistry.register(
             });
 
             conference.on(JitsiConferenceEvents.LOBBY_USER_JOINED, (id, name) => {
+                const { soundsParticipantKnocking } = getState()['features/base/settings'];
+
                 batch(() => {
                     dispatch(
                         participantIsKnockingOrUpdated({
@@ -103,7 +105,9 @@ StateListenerRegistry.register(
                             name
                         })
                     );
-                    dispatch(playSound(KNOCKING_PARTICIPANT_SOUND_ID));
+                    if (soundsParticipantKnocking) {
+                        dispatch(playSound(KNOCKING_PARTICIPANT_SOUND_ID));
+                    }
 
                     const isParticipantsPaneVisible = getParticipantsPaneOpen(getState());
 

--- a/react/features/settings/actions.js
+++ b/react/features/settings/actions.js
@@ -191,6 +191,7 @@ export function submitSoundsTab(newState: Object): Function {
         const shouldNotUpdateReactionSounds = getModeratorTabProps(getState()).startReactionsMuted;
         const shouldUpdate = (newState.soundsIncomingMessage !== currentState.soundsIncomingMessage)
             || (newState.soundsParticipantJoined !== currentState.soundsParticipantJoined)
+            || (newState.soundsParticipantKnocking !== currentState.soundsParticipantKnocking)
             || (newState.soundsParticipantLeft !== currentState.soundsParticipantLeft)
             || (newState.soundsTalkWhileMuted !== currentState.soundsTalkWhileMuted)
             || (newState.soundsReactions !== currentState.soundsReactions);
@@ -199,6 +200,7 @@ export function submitSoundsTab(newState: Object): Function {
             const settingsToUpdate = {
                 soundsIncomingMessage: newState.soundsIncomingMessage,
                 soundsParticipantJoined: newState.soundsParticipantJoined,
+                soundsParticipantKnocking: newState.soundsParticipantKnocking,
                 soundsParticipantLeft: newState.soundsParticipantLeft,
                 soundsTalkWhileMuted: newState.soundsTalkWhileMuted,
                 soundsReactions: newState.soundsReactions

--- a/react/features/settings/components/web/SoundsTab.js
+++ b/react/features/settings/components/web/SoundsTab.js
@@ -31,6 +31,11 @@ export type Props = {
     soundsParticipantJoined: Boolean,
 
     /**
+     * Whether or not the sound for the participant entering the lobby should play.
+     */
+    soundsParticipantKnocking: Boolean,
+
+    /**
      * Whether or not the sound for the participant left should play.
      */
     soundsParticipantLeft: Boolean,
@@ -98,6 +103,7 @@ class SoundsTab extends AbstractDialogTab<Props> {
         const {
             soundsIncomingMessage,
             soundsParticipantJoined,
+            soundsParticipantKnocking,
             soundsParticipantLeft,
             soundsTalkWhileMuted,
             soundsReactions,
@@ -139,6 +145,11 @@ class SoundsTab extends AbstractDialogTab<Props> {
                     isChecked = { soundsTalkWhileMuted }
                     label = { t('settings.talkWhileMuted') }
                     name = 'soundsTalkWhileMuted'
+                    onChange = { this._onChange } />
+                <Checkbox
+                    isChecked = { soundsParticipantKnocking }
+                    label = { t('settings.participantKnocking') }
+                    name = 'soundsParticipantKnocking'
                     onChange = { this._onChange } />
             </div>
         );

--- a/react/features/settings/functions.js
+++ b/react/features/settings/functions.js
@@ -230,6 +230,7 @@ export function getSoundsTabProps(stateful: Object | Function) {
     const {
         soundsIncomingMessage,
         soundsParticipantJoined,
+        soundsParticipantKnocking,
         soundsParticipantLeft,
         soundsTalkWhileMuted,
         soundsReactions
@@ -240,6 +241,7 @@ export function getSoundsTabProps(stateful: Object | Function) {
     return {
         soundsIncomingMessage,
         soundsParticipantJoined,
+        soundsParticipantKnocking,
         soundsParticipantLeft,
         soundsTalkWhileMuted,
         soundsReactions,


### PR DESCRIPTION
This adds the option to mute the knocking sound effect when a user enters the lobby on the SoundsTab.