### PR TITLE
feat(base/ui/web): added autofocus prop to button component

### DIFF
--- a/react/features/base/ui/components/types.ts
+++ b/react/features/base/ui/components/types.ts
@@ -10,6 +10,11 @@ export interface ButtonProps {
     accessibilityLabel?: string;
 
     /**
+     * Whether or not the button should automatically focus.
+     */
+    autoFocus?: boolean;
+
+    /**
      * Whether or not the button is disabled.
      */
     disabled?: boolean;

--- a/react/features/base/ui/components/web/Button.tsx
+++ b/react/features/base/ui/components/web/Button.tsx
@@ -178,6 +178,7 @@ const useStyles = makeStyles()((theme: Theme) => {
 
 const Button = React.forwardRef<any, any>(({
     accessibilityLabel,
+    autoFocus = false,
     className,
     disabled,
     fullWidth,
@@ -197,6 +198,7 @@ const Button = React.forwardRef<any, any>(({
     return (
         <button
             aria-label = { accessibilityLabel }
+            autoFocus = { autoFocus }
             className = { cx(styles.button, styles[type],
                 disabled && styles.disabled,
                 icon && !(labelKey || label) && `${styles.iconButton} iconButton`,

--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -162,9 +162,7 @@ class Chat extends AbstractChat<Props> {
                     <MessageContainer
                         messages = { this.props._messages } />
                     <MessageRecipient />
-
                     <ChatInput
-                        onResize = { this._onChatInputResize }
                         onSend = { this._onSendMessage } />
                 </div>
             </>

--- a/react/features/polls/components/web/PollsPane.tsx
+++ b/react/features/polls/components/web/PollsPane.tsx
@@ -24,6 +24,7 @@ const PollsPane = (props: AbstractProps) => {
             <div className = 'poll-footer poll-create-footer'>
                 <Button
                     accessibilityLabel = { t('polls.create.create') }
+                    autoFocus = { true }
                     fullWidth = { true }
                     labelKey = { 'polls.create.create' }
                     onClick = { onCreate } />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
After we press the chat tab, chat input gets automatically focused. 
This isn't the case for when we press the polls tab. Create a Poll button doesn't get focused.

1. Added autoFocus prop to UI Button component.
2. Set autoFocus default prop to false.
3. Added autoFocus = true to Create a Poll button.