### PR TITLE
fix(prejoin) don't hide during auth

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -21,8 +21,7 @@ import { isFatalJitsiConnectionError } from './react/features/base/lib-jitsi-mee
 import { getCustomerDetails } from './react/features/jaas/actions.any';
 import { isVpaasMeeting, getJaasJWT } from './react/features/jaas/functions';
 import {
-    setPrejoinDisplayNameRequired,
-    setPrejoinPageVisibility
+    setPrejoinDisplayNameRequired
 } from './react/features/prejoin/actions';
 const logger = Logger.getLogger(__filename);
 
@@ -247,7 +246,6 @@ function requestAuth(roomName) {
             resolve(connection);
         };
 
-        APP.store.dispatch(setPrejoinPageVisibility(false));
         APP.store.dispatch(
             openDialog(LoginDialog, { onSuccess,
                 roomName })

--- a/modules/UI/authentication/AuthHandler.js
+++ b/modules/UI/authentication/AuthHandler.js
@@ -17,7 +17,6 @@ import {
 import { getReplaceParticipant } from '../../../react/features/base/config/functions';
 import { isDialogOpen } from '../../../react/features/base/dialog';
 import { setJWT } from '../../../react/features/base/jwt';
-import { setPrejoinPageVisibility } from '../../../react/features/prejoin';
 import UIUtil from '../util/UIUtil';
 
 import ExternalLoginDialog from './LoginDialog';
@@ -181,7 +180,6 @@ function authenticate(room: Object, lockPassword: string) {
     if (isTokenAuthEnabled(config) || room.isExternalAuthEnabled()) {
         doExternalAuth(room, lockPassword);
     } else {
-        APP.store.dispatch(setPrejoinPageVisibility(false));
         APP.store.dispatch(openLoginDialog());
     }
 }

--- a/react/features/authentication/middleware.native.js
+++ b/react/features/authentication/middleware.native.js
@@ -15,7 +15,6 @@ import {
     JitsiConnectionErrors
 } from '../base/lib-jitsi-meet';
 import { MiddlewareRegistry } from '../base/redux';
-import { setPrejoinPageVisibility } from '../prejoin';
 
 import {
     CANCEL_LOGIN,
@@ -121,7 +120,6 @@ MiddlewareRegistry.register(store => next => action => {
                 && error.name === JitsiConnectionErrors.PASSWORD_REQUIRED
                 && typeof error.recoverable === 'undefined') {
             error.recoverable = true;
-            store.dispatch(setPrejoinPageVisibility(false));
             store.dispatch(openLoginDialog());
         }
         break;

--- a/react/features/base/conference/middleware.web.js
+++ b/react/features/base/conference/middleware.web.js
@@ -46,10 +46,7 @@ MiddlewareRegistry.register(store => next => action => {
     case CONFERENCE_FAILED: {
         const errorName = action.error?.name;
 
-        if (errorName === JitsiConferenceErrors.MEMBERS_ONLY_ERROR
-            || errorName === JitsiConferenceErrors.PASSWORD_REQUIRED) {
-            dispatch(setPrejoinPageVisibility(false));
-        } else if (enableForcedReload && errorName === JitsiConferenceErrors.CONFERENCE_RESTARTED) {
+        if (enableForcedReload && errorName === JitsiConferenceErrors.CONFERENCE_RESTARTED) {
             dispatch(setSkipPrejoinOnReload(true));
         }
 


### PR DESCRIPTION
Fix the focus issue by disabling autofocus in case an auth (login, ait
for owner or password) dialog is shown.

Fixes: https://github.com/jitsi/docker-jitsi-meet/issues/1336

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
