### PR TITLE
feat(conference): removed padding from invite button

### DIFF
--- a/react/features/conference/components/native/styles.js
+++ b/react/features/conference/components/native/styles.js
@@ -85,8 +85,7 @@ export default {
     },
 
     lonelyButton: {
-        borderRadius: BaseTheme.spacing[4],
-        paddingHorizontal: BaseTheme.spacing[1]
+        borderRadius: BaseTheme.spacing[4]
     },
 
     lonelyMeetingContainer: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
When pressed, ripple background didn't fill button's container because of the extra padding.