### PR TITLE
fix(local-recording) Fixes

### DIFF
--- a/css/_subject.scss
+++ b/css/_subject.scss
@@ -12,6 +12,7 @@
     &#autoHide.with-always-on {
         overflow: hidden;
         animation: hideSubject forwards .6s ease-out;
+        margin-left: 4px;
 
         & > .subject-info-container {
             justify-content: flex-start;

--- a/react/features/recording/components/Recording/StartRecordingDialogContent.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.js
@@ -452,7 +452,7 @@ class StartRecordingDialogContent extends Component<Props> {
             );
         }
 
-        if (this.props.fileRecordingsServiceEnabled) {
+        if (this.props.fileRecordingsServiceEnabled || this._localRecordingAvailable) {
             switchContent = (
                 <Switch
                     className = 'recording-switch'

--- a/react/features/recording/functions.js
+++ b/react/features/recording/functions.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { JitsiRecordingConstants } from '../base/lib-jitsi-meet';
+import { isMobileBrowser } from '../base/environment/utils';
+import { JitsiRecordingConstants, browser } from '../base/lib-jitsi-meet';
 import { getLocalParticipant, getRemoteParticipants, isLocalParticipantModerator } from '../base/participants';
 import { isInBreakoutRoom } from '../breakout-rooms/functions';
 import { isEnabled as isDropboxEnabled } from '../dropbox';
@@ -155,7 +156,8 @@ export function getRecordButtonProps(state: Object): ?string {
         localRecording
     } = state['features/base/config'];
     const { features = {} } = getLocalParticipant(state);
-    let localRecordingEnabled = !localRecording?.disable;
+    const supportsLocalRecording = browser.isChromiumBased() && !browser.isElectron() && !isMobileBrowser();
+    let localRecordingEnabled = !localRecording?.disable && supportsLocalRecording;
 
     if (navigator.product === 'ReactNative') {
         localRecordingEnabled = false;

--- a/react/features/recording/middleware.js
+++ b/react/features/recording/middleware.js
@@ -176,12 +176,11 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => async action => 
 
     case STOP_LOCAL_RECORDING: {
         const { localRecording } = getState()['features/base/config'];
-        const { onlySelf } = action;
 
         if (LocalRecordingManager.isRecordingLocally()) {
             LocalRecordingManager.stopLocalRecording();
             dispatch(updateLocalRecordingStatus(false));
-            if (localRecording?.notifyAllParticipants && !onlySelf) {
+            if (localRecording?.notifyAllParticipants && !LocalRecordingManager.selfRecording) {
                 dispatch(playSound(RECORDING_OFF_SOUND_ID));
             }
         }


### PR DESCRIPTION
Allow service change when only Dropbox and Local recording are enabled
Add space between REC indicator and meeting title
Hide Recording button if the feature is enabled but not supported
Don't play Stop recording sound on self recording