### PR TITLE
fix(util) fix parsing strings in parseURLParams

### DIFF
--- a/react/features/base/util/parseURLParams.js
+++ b/react/features/base/util/parseURLParams.js
@@ -23,9 +23,13 @@ const blacklist = [ '__proto__', 'constructor', 'prototype' ];
  * @returns {Object}
  */
 export function parseURLParams(
-        url: URL,
+        url: URL | string,
         dontParse: boolean = false,
         source: string = 'hash'): Object {
+    if (typeof url === 'string') {
+        // eslint-disable-next-line no-param-reassign
+        url = new URL(url);
+    }
     const paramStr = source === 'search' ? url.search : url.hash;
     const params = {};
     const paramParts = (paramStr && paramStr.substr(1).split('&')) || [];


### PR DESCRIPTION
After https://github.com/jitsi/jitsi-meet/pull/11607 we might call it
with a string. Be nice and accept that in addition to URL objects.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
