### PR TITLE
feat: whitelist domains for jwt enabled rooms, closes: #11999

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -69,6 +69,7 @@ VirtualHost "jitmeet.example.com"
     breakout_rooms_muc = "breakout.jitmeet.example.com"
     main_muc = "conference.jitmeet.example.com"
     -- muc_lobby_whitelist = { "recorder.jitmeet.example.com" } -- Here we can whitelist jibri to enter lobby enabled rooms
+    -- muc_token_verification_whitelist = { "recorder.jitmeet.example.com" } -- Here we can whitelist jibri to enter jwt auth enabled rooms
 
 Component "conference.jitmeet.example.com" "muc"
     restrict_room_creation = true

--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -64,6 +64,7 @@ const AVATAR_CHECKER_FUNCTIONS = [
 export function getActiveSpeakersToBeDisplayed(stateful: IStore | Function) {
     const state = toState(stateful);
     const {
+        dominantSpeaker,
         fakeParticipants,
         sortedRemoteScreenshares,
         sortedRemoteVirtualScreenshareParticipants,
@@ -72,8 +73,8 @@ export function getActiveSpeakersToBeDisplayed(stateful: IStore | Function) {
     const { visibleRemoteParticipants } = state['features/filmstrip'];
     const activeSpeakers = new Map(speakersList);
 
-    // Do not re-sort the active speakers if all of them are currently visible.
-    if (typeof visibleRemoteParticipants === 'undefined' || activeSpeakers.size <= visibleRemoteParticipants.size) {
+    // Do not re-sort the active speakers if dominant speaker is currently visible.
+    if (dominantSpeaker && visibleRemoteParticipants.has(dominantSpeaker)) {
         return activeSpeakers;
     }
     let availableSlotsForActiveSpeakers = visibleRemoteParticipants.size;

--- a/resources/prosody-plugins/mod_token_verification.lua
+++ b/resources/prosody-plugins/mod_token_verification.lua
@@ -39,7 +39,9 @@ log("debug",
 
 -- option to disable room modification (sending muc config form) for guest that do not provide token
 local require_token_for_moderation;
+local whitelist;
 local function load_config()
+    whitelist = module:get_option_set('muc_token_verification_whitelist', {});
     require_token_for_moderation = module:get_option_boolean("token_verification_require_token_for_moderation");
 end
 load_config();
@@ -50,9 +52,9 @@ local function verify_user(session, stanza)
 		tostring(session.auth_token),
 		tostring(session.jitsi_meet_room));
 
-	-- token not required for admin users
+	-- token not required for admin and whitelist users
 	local user_jid = stanza.attr.from;
-	if is_admin(user_jid) then
+	if is_admin(user_jid) or whitelist:contains(user_jid) then
 		log("debug", "Token not required from admin user: %s", user_jid);
 		return true;
 	end


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

This mr provides ability to configure domains to allow whitelisted domains to enter jwt auth enabled rooms. 