### PR TITLE
feat(old-client-notification) bump notice for anything older than 2022

### DIFF
--- a/react/features/old-client-notification/functions.js
+++ b/react/features/old-client-notification/functions.js
@@ -20,7 +20,7 @@ export function isOldJitsiMeetElectronApp() {
 
     const majorVersion = Number(match[3]);
 
-    if (isNaN(majorVersion) || majorVersion >= 2) {
+    if (isNaN(majorVersion) || majorVersion >= 2022) {
         return false;
     }
 


### PR DESCRIPTION
Bumped to catch old macOS versions which were not signed and thus did
not have autoupdater working (ie. everything older than
https://github.com/jitsi/jitsi-meet-electron/releases/tag/v2021.11.2)

Signed-off-by: Christoph Settgast <csett86@web.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
