### PR TITLE
fix: Drops participants count white background.

### DIFF
--- a/react/features/conference/components/web/ParticipantsCount.js
+++ b/react/features/conference/components/web/ParticipantsCount.js
@@ -6,7 +6,6 @@ import type { Dispatch } from 'redux';
 import { openDialog } from '../../../base/dialog';
 import { IconUserGroups } from '../../../base/icons';
 import { Label } from '../../../base/label';
-import { COLORS } from '../../../base/label/constants';
 import { getParticipantCount } from '../../../base/participants';
 import { connect } from '../../../base/redux';
 import { SpeakerStats } from '../../../speaker-stats';

--- a/react/features/conference/components/web/ParticipantsCount.js
+++ b/react/features/conference/components/web/ParticipantsCount.js
@@ -87,7 +87,6 @@ class ParticipantsCount extends PureComponent<Props> {
 
         return (
             <Label
-                color = { COLORS.white }
                 icon = { IconUserGroups }
                 onClick = { !this.props._isSpeakerStatsDisabled && this._onClick }
                 text = { count } />


### PR DESCRIPTION
Currently, it is white background with white icon.

Before:
![Screen Shot 2022-10-19 at 10 54 54 AM](https://user-images.githubusercontent.com/3263098/196742842-382bdf7e-bfed-4a34-9f89-5f8c3589803a.png)

After:
![image (2)](https://user-images.githubusercontent.com/3263098/196742920-c0e8cc48-dc5a-4fee-84cd-8efdfc9c4e1c.png)
