### PR TITLE
feat(rn,config) default to VP8 on mobile

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -481,7 +481,7 @@ export interface IConfig {
                 standard?: number;
             };
         };
-        minHeightForQualityLvl: {
+        minHeightForQualityLvl?: {
             [key: number]: string;
         };
         preferredCodec?: string;

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -52,10 +52,11 @@ const INITIAL_RN_STATE: IConfig = {
     disableAudioLevels: true,
 
     p2p: {
-        disabledCodec: '',
-        disableH264: false, // deprecated
-        preferredCodec: 'H264',
-        preferH264: true // deprecated
+        preferredCodec: 'VP8'
+    },
+
+    videoQuality: {
+        preferredCodec: 'VP8'
     }
 };
 


### PR DESCRIPTION
VP9 is too resource intensive.

H.264 might be coming back for P2P but we need to fix support for Android first, since it's not available with the default software codec factory.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
