### PR TITLE
fix(etherpad) close menu when opening / closing document

### DIFF
--- a/react/features/etherpad/components/SharedDocumentButton.web.js
+++ b/react/features/etherpad/components/SharedDocumentButton.web.js
@@ -8,6 +8,7 @@ import { IconShareDoc } from '../../base/icons';
 import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { toggleDocument } from '../../etherpad/actions';
+import { setOverflowMenuVisible } from '../../toolbox/actions.web';
 
 type Props = AbstractButtonProps & {
 
@@ -67,6 +68,7 @@ class SharedDocumentButton extends AbstractButton<Props, *> {
             }));
 
         dispatch(toggleDocument());
+        dispatch(setOverflowMenuVisible(false));
     }
 
     /**


### PR DESCRIPTION
Specially when we oopen it, mouse tracking will no longer work, so it
would remain open.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
