### PR TITLE
fix: display dial-in code on a new line

### DIFF
--- a/react/features/invite/components/add-people-dialog/web/DialInNumber.js
+++ b/react/features/invite/components/add-people-dialog/web/DialInNumber.js
@@ -106,7 +106,7 @@ class DialInNumber extends Component<Props> {
                             { phoneNumber }
                         </span>
                     </span>
-                    <span className = 'spacer'>&nbsp;</span>
+                    <br/>
                     <span className = 'conference-id'>
                         <span className = 'info-label'>
                             { t('info.dialInConferenceID') }

--- a/react/features/invite/components/add-people-dialog/web/DialInNumber.js
+++ b/react/features/invite/components/add-people-dialog/web/DialInNumber.js
@@ -106,7 +106,7 @@ class DialInNumber extends Component<Props> {
                             { phoneNumber }
                         </span>
                     </span>
-                    <br/>
+                    <br />
                     <span className = 'conference-id'>
                         <span className = 'info-label'>
                             { t('info.dialInConferenceID') }


### PR DESCRIPTION
## Issue
In the "invite people" modal, the phone number and the PIN code are displayed on the same line. It causes the PIN code to break in the middle, misleading people when they try to join a conference by phone.

## Changes
A very small change, to add a line break between phone number and PIN code

## See it in action

### Before
![image](https://user-images.githubusercontent.com/18146038/182895906-572b8835-1ca3-4aac-a1fd-fc8c795c8bc2.png)

### After
![image](https://user-images.githubusercontent.com/18146038/182895922-30465e60-412c-4484-b927-a10348dfd932.png)


<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
