### PR TITLE
feat(settings/native): start car mode in low bandwidth mode

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1010,6 +1010,7 @@
         "profileSection": "Profile",
         "serverURL": "Server URL",
         "showAdvanced": "Show advanced settings",
+        "startCarModeInLowBandwidthMode": "Start car mode in low bandwidth mode",
         "startWithAudioMuted": "Start with audio muted",
         "startWithVideoMuted": "Start with video muted",
         "terms": "Terms",

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -37,6 +37,7 @@ const DEFAULT_STATE: ISettingsState = {
     soundsTalkWhileMuted: true,
     soundsReactions: true,
     startAudioOnly: false,
+    startCarMode: false,
     startWithAudioMuted: false,
     startWithVideoMuted: false,
     userSelectedAudioOutputDeviceId: undefined,
@@ -74,6 +75,7 @@ export interface ISettingsState {
     soundsReactions?: boolean;
     soundsTalkWhileMuted?: boolean;
     startAudioOnly?: boolean;
+    startCarMode?: boolean;
     startWithAudioMuted?: boolean;
     startWithVideoMuted?: boolean;
     userSelectedAudioOutputDeviceId?: string;

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -61,12 +61,17 @@ type Props = AbstractProps & {
     _aspectRatio: Symbol,
 
     /**
+     * Whether the audio only is enabled or not.
+     */
+    _audioOnlyEnabled: boolean,
+
+    /**
      * Branding styles for conference.
      */
     _brandingStyles: Object,
 
     /**
-     * Wherther the calendar feature is enabled or not.
+     * Whether the calendar feature is enabled or not.
      */
     _calendarEnabled: boolean,
 
@@ -135,6 +140,11 @@ type Props = AbstractProps & {
     _showLobby: boolean,
 
     /**
+     * Indicates whether the car mode is enabled.
+     */
+    _startCarMode: boolean,
+
+    /**
      * The redux {@code dispatch} function.
      */
     dispatch: Function,
@@ -142,7 +152,12 @@ type Props = AbstractProps & {
     /**
     * Object containing the safe area insets.
     */
-    insets: Object
+    insets: Object,
+
+    /**
+     * Default prop for navigating between screen components(React Navigation).
+     */
+    navigation: Object
 };
 
 type State = {
@@ -192,7 +207,17 @@ class Conference extends AbstractConference<Props, State> {
      * @returns {void}
      */
     componentDidMount() {
+        const {
+            _audioOnlyEnabled,
+            _startCarMode,
+            navigation
+        } = this.props;
+
         BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
+
+        if (_audioOnlyEnabled && _startCarMode) {
+            navigation.navigate(screen.conference.carmode);
+        }
     }
 
     /**
@@ -536,6 +561,8 @@ function _mapStateToProps(state) {
     const { isOpen } = state['features/participants-pane'];
     const { aspectRatio, reducedUI } = state['features/base/responsive-ui'];
     const { backgroundColor } = state['features/dynamic-branding'];
+    const { startCarMode } = state['features/base/settings'];
+    const { enabled: audioOnlyEnabled } = state['features/base/audio-only'];
     const participantCount = getParticipantCount(state);
     const brandingStyles = backgroundColor ? {
         backgroundColor
@@ -544,6 +571,7 @@ function _mapStateToProps(state) {
     return {
         ...abstractMapStateToProps(state),
         _aspectRatio: aspectRatio,
+        _audioOnlyEnabled: Boolean(audioOnlyEnabled),
         _brandingStyles: brandingStyles,
         _calendarEnabled: isCalendarEnabled(state),
         _connecting: isConnecting(state),
@@ -556,6 +584,7 @@ function _mapStateToProps(state) {
         _reducedUI: reducedUI,
         _shouldEnableAutoKnock: shouldEnableAutoKnock(state),
         _showLobby: getIsLobbyVisible(state),
+        _startCarMode: startCarMode,
         _toolboxVisible: isToolboxVisible(state)
     };
 }

--- a/react/features/conference/components/native/carmode/CarMode.tsx
+++ b/react/features/conference/components/native/carmode/CarMode.tsx
@@ -1,23 +1,16 @@
 /* eslint-disable lines-around-comment */
-import React, { useCallback, useEffect, useLayoutEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { Platform, View } from 'react-native';
+import React, { useEffect } from 'react';
+import { View } from 'react-native';
 import Orientation from 'react-native-orientation-locker';
 import { withSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
-// @ts-ignore
-import { IconClose } from '../../../../base/icons';
 // @ts-ignore
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
 // @ts-ignore
 import { LoadingIndicator, TintedView } from '../../../../base/react';
 // @ts-ignore
 import { isLocalVideoTrackDesktop } from '../../../../base/tracks';
-// @ts-ignore
-import HeaderNavigationButton from '../../../../mobile/navigation/components/HeaderNavigationButton';
-// @ts-ignore
-import { screen } from '../../../../mobile/navigation/routes';
 // @ts-ignore
 import { setPictureInPictureEnabled } from '../../../../mobile/picture-in-picture/functions';
 // @ts-ignore
@@ -33,39 +26,15 @@ import TitleBar from './TitleBar';
 // @ts-ignore
 import styles from './styles';
 
-
 /**
  * Implements the carmode component.
  *
  * @returns { JSX.Element} - The carmode component.
  */
-const CarMode = ({ navigation }: any): JSX.Element => {
+const CarMode = (): JSX.Element => {
     const dispatch = useDispatch();
-    const { t } = useTranslation();
     const connecting = useSelector(isConnecting);
     const isSharing = useSelector(isLocalVideoTrackDesktop);
-
-    const goBack = useCallback(() => {
-        navigation.navigate(screen.conference.main);
-
-        return true;
-    }, [ dispatch ]);
-
-    const headerLeft = useCallback(() => {
-        if (Platform.OS === 'ios') {
-            return (
-                <HeaderNavigationButton
-                    label = { t('dialog.close') }
-                    onPress = { goBack } />
-            );
-        }
-
-        return (
-            <HeaderNavigationButton
-                onPress = { goBack }
-                src = { IconClose } />
-        );
-    }, []);
 
     useEffect(() => {
         dispatch(setIsCarmode(true));
@@ -80,12 +49,6 @@ const CarMode = ({ navigation }: any): JSX.Element => {
             }
         };
     }, []);
-
-    useLayoutEffect(() => {
-        navigation.setOptions({
-            headerLeft
-        });
-    }, [ navigation ]);
 
     return (
         <JitsiScreen

--- a/react/features/conference/components/native/carmode/CarMode.tsx
+++ b/react/features/conference/components/native/carmode/CarMode.tsx
@@ -1,16 +1,23 @@
 /* eslint-disable lines-around-comment */
-import React, { useEffect } from 'react';
-import { View } from 'react-native';
+import React, { useCallback, useEffect, useLayoutEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Platform, View } from 'react-native';
 import Orientation from 'react-native-orientation-locker';
 import { withSafeAreaInsets } from 'react-native-safe-area-context';
 import { useDispatch, useSelector } from 'react-redux';
 
+// @ts-ignore
+import { IconClose } from '../../../../base/icons';
 // @ts-ignore
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
 // @ts-ignore
 import { LoadingIndicator, TintedView } from '../../../../base/react';
 // @ts-ignore
 import { isLocalVideoTrackDesktop } from '../../../../base/tracks';
+// @ts-ignore
+import HeaderNavigationButton from '../../../../mobile/navigation/components/HeaderNavigationButton';
+// @ts-ignore
+import { screen } from '../../../../mobile/navigation/routes';
 // @ts-ignore
 import { setPictureInPictureEnabled } from '../../../../mobile/picture-in-picture/functions';
 // @ts-ignore
@@ -26,15 +33,39 @@ import TitleBar from './TitleBar';
 // @ts-ignore
 import styles from './styles';
 
+
 /**
  * Implements the carmode component.
  *
  * @returns { JSX.Element} - The carmode component.
  */
-const CarMode = (): JSX.Element => {
+const CarMode = ({ navigation }: any): JSX.Element => {
     const dispatch = useDispatch();
+    const { t } = useTranslation();
     const connecting = useSelector(isConnecting);
     const isSharing = useSelector(isLocalVideoTrackDesktop);
+
+    const goBack = useCallback(() => {
+        navigation.navigate(screen.conference.main);
+
+        return true;
+    }, [ dispatch ]);
+
+    const headerLeft = useCallback(() => {
+        if (Platform.OS === 'ios') {
+            return (
+                <HeaderNavigationButton
+                    label = { t('dialog.close') }
+                    onPress = { goBack } />
+            );
+        }
+
+        return (
+            <HeaderNavigationButton
+                onPress = { goBack }
+                src = { IconClose } />
+        );
+    }, []);
 
     useEffect(() => {
         dispatch(setIsCarmode(true));
@@ -49,6 +80,12 @@ const CarMode = (): JSX.Element => {
             }
         };
     }, []);
+
+    useLayoutEffect(() => {
+        navigation.setOptions({
+            headerLeft
+        });
+    }, [ navigation ]);
 
     return (
         <JitsiScreen

--- a/react/features/settings/components/native/SettingsView.tsx
+++ b/react/features/settings/components/native/SettingsView.tsx
@@ -89,6 +89,11 @@ interface State {
     serverURL: string;
 
     /**
+     * State variable for start car mode.
+     */
+    startCarMode: boolean;
+
+    /**
      * State variable for the start with audio muted switch.
      */
     startWithAudioMuted: boolean;
@@ -135,6 +140,7 @@ interface Props extends WithTranslation {
         displayName: string;
         email: string;
         serverURL: string;
+        startCarMode: boolean;
         startWithAudioMuted: boolean;
         startWithVideoMuted: boolean;
     };
@@ -185,6 +191,7 @@ class SettingsView extends Component<Props, State> {
             displayName,
             email,
             serverURL,
+            startCarMode,
             startWithAudioMuted,
             startWithVideoMuted
         } = props._settings || {};
@@ -197,6 +204,7 @@ class SettingsView extends Component<Props, State> {
             displayName,
             email,
             serverURL,
+            startCarMode,
             startWithAudioMuted,
             startWithVideoMuted
         };
@@ -213,6 +221,8 @@ class SettingsView extends Component<Props, State> {
         this._onDisableSelfView = this._onDisableSelfView.bind(this);
         this._onStartAudioMutedChange
             = this._onStartAudioMutedChange.bind(this);
+        this._onStartCarmodeInLowBandwidthMode
+            = this._onStartCarmodeInLowBandwidthMode.bind(this);
         this._onStartVideoMutedChange
             = this._onStartVideoMutedChange.bind(this);
         this._setURLFieldReference = this._setURLFieldReference.bind(this);
@@ -250,6 +260,7 @@ class SettingsView extends Component<Props, State> {
             displayName,
             email,
             serverURL,
+            startCarMode,
             startWithAudioMuted,
             startWithVideoMuted
         } = this.state;
@@ -324,6 +335,13 @@ class SettingsView extends Component<Props, State> {
                             textContentType = { 'URL' } // iOS only
                             theme = { textInputTheme }
                             value = { serverURL } />
+                        <Divider style = { styles.fieldSeparator } />
+                        <FormRow label = 'settingsView.startCarModeInLowBandwidthMode'>
+                            <Switch
+                                checked = { startCarMode }
+                                // @ts-ignore
+                                onChange = { this._onStartCarmodeInLowBandwidthMode } />
+                        </FormRow>
                         <Divider style = { styles.fieldSeparator } />
                         <FormRow
                             label = 'settingsView.startWithAudioMuted'>
@@ -529,6 +547,23 @@ class SettingsView extends Component<Props, State> {
 
         this._updateSettings({
             disableSelfView
+        });
+    }
+
+    /** .
+     * Handles car mode in low bandwidth mode.
+     *
+     * @param {boolean} startCarMode - The new value.
+     * @private
+     * @returns {void}
+     */
+    _onStartCarmodeInLowBandwidthMode(startCarMode: boolean) {
+        this.setState({
+            startCarMode
+        });
+
+        this._updateSettings({
+            startCarMode
         });
     }
 

--- a/react/features/toolbox/components/native/AudioOnlyButton.js
+++ b/react/features/toolbox/components/native/AudioOnlyButton.js
@@ -1,11 +1,15 @@
 // @flow
 
-import { toggleAudioOnly } from '../../../base/audio-only';
+import { setAudioOnly, toggleAudioOnly } from '../../../base/audio-only';
 import { AUDIO_ONLY_BUTTON_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconAudioOnly, IconAudioOnlyOff } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
+import {
+    navigate
+} from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
+import { screen } from '../../../mobile/navigation/routes';
 
 /**
  * The type of the React {@code Component} props of {@link AudioOnlyButton}.
@@ -16,6 +20,11 @@ type Props = AbstractButtonProps & {
      * Whether the current conference is in audio only mode or not.
      */
     _audioOnly: boolean,
+
+    /**
+     * Indicates whether the car mode is enabled.
+     */
+    _startCarMode: boolean,
 
     /**
      * The redux {@code dispatch} function.
@@ -41,8 +50,18 @@ class AudioOnlyButton extends AbstractButton<Props, *> {
      * @returns {void}
      */
     _handleClick() {
-        this.props.dispatch(toggleAudioOnly());
+        const { _audioOnly, _startCarMode, dispatch } = this.props;
+
+        if (!_audioOnly && _startCarMode) {
+            dispatch(setAudioOnly(true));
+            navigate(screen.conference.carmode);
+        } else if (_audioOnly && _startCarMode) {
+            dispatch(setAudioOnly(false));
+        } else {
+            dispatch(toggleAudioOnly());
+        }
     }
+
 
     /**
      * Indicates whether this button is in toggled state or not.
@@ -70,10 +89,12 @@ class AudioOnlyButton extends AbstractButton<Props, *> {
 function _mapStateToProps(state, ownProps): Object {
     const { enabled: audioOnly } = state['features/base/audio-only'];
     const enabledInFeatureFlags = getFeatureFlag(state, AUDIO_ONLY_BUTTON_ENABLED, true);
+    const { startCarMode } = state['features/base/settings'];
     const { visible = enabledInFeatureFlags } = ownProps;
 
     return {
         _audioOnly: Boolean(audioOnly),
+        _startCarMode: startCarMode,
         visible
     };
 }

--- a/react/features/toolbox/components/native/AudioOnlyButton.js
+++ b/react/features/toolbox/components/native/AudioOnlyButton.js
@@ -55,8 +55,6 @@ class AudioOnlyButton extends AbstractButton<Props, *> {
         if (!_audioOnly && _startCarMode) {
             dispatch(setAudioOnly(true));
             navigate(screen.conference.carmode);
-        } else if (_audioOnly && _startCarMode) {
-            dispatch(setAudioOnly(false));
         } else {
             dispatch(toggleAudioOnly());
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

1. Added 'Start car mode in low bandwidth mode' switch to Settings screen.
2. And the switch is checked and 'Join in low bandwidth mode' button inside Prejoin screen is pressed, the participant goes straight to Carmode screen.
