### PR TITLE
fix(prejoin) use the conference display name instead of the room name

### DIFF
--- a/react/features/base/premeeting/components/web/PreMeetingScreen.js
+++ b/react/features/base/premeeting/components/web/PreMeetingScreen.js
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import { connect } from '../../../../base/redux';
 import DeviceStatus from '../../../../prejoin/components/preview/DeviceStatus';
 import { Toolbox } from '../../../../toolbox/components/web';
-import { getRoomName } from '../../../conference';
+import { getConferenceName } from '../../../conference/functions';
 import { PREMEETING_BUTTONS, THIRD_PARTY_PREJOIN_BUTTONS } from '../../../config/constants';
 import { getToolbarButtons, isToolbarButtonEnabled } from '../../../config/functions.web';
 import { withPixelLineHeight } from '../../../styles/functions.web';
@@ -206,7 +206,7 @@ function mapStateToProps(state, ownProps): Object {
             ? premeetingButtons
             : premeetingButtons.filter(b => isToolbarButtonEnabled(b, toolbarButtons)),
         _premeetingBackground: premeetingBackground,
-        _roomName: getRoomName(state)
+        _roomName: getConferenceName(state)
     };
 }
 

--- a/react/features/lobby/components/native/LobbyScreen.js
+++ b/react/features/lobby/components/native/LobbyScreen.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Text, View, TextInput } from 'react-native';
 
-import { getRoomName } from '../../../base/conference';
+import { getConferenceName } from '../../../base/conference/functions';
 import { translate } from '../../../base/i18n';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
 import { LoadingIndicator } from '../../../base/react';
@@ -301,7 +301,7 @@ function _mapStateToProps(state: Object, ownProps: Props) {
     return {
         ...abstractMapStateToProps(state, ownProps),
         _aspectRatio: state['features/base/responsive-ui'].aspectRatio,
-        _roomName: getRoomName(state)
+        _roomName: getConferenceName(state)
     };
 }
 

--- a/react/features/prejoin/components/Prejoin.native.tsx
+++ b/react/features/prejoin/components/Prejoin.native.tsx
@@ -18,7 +18,7 @@ import { appNavigate } from '../../app/actions.native';
 // @ts-ignore
 import { setAudioOnly } from '../../base/audio-only/actions';
 // @ts-ignore
-import { getRoomName } from '../../base/conference/functions';
+import { getConferenceName } from '../../base/conference/functions';
 // @ts-ignore
 import { connect } from '../../base/connection/actions.native';
 import { IconClose } from '../../base/icons/svg/index';
@@ -64,7 +64,7 @@ const Prejoin: React.FC<PrejoinProps> = ({ navigation }: PrejoinProps) => {
     );
     const localParticipant = useSelector((state: any) => getLocalParticipant(state));
     const isDisplayNameMandatory = useSelector(state => isDisplayNameRequired(state));
-    const roomName = useSelector(state => getRoomName(state));
+    const roomName = useSelector(state => getConferenceName(state));
     const participantName = localParticipant?.name;
     const [ displayName, setDisplayName ]
         = useState(participantName || '');


### PR DESCRIPTION
The room name could be a UUID and the conference display name an actual
name, using the subject.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
