### PR TITLE
fix: add a missing comma in json list

### DIFF
--- a/config.js
+++ b/config.js
@@ -701,7 +701,7 @@ var config = {
     //    'chat',
     //    'closedcaptions',
     //    'desktop',
-    //    'dock-iframe'
+    //    'dock-iframe',
     //    'download',
     //    'embedmeeting',
     //    'etherpad',


### PR DESCRIPTION
There is a missing comma in `toolbarButtons`  in `config.js`. Normally this line is commented but when it's uncommented, the UI fails.
