### PR TITLE
fix(dropbox) fix incorrect button labels and click on web

### DIFF
--- a/react/features/recording/components/Recording/StartRecordingDialogContent.js
+++ b/react/features/recording/components/Recording/StartRecordingDialogContent.js
@@ -434,7 +434,8 @@ class StartRecordingDialogContent extends Component<Props> {
             switchContent = (
                 <Container className = 'recording-switch'>
                     <Button
-                        label = { 'recording.signOut' }
+                        label = { t('recording.signOut') }
+                        onClick = { this._onSignOut }
                         onPress = { this._onSignOut }
                         type = { BUTTON_TYPES.SECONDARY } />
                 </Container>
@@ -444,7 +445,8 @@ class StartRecordingDialogContent extends Component<Props> {
             switchContent = (
                 <Container className = 'recording-switch'>
                     <Button
-                        label = { 'recording.signIn' }
+                        label = { t('recording.signIn') }
+                        onClick = { this._onSignIn }
                         onPress = { this._onSignIn }
                         type = { BUTTON_TYPES.PRIMARY } />
                 </Container>


### PR DESCRIPTION
The web and mobile Button components are not implemented the same way
and this came to bite us.

This is a stopgap fix, the real fix needs to be to make them have
exactly the same shared props and behavior.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
