### PR TITLE
ref(callstats): Removes redundant config.js option.

### DIFF
--- a/config.js
+++ b/config.js
@@ -824,7 +824,7 @@ var config = {
     // Application ID and Secret.
     // callStatsID: '',
     // callStatsSecret: '',
-    // callstatsStoreLogs: true,
+    // callStatsApplicationLogsDisabled: false,
 
     // The callstats initialize config params as described in the API:
     // https://docs.callstats.io/docs/javascript#callstatsinitialize-with-app-secret

--- a/react/features/base/logging/JitsiMeetLogStorage.ts
+++ b/react/features/base/logging/JitsiMeetLogStorage.ts
@@ -51,22 +51,6 @@ export default class JitsiMeetLogStorage {
     }
 
     /**
-     * Checks whether callstats logs storage is enabled.
-     *
-     * @returns {boolean} <tt>true</tt> when this storage can store logs to
-     * callstats, <tt>false</tt> otherwise.
-     */
-    canStoreLogsCallstats() {
-        const { callstatsStoreLogs } = this.getState()['features/base/config'];
-
-        // The behavior prior to adding this configuration parameter, is to send logs to callstats (if callstats is
-        // enabled). So, in order to maintain backwards compatibility I set the default of this option to be true, i.e.
-        // if the config.callstatsStoreLogs is not set, the JS console logs will be sent to callstats (if callstats is
-        // enabled)
-        return callstatsStoreLogs || callstatsStoreLogs === undefined;
-    }
-
-    /**
      * Checks whether rtcstats logs storage is enabled.
      *
      * @returns {boolean} <tt>true</tt> when this storage can store logs to
@@ -92,9 +76,9 @@ export default class JitsiMeetLogStorage {
      */
     storeLogs(logEntries: Array<string | any>) {
 
-        if (this.canStoreLogsCallstats()) {
-            this.storeLogsCallstats(logEntries);
-        }
+        // XXX the config.callStatsApplicationLogsDisabled controls whether or not the logs will be sent to callstats.
+        // this is done in LJM
+        this.storeLogsCallstats(logEntries);
 
         if (this.canStoreLogsRtcstats()) {
             RTCStats.sendLogs(logEntries);


### PR DESCRIPTION
289ece42df8425d9a516df8333fe8ff346898b3a adds a redundant config.js parameter called `callstatsStoreLogs`. The pre-existing configuration option that was not listed in the config.js. This PR removes the redundant config.js parameter and adds the pre-existing configuration parameter in config.js