### PR TITLE
feat(base/ui): fixed native button active style

### DIFF
--- a/react/features/base/ui/components/native/Button.tsx
+++ b/react/features/base/ui/components/native/Button.tsx
@@ -15,6 +15,7 @@ import styles from './buttonStyles';
 
 export interface IButtonProps extends ButtonProps {
     color?: string;
+    contentStyle?:  Object | undefined;
     labelStyle?: Object | undefined;
     style?: Object | undefined;
 }
@@ -22,6 +23,7 @@ export interface IButtonProps extends ButtonProps {
 const Button: React.FC<IButtonProps> = ({
     accessibilityLabel,
     color: buttonColor,
+    contentStyle,
     disabled,
     icon,
     labelKey,
@@ -88,6 +90,10 @@ const Button: React.FC<IButtonProps> = ({
             accessibilityLabel = { t(accessibilityLabel ?? '') }
             children = { t(labelKey ?? '') }
             color = { color }
+            contentStyle = {[
+                styles.buttonContent,
+                contentStyle
+            ]}
             disabled = { disabled }
             // @ts-ignore
             icon = { icon }

--- a/react/features/base/ui/components/native/Button.tsx
+++ b/react/features/base/ui/components/native/Button.tsx
@@ -15,7 +15,7 @@ import styles from './buttonStyles';
 
 export interface IButtonProps extends ButtonProps {
     color?: string;
-    contentStyle?:  Object | undefined;
+    contentStyle?: Object | undefined;
     labelStyle?: Object | undefined;
     style?: Object | undefined;
 }
@@ -90,10 +90,10 @@ const Button: React.FC<IButtonProps> = ({
             accessibilityLabel = { t(accessibilityLabel ?? '') }
             children = { t(labelKey ?? '') }
             color = { color }
-            contentStyle = {[
+            contentStyle = { [
                 styles.buttonContent,
                 contentStyle
-            ]}
+            ] }
             disabled = { disabled }
             // @ts-ignore
             icon = { icon }

--- a/react/features/base/ui/components/native/buttonStyles.ts
+++ b/react/features/base/ui/components/native/buttonStyles.ts
@@ -23,6 +23,10 @@ export default {
         ...buttonLabel
     },
 
+    buttonContent: {
+        height: BUTTON_HEIGHT
+    },
+
     buttonLabelDisabled: {
         ...buttonLabel,
         color: BaseTheme.palette.text03


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

When tapping one of our native buttons, the transparent active background doesn't cover the full content of its parent. 