### PR TITLE
feat(conference): disabled pip if not in conference room

### DIFF
--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -572,7 +572,6 @@ export default withSafeAreaInsets(connect(_mapStateToProps)(props => {
     }, [ isFocused ]);
 
     return (
-        <Conference
-            { ...props }/>
+        <Conference { ...props } />
     );
 }));

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React from 'react';
+import { useIsFocused } from '@react-navigation/native';
+import React, { useEffect } from 'react';
 import { BackHandler, NativeModules, SafeAreaView, StatusBar, View } from 'react-native';
 import { withSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -192,7 +193,6 @@ class Conference extends AbstractConference<Props, State> {
      */
     componentDidMount() {
         BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
-        setPictureInPictureEnabled(true);
     }
 
     /**
@@ -233,7 +233,6 @@ class Conference extends AbstractConference<Props, State> {
         BackHandler.removeEventListener('hardwareBackPress', this._onHardwareBackPress);
 
         clearTimeout(this._expandedLabelTimeout.current);
-        setPictureInPictureEnabled(false);
     }
 
     /**
@@ -561,4 +560,19 @@ function _mapStateToProps(state) {
     };
 }
 
-export default withSafeAreaInsets(connect(_mapStateToProps)(Conference));
+export default withSafeAreaInsets(connect(_mapStateToProps)(props => {
+    const isFocused = useIsFocused();
+
+    useEffect(() => {
+        if (isFocused) {
+            setPictureInPictureEnabled(true);
+        } else {
+            setPictureInPictureEnabled(false);
+        }
+    }, [ isFocused ]);
+
+    return (
+        <Conference
+            { ...props }/>
+    );
+}));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Conference is now a navigation screen and we hide it when we navigate to a different screen. 
Only if we leave the conference room, we unmount it.
Based on that, we need to check if the screen is focused or not. This helps us enable or disable PiP.