### PR TITLE
chore(deps) @jitsi/rtcstats 9.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@jitsi/js-utils": "2.0.4",
         "@jitsi/logger": "2.0.0",
         "@jitsi/rnnoise-wasm": "0.1.0",
-        "@jitsi/rtcstats": "9.3.0",
+        "@jitsi/rtcstats": "9.4.0",
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.10.2",
@@ -3780,9 +3780,9 @@
       "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
     },
     "node_modules/@jitsi/rtcstats": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.3.0.tgz",
-      "integrity": "sha512-aipr1Tt/vfouMmgISCSu64Np3pD1u51y/2SztYNDt5bd6f79Qrieceu0JFqZWxC9KQRsamoJL7Mb9qxo2KkULg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.4.0.tgz",
+      "integrity": "sha512-NZXgJUAX6Mvexes7zAnHOiU+F2O7NIdyRUcir1YUD85mvBV0DMjuwUnIL5XaYkCzDuE3rTcV2FX9B80BTRlnLQ==",
       "dependencies": {
         "@jitsi/js-utils": "^2.0.0",
         "sdp": "^3.0.3",
@@ -23208,9 +23208,9 @@
       "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
     },
     "@jitsi/rtcstats": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.3.0.tgz",
-      "integrity": "sha512-aipr1Tt/vfouMmgISCSu64Np3pD1u51y/2SztYNDt5bd6f79Qrieceu0JFqZWxC9KQRsamoJL7Mb9qxo2KkULg==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.4.0.tgz",
+      "integrity": "sha512-NZXgJUAX6Mvexes7zAnHOiU+F2O7NIdyRUcir1YUD85mvBV0DMjuwUnIL5XaYkCzDuE3rTcV2FX9B80BTRlnLQ==",
       "requires": {
         "@jitsi/js-utils": "^2.0.0",
         "sdp": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@jitsi/js-utils": "2.0.4",
     "@jitsi/logger": "2.0.0",
     "@jitsi/rnnoise-wasm": "0.1.0",
-    "@jitsi/rtcstats": "9.3.0",
+    "@jitsi/rtcstats": "9.4.0",
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.10.2",


### PR DESCRIPTION
Updated rtcstats to version 9.4.0 to include fixes for SDP logging.