### PR TITLE
fix(external-api) fix error if setting some options too early

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -3094,34 +3094,12 @@ export default {
      * @param email {string} the new email
      */
     changeLocalEmail(email = '') {
-        const localParticipant = getLocalParticipant(APP.store.getState());
-
         const formattedEmail = String(email).trim();
-
-        if (formattedEmail === localParticipant.email) {
-            return;
-        }
-
-        const localId = localParticipant.id;
-
-        APP.store.dispatch(participantUpdated({
-            // XXX Only the local participant is allowed to update without
-            // stating the JitsiConference instance (i.e. participant property
-            // `conference` for a remote participant) because the local
-            // participant is uniquely identified by the very fact that there is
-            // only one local participant.
-
-            id: localId,
-            local: true,
-            email: formattedEmail
-        }));
 
         APP.store.dispatch(updateSettings({
             email: formattedEmail
         }));
-        APP.API.notifyEmailChanged(localId, {
-            email: formattedEmail
-        });
+
         sendData(commands.EMAIL, formattedEmail);
     },
 
@@ -3130,29 +3108,12 @@ export default {
      * @param url {string} the new url
      */
     changeLocalAvatarUrl(url = '') {
-        const { avatarURL, id } = getLocalParticipant(APP.store.getState());
-
         const formattedUrl = String(url).trim();
-
-        if (formattedUrl === avatarURL) {
-            return;
-        }
-
-        APP.store.dispatch(participantUpdated({
-            // XXX Only the local participant is allowed to update without
-            // stating the JitsiConference instance (i.e. participant property
-            // `conference` for a remote participant) because the local
-            // participant is uniquely identified by the very fact that there is
-            // only one local participant.
-
-            id,
-            local: true,
-            avatarURL: formattedUrl
-        }));
 
         APP.store.dispatch(updateSettings({
             avatarURL: formattedUrl
         }));
+
         sendData(commands.AVATAR_URL, url);
     },
 
@@ -3193,23 +3154,6 @@ export default {
      */
     changeLocalDisplayName(nickname = '') {
         const formattedNickname = getNormalizedDisplayName(nickname);
-        const { id, name } = getLocalParticipant(APP.store.getState());
-
-        if (formattedNickname === name) {
-            return;
-        }
-
-        APP.store.dispatch(participantUpdated({
-            // XXX Only the local participant is allowed to update without
-            // stating the JitsiConference instance (i.e. participant property
-            // `conference` for a remote participant) because the local
-            // participant is uniquely identified by the very fact that there is
-            // only one local participant.
-
-            id,
-            local: true,
-            name: formattedNickname
-        }));
 
         APP.store.dispatch(updateSettings({
             displayName: formattedNickname

--- a/react/features/external-api/subscriber.js
+++ b/react/features/external-api/subscriber.js
@@ -23,7 +23,7 @@ StateListenerRegistry.register(
         const localParticipant = getLocalParticipant(store.getState());
         const { defaultLocalDisplayName } = store.getState()['features/base/config'];
 
-        // Initial setting of the display name occurs happens on app
+        // Initial setting of the display name happens on app
         // initialization, before the local participant is ready. The initial
         // settings is not desired to be fired anyways, only changes.
         if (localParticipant) {
@@ -35,6 +35,23 @@ StateListenerRegistry.register(
                     displayName,
                     defaultLocalDisplayName
                 )
+            });
+        }
+    });
+
+StateListenerRegistry.register(
+    /* selector */ state => state['features/base/settings'].email,
+    /* listener */ (email, store) => {
+        const localParticipant = getLocalParticipant(store.getState());
+
+        // Initial setting of the email happens on app
+        // initialization, before the local participant is ready. The initial
+        // settings is not desired to be fired anyways, only changes.
+        if (localParticipant) {
+            const { id } = localParticipant;
+
+            APP.API.notifyEmailChanged(id, {
+                email
             });
         }
     });


### PR DESCRIPTION
Specifically: display-name, email and avatar. These are the most common
ones, and the ones currently used by Spot for example.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
