### PR TITLE
fix(face-landmarks) fix createImageBitMap polyfill on Safari 14

### DIFF
--- a/react/features/face-landmarks/createImageBitmap.js
+++ b/react/features/face-landmarks/createImageBitmap.js
@@ -1,5 +1,5 @@
 /*
-* Safari polyfill for createImageBitmap
+* Safari < 15 polyfill for createImageBitmap
 * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/createImageBitmap
 *
 * Support source image types: Canvas.
@@ -15,6 +15,9 @@ if (!('createImageBitmap' in window)) {
                 reject(new Error('createImageBitmap does not handle the provided image source type'));
             }
             const img = document.createElement('img');
+
+            // eslint-disable-next-line no-empty-function
+            img.close = () => {};
 
             img.addEventListener('load', () => {
                 resolve(img);


### PR DESCRIPTION
The polyfill returns an Image object instead of an ImageBitmap. The
latter has a close method, however, which we call.

Make sure we provide a dummy close method to avoid errors.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
