### PR TITLE
feat(external-api) Add endConference command

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -18,6 +18,7 @@ import {
 } from '../../react/features/av-moderation/actions';
 import { isEnabledFromState } from '../../react/features/av-moderation/functions';
 import {
+    endConference,
     getCurrentConference,
     sendTones,
     setFollowMe,
@@ -708,6 +709,19 @@ function initCommands() {
         },
         'toggle-virtual-background': () => {
             APP.store.dispatch(toggleDialog(VirtualBackgroundDialog));
+        },
+        'end-conference': () => {
+            APP.store.dispatch(endConference());
+            const state = APP.store.getState();
+            const conference = getCurrentConference(state);
+
+            if (!conference) {
+                logger.error('Conference not yet available');
+            } else if (conference.isEndConferenceSupported()) {
+                APP.store.dispatch(endConference());
+            } else {
+                logger.error(' End Conference not supported');
+            }
         }
     };
     transport.on('event', ({ data, name }) => {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -37,6 +37,7 @@ const commands = {
     closeBreakoutRoom: 'close-breakout-room',
     displayName: 'display-name',
     e2eeKey: 'e2ee-key',
+    endConference: 'end-conference',
     email: 'email',
     grantModerator: 'grant-moderator',
     hangup: 'video-hangup',


### PR DESCRIPTION
Command to trigger same action as that accomplished by the new "End Meeting for all" button.

Without this command, it will be difficult to write effective click handlers for 'end-meeting' (introduced in https://github.com/jitsi/jitsi-meet/pull/12179).
