### PR TITLE
Misspelling. Update main-ca.json

### DIFF
--- a/lang/main-ca.json
+++ b/lang/main-ca.json
@@ -570,7 +570,7 @@
         "joinTitle": "Entra a la reunió",
         "joinWithPasswordMessage": "S'està intentant unir-s'hi amb contrasenya, espereu...",
         "joiningMessage": "Us unireu a la reunió de seguida que algú accepti la sol·licitud",
-        "joiningTitle": "S'està demanat per a entrar a la reunió...",
+        "joiningTitle": "S'ha demanat per a entrar a la reunió...",
         "joiningWithPasswordTitle": "Afegeix-m'hi amb contrasenya...",
         "knockButton": "Demana d'unir-se",
         "knockTitle": "Algú vol unir-se a la reunió",


### PR DESCRIPTION
There is a misspelling in the "joiningTitle" label. "S'està demanat per a entrar a la reunió...", should be "S'ha demanat per a entrar a la reunió..."

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
