### PR TITLE
fix(dynamic-branding) fix loading on web

### DIFF
--- a/react/features/dynamic-branding/functions.any.js
+++ b/react/features/dynamic-branding/functions.any.js
@@ -36,7 +36,11 @@ export function extractFqnFromPath(state?: Object) {
  */
 export async function getDynamicBrandingUrl(stateful: Object | Function) {
     const state = toState(stateful);
-    const config = state['features/base/config'];
+
+    // NB: On web this is dispatched really early, before the config has been stored in the
+    // state. Thus, fetch it from the window global.
+    const config
+        = navigator.product === 'ReactNative' ? state['features/base/config'] : window.config;
     const { dynamicBrandingUrl } = config;
 
     if (dynamicBrandingUrl) {


### PR DESCRIPTION
The configuration is not stored in Redux by the time we try to fetch it,
so use the global on Window, which will.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
