### PR TITLE
fix(connection-stats) Do not display max enabled resolution on SS tile.

### DIFF
--- a/react/features/connection-stats/components/ConnectionStatsTable.tsx
+++ b/react/features/connection-stats/components/ConnectionStatsTable.tsx
@@ -637,7 +637,7 @@ class ConnectionStatsTable extends Component<IProps> {
      * @returns {ReactElement}
      */
     _renderResolution() {
-        const { resolution, maxEnabledResolution, t, videoSsrc } = this.props;
+        const { isVirtualScreenshareParticipant, maxEnabledResolution, resolution, t, videoSsrc } = this.props;
         let resolutionString = 'N/A';
 
         if (resolution && videoSsrc) {
@@ -646,7 +646,7 @@ class ConnectionStatsTable extends Component<IProps> {
             if (width && height) {
                 resolutionString = `${width}x${height}`;
 
-                if (maxEnabledResolution && maxEnabledResolution < 720) {
+                if (maxEnabledResolution && maxEnabledResolution < 720 && !isVirtualScreenshareParticipant) {
                     const maxEnabledResolutionTitle = t('connectionindicator.maxEnabledResolution');
 
                     resolutionString += ` (${maxEnabledResolutionTitle} ${maxEnabledResolution}p)`;


### PR DESCRIPTION

![Screen Shot 2022-11-10 at 3 35 50 PM](https://user-images.githubusercontent.com/54324652/201204045-1ae60e34-6e30-40a8-ab6e-8f4edcdbbe3c.png)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
