### PR TITLE
update(rtcstats): adjusted poll intervals in comments to match default value

### DIFF
--- a/config.js
+++ b/config.js
@@ -965,10 +965,10 @@ var config = {
         // In order to enable rtcstats one needs to provide a endpoint url.
         // rtcstatsEndpoint: wss://rtcstats-server-pilot.jitsi.net/,
 
-        // The interval at which rtcstats will poll getStats, defaults to 1000ms.
+        // The interval at which rtcstats will poll getStats, defaults to 10000ms.
         // If the value is set to 0 getStats won't be polled and the rtcstats client
         // will only send data related to RTCPeerConnection events.
-        // rtcstatsPollInterval: 1000,
+        // rtcstatsPollInterval: 10000,
 
         // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
         // scriptURLs: [


### PR DESCRIPTION
Updated the rtcstats poll intervalls in the comments of config.js, as I overlooked that suggestion in PR12024 before merging it.

