### PR TITLE
feat(base/modal): renamed prop and fixed scroll inside webview

### DIFF
--- a/react/features/base/modal/components/JitsiKeyboardAvoidingView.js
+++ b/react/features/base/modal/components/JitsiKeyboardAvoidingView.js
@@ -25,6 +25,11 @@ type Props = {
     contentContainerStyle?: StyleType,
 
     /**
+     * Disable forced keyboard dismiss?
+     */
+    disableForcedKeyboardDismiss?: boolean,
+
+    /**
      * Is a text input rendered at the bottom of the screen?
      */
     hasBottomTextInput: boolean,
@@ -33,11 +38,6 @@ type Props = {
      * Is the screen rendering a tab navigator?
      */
     hasTabNavigator: boolean,
-
-    /**
-     * Is the keyboard already dismissible?
-     */
-    keyboardAlreadyDismissible?: boolean,
 
     /**
      * Additional style to be appended to the KeyboardAvoidingView.
@@ -51,7 +51,7 @@ const JitsiKeyboardAvoidingView = (
             contentContainerStyle,
             hasTabNavigator,
             hasBottomTextInput,
-            keyboardAlreadyDismissible,
+            disableForcedKeyboardDismiss,
             style
         }: Props) => {
     const headerHeight = useHeaderHeight();
@@ -74,7 +74,7 @@ const JitsiKeyboardAvoidingView = (
         ? headerHeight + StatusBar.currentHeight : headerHeight;
 
     // Tells the view what to do with taps
-    const shouldSetResponse = useCallback(() => !keyboardAlreadyDismissible);
+    const shouldSetResponse = useCallback(() => !disableForcedKeyboardDismiss);
     const onRelease = useCallback(() => Keyboard.dismiss());
 
     return (

--- a/react/features/base/modal/components/JitsiScreen.js
+++ b/react/features/base/modal/components/JitsiScreen.js
@@ -23,6 +23,11 @@ type Props = {
     children: React$Node,
 
     /**
+     * Disabled forced keyboard dismiss?
+     */
+    disableForcedKeyboardDismiss?: boolean,
+
+    /**
      * Optional function that renders a footer component, if needed.
      */
     footerComponent?: Function,
@@ -36,11 +41,6 @@ type Props = {
      * Is the screen rendering a tab navigator?
      */
     hasTabNavigator?: boolean,
-
-    /**
-     * Is the keyboard already dismissible?
-     */
-    keyboardAlreadyDismissible?: boolean,
 
     /**
      * Insets for the SafeAreaView.
@@ -59,7 +59,7 @@ const JitsiScreen = ({
     footerComponent,
     hasTabNavigator = false,
     hasBottomTextInput = false,
-    keyboardAlreadyDismissible = false,
+    disableForcedKeyboardDismiss = false,
     safeAreaInsets = [ 'left', 'right' ],
     style
 }: Props) => (
@@ -67,9 +67,9 @@ const JitsiScreen = ({
         style = { styles.jitsiScreenContainer }>
         <JitsiKeyboardAvoidingView
             contentContainerStyle = { contentContainerStyle }
+            disableForcedKeyboardDismiss = { disableForcedKeyboardDismiss }
             hasBottomTextInput = { hasBottomTextInput }
             hasTabNavigator = { hasTabNavigator }
-            keyboardAlreadyDismissible = { keyboardAlreadyDismissible }
             style = { style }>
             <SafeAreaView
                 edges = { safeAreaInsets }

--- a/react/features/base/modal/components/JitsiScreenWebView.js
+++ b/react/features/base/modal/components/JitsiScreenWebView.js
@@ -20,6 +20,7 @@ type Props = {
 
 const JitsiScreenWebView = ({ source, style }: Props) => (
     <JitsiScreen
+        disableForcedKeyboardDismiss = { true }
         style = { style }>
         <WebView source = {{ uri: source }} />
     </JitsiScreen>

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -53,9 +53,9 @@ class Chat extends AbstractChat<Props> {
 
         return (
             <JitsiScreen
+                disableForcedKeyboardDismiss = { true }
                 hasBottomTextInput = { true }
                 hasTabNavigator = { true }
-                keyboardAlreadyDismissible = { true }
                 style = { styles.chatContainer }>
                 <MessageContainer messages = { _messages } />
                 <MessageRecipient privateMessageRecipient = { privateMessageRecipient } />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
1. Renamed prop that takes care of dismissing keyboard inside navigation screens.
2. Fixes #11931