### PR TITLE
ref(config): add enableOpusDtx flag

### DIFF
--- a/config.js
+++ b/config.js
@@ -208,9 +208,12 @@ var config = {
 
     // Specify audio quality stereo and opusMaxAverageBitrate values in order to enable HD audio.
     // Beware, by doing so, you are disabling echo cancellation, noise suppression and AGC.
+    // Specify enableOpusDtx to enable support for opus-dtx where
+    // audio packets won’t be transmitted while participant is silent or muted.
     // audioQuality: {
     //     stereo: false,
     //     opusMaxAverageBitrate: null, // Value to fit the 6000 to 510000 range.
+    //     enableOpusDtx: false,
     // },
 
     // Video


### PR DESCRIPTION
Added config option for enabling Opus DTX flag which used for reduction in the audio traffic, when a participant is silent then the audio packet won’t be transmitted.
