### PR TITLE
fix(rtcstats): Fix rtcstats poll interval typo and increase default value

### DIFF
--- a/config.js
+++ b/config.js
@@ -968,7 +968,7 @@ var config = {
         // The interval at which rtcstats will poll getStats, defaults to 1000ms.
         // If the value is set to 0 getStats won't be polled and the rtcstats client
         // will only send data related to RTCPeerConnection events.
-        // rtcstatsPolIInterval: 1000,
+        // rtcstatsPollInterval: 1000,
 
         // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
         // scriptURLs: [

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -99,7 +99,7 @@ export interface IConfig {
         obfuscateRoomName?: boolean;
         rtcstatsEnabled?: boolean;
         rtcstatsEndpoint?: string;
-        rtcstatsPolIInterval?: number;
+        rtcstatsPollInterval?: number;
         scriptURLs?: Array<string>;
     };
     apiLogLevels?: Array<'warn' | 'log' | 'error' | 'info' | 'debug'>;

--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -42,7 +42,7 @@ MiddlewareRegistry.register(store => next => action => {
             // original non proxy versions of these functions.
             try {
                 // Default poll interval is 1000ms and standard stats will be used, if not provided in the config.
-                const pollInterval = analytics.rtcstatsPollInterval || 1000;
+                const pollInterval = analytics.rtcstatsPollInterval || 10000;
                 const useLegacy = analytics.rtcstatsUseLegacy || false;
 
 


### PR DESCRIPTION
This PR fixes two typos in the poll interval variable names.

Additionally it increases the default value from 1s to 10s to avoid frequent polling if the default fallback value is used.