### PR TITLE
fix(screenshare): Pass _desktopSharingSourceDevice as shareOptions when available

### DIFF
--- a/react/features/base/conference/middleware.web.js
+++ b/react/features/base/conference/middleware.web.js
@@ -186,6 +186,11 @@ async function _toggleScreenSharing({ enabled, audioOnly = false, shareOptions =
 
     if (enable) {
         let tracks;
+        const { _desktopSharingSourceDevice } = state['features/base/config'];
+
+        if (!shareOptions.desktopSharingSources && _desktopSharingSourceDevice) {
+            shareOptions.desktopSharingSourceDevice = _desktopSharingSourceDevice;
+        }
         const options = {
             devices: [ VIDEO_TYPE.DESKTOP ],
             ...shareOptions


### PR DESCRIPTION
Fixes an issue when external cam as screensharing source fails on Spot with multi-stream enabled.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
