### PR TITLE
show picture-in-picture button while share screen 

### DIFF
--- a/react/features/base/flags/constants.ts
+++ b/react/features/base/flags/constants.ts
@@ -164,7 +164,7 @@ export const PIP_ENABLED = 'pip.enabled';
  * Flag indicating if Picture-in-Picture button should be shown while screen sharing.
  * Default: disabled (false).
  */
-export const PIP_AT_SCREEN_SHARING_ENABLED = 'pip-at-screen-sharing.enabled';
+export const PIP_WHILE_SCREEN_SHARING_ENABLED = 'pip-while-screen-sharing.enabled';
 
 /**
  * Flag indicating if the prejoin page should be enabled.

--- a/react/features/base/flags/constants.ts
+++ b/react/features/base/flags/constants.ts
@@ -161,6 +161,12 @@ export const OVERFLOW_MENU_ENABLED = 'overflow-menu.enabled';
 export const PIP_ENABLED = 'pip.enabled';
 
 /**
+ * Flag indicating if Picture-in-Picture button should be shown while translation.
+ * Default: disabled (false).
+ */
+export const PIP_AT_TRANSLATION_ENABLED = 'pip-at-translation.enabled';
+
+/**
  * Flag indicating if the prejoin page should be enabled.
  * Default: enabled (true).
  */

--- a/react/features/base/flags/constants.ts
+++ b/react/features/base/flags/constants.ts
@@ -161,10 +161,10 @@ export const OVERFLOW_MENU_ENABLED = 'overflow-menu.enabled';
 export const PIP_ENABLED = 'pip.enabled';
 
 /**
- * Flag indicating if Picture-in-Picture button should be shown while translation.
+ * Flag indicating if Picture-in-Picture button should be shown while screen sharing.
  * Default: disabled (false).
  */
-export const PIP_AT_TRANSLATION_ENABLED = 'pip-at-translation.enabled';
+export const PIP_AT_SCREEN_SHARING_ENABLED = 'pip-at-screen-sharing.enabled';
 
 /**
  * Flag indicating if the prejoin page should be enabled.

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -2,7 +2,7 @@
 
 import { NativeModules, Platform } from 'react-native';
 
-import { PIP_AT_TRANSLATION_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_AT_SCREEN_SHARING_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
@@ -63,10 +63,10 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  * }}
  */
 function _mapStateToProps(state): Object {
-    const pinEnabled = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    const pinAtTranslationEnabled = getFeatureFlag(state, PIP_AT_TRANSLATION_ENABLED, false);
+    const pipEnabled = Boolean(getFeatureFlag(state, PIP_ENABLED));
+    const pipAtScreenSharingEnabled = getFeatureFlag(state, PIP_AT_SCREEN_SHARING_ENABLED, false);
 
-    let enabled = pinEnabled && (!isLocalVideoTrackDesktop(state) || pinAtTranslationEnabled);
+    let enabled = pipEnabled && (!isLocalVideoTrackDesktop(state) || pipAtScreenSharingEnabled);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -2,7 +2,7 @@
 
 import { NativeModules, Platform } from 'react-native';
 
-import { PIP_AT_SCREEN_SHARING_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_WHILE_SCREEN_SHARING_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
@@ -64,9 +64,9 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  */
 function _mapStateToProps(state): Object {
     const pipEnabled = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    const pipAtScreenSharingEnabled = getFeatureFlag(state, PIP_AT_SCREEN_SHARING_ENABLED, false);
+    const pipWhileScreenSharingEnabled = getFeatureFlag(state, PIP_WHILE_SCREEN_SHARING_ENABLED, false);
 
-    let enabled = pipEnabled && (!isLocalVideoTrackDesktop(state) || pipAtScreenSharingEnabled);
+    let enabled = pipEnabled && (!isLocalVideoTrackDesktop(state) || pipWhileScreenSharingEnabled);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -64,7 +64,7 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  */
 function _mapStateToProps(state): Object {
     const flag = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    let enabled = flag && !isLocalVideoTrackDesktop(state);
+    let enabled = flag //&& !isLocalVideoTrackDesktop(state);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -8,6 +8,7 @@ import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { enterPictureInPicture } from '../actions';
+
 // import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 
 type Props = AbstractButtonProps & {
@@ -64,7 +65,7 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  */
 function _mapStateToProps(state): Object {
     const flag = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    let enabled = flag // && !isLocalVideoTrackDesktop(state);
+    let enabled = flag; // && !isLocalVideoTrackDesktop(state);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -2,7 +2,7 @@
 
 import { NativeModules, Platform } from 'react-native';
 
-import { PIP_WHILE_SCREEN_SHARING_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_ENABLED, PIP_WHILE_SCREEN_SHARING_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -2,15 +2,13 @@
 
 import { NativeModules, Platform } from 'react-native';
 
-import { PIP_ENABLED, PIP_AT_TRANSLATION_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_AT_TRANSLATION_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
-import { enterPictureInPicture } from '../actions';
 import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
-
-// import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
+import { enterPictureInPicture } from '../actions';
 
 type Props = AbstractButtonProps & {
 

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -2,12 +2,13 @@
 
 import { NativeModules, Platform } from 'react-native';
 
-import { PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
+import { PIP_ENABLED, PIP_AT_TRANSLATION_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { enterPictureInPicture } from '../actions';
+import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 
 // import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 
@@ -64,8 +65,10 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  * }}
  */
 function _mapStateToProps(state): Object {
-    const flag = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    let enabled = flag; // && !isLocalVideoTrackDesktop(state);
+    const pinEnabled = Boolean(getFeatureFlag(state, PIP_ENABLED));
+    const pinAtTranslationEnabled = getFeatureFlag(state, PIP_AT_TRANSLATION_ENABLED, false);
+
+    let enabled = pinEnabled && (!isLocalVideoTrackDesktop(state) || pinAtTranslationEnabled);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -8,7 +8,7 @@ import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { enterPictureInPicture } from '../actions';
-//import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
+// import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 
 type Props = AbstractButtonProps & {
 
@@ -64,7 +64,7 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  */
 function _mapStateToProps(state): Object {
     const flag = Boolean(getFeatureFlag(state, PIP_ENABLED));
-    let enabled = flag //&& !isLocalVideoTrackDesktop(state);
+    let enabled = flag // && !isLocalVideoTrackDesktop(state);
 
     // Override flag for Android, since it might be unsupported.
     if (Platform.OS === 'android' && !NativeModules.PictureInPicture.SUPPORTED) {

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -7,8 +7,8 @@ import { translate } from '../../../base/i18n';
 import { IconMenuDown } from '../../../base/icons';
 import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
-import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 import { enterPictureInPicture } from '../actions';
+//import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 
 type Props = AbstractButtonProps & {
 


### PR DESCRIPTION
show picture-in-picture button while share screen to allow compact JitsiMeetView
(significant when SDK is embedded in some host app)