### PR TITLE
Pass the server's URL as the reachability URL.

### DIFF
--- a/react/features/base/net-info/NetworkInfoService.native.js
+++ b/react/features/base/net-info/NetworkInfoService.native.js
@@ -43,9 +43,13 @@ export default class NetworkInfoService extends EventEmitter {
     /**
      * Starts the service.
      *
+     * @param {string} reachabilityUrl - The new state given by the native library.
      * @returns {void}
      */
-    start() {
+    start(reachabilityUrl: string) {
+        NetInfo.configure({
+            reachabilityUrl
+        });
         this._subscription = NetInfo.addEventListener(netInfoState => {
             this.emit(ONLINE_STATE_CHANGED_EVENT, NetworkInfoService._convertNetInfoState(netInfoState));
         });

--- a/react/features/base/net-info/middleware.js
+++ b/react/features/base/net-info/middleware.js
@@ -2,6 +2,7 @@
 
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../app';
 import { MiddlewareRegistry } from '../redux';
+import { DEFAULT_SERVER_URL } from '../settings/constants';
 
 import NetworkInfoService from './NetworkInfoService';
 import { _storeNetworkInfoCleanup, setNetworkInfo } from './actions';
@@ -46,7 +47,9 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
             dispatch(_storeNetworkInfoCleanup(stop));
 
-            networkInfoService.start();
+            const serverURL = getState()['features/base/settings'].serverURL || DEFAULT_SERVER_URL;
+
+            networkInfoService.start(`${serverURL}/config.js`);
         }
         break;
     case APP_WILL_UNMOUNT: {


### PR DESCRIPTION
Fixes #6474 by setting a `reachabilityURL` on `NetInfo` before starting it.

NetInfo is already set up to make a [HEAD request](https://github.com/react-native-netinfo/react-native-netinfo/blob/a6fb54f4bfc507225219b31ac8b1ac76b5d7f126/src/internal/internetReachability.ts#L72) so that part isn't a concern.

A few questions I have for this PR that my JavaScript experience isn't high enough to figure out:
- Is there a better way to get the config.js URL than getting the server URL and appending `/config.js` to it?
- On Element iOS we use the [shared JitsiMeet](https://github.com/vector-im/element-ios/blob/7d0027e7bad4436e32fb2302d87a14172102f6e9/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift#L63) object and then update the [defaultConferenceOptions](https://github.com/vector-im/element-ios/blob/7d0027e7bad4436e32fb2302d87a14172102f6e9/Riot/Modules/Integrations/Widgets/Jitsi/JitsiService.swift#L100) with a specific server. In this instance I see the HEAD requests still going to meet.jit.si/config.js - I'm not sure if this is because the serverURL is set after NetworkInfoService is started, or because the conference options are setting a different serverURL?

**Screenshot of it working:**
![Screenshot 2022-06-23 at 12 35 13 pm](https://user-images.githubusercontent.com/6060466/175289651-39afbae3-23ef-45fb-b6eb-705698117a7f.png)

