### PR TITLE
fix: always display transcription

### DIFF
--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -117,7 +117,7 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
                 newTranscriptMessage));
 
         } else if (json.type === JSON_TYPE_TRANSCRIPTION_RESULT
-        && i18next.language === translationLanguage) {
+                && json.language.slice(0, 2) === translationLanguage) {
             // Displays interim and final results without any translation if
             // translations are disabled.
 

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -1,4 +1,3 @@
-import i18next from 'i18next';
 import { AnyAction } from 'redux';
 
 import { IStore } from '../app/types';


### PR DESCRIPTION
This PR fixes transcriptions not being displayed.

# Situation

As of version 2.0.7830 of Jitsi, one can choose the transcription source language when enabling subtitles.
Jigasi would send transcriptions in that source language, by specifying a `language` key in the result JSON.
However, there is a check that makes sure the Jitsi interface is the same language as the transcription result.

# Problem
This causes an issue where, if the user chooses a transcription language that is not the same as their UI language, the subtitles will not show up, without any error message.

# Fix
This PR removes the language check, which fixes the display of subtitles.

Please let me know if there is anything I can improve.
This PR is part of a project with @openfun to improve the accessibility of its videoconference platforms.