### PR TITLE
fix: Fixes lua log lines.

### DIFF
--- a/resources/prosody-plugins/mod_av_moderation_component.lua
+++ b/resources/prosody-plugins/mod_av_moderation_component.lua
@@ -8,7 +8,7 @@ local st = require 'util.stanza';
 
 local muc_component_host = module:get_option_string('muc_component');
 if muc_component_host == nil then
-    log('error', 'No muc_component specified. No muc to operate on!');
+    module:log('error', 'No muc_component specified. No muc to operate on!');
     return;
 end
 

--- a/resources/prosody-plugins/mod_conference_duration_component.lua
+++ b/resources/prosody-plugins/mod_conference_duration_component.lua
@@ -13,11 +13,11 @@ end
 
 local muc_component_host = module:get_option_string("muc_component");
 if muc_component_host == nil then
-    log("error", "No muc_component specified. No muc to operate on!");
+    module:log("error", "No muc_component specified. No muc to operate on!");
     return;
 end
 
-log("info", "Starting conference duration timer for %s", muc_component_host);
+module:log("info", "Starting conference duration timer for %s", muc_component_host);
 
 function occupant_joined(event)
     local room = event.room;

--- a/resources/prosody-plugins/mod_speakerstats_component.lua
+++ b/resources/prosody-plugins/mod_speakerstats_component.lua
@@ -20,12 +20,12 @@ local muc_component_host = module:get_option_string("muc_component");
 local muc_domain_base = module:get_option_string("muc_mapper_domain_base");
 
 if muc_component_host == nil or muc_domain_base == nil then
-    log("error", "No muc_component specified. No muc to operate on!");
+    module:log("error", "No muc_component specified. No muc to operate on!");
     return;
 end
 local breakout_room_component_host = "breakout." .. muc_domain_base;
 
-log("info", "Starting speakerstats for %s", muc_component_host);
+module:log("info", "Starting speakerstats for %s", muc_component_host);
 
 local main_muc_service;
 


### PR DESCRIPTION
When using directly log( the log lines come from `general` not from the module itself.
`Aug 29 19:38:08 general	info	Starting speakerstats for conference...`

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
