### PR TITLE
feat(external-api) Add functions to query supported commands/events

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1080,6 +1080,24 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns array of commands supported by executeCommand().
+     *
+     * @returns {Array<string>} Array of commands.
+     */
+    getSupportedCommands() {
+        return Object.keys(commands);
+    }
+
+    /**
+     * Returns array of events supported by addEventListener().
+     *
+     * @returns {Array<string>} Array of events.
+     */
+    getSupportedEvents() {
+        return Object.values(events);
+    }
+
+    /**
      * Check if the video is available.
      *
      * @returns {Promise} - Resolves with true if the video available, with


### PR DESCRIPTION
New functions to allow for devs to query for array of commands/events that is supported in current version of the API.

Also makes it possible to programmatically check for support of a command and fallback to some alternative if not yet supported.

Related discussion: https://github.com/jitsi/jitsi-meet/issues/11985#issuecomment-1208018962