### PR TITLE
feat(external-api) Add command to show custom in-meeting notification

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -75,7 +75,12 @@ import {
     resizeLargeVideo
 } from '../../react/features/large-video/actions.web';
 import { toggleLobbyMode, answerKnockingParticipant } from '../../react/features/lobby/actions';
-import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE, showNotification } from '../../react/features/notifications';
+import {
+    hideNotification,
+    NOTIFICATION_TIMEOUT_TYPE,
+    NOTIFICATION_TYPE,
+    showNotification
+} from '../../react/features/notifications';
 import {
     close as closeParticipantsPane,
     open as openParticipantsPane
@@ -469,15 +474,17 @@ function initCommands() {
          *
          * @param { string } arg.title - Notification title.
          * @param { string } arg.description - Notification description.
+         * @param { string } arg.uid - Optional unique identifier for the notification.
          * @param { string } arg.type - Notification type, either `error`, `info`, `normal`, `success` or `warning`.
-         *                              Defaults to "normal" if not provided.
+         * Defaults to "normal" if not provided.
          * @param { string } arg.timeout - Timeout type, either `short`, `medium`, `long` or `sticky`.
-         *                                 Defaults to "short" if not provided.
+         * Defaults to "short" if not provided.
          * @returns {void}
          */
         'show-notification': ({
             title,
             description,
+            uid,
             type = NOTIFICATION_TYPE.NORMAL,
             timeout = NOTIFICATION_TIMEOUT_TYPE.SHORT
         }) => {
@@ -497,10 +504,21 @@ function initCommands() {
             }
 
             APP.store.dispatch(showNotification({
+                uid,
                 title,
                 description,
                 appearance: type
             }, timeout));
+        },
+
+        /**
+         * Removes a notification given a unique identifier.
+         *
+         * @param { string } uid - Unique identifier for the notification to be removed.
+         * @returns {void}
+         */
+        'hide-notification': uid => {
+            APP.store.dispatch(hideNotification(uid));
         },
 
         /**

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -75,6 +75,7 @@ import {
     resizeLargeVideo
 } from '../../react/features/large-video/actions.web';
 import { toggleLobbyMode, answerKnockingParticipant } from '../../react/features/lobby/actions';
+import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE, showNotification } from '../../react/features/notifications';
 import {
     close as closeParticipantsPane,
     open as openParticipantsPane
@@ -97,10 +98,6 @@ import VirtualBackgroundDialog from '../../react/features/virtual-background/com
 import { getJitsiMeetTransport } from '../transport';
 
 import { API_ID, ENDPOINT_TEXT_MESSAGE_NAME } from './constants';
-import {
-    NOTIFICATION_TIMEOUT_TYPE,
-    NOTIFICATION_TYPE, showNotification
-} from "../../react/features/notifications";
 
 const logger = Logger.getLogger(__filename);
 
@@ -482,25 +479,27 @@ function initCommands() {
             title,
             description,
             type = NOTIFICATION_TYPE.NORMAL,
-            timeout = NOTIFICATION_TIMEOUT_TYPE.SHORT,
+            timeout = NOTIFICATION_TIMEOUT_TYPE.SHORT
         }) => {
             const validTypes = Object.values(NOTIFICATION_TYPE);
             const validTimeouts = Object.values(NOTIFICATION_TIMEOUT_TYPE);
 
             if (!validTypes.includes(type)) {
                 logger.error(`Invalid notification type "${type}". Expecting one of ${validTypes}`);
+
                 return;
             }
 
             if (!validTimeouts.includes(timeout)) {
                 logger.error(`Invalid notification timeout "${timeout}". Expecting one of ${validTimeouts}`);
+
                 return;
             }
 
             APP.store.dispatch(showNotification({
                 title,
                 description,
-                appearance: type,
+                appearance: type
             }, timeout));
         },
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -97,6 +97,10 @@ import VirtualBackgroundDialog from '../../react/features/virtual-background/com
 import { getJitsiMeetTransport } from '../transport';
 
 import { API_ID, ENDPOINT_TEXT_MESSAGE_NAME } from './constants';
+import {
+    NOTIFICATION_TIMEOUT_TYPE,
+    NOTIFICATION_TYPE, showNotification
+} from "../../react/features/notifications";
 
 const logger = Logger.getLogger(__filename);
 
@@ -461,6 +465,43 @@ function initCommands() {
             logger.debug('Share video command received');
             sendAnalytics(createApiEvent('share.video.stop'));
             APP.store.dispatch(stopSharedVideo());
+        },
+
+        /**
+         * Shows a custom in-meeting notification.
+         *
+         * @param { string } arg.title - Notification title.
+         * @param { string } arg.description - Notification description.
+         * @param { string } arg.type - Notification type, either `error`, `info`, `normal`, `success` or `warning`.
+         *                              Defaults to "normal" if not provided.
+         * @param { string } arg.timeout - Timeout type, either `short`, `medium`, `long` or `sticky`.
+         *                                 Defaults to "short" if not provided.
+         * @returns {void}
+         */
+        'show-notification': ({
+            title,
+            description,
+            type = NOTIFICATION_TYPE.NORMAL,
+            timeout = NOTIFICATION_TIMEOUT_TYPE.SHORT,
+        }) => {
+            const validTypes = Object.values(NOTIFICATION_TYPE);
+            const validTimeouts = Object.values(NOTIFICATION_TIMEOUT_TYPE);
+
+            if (!validTypes.includes(type)) {
+                logger.error(`Invalid notification type "${type}". Expecting one of ${validTypes}`);
+                return;
+            }
+
+            if (!validTimeouts.includes(timeout)) {
+                logger.error(`Invalid notification timeout "${timeout}". Expecting one of ${validTimeouts}`);
+                return;
+            }
+
+            APP.store.dispatch(showNotification({
+                title,
+                description,
+                appearance: type,
+            }, timeout));
         },
 
         /**

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -40,6 +40,7 @@ const commands = {
     email: 'email',
     grantModerator: 'grant-moderator',
     hangup: 'video-hangup',
+    hideNotification: 'hide-notification',
     initiatePrivateChat: 'initiate-private-chat',
     joinBreakoutRoom: 'join-breakout-room',
     localSubject: 'local-subject',

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -63,6 +63,7 @@ const commands = {
     setSubtitles: 'set-subtitles',
     setTileView: 'set-tile-view',
     setVideoQuality: 'set-video-quality',
+    showNotification: 'show-notification',
     startRecording: 'start-recording',
     startShareVideo: 'start-share-video',
     stopRecording: 'stop-recording',

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -104,7 +104,7 @@ export function showErrorNotification(props: Object, type: ?string) {
  * Queues a notification for display.
  *
  * @param {Object} props - The props needed to show the notification component.
- * @param {string} type - Notification type.
+ * @param {string} type - Timeout type.
  * @returns {Function}
  */
 export function showNotification(props: Object = {}, type: ?string) {


### PR DESCRIPTION
This allows IFrame API users to push custom notifications. Example usage:

```javascript
api.executeCommand("showNotification", {
    title: "Recording still in progress",
    description: "Please stop the recording before leaving the room in order to save it.",
});
```

or with custom notification type and timeout:

```javascript
api.executeCommand("showNotification", {
    title: "Recording still in progress",
    description: "Please stop the recording before leaving the room in order to save it.",
    type: "warning",
    timeout: "sticky",
});
```

Example use case: https://community.jitsi.org/t/questions-regarding-the-new-localrecording-feature/115339/14?u=shawn