### PR TITLE
feat(polls/native): added thumbColor for android

### DIFF
--- a/react/features/polls/components/native/PollAnswer.tsx
+++ b/react/features/polls/components/native/PollAnswer.tsx
@@ -46,6 +46,7 @@ const PollAnswer = (props: AbstractProps) => {
                             checked = { checkBoxStates[index] }
                             /* eslint-disable-next-line react/jsx-no-bind */
                             onChange = { state => setCheckbox(index, state) }
+                            thumbColor = { BaseTheme.palette.icon01 }
                             trackColor = {{ true: BaseTheme.palette.action01 }} />
                         <Text style = { chatStyles.switchLabel }>{answer.name}</Text>
                     </View>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

For some reason, on this screen, Switch thumbColor takes the default android green color.
Changed it to white to match the other screens where it is used.