### PR TITLE
fix(Toolbox) Render the virtual background button in multi-stream mode.

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -12,7 +12,7 @@ import {
     sendAnalytics
 } from '../../../analytics';
 import { ContextMenu, ContextMenuItemGroup } from '../../../base/components';
-import { getToolbarButtons } from '../../../base/config';
+import { getMultipleVideoSendingSupportFeatureFlag, getToolbarButtons } from '../../../base/config';
 import { isToolbarButtonEnabled } from '../../../base/config/functions.web';
 import { openDialog, toggleDialog } from '../../../base/dialog';
 import { isIosMobileBrowser, isMobileBrowser } from '../../../base/environment/utils';
@@ -205,7 +205,12 @@ type Props = {
     _localVideo: Object,
 
     /**
-     *Whether or not the overflow menu is displayed in a drawer drawer.
+     * Whether or not multi-stream send support is enabled.
+     */
+    _multiStreamModeEnabled: boolean,
+
+    /**
+     * Whether or not the overflow menu is displayed in a drawer drawer.
      */
     _overflowDrawer: boolean,
 
@@ -631,6 +636,7 @@ class Toolbox extends Component<Props> {
             _isIosMobile,
             _isMobile,
             _hasSalesforce,
+            _multiStreamModeEnabled,
             _screenSharing
         } = this.props;
 
@@ -761,7 +767,7 @@ class Toolbox extends Component<Props> {
             group: 3
         };
 
-        const virtualBackground = !_screenSharing && {
+        const virtualBackground = (_multiStreamModeEnabled || !_screenSharing) && {
             key: 'select-background',
             Content: VideoBackgroundButton,
             group: 3
@@ -1445,6 +1451,7 @@ function _mapStateToProps(state, ownProps) {
         _hasSalesforce: isSalesforceEnabled(state),
         _localParticipantID: localParticipant?.id,
         _localVideo: localVideo,
+        _multiStreamModeEnabled: getMultipleVideoSendingSupportFeatureFlag(state),
         _overflowMenuVisible: overflowMenuVisible,
         _overflowDrawer: overflowDrawer,
         _participantsPaneOpen: getParticipantsPaneOpen(state),


### PR DESCRIPTION
In multi-stream mode, both camera and desktop streams are available at the same time. Virtual backgrounds can be applied to the camera stream while screensharing is in progress.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
