### PR TITLE
update(rtcstats): fix one more left over comment around poll intervall

### DIFF
--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -41,7 +41,7 @@ MiddlewareRegistry.register(store => next => action => {
             // init, we need to add these proxies before it initializes, otherwise lib-jitsi-meet will use the
             // original non proxy versions of these functions.
             try {
-                // Default poll interval is 1000ms and standard stats will be used, if not provided in the config.
+                // Default poll interval is 10000ms and standard stats will be used, if not provided in the config.
                 const pollInterval = analytics.rtcstatsPollInterval || 10000;
                 const useLegacy = analytics.rtcstatsUseLegacy || false;
 


### PR DESCRIPTION
As pointed out in PR12024 I forgot to update yet another default value in the comments in PR12031.

Hopefully I got them all now.

