### PR TITLE
fix(screenshare-jwt) Disable screen share based on jwt

### DIFF
--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -39,9 +39,10 @@ export function getJwtName(state: IState) {
  * @param {IState} state - The app state.
  * @param {string} feature - The feature we want to check.
  * @param {boolean} ifNoToken - Default value if there is no token.
- * @returns {string}
+ * @param {boolean} ifNotInFeatures - Default value if features prop exists but does not have the {@code feature}.
+ * @returns {bolean}
  */
-export function isJwtFeatureEnabled(state: IState, feature: string, ifNoToken = false) {
+export function isJwtFeatureEnabled(state: IState, feature: string, ifNoToken = false, ifNotInFeatures = false) {
     const { jwt } = state['features/base/jwt'];
 
     if (!jwt) {
@@ -53,6 +54,10 @@ export function isJwtFeatureEnabled(state: IState, feature: string, ifNoToken = 
     // If `features` is undefined, act as if everything is enabled.
     if (typeof features === 'undefined') {
         return true;
+    }
+
+    if (typeof features[feature as keyof typeof features] === 'undefined') {
+        return ifNotInFeatures;
     }
 
     return String(features[feature as keyof typeof features]) === 'true';

--- a/react/features/toolbox/functions.web.ts
+++ b/react/features/toolbox/functions.web.ts
@@ -1,6 +1,8 @@
 import { IState } from '../app/types';
 import { getToolbarButtons } from '../base/config/functions.web';
 import { hasAvailableDevices } from '../base/devices/functions';
+import { MEET_FEATURES } from '../base/jwt/constants';
+import { isJwtFeatureEnabled } from '../base/jwt/functions';
 import { isScreenMediaShared } from '../screen-share/functions';
 import { isWhiteboardVisible } from '../whiteboard/functions';
 
@@ -84,8 +86,9 @@ export function isAudioSettingsButtonDisabled(state: IState) {
 export function isDesktopShareButtonDisabled(state: IState) {
     const { muted, unmuteBlocked } = state['features/base/media'].video;
     const videoOrShareInProgress = !muted || isScreenMediaShared(state);
+    const enabledInJwt = isJwtFeatureEnabled(state, MEET_FEATURES.SCREEN_SHARING, true, true);
 
-    return unmuteBlocked && !videoOrShareInProgress;
+    return !enabledInJwt || (unmuteBlocked && !videoOrShareInProgress);
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->


- if no JWT - screen share is enabled
- if JWT but no features mentioned- screen share is enabled
- if JWT has some features but does not contain 'screen-sharing' - screen share is enabled
- if JWT contains an explicit true/false/"true"/"false" value, the value will be considered.
