### PR TITLE
fix(video-mute) prevent multiple camera track creation

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -479,6 +479,11 @@ export default {
      */
     _localTracksInitialized: false,
 
+    /**
+     * Flag used to prevent the creation of another local video track in this.muteVideo if one is already in progress.
+     */
+    isCreatingLocalTrack: false,
+
     isSharingScreen: false,
 
     /**
@@ -1106,10 +1111,12 @@ export default {
 
         const localVideo = getLocalJitsiVideoTrack(APP.store.getState());
 
-        if (!localVideo && !mute) {
+        if (!localVideo && !mute && !this.isCreatingLocalTrack) {
             const maybeShowErrorDialog = error => {
                 showUI && APP.store.dispatch(notifyCameraError(error));
             };
+
+            this.isCreatingLocalTrack = true;
 
             // Try to create local video if there wasn't any.
             // This handles the case when user joined with no video
@@ -1132,6 +1139,9 @@ export default {
                     logger.debug(`muteVideo: calling useVideoStream for track: ${videoTrack}`);
 
                     return this.useVideoStream(videoTrack);
+                })
+                .finally(() => {
+                    this.isCreatingLocalTrack = false;
                 });
         } else {
             // FIXME show error dialog if it fails (should be handled by react)


### PR DESCRIPTION
### Bug Description
I've noticed in the case of pressing the "v" shortcut or camera button in rapid succession, we call `muteVideo` multiple times. https://bbgithub.dev.bloomberg.com/bb-room/jitsi-meet/blob/develop/conference.js#L1053 

If the local video hasn't been created yet, https://bbgithub.dev.bloomberg.com/bb-room/jitsi-meet/blob/develop/conference.js#L1091 will try to create another local track while one is already in progress. 

**From a user perspective, if two local camera tracks are created, they might still see their device's camera light on even though visual indicators show it is muted.**  

---

Flow of pressing the "v" shortcut to toggle camera:
VideoMuteButton#_onKeyboardShortcut -> AbstractButton#_onClick -> AbstractVideoMuteButton#_handleClick -> VideoMuteButton#setVideoMuted -> conference#muteVideo

Flow of clicking camera button:
AbstractButton#_onClick -> AbstractVideoMuteButton#_handleClick -> VideoMuteButton#setVideoMuted -> conference#muteVideo

### Potential fix
Add a property to keep track if a pending local track creation is in progress. 

