### PR TITLE
fix(remote-control): when multistream is enabled

### DIFF
--- a/react/features/remote-control/subscriber.js
+++ b/react/features/remote-control/subscriber.js
@@ -1,5 +1,10 @@
 // @flow
 
+import {
+    getParticipantById,
+    getVirtualScreenshareParticipantByOwnerId,
+    getVirtualScreenshareParticipantOwnerId
+} from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
 
 import { resume, pause } from './actions';
@@ -15,6 +20,22 @@ StateListenerRegistry.register(
 
         if (!controlled) {
             return undefined;
+        }
+
+        const participant = getParticipantById(state, participantId);
+
+        if (participant?.isVirtualScreenshareParticipant) {
+            // multistream support is enabled and the user has selected the desktop sharing thumbnail.
+            const id = getVirtualScreenshareParticipantOwnerId(participantId);
+
+            return id === controlled;
+        }
+
+        const virtualParticipant = getVirtualScreenshareParticipantByOwnerId(state, participantId);
+
+        if (virtualParticipant) { // multistream is enabled and the user has selected the camera thumbnail.
+            return false;
+
         }
 
         return controlled === participantId;


### PR DESCRIPTION
The remote control controller events were sent for the camera
participant instead of the screen sharing one.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
