### PR TITLE
flag to hide settings button in overflow menu

### DIFF
--- a/react/features/base/flags/constants.ts
+++ b/react/features/base/flags/constants.ts
@@ -210,6 +210,12 @@ export const SECURITY_OPTIONS_ENABLED = 'security-options.enabled';
 export const SERVER_URL_CHANGE_ENABLED = 'server-url-change.enabled';
 
 /**
+ * Flag indicating if settings should be enabled.
+ * Default: enabled (true).
+ */
+export const SETTINGS_ENABLED = 'settings.enabled';
+
+/**
  * Flag indicating if tile view feature should be enabled.
  * Default: enabled.
  */

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable lines-around-comment */
-import { translate } from '../../../../base/i18n/functions';
+
+import { SETTINGS_ENABLED, getFeatureFlag } from '../../../../base/flags';
+import { translate } from '../../../../base/i18n';
 import { IconSettings } from '../../../../base/icons/svg';
+import { connect } from '../../../../base/redux';
 // @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
 // @ts-ignore
@@ -29,5 +32,20 @@ class SettingsButton extends AbstractButton<AbstractButtonProps, any, any> {
     }
 }
 
+
+/**
+ * Maps part of the redux state to the component's props.
+ *
+ * @param {Object} state - The redux store/state.
+ * @returns {Object}
+ */
+function _mapStateToProps(state: Object) {
+    const enabled = getFeatureFlag(state, SETTINGS_ENABLED, true);
+
+    return {
+        visible: enabled
+    };
+}
+
 // @ts-ignore
-export default translate(SettingsButton);
+export default translate(connect(_mapStateToProps)(SettingsButton));

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -9,7 +9,6 @@ import { navigate }
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 // @ts-ignore
 import { screen } from '../../../../mobile/navigation/routes';
-
 import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
 import { translate } from '../../../i18n';
 import { IconSettings } from '../../../icons/svg';

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,8 +1,14 @@
+/* eslint-disable lines-around-comment */
+
 import { IReduxState } from '../../../../app/types';
+// @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
 import { navigate }
+// @ts-ignore
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
+// @ts-ignore
 import { screen } from '../../../../mobile/navigation/routes';
+// @ts-ignore
 import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
 import { translate } from '../../../i18n/functions';
 import { IconSettings } from '../../../icons/svg';

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -9,9 +9,12 @@ import { navigate }
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 // @ts-ignore
 import { screen } from '../../../../mobile/navigation/routes';
+// @ts-ignore
 import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
+// @ts-ignore
 import { translate } from '../../../i18n';
 import { IconSettings } from '../../../icons/svg';
+// @ts-ignore
 import { connect } from '../../../redux';
 
 /**

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,9 +1,6 @@
 /* eslint-disable lines-around-comment */
 
-import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
-import { translate } from '../../../i18n';
-import { IconSettings } from '../../../icons/svg';
-import { connect } from '../../../redux';
+
 // @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
 // @ts-ignore
@@ -12,6 +9,11 @@ import { navigate }
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 // @ts-ignore
 import { screen } from '../../../../mobile/navigation/routes';
+
+import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
+import { translate } from '../../../i18n';
+import { IconSettings } from '../../../icons/svg';
+import { connect } from '../../../redux';
 
 /**
  * Implements an {@link AbstractButton} to open the carmode.

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable lines-around-comment */
 
-import { SETTINGS_ENABLED, getFeatureFlag } from '../../../../base/flags';
-import { translate } from '../../../../base/i18n';
-import { IconSettings } from '../../../../base/icons/svg';
-import { connect } from '../../../../base/redux';
+import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
+import { translate } from '../../../i18n';
+import { IconSettings } from '../../../icons/svg';
+import { connect } from '../../../redux';
 // @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
 // @ts-ignore

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,21 +1,12 @@
-/* eslint-disable lines-around-comment */
-
-
-// @ts-ignore
+import { IReduxState } from '../../../../app/types';
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
-// @ts-ignore
 import { navigate }
-// @ts-ignore
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
-// @ts-ignore
 import { screen } from '../../../../mobile/navigation/routes';
-// @ts-ignore
 import { SETTINGS_ENABLED, getFeatureFlag } from '../../../flags';
-// @ts-ignore
-import { translate } from '../../../i18n';
+import { translate } from '../../../i18n/functions';
 import { IconSettings } from '../../../icons/svg';
-// @ts-ignore
-import { connect } from '../../../redux';
+import { connect } from '../../../redux/functions';
 
 /**
  * Implements an {@link AbstractButton} to open the carmode.
@@ -40,10 +31,10 @@ class SettingsButton extends AbstractButton<AbstractButtonProps, any, any> {
 /**
  * Maps part of the redux state to the component's props.
  *
- * @param {Object} state - The redux store/state.
+ * @param {IReduxState} state - The Redux state.
  * @returns {Object}
  */
-function _mapStateToProps(state: Object) {
+function _mapStateToProps(state: IReduxState) {
     const enabled = getFeatureFlag(state, SETTINGS_ENABLED, true);
 
     return {


### PR DESCRIPTION
`settings.enabled` allows to hide `settings button` in `overflow menu`