### PR TITLE
fix: Do not send the videoType for audio tracks

### DIFF
--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -65,7 +65,7 @@ MiddlewareRegistry.register(store => next => action => {
             const { ssrc, videoType } = jitsiTrack || { };
 
             // Remote tracks store their ssrc in the jitsiTrack object. Local tracks don't. See getSsrcByTrack.
-            if (videoType && ssrc && !jitsiTrack.isLocal()) {
+            if (videoType && ssrc && !jitsiTrack.isLocal() && !jitsiTrack.isAudioTrack()) {
                 RTCStats.sendVideoTypeData({
                     ssrc,
                     videoType
@@ -81,7 +81,7 @@ MiddlewareRegistry.register(store => next => action => {
 
             // if the videoType of the remote track has changed we expect to find it in track.videoType. grep for
             // trackVideoTypeChanged.
-            if (videoType && ssrc && !jitsiTrack.isLocal()) {
+            if (videoType && ssrc && !jitsiTrack.isLocal() && !jitsiTrack.isAudioTrack()) {
 
                 RTCStats.sendVideoTypeData({
                     ssrc,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

This PR prevents sending the video type for audio tracks. Why does this happen? because audio tracks sometimes have their videoType set to 'camera' (the default value for video type) and this ends up in the rtcstats redshift database as 'audio/camera' polluting our data.