### PR TITLE
feat(logging): Store JS console logs in RTCStats.

### DIFF
--- a/config.js
+++ b/config.js
@@ -822,6 +822,7 @@ var config = {
     // Application ID and Secret.
     // callStatsID: '',
     // callStatsSecret: '',
+    // callstatsStoreLogs: true,
 
     // The callstats initialize config params as described in the API:
     // https://docs.callstats.io/docs/javascript#callstatsinitialize-with-app-secret
@@ -958,6 +959,7 @@ var config = {
         // PeerConnection states along with getStats metrics polled at the specified
         // interval.
         // rtcstatsEnabled: false,
+        // rtcstatsStoreLogs: false,
 
         // In order to enable rtcstats one needs to provide a endpoint url.
         // rtcstatsEndpoint: wss://rtcstats-server-pilot.jitsi.net/,

--- a/react/features/base/logging/JitsiMeetLogStorage.ts
+++ b/react/features/base/logging/JitsiMeetLogStorage.ts
@@ -1,3 +1,8 @@
+/* eslint-disable lines-around-comment */
+// @ts-ignore
+import RTCStats from '../../rtcstats/RTCStats';
+// @ts-ignore
+import { canSendRtcstatsData } from '../../rtcstats/functions';
 // @ts-ignore
 import { getCurrentConference } from '../conference';
 
@@ -46,6 +51,38 @@ export default class JitsiMeetLogStorage {
     }
 
     /**
+     * Checks whether callstats logs storage is enabled.
+     *
+     * @returns {boolean} <tt>true</tt> when this storage can store logs to
+     * callstats, <tt>false</tt> otherwise.
+     */
+    canStoreLogsCallstats() {
+        const { callstatsStoreLogs } = this.getState()['features/base/config'];
+
+        // The behavior prior to adding this configuration parameter, is to send logs to callstats (if callstats is
+        // enabled). So, in order to maintain backwards compatibility I set the default of this option to be true, i.e.
+        // if the config.callstatsStoreLogs is not set, the JS console logs will be sent to callstats (if callstats is
+        // enabled)
+        return callstatsStoreLogs || callstatsStoreLogs === undefined;
+    }
+
+    /**
+     * Checks whether rtcstats logs storage is enabled.
+     *
+     * @returns {boolean} <tt>true</tt> when this storage can store logs to
+     * rtcstats, <tt>false</tt> otherwise.
+     */
+    canStoreLogsRtcstats() {
+
+        const config = this.getState()['features/base/config'];
+
+        // Saving the logs in RTCStats is a new feature and so there is no prior behavior that needs to be maintained.
+        // That said, this is still experimental and needs to be rolled out gradually so we want this to be off by
+        // default.
+        return config?.analytics?.rtcstatsStoreLogs && canSendRtcstatsData(this.getState());
+    }
+
+    /**
      * Called by the <tt>LogCollector</tt> to store a series of log lines into
      * batch.
      *
@@ -54,6 +91,23 @@ export default class JitsiMeetLogStorage {
      * @returns {void}
      */
     storeLogs(logEntries: Array<string|any>) {
+
+        if (this.canStoreLogsCallstats()) {
+            this.storeLogsCallstats(logEntries);
+        }
+
+        if (this.canStoreLogsRtcstats()) {
+            RTCStats.sendLogs(logEntries);
+        }
+    }
+
+    /**
+     * Store the console logs in callstats (if callstats is enabled).
+     *
+     * @param {Array<string|any>} logEntries - The log entries to send to the rtcstats server.
+     * @returns {void}
+     */
+    storeLogsCallstats(logEntries: Array<string|any>) {
         const conference = getCurrentConference(this.getState());
 
         if (!conference || !conference.isCallstatsEnabled()) {

--- a/react/features/rtcstats/RTCStats.js
+++ b/react/features/rtcstats/RTCStats.js
@@ -86,6 +86,16 @@ class RTCStats {
     }
 
     /**
+     * Send console logs to rtcstats server.
+     *
+     * @param {Array<string|any>} logEntries - The log entries to send to the rtcstats server.
+     * @returns {void}
+     */
+    sendLogs(logEntries) {
+        this.trace && this.trace.statsEntry('logs', null, logEntries);
+    }
+
+    /**
      * Send dominant speaker data, the data will be processed by rtcstats-server and saved in the dump file.
      *
      * @param {Object} dominantSpeakerData - Dominant speaker data to be saved in the rtcstats dump.


### PR DESCRIPTION
With this commit JS console logs can optionally be sent to the RTCstats server
for storage and processing.

The functionality is off by default and can be enabled by setting to `true` the
config.js option

    config.analytics.rtcstatsStoreLogs: false // off by default

Obviously, if rtcstats is disabled/not configured nothing will be sent to the
rtcstats backend, even if this setting is set to `true`.

This commit also adds a config.js option that can be used to disable sending the
logs back to callstats:

    config.callstatsStoreLogs: true // on by default

Obviously, if callstats is disabled nothing would be sent in the first place,
but if callstats is enabled and this new configuration parameter is set to
`false`, then callstats will be kept active but no logs will be sent to callstats.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
