### PR TITLE
fix(persistent_lobby): properly destroy main room when empty

### DIFF
--- a/resources/prosody-plugins/mod_persistent_lobby.lua
+++ b/resources/prosody-plugins/mod_persistent_lobby.lua
@@ -84,12 +84,10 @@ local function has_persistent_lobby(room)
 end
 
 
--- Helper method to trigger main room destroy if room is persistent (no auto-delete) and destroy not yet triggered
+-- Helper method to trigger main room destroy
 local function trigger_room_destroy(room)
-    if room.get_persistent(room) and room._data.room_destroy_triggered == nil then
-        room._data.room_destroy_triggered = true;
-        main_muc_module:fire_event("muc-room-destroyed", { room = room; });
-    end
+    room:set_persistent(false);
+    room:destroy(nil, 'main room and lobby now empty');
 end
 
 


### PR DESCRIPTION
Main room was not being properly destroyed -- it was only artificially triggering the "muc-room-destroyed" event :(

Did a quick test with mod_lobby_autostart and it now appears to do the right thing.

Related community post: https://community.jitsi.org/t/new-prosody-module-to-automatically-start-lobby-and-to-bypass-lobby-with-jwt/116517/46?u=shawn