### PR TITLE
doc: apache: set Content-Security-Policy header

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -16,7 +16,7 @@
     SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
 
     Header always unset Content-Security-Policy
-    Header always set Content-Security-Policy "default-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none';"
+    Header always set Content-Security-Policy "default-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none';"
     Header always set Strict-Transport-Security "max-age=63072000"
 
     DocumentRoot "/usr/share/jitsi-meet"

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -16,7 +16,7 @@
     SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
 
     Header always unset Content-Security-Policy
-    Header always set Content-Security-Policy "default-src 'self'; font-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none';"
+    Header always set Content-Security-Policy "default-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none';"
     Header always set Strict-Transport-Security "max-age=63072000"
 
     DocumentRoot "/usr/share/jitsi-meet"

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -15,6 +15,8 @@
     SSLCertificateFile /etc/jitsi/meet/jitsi-meet.example.com.crt
     SSLCertificateKeyFile /etc/jitsi/meet/jitsi-meet.example.com.key
 
+    Header always unset Content-Security-Policy
+    Header always set Content-Security-Policy "default-src 'self'; font-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; object-src 'none';"
     Header always set Strict-Transport-Security "max-age=63072000"
 
     DocumentRoot "/usr/share/jitsi-meet"


### PR DESCRIPTION
- only allow resources from self, and inline scripts
- fixes https://github.com/jitsi/jitsi-meet/issues/2544
- unset headers set by global server config, to prevent sending duplicate headers
- test at https://securityheaders.com/
- custom jitsi instances may require changing the default value, for example https://meet.jit.si loads images/scripts/styles from https://web-cdn.jitsi.net/, https://api.amplitude.com/, https://api.callstats.io/, https://auth.callstats.io/, https://collector.callstats.io/,

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
