### PR TITLE
(feat) OpenResty Support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Description: WebRTC JavaScript video conferences
 
 Package: jitsi-meet-web-config
 Architecture: all
-Depends: openssl, nginx | nginx-full | nginx-extras | apache2, curl
+Depends: openssl, nginx | nginx-full | nginx-extras | openresty | apache2, curl
 Description: Configuration for web serving of Jitsi Meet
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
  Videobridge to provide high quality, scalable video conferences.

--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -57,6 +57,10 @@ case "$1" in
            || [ "$NGINX_EXTRAS_INSTALL_CHECK" = "unpacked" ] ; then
             FORCE_NGINX="true"
         fi
+        OPENRESTY_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'openresty' 2>/dev/null | awk '{print $3}' || true)"
+        if [ "$OPENRESTY_INSTALL_CHECK" = "installed" ] || [ "$OPENRESTY_INSTALL_CHECK" = "unpacked" ] ; then
+            FORCE_OPENRESTY="true"
+        fi
         APACHE_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'apache2' 2>/dev/null | awk '{print $3}' || true)"
         if [ "$APACHE_INSTALL_CHECK" = "installed" ] || [ "$APACHE_INSTALL_CHECK" = "unpacked" ] ; then
             FORCE_APACHE="true"
@@ -182,21 +186,41 @@ case "$1" in
             echo "config.flags.receiveMultipleVideoStreams = true;" >> $JITSI_MEET_CONFIG
         fi
 
-        if [[ "$FORCE_NGINX" = "true" && ( -z "$JVB_HOSTNAME_OLD" || "$RECONFIGURING" = "true" ) ]] ; then
+        if [[ "$FORCE_OPENRESTY" = "true" ]]; then
+            NGX_COMMON_CONF_PATH="/usr/local/openresty/nginx/conf/$JVB_HOSTNAME.conf"
+            NGX_SVC_NAME=openresty
+            OPENRESTY_NGX_CONF="/usr/local/openresty/nginx/conf/nginx.conf"
+        else
+            NGX_COMMON_CONF_PATH="/etc/nginx/sites-available/$JVB_HOSTNAME.conf"
+            NGX_SVC_NAME=nginx
+        fi
+
+        if [[ ( "$FORCE_NGINX" = "true" || "$FORCE_OPENRESTY" = "true" ) && ( -z "$JVB_HOSTNAME_OLD" || "$RECONFIGURING" = "true" ) ]] ; then
 
             # this is a reconfigure, lets just delete old links
             if [ "$RECONFIGURING" = "true" ] ; then
                 rm -f /etc/nginx/sites-enabled/$JVB_HOSTNAME_OLD.conf
                 rm -f /etc/jitsi/meet/$JVB_HOSTNAME_OLD-config.js
+                if [[ "$FORCE_OPENRESTY" = "true" ]]; then
+                    sed -i "/include.*$JVB_HOSTNAME_OLD/d" "$OPENRESTY_NGX_CONF"
+                fi
             fi
 
             # nginx conf
-            if [ ! -f /etc/nginx/sites-available/$JVB_HOSTNAME.conf ] ; then
-                cp /usr/share/jitsi-meet-web-config/jitsi-meet.example /etc/nginx/sites-available/$JVB_HOSTNAME.conf
-                if [ ! -f /etc/nginx/sites-enabled/$JVB_HOSTNAME.conf ] ; then
-                    ln -s /etc/nginx/sites-available/$JVB_HOSTNAME.conf /etc/nginx/sites-enabled/$JVB_HOSTNAME.conf
+            if [ ! -f "$NGX_COMMON_CONF_PATH" ] ; then
+                cp /usr/share/jitsi-meet-web-config/jitsi-meet.example "$NGX_COMMON_CONF_PATH"
+                if [ ! -f /etc/nginx/sites-enabled/$JVB_HOSTNAME.conf ] && ! [[ "$FORCE_OPENRESTY" = "true" ]] ; then
+                    ln -s "$NGX_COMMON_CONF_PATH" /etc/nginx/sites-enabled/$JVB_HOSTNAME.conf
                 fi
-                sed -i "s/jitsi-meet.example.com/$JVB_HOSTNAME/g" /etc/nginx/sites-available/$JVB_HOSTNAME.conf
+                sed -i "s/jitsi-meet.example.com/$JVB_HOSTNAME/g" "$NGX_COMMON_CONF_PATH"
+
+                if [[ "$FORCE_OPENRESTY" = "true" ]]; then
+                    OPENRESTY_NGX_CONF_MD5_ORIG=$(dpkg-query -s openresty | sed -n '/\/nginx\.conf /{s@.* @@;p}')
+                    OPENRESTY_NGX_CONF_MD5_USERS=$(md5sum "$OPENRESTY_NGX_CONF" | sed 's@ .*@@')
+                    if [[ "$OPENRESTY_NGX_CONF_MD5_USERS" = "$OPENRESTY_NGX_CONF_MD5_ORIG" ]]; then
+                       sed -i "/^http \x7b/,/^\x7d/s@^\x7d@\tinclude $NGX_COMMON_CONF_PATH;\n\x7d@" "$OPENRESTY_NGX_CONF"
+                    fi
+                fi
             fi
 
             if [ "$CERT_CHOICE" = "$UPLOADED_CERT_CHOICE" ] ; then
@@ -204,14 +228,14 @@ case "$1" in
                 CERT_KEY_ESC=$(echo $CERT_KEY | sed 's/\./\\\./g')
                 CERT_KEY_ESC=$(echo $CERT_KEY_ESC | sed 's/\//\\\//g')
                 sed -i "s/ssl_certificate_key\ \/etc\/jitsi\/meet\/.*key/ssl_certificate_key\ $CERT_KEY_ESC/g" \
-                    /etc/nginx/sites-available/$JVB_HOSTNAME.conf
+                    "$NGX_COMMON_CONF_PATH"
                 CERT_CRT_ESC=$(echo $CERT_CRT | sed 's/\./\\\./g')
                 CERT_CRT_ESC=$(echo $CERT_CRT_ESC | sed 's/\//\\\//g')
                 sed -i "s/ssl_certificate\ \/etc\/jitsi\/meet\/.*crt/ssl_certificate\ $CERT_CRT_ESC/g" \
-                    /etc/nginx/sites-available/$JVB_HOSTNAME.conf
+                    "$NGX_COMMON_CONF_PATH"
             fi
 
-            invoke-rc.d nginx reload || true
+            invoke-rc.d $NGX_SVC_NAME reload || true
         elif [[ "$FORCE_APACHE" = "true" && ( -z "$JVB_HOSTNAME_OLD" || "$RECONFIGURING" = "true" ) ]] ; then
 
             # this is a reconfigure, lets just delete old links

--- a/debian/jitsi-meet-web-config.postrm
+++ b/debian/jitsi-meet-web-config.postrm
@@ -24,6 +24,9 @@ set -e
 
 case "$1" in
     remove)
+        if [ -x "/etc/init.d/openresty" ]; then
+            invoke-rc.d openresty reload || true
+        fi
         if [ -x "/etc/init.d/nginx" ]; then
             invoke-rc.d nginx reload || true
         fi
@@ -38,6 +41,7 @@ case "$1" in
             rm -f /etc/jitsi/meet/$JVB_HOSTNAME-config.js
             rm -f /etc/nginx/sites-available/$JVB_HOSTNAME.conf
             rm -f /etc/nginx/sites-enabled/$JVB_HOSTNAME.conf
+            rm -f /usr/local/openresty/nginx/conf/$JVB_HOSTNAME.conf
             rm -f /etc/apache2/sites-available/$JVB_HOSTNAME.conf
             rm -f /etc/apache2/sites-enabled/$JVB_HOSTNAME.conf
             rm -f /etc/jitsi/meet/$JVB_HOSTNAME.key

--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -37,6 +37,7 @@ curl https://get.acme.sh | sh -s email=$EMAIL
 NGINX_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'nginx' 2>/dev/null | awk '{print $3}' || true)"
 NGINX_FULL_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'nginx-full' 2>/dev/null | awk '{print $3}' || true)"
 NGINX_EXTRAS_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'nginx-extras' 2>/dev/null | awk '{print $3}' || true)"
+OPENRESTY_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'openresty' 2>/dev/null | awk '{print $3}' || true)"
 APACHE_INSTALL_CHECK="$(dpkg-query -f '${Status}' -W 'apache2' 2>/dev/null | awk '{print $3}' || true)"
 
 RELOAD_CMD=""
@@ -44,6 +45,8 @@ if [ "$NGINX_INSTALL_CHECK" = "installed" ] || [ "$NGINX_INSTALL_CHECK" = "unpac
    || [ "$NGINX_FULL_INSTALL_CHECK" = "installed" ] || [ "$NGINX_FULL_INSTALL_CHECK" = "unpacked" ] \
    || [ "$NGINX_EXTRAS_INSTALL_CHECK" = "installed" ] || [ "$NGINX_EXTRAS_INSTALL_CHECK" = "unpacked" ]; then
     RELOAD_CMD="systemctl force-reload nginx.service"
+elif [ "$OPENRESTY_INSTALL_CHECK" = "installed" ] || [ "$OPENRESTY_INSTALL_CHECK" = "unpacked" ] ; then
+    RELOAD_CMD="systemctl force-reload openresty.service"
 elif [ "$APACHE_INSTALL_CHECK" = "installed" ] || [ "$APACHE_INSTALL_CHECK" = "unpacked" ] ; then
     RELOAD_CMD="systemctl force-reload apache2.service"
 else


### PR DESCRIPTION
This PR adds suppot for users to use [OpenResty](https://openresty.org) as web-server and don't duplicate "nginxes" by installing additional NginX copy on the user system.

OpenResty, if any, is a bundle of nginx+lua-module+luajit+bunch of lua libraries and so on.
It is very usable for high customisation, so I personally prefer to use it instead of "base" nginx.


(also, if any, I am not connected with openresty organisation, just an user)