### PR TITLE
fix(android) fix crash in Android < 10

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiInitializer.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiInitializer.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.meet.sdk;
 
+import android.app.Application;
 import android.content.Context;
 import android.util.Log;
 
@@ -22,6 +23,7 @@ import androidx.annotation.NonNull;
 import androidx.startup.Initializer;
 
 import com.facebook.soloader.SoLoader;
+import org.wonday.orientation.OrientationActivityLifecycle;
 
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +39,10 @@ public class JitsiInitializer implements Initializer<Boolean> {
 
         // Register our uncaught exception handler.
         JitsiMeetUncaughtExceptionHandler.register();
+
+        // Register activity lifecycle handler for the orientation locker module.
+        ((Application) context).registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
+
         return true;
     }
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -31,7 +31,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.facebook.react.modules.core.PermissionListener;
 
-import org.wonday.orientation.OrientationActivityLifecycle;
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 
 import java.util.HashMap;
@@ -104,7 +103,6 @@ public class JitsiMeetActivity extends AppCompatActivity
         this.jitsiView = findViewById(R.id.jitsiView);
 
         registerForBroadcastMessages();
-        registerActivityLifecycleCallbacks(OrientationActivityLifecycle.getInstance());
 
         if (!extraInitialize()) {
             initialize();


### PR DESCRIPTION
Activity.registerActivityLifecycleCallbacks is only available in API level 29.

Ref: https://developer.android.com/reference/android/app/Activity.html#registerActivityLifecycleCallbacks(android.app.Application.ActivityLifecycleCallbacks)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
