### PR TITLE
fix(audio-share): Fix audio-only SS in multi-stream mode.

### DIFF
--- a/react/features/base/conference/middleware.web.js
+++ b/react/features/base/conference/middleware.web.js
@@ -7,7 +7,7 @@ import {
     setPrejoinPageVisibility,
     setSkipPrejoinOnReload
 } from '../../prejoin';
-import { setScreenAudioShareState, setScreenshareAudioTrack } from '../../screen-share';
+import { isAudioOnlySharing, setScreenAudioShareState, setScreenshareAudioTrack } from '../../screen-share';
 import { isScreenshotCaptureEnabled, toggleScreenshotCaptureSummary } from '../../screenshot-capture';
 import { AudioMixerEffect } from '../../stream-effects/audio-mixer/AudioMixerEffect';
 import { setAudioOnly } from '../audio-only';
@@ -134,11 +134,18 @@ async function _maybeApplyAudioMixerEffect(desktopAudioTrack, state) {
 async function _toggleScreenSharing({ enabled, audioOnly = false }, store) {
     const { dispatch, getState } = store;
     const state = getState();
+    const audioOnlySharing = isAudioOnlySharing(state);
     const conference = getCurrentConference(state);
     const localAudio = getLocalJitsiAudioTrack(state);
     const localScreenshare = getLocalDesktopTrack(state['features/base/tracks']);
 
-    if (enabled) {
+    // ShareAudioDialog passes undefined when the user hits continue in the share audio demo modal. Audio screen-share
+    // state is toggled based on the current state of audio share in that case.
+    const enable = audioOnly
+        ? enabled ?? !audioOnlySharing
+        : enabled;
+
+    if (enable) {
         let tracks;
 
         try {
@@ -210,6 +217,6 @@ async function _toggleScreenSharing({ enabled, audioOnly = false }, store) {
     }
 
     if (audioOnly) {
-        dispatch(setScreenAudioShareState(enabled));
+        dispatch(setScreenAudioShareState(enable));
     }
 }

--- a/react/features/screen-share/actions.js
+++ b/react/features/screen-share/actions.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { getMultipleVideoSendingSupportFeatureFlag } from '../base/config/functions.any';
 import { openDialog } from '../base/dialog/actions';
 import { browser } from '../base/lib-jitsi-meet';
 import { shouldHideShareAudioHelper } from '../base/settings';
@@ -86,12 +85,6 @@ export function startAudioScreenShareFlow() {
         // available for audio screen sharing, namely full window audio.
         // If we're already sharing audio, toggle off.
         if (shouldHideShareAudioHelper(state) || browser.isElectron() || audioOnlySharing) {
-            if (getMultipleVideoSendingSupportFeatureFlag(state)) {
-                dispatch(toggleScreensharing(!audioOnlySharing, true));
-
-                return;
-            }
-
             // We don't want to explicitly set the screens share state, by passing undefined we let the
             // underlying logic decide if it's on or off.
             dispatch(toggleScreensharing(undefined, true));

--- a/react/features/screen-share/functions.js
+++ b/react/features/screen-share/functions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { getMultipleVideoSupportFeatureFlag } from '../base/config';
+import { getMultipleVideoSendingSupportFeatureFlag } from '../base/config';
 import { isWindows } from '../base/environment';
 import { isMobileBrowser } from '../base/environment/utils';
 import { browser } from '../base/lib-jitsi-meet';
@@ -57,8 +57,7 @@ export function isScreenVideoShared(state: Object) {
     const tracks = state['features/base/tracks'];
     const localScreenshare = getLocalDesktopTrack(tracks);
 
-    if (getMultipleVideoSupportFeatureFlag(state)) {
-
+    if (getMultipleVideoSendingSupportFeatureFlag(state)) {
         return localScreenshare && localScreenshare.jitsiTrack && !localScreenshare.jitsiTrack.isMuted();
     }
     const localVideo = getLocalVideoTrack(tracks);


### PR DESCRIPTION
ShareAudioDialog passes undefined when the user hits continue in the share audio demo modal. Toggle state of audio-share based on the current state of audio share in that case.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
