### PR TITLE
fix: Fix log message.

### DIFF
--- a/resources/prosody-plugins/mod_end_conference.lua
+++ b/resources/prosody-plugins/mod_end_conference.lua
@@ -15,7 +15,7 @@ local END_CONFERENCE_REASON = 'The meeting has been terminated';
 
 local end_conference_component = module:get_option_string('end_conference_component', 'endconference.'..module.host);
 if end_conference_component == nil then
-    log('error', 'No end_conference_component specified.');
+    module:log('error', 'No end_conference_component specified.');
     return;
 end
 

--- a/resources/prosody-plugins/mod_end_conference.lua
+++ b/resources/prosody-plugins/mod_end_conference.lua
@@ -26,7 +26,7 @@ module:depends("jitsi_session");
 
 local muc_component_host = module:get_option_string('muc_component');
 if muc_component_host == nil then
-    log('error', 'No muc_component specified. No muc to operate on!');
+    module:log('error', 'No muc_component specified. No muc to operate on!');
     return;
 end
 
@@ -61,17 +61,17 @@ function on_message(event)
         local from = event.stanza.attr.from;
         local occupant = room:get_occupant_by_real_jid(from);
         if not occupant then
-            log('warn', 'No occupant %s found for %s', from, room.jid);
+            module:log('warn', 'No occupant %s found for %s', from, room.jid);
             return false;
         end
         if occupant.role ~= 'moderator' then
-            log('warn', 'Occupant %s is not moderator and not allowed this operation for %s', from, room.jid);
+            module:log('warn', 'Occupant %s is not moderator and not allowed this operation for %s', from, room.jid);
             return false;
         end
 
         -- destroy the room
         room:destroy(nil, END_CONFERENCE_REASON);
-        log('info', 'Room %s destroyed by occupant %s', room.jid, from);
+        module:log('info', 'Room %s destroyed by occupant %s', room.jid, from);
         return true;
     end
 


### PR DESCRIPTION
From `general error No muc_component specified` to `endconference.meet.damencho.net:end_conference error No muc_component specified`

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
