### PR TITLE
feat: configurable default known domains

### DIFF
--- a/config.js
+++ b/config.js
@@ -1295,6 +1295,7 @@ var config = {
      _immediateReloadThreshold
      debug
      debugAudioLevels
+     defaultKnownDomains
      deploymentInfo
      dialOutAuthUrl
      dialOutCodesUrl

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -173,6 +173,7 @@ export interface IConfig {
         };
     };
     corsAvatarURLs?: Array<string>;
+    defaultKnownDomains?: Array<string>;
     defaultLanguage?: string;
     defaultLocalDisplayName?: string;
     defaultLogoUrl?: string;

--- a/react/features/base/known-domains/middleware.ts
+++ b/react/features/base/known-domains/middleware.ts
@@ -3,10 +3,30 @@ import { getDefaultURL } from '../../app/functions';
 import { IStore } from '../../app/types';
 import { APP_WILL_MOUNT } from '../app/actionTypes';
 import { SET_ROOM } from '../conference/actionTypes';
+import { SET_CONFIG } from '../config/actionTypes';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import { parseURIString } from '../util/uri';
 
 import { addKnownDomains } from './actions';
+
+
+/**
+ * The default list of domains known to the feature base/known-domains.
+ * Generally, it should be in sync with the domains associated with the app
+ * through its manifest (in other words, Universal Links, deep linking). Anyway,
+ * we need a hardcoded list because it has proven impossible to programmatically
+ * read the information out of the app's manifests: App Store strips the
+ * associated domains manifest out of the app so it's never downloaded on the
+ * client and we did not spend a lot of effort to read the associated domains
+ * out of the Android manifest.
+ */
+export const DEFAULT_KNOWN_DOMAINS = [
+    'alpha.jitsi.net',
+    'beta.meet.jit.si',
+    'meet.jit.si',
+    '8x8.vc'
+];
+
 
 MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
@@ -19,6 +39,10 @@ MiddlewareRegistry.register(store => next => action => {
     case SET_ROOM:
         _setRoom(store);
         break;
+
+    case SET_CONFIG:
+        _setConfig(store);
+        break;
     }
 
     return result;
@@ -30,7 +54,7 @@ MiddlewareRegistry.register(store => next => action => {
  *
  * @param {Object} store - The redux store.
  * @private
- * @returns {Promise}
+ * @returns {void}
  */
 function _appWillMount({ dispatch, getState }: IStore) {
     const defaultURL = parseURIString(getDefaultURL(getState));
@@ -44,7 +68,7 @@ function _appWillMount({ dispatch, getState }: IStore) {
  *
  * @param {Object} store - The redux store.
  * @private
- * @returns {Promise}
+ * @returns {void}
  */
 function _setRoom({ dispatch, getState }: IStore) {
     const { locationURL } = getState()['features/base/connection'];
@@ -53,4 +77,19 @@ function _setRoom({ dispatch, getState }: IStore) {
     locationURL
         && (host = locationURL.host)
         && dispatch(addKnownDomains(host));
+}
+
+/**
+ * Adds default domains to the list of domains known to the feature
+ * base/known-domains.
+ *
+ * @param {Object} store - The redux store.
+ * @private
+ * @returns {void}
+ */
+function _setConfig({ dispatch, getState }: IStore) {
+    const state = getState();
+    const { defaultKnownDomains = DEFAULT_KNOWN_DOMAINS } = state['features/base/config'];
+
+    dispatch(addKnownDomains(defaultKnownDomains));
 }

--- a/react/features/base/known-domains/reducer.ts
+++ b/react/features/base/known-domains/reducer.ts
@@ -3,22 +3,6 @@ import ReducerRegistry from '../redux/ReducerRegistry';
 
 import { ADD_KNOWN_DOMAINS } from './actionTypes';
 
-/**
- * The default list of domains known to the feature base/known-domains.
- * Generally, it should be in sync with the domains associated with the app
- * through its manifest (in other words, Universal Links, deep linking). Anyway,
- * we need a hardcoded list because it has proven impossible to programmatically
- * read the information out of the app's manifests: App Store strips the
- * associated domains manifest out of the app so it's never downloaded on the
- * client and we did not spend a lot of effort to read the associated domains
- * out of the Android manifest.
- */
-export const DEFAULT_STATE = [
-    'alpha.jitsi.net',
-    'beta.meet.jit.si',
-    'meet.jit.si',
-    '8x8.vc'
-];
 
 const STORE_NAME = 'features/base/known-domains';
 
@@ -26,7 +10,7 @@ PersistenceRegistry.register(STORE_NAME);
 
 export type IKnownDomainsState = Array<string>;
 
-ReducerRegistry.register<IKnownDomainsState>(STORE_NAME, (state = DEFAULT_STATE, action): IKnownDomainsState => {
+ReducerRegistry.register<IKnownDomainsState>(STORE_NAME, (state: Array<string> = [], action): IKnownDomainsState => {
     switch (action.type) {
     case ADD_KNOWN_DOMAINS:
         return _addKnownDomains(state, action.knownDomains);


### PR DESCRIPTION
Ref: https://community.jitsi.org/t/customise-default-known-domains/115964

Make default list of known-domains customisable from config.js. This is currently hardcoded to jitsi/8x8 domains.

Had to move the values from default state to middleware so we can defer it until configs have been loaded. Downside of this is that the order of domains could now be different since some `addKnownDomains` calls are triggered before configs loaded.