### PR TITLE
fix(debian) skip all configuration with non interactive Debian frontend

### DIFF
--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -27,6 +27,12 @@ case "$1" in
         # loading debconf
         . /usr/share/debconf/confmodule
 
+        # Skip all processing if running with DEBIAN_FRONTEND=noninteractive
+        XDEB_FRONTEND=$(echo "$DEBIAN_FRONTEND" | tr '[:upper:]' '[:lower:]')
+        if [ "$XDEB_FRONTEND" = "noninteractive"]; then
+            exit 0
+        fi
+
         # try to get host from jitsi-videobridge
         db_get jitsi-videobridge/jvb-hostname
         if [ -z "$RET" ] ; then


### PR DESCRIPTION
This is the case of Docker, for example, so this would allow us to
remove some hacks.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
