### PR TITLE
feature(rtcstats): expose sendSdp as config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -967,6 +967,10 @@ var config = {
         // will only send data related to RTCPeerConnection events.
         // rtcstatsPollInterval: 10000,
 
+        // This determines if rtcstats sends the SDP to the rtcstats server or replaces
+        // all SDPs with an emtpy string instead.
+        // rtcstatsSendSdp: false,
+
         // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
         // scriptURLs: [
         //      "libs/analytics-ga.min.js", // google-analytics

--- a/react/features/rtcstats/RTCStats.js
+++ b/react/features/rtcstats/RTCStats.js
@@ -41,7 +41,7 @@ class RTCStats {
      * @param {string} options.useLegacy - Switch to legacy chrome webrtc statistics. Parameter will only have
      * an effect on chrome based applications.
      * @param {number} options.pollInterval - The getstats poll interval in ms.
-     * @param {boolean} options.sendSdp - Determines if the client sends SDP to the rtcstats server
+     * @param {boolean} options.sendSdp - Determines if the client sends SDP to the rtcstats server.
      * @returns {void}
      */
     init(options) {

--- a/react/features/rtcstats/RTCStats.js
+++ b/react/features/rtcstats/RTCStats.js
@@ -41,11 +41,12 @@ class RTCStats {
      * @param {string} options.useLegacy - Switch to legacy chrome webrtc statistics. Parameter will only have
      * an effect on chrome based applications.
      * @param {number} options.pollInterval - The getstats poll interval in ms.
+     * @param {boolean} options.sendSdp - Determines if the client sends SDP to the rtcstats server
      * @returns {void}
      */
     init(options) {
 
-        const { endpoint, useLegacy, pollInterval } = options;
+        const { endpoint, useLegacy, pollInterval, sendSdp } = options;
 
         const traceOptions = {
             endpoint,
@@ -56,7 +57,8 @@ class RTCStats {
         const rtcstatsOptions = {
             connectionFilter,
             pollInterval,
-            useLegacy
+            useLegacy,
+            sendSdp
         };
 
         this.trace = traceInit(traceOptions);

--- a/react/features/rtcstats/middleware.js
+++ b/react/features/rtcstats/middleware.js
@@ -44,6 +44,7 @@ MiddlewareRegistry.register(store => next => action => {
                 // Default poll interval is 10000ms and standard stats will be used, if not provided in the config.
                 const pollInterval = analytics.rtcstatsPollInterval || 10000;
                 const useLegacy = analytics.rtcstatsUseLegacy || false;
+                const sendSdp = analytics.rtcstatsSendSdp || false;
 
 
                 // Initialize but don't connect to the rtcstats server wss, as it will start sending data for all
@@ -51,7 +52,8 @@ MiddlewareRegistry.register(store => next => action => {
                 RTCStats.init({
                     endpoint: analytics.rtcstatsEndpoint,
                     useLegacy,
-                    pollInterval
+                    pollInterval,
+                    sendSdp
                 });
             } catch (error) {
                 logger.error('Failed to initialize RTCStats: ', error);


### PR DESCRIPTION
This PR exposes RTCstats sendSdp option via config.js.

Only if rtcstats is enabled via config.js this setting will take affect. It allows to decide if SDP from all API calls on the endpoints to be send to the rtcstats-server, or not if bandwidth and storage space are a concern.

The default value is: false - which means by default SDP does not get send to the rtcstats-server.