### PR TITLE
fix(screenshare) disable sound when presenter stops sharing

### DIFF
--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -378,6 +378,7 @@ export function hiddenParticipantLeft(id) {
  * participant is allowed to not specify an associated {@code JitsiConference}
  * instance.
  * @param {boolean} isReplaced - Whether the participant is to be replaced in the meeting.
+ * @param {boolean} isVirtualScreenshareParticipant - Whether the participant is a virtual screen share participant.
  * @returns {{
  *     type: PARTICIPANT_LEFT,
  *     participant: {
@@ -386,13 +387,14 @@ export function hiddenParticipantLeft(id) {
  *     }
  * }}
  */
-export function participantLeft(id, conference, isReplaced) {
+export function participantLeft(id, conference, isReplaced, isVirtualScreenshareParticipant) {
     return {
         type: PARTICIPANT_LEFT,
         participant: {
             conference,
             id,
-            isReplaced
+            isReplaced,
+            isVirtualScreenshareParticipant
         }
     };
 }

--- a/react/features/base/participants/subscriber.js
+++ b/react/features/base/participants/subscriber.js
@@ -52,14 +52,14 @@ function _updateScreenshareParticipants({ getState, dispatch }) {
     }
 
     if (localScreenShare && !newLocalSceenshareSourceName) {
-        dispatch(participantLeft(localScreenShare.id, conference));
+        dispatch(participantLeft(localScreenShare.id, conference, undefined, true));
     }
 
     const removedScreenshareSourceNames = _.difference(previousScreenshareSourceNames, currentScreenshareSourceNames);
     const addedScreenshareSourceNames = _.difference(currentScreenshareSourceNames, previousScreenshareSourceNames);
 
     if (removedScreenshareSourceNames.length) {
-        removedScreenshareSourceNames.forEach(id => dispatch(participantLeft(id, conference)));
+        removedScreenshareSourceNames.forEach(id => dispatch(participantLeft(id, conference, undefined, true)));
     }
 
     if (addedScreenshareSourceNames.length) {


### PR DESCRIPTION
# Description
With multi-stream enabled, we shouldn't hear a "participant left" sound when the presenter stops sharing. 
Ref: https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/participants/middleware.js#L258 

# Fix
Add `isVirtualScreenshareParticipant` field to the `PARTICIPANT_LEFT` action and ensure it is passed as `true` when a virtual screenshare participant is scheduled to be removed. 