### PR TITLE
fix(build) - increase heap size node for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ WEBPACK_DEV_SERVER = ./node_modules/.bin/webpack serve --mode development
 all: compile deploy clean
 
 compile:
+	NODE_OPTIONS=--max-old-space-size=8192 \
 	$(WEBPACK)
 
 clean:


### PR DESCRIPTION
- when doing "make" fixes issue of "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory"