### PR TITLE
chore(deps) @react-native-async-storage 1.17.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -457,7 +457,7 @@ PODS:
     - React-perflogger (= 0.68.4)
   - RNCalendarEvents (2.2.0):
     - React
-  - RNCAsyncStorage (1.15.14):
+  - RNCAsyncStorage (1.17.3):
     - React-Core
   - RNCClipboard (1.5.1):
     - React-Core
@@ -770,7 +770,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 088723cf020113e64736a709f52719dbb359c73e
   ReactCommon: 1a4f19f3b4366feec03a98bdbb200b6085c5000f
   RNCalendarEvents: 7e65eb4a94f53c1744d1e275f7fafcfaa619f7a3
-  RNCAsyncStorage: ea6b5c280997b2b32a587793163b1f10e580c4f7
+  RNCAsyncStorage: 005c0e2f09575360f142d0d1f1f15e4ec575b1af
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNCMaskedView: c298b644a10c0c142055b3ae24d83879ecb13ccd
   RNDefaultPreference: 08bdb06cfa9188d5da97d4642dac745218d7fb31

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.10.2",
         "@mui/styles": "5.10.2",
-        "@react-native-async-storage/async-storage": "1.15.14",
+        "@react-native-async-storage/async-storage": "1.17.3",
         "@react-native-community/clipboard": "1.5.1",
         "@react-native-community/netinfo": "7.1.7",
         "@react-native-community/slider": "4.1.12",
@@ -4427,14 +4427,14 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "1.15.14",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz",
-      "integrity": "sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.3.tgz",
+      "integrity": "sha512-2dxdlGwBjBP2qYu6F72U7cRRFshISYiNEWCaQNOJtxUERCMaYRWcniYqhL248KSbGUMpRhFCEtliztsiGoYYMA==",
       "dependencies": {
         "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || ^0.60.6 || ^0.61.5 || ^0.62.2 || ^0.63.2 || ^0.64.0 || ^0.65.0 || ^0.66.0 || 1000.0.0"
+        "react-native": "^0.0.0-0 || 0.60 - 0.68 || 1000.0.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -23642,9 +23642,9 @@
       "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@react-native-async-storage/async-storage": {
-      "version": "1.15.14",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.14.tgz",
-      "integrity": "sha512-eJF2horabXazwszCyyXDe4w7sBSWlB0WPA8akKXuN2n7WXKHYeQJPN41lS9OahrhSZuZwqftNFE9VWgPXA8wyA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.3.tgz",
+      "integrity": "sha512-2dxdlGwBjBP2qYu6F72U7cRRFshISYiNEWCaQNOJtxUERCMaYRWcniYqhL248KSbGUMpRhFCEtliztsiGoYYMA==",
       "requires": {
         "merge-options": "^3.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.10.2",
     "@mui/styles": "5.10.2",
-    "@react-native-async-storage/async-storage": "1.15.14",
+    "@react-native-async-storage/async-storage": "1.17.3",
     "@react-native-community/clipboard": "1.5.1",
     "@react-native-community/netinfo": "7.1.7",
     "@react-native-community/slider": "4.1.12",


### PR DESCRIPTION
We need @react-native-async-storage at least at 1.17.3 for the React Native SDK to not have peer dependency issues. This is also the version that is actually supporting React Native 0.68