### PR TITLE
Add mime.type mapping for wav files.

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -1,8 +1,9 @@
 server_names_hash_bucket_size 64;
 
 types {
-# nginx's default mime.types doesn't include a mapping for wasm
+# nginx's default mime.types doesn't include a mapping for wasm or wav.
     application/wasm     wasm;
+    audio/wav            wav;
 }
 upstream prosody {
     zone upstreams 64K;


### PR DESCRIPTION
Add mime.type mapping for wav files so Firefox supports playback of these sounds.

Addresses issue: #11860 
