### PR TITLE
feat(large-video) Show SS on large-video instead of camera tile.

### DIFF
--- a/react/features/large-video/actions.any.js
+++ b/react/features/large-video/actions.any.js
@@ -2,14 +2,17 @@
 
 import type { Dispatch } from 'redux';
 
+import { getMultipleVideoSupportFeatureFlag } from '../base/config';
 import { MEDIA_TYPE } from '../base/media';
 import {
     getDominantSpeakerParticipant,
     getLocalParticipant,
     getPinnedParticipant,
-    getRemoteParticipants
+    getRemoteParticipants,
+    getVirtualScreenshareParticipantByOwnerId
 } from '../base/participants';
 import { isStageFilmstripAvailable } from '../filmstrip/functions';
+import { getAutoPinSetting } from '../video-layout';
 
 import {
     SELECT_LARGE_VIDEO_PARTICIPANT,
@@ -135,16 +138,26 @@ function _electParticipantInLargeVideo(state) {
         return participant.id;
     }
 
-    // Pick the most recent remote screenshare that was added to the conference.
-    const remoteScreenShares = state['features/video-layout'].remoteScreenShares;
+    if (getAutoPinSetting()) {
+        // Pick the most recent remote screenshare that was added to the conference.
+        const remoteScreenShares = state['features/video-layout'].remoteScreenShares;
 
-    if (remoteScreenShares?.length) {
-        return remoteScreenShares[remoteScreenShares.length - 1];
+        if (remoteScreenShares?.length) {
+            return remoteScreenShares[remoteScreenShares.length - 1];
+        }
     }
 
     // Next, pick the dominant speaker (other than self).
     participant = getDominantSpeakerParticipant(state);
     if (participant && !participant.local) {
+        // Return the screensharing participant id associated with this endpoint if multi-stream is enabled and
+        // auto pin latest screenshare is disabled.
+        if (getMultipleVideoSupportFeatureFlag(state)) {
+            const screenshareParticipant = getVirtualScreenshareParticipantByOwnerId(state, participant.id);
+
+            return screenshareParticipant?.id ?? participant.id;
+        }
+
         return participant.id;
     }
 


### PR DESCRIPTION
This is helpful in live streaming scenarios when AUTO_PIN_LATEST_SCREEN_SHARE is disabled and multi-stream is enabled. Dominant speaker's SS tile (if available) will be on stage instead of their camera tile. Fixes https://github.com/jitsi/jitsi-meet/issues/10869.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
