### PR TITLE
fix(filmstrip): Remove SS ep from list of active speakers.

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -63,12 +63,12 @@ export function getActiveSpeakersToBeDisplayed(stateful: Object | Function) {
         speakersList
     } = state['features/base/participants'];
     const { visibleRemoteParticipants } = state['features/filmstrip'];
+    const activeSpeakers = new Map(speakersList);
 
     // Do not re-sort the active speakers if all of them are currently visible.
-    if (typeof visibleRemoteParticipants === 'undefined' || speakersList.size <= visibleRemoteParticipants.size) {
-        return speakersList;
+    if (typeof visibleRemoteParticipants === 'undefined' || activeSpeakers.size <= visibleRemoteParticipants.size) {
+        return activeSpeakers;
     }
-    const activeSpeakers = new Map(speakersList);
     let availableSlotsForActiveSpeakers = visibleRemoteParticipants.size;
 
     // Remove screenshares from the count.

--- a/react/features/filmstrip/functions.any.js
+++ b/react/features/filmstrip/functions.any.js
@@ -49,10 +49,12 @@ export function updateRemoteParticipants(store: Object, participantId: ?number) 
 
             remoteParticipants.delete(ownerId);
             remoteParticipants.delete(screenshare);
+            speakers.delete(ownerId);
         }
     } else {
         for (const screenshare of screenShares.keys()) {
             remoteParticipants.delete(screenshare);
+            speakers.delete(screenshare);
         }
     }
 


### PR DESCRIPTION
This fixes a case where duplicate SS tile appears when SS ep is the dominant speaker and all the active speakers are currently visisble.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
