### PR TITLE
chore(deps) react-native-watch-connectivity@latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -475,7 +475,7 @@ PODS:
     - React-Core
   - RNSVG (12.1.0):
     - React
-  - RNWatch (1.0.4):
+  - RNWatch (1.0.11):
     - React
   - Yoga (1.14.0)
 
@@ -764,7 +764,7 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSound: 27e8268bdb0a1f191f219a33267f7e0445e8d62f
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
-  RNWatch: 99637948ec9b5c9ec5a41920642594ad5ba07e80
+  RNWatch: dae6c858a2051dbdcfb00b9a86cf4d90400263b4
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
 
 PODFILE CHECKSUM: 0e8826a5cb9ee147354a83321ecb3104132f510b

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,7 @@
         "react-native-tab-view": "3.1.1",
         "react-native-url-polyfill": "1.3.0",
         "react-native-video": "https://git@github.com/jitsi/react-native-video#4f6dad990d17ce42894df993780b5386a9c11b85",
-        "react-native-watch-connectivity": "1.0.4",
+        "react-native-watch-connectivity": "1.0.11",
         "react-native-webrtc": "1.100.1",
         "react-native-webview": "11.15.1",
         "react-native-youtube-iframe": "2.2.1",
@@ -16754,9 +16754,9 @@
       }
     },
     "node_modules/react-native-watch-connectivity": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-watch-connectivity/-/react-native-watch-connectivity-1.0.4.tgz",
-      "integrity": "sha512-Z7p7fzF6gaWHHM5kVYvM2l5bslc+59obqvfXA+DwqjOaO640APDjU7Sl8R2oglJhzLJArbmO25lH1YY1pSd8AQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-native-watch-connectivity/-/react-native-watch-connectivity-1.0.11.tgz",
+      "integrity": "sha512-MhR3zN/TtsjEiErraVmQS1H+Vza4zXjZTsOLuiguQu3J4lRzRFr0KkRlT27NUWXOPenu7bu7fWdqs9NxaDtoiA==",
       "dependencies": {
         "lodash.sortby": "^4.7.0"
       },
@@ -33442,9 +33442,9 @@
       }
     },
     "react-native-watch-connectivity": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-watch-connectivity/-/react-native-watch-connectivity-1.0.4.tgz",
-      "integrity": "sha512-Z7p7fzF6gaWHHM5kVYvM2l5bslc+59obqvfXA+DwqjOaO640APDjU7Sl8R2oglJhzLJArbmO25lH1YY1pSd8AQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/react-native-watch-connectivity/-/react-native-watch-connectivity-1.0.11.tgz",
+      "integrity": "sha512-MhR3zN/TtsjEiErraVmQS1H+Vza4zXjZTsOLuiguQu3J4lRzRFr0KkRlT27NUWXOPenu7bu7fWdqs9NxaDtoiA==",
       "requires": {
         "lodash.sortby": "^4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-native-tab-view": "3.1.1",
     "react-native-url-polyfill": "1.3.0",
     "react-native-video": "https://git@github.com/jitsi/react-native-video#4f6dad990d17ce42894df993780b5386a9c11b85",
-    "react-native-watch-connectivity": "1.0.4",
+    "react-native-watch-connectivity": "1.0.11",
     "react-native-webrtc": "1.100.1",
     "react-native-webview": "11.15.1",
     "react-native-youtube-iframe": "2.2.1",


### PR DESCRIPTION
This fixes the Android build because the old version depended on fbjs
wiithout actually listing it as a dependency.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
