### PR TITLE
Exit out early if no input data to NoiseSuppressorWorklet

### DIFF
--- a/react/features/stream-effects/noise-suppression/NoiseSuppressorWorklet.ts
+++ b/react/features/stream-effects/noise-suppression/NoiseSuppressorWorklet.ts
@@ -106,6 +106,12 @@ class NoiseSuppressorWorklet extends AudioWorkletProcessor {
         const inData = inputs[0][0];
         const outData = outputs[0][0];
 
+        // Exit out early if there is no input data (input node not connected/disconnected)
+        // as rest of worklet will crash otherwise
+        if (!inData) {
+            return true;
+        }
+
         // Append new raw PCM sample.
         this._circularBuffer.set(inData, this._inputBufferLength);
         this._inputBufferLength += inData.length;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Disconnecting the input node to the worklet causes the worklet to crash. Adding a guard clause for empty input prevents this.