### PR TITLE
fix(external-api) Remove muted SS tracks from the list of participants currently screensharing

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -35,6 +35,7 @@ import {
     LOCAL_PARTICIPANT_DEFAULT_ID,
     getLocalParticipant,
     getParticipantById,
+    getScreenshareParticipantIds,
     grantModerator,
     hasRaisedHand,
     isLocalParticipantModerator,
@@ -855,8 +856,7 @@ function initCommands() {
             callback(Boolean(APP.store.getState()['features/base/config'].startSilent));
             break;
         case 'get-content-sharing-participants': {
-            const tracks = getState()['features/base/tracks'];
-            const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
+            const sharingParticipantIds = getScreenshareParticipantIds(APP.store.getState());
 
             callback({
                 sharingParticipantIds

--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -10,6 +10,7 @@ import { GRAVATAR_BASE_URL } from '../avatar/constants';
 import { isCORSAvatarURL } from '../avatar/functions';
 import { getMultipleVideoSupportFeatureFlag } from '../config/functions.any';
 import i18next from '../i18n/i18next';
+import { VIDEO_TYPE } from '../media/constants';
 import { toState } from '../redux/functions';
 import { getScreenShareTrack } from '../tracks/functions';
 import { createDeferred } from '../util/helpers';
@@ -456,6 +457,19 @@ export function getScreenshareParticipantDisplayName(stateful: IStateful, id: st
     const ownerDisplayName = getParticipantDisplayName(stateful, getVirtualScreenshareParticipantOwnerId(id));
 
     return i18next.t('screenshareDisplayName', { name: ownerDisplayName });
+}
+
+/**
+ * Returns a list of IDs of the participants that are currently screensharing.
+ *
+ * @param {(Function|Object)} stateful - The (whole) redux state, or redux's {@code getState} function to be used to
+ * retrieve the state.
+ * @returns {Array<string>}
+ */
+export function getScreenshareParticipantIds(stateful: IStateful): Array<string> {
+    return toState(stateful)['features/base/tracks']
+        .filter(track => track.videoType === VIDEO_TYPE.DESKTOP && !track.muted)
+        .map(t => t.participantId);
 }
 
 /**

--- a/react/features/base/tracks/subscriber.ts
+++ b/react/features/base/tracks/subscriber.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import { getScreenshareParticipantIds } from '../participants/functions';
 import StateListenerRegistry from '../redux/StateListenerRegistry';
 
 import { isLocalCameraTrackMuted } from './functions';
@@ -8,8 +9,7 @@ import { isLocalCameraTrackMuted } from './functions';
  * Notifies when the list of currently sharing participants changes.
  */
 StateListenerRegistry.register(
-    /* selector */ state =>
-        state['features/base/tracks'].filter(tr => tr.videoType === 'desktop').map(t => t.participantId),
+    /* selector */ state => getScreenshareParticipantIds(state),
     /* listener */ (participantIDs, store, previousParticipantIDs) => {
         if (typeof APP !== 'object') {
             return;


### PR DESCRIPTION
Fixes an issue where 'contentSharingParticipantsChanged' event and 'getContentSharingParticipants' API continue to list IDs of the participants that have already stopped their screenshares.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
