### PR TITLE
refactor(end-conference): distinguish component vs host module logic

### DIFF
--- a/resources/prosody-plugins/mod_end_conference.lua
+++ b/resources/prosody-plugins/mod_end_conference.lua
@@ -13,14 +13,16 @@ local get_room_by_name_and_subdomain = module:require 'util'.get_room_by_name_an
 
 local END_CONFERENCE_REASON = 'The meeting has been terminated';
 
-local end_conference_component = module:get_option_string('end_conference_component', 'endconference.'..module.host);
-if end_conference_component == nil then
-    module:log('error', 'No end_conference_component specified.');
-    return;
+-- Since this file serves as both the host module and the component, we rely on the assumption that
+-- end_conference_component var would only be define for the host and not in the end_conference component
+local end_conference_component = module:get_option_string('end_conference_component');
+if end_conference_component then
+    -- Advertise end conference so client can pick up the address and use it
+    module:add_identity('component', 'end_conference', end_conference_component);
+    return;  -- nothing left to do if called as host module
 end
 
--- Advertise end conference so client can pick up the address and use it
-module:add_identity('component', 'end_conference', end_conference_component);
+-- What follows is logic for the end_conference component
 
 module:depends("jitsi_session");
 


### PR DESCRIPTION
Fixes https://github.com/jitsi/jitsi-meet/issues/12562 

At present, a single lua file is used as both the host module and the component implementation. This means that:
1. `module:add_identity` is called twice, once correctly and the second with the wrong name i.e. `endconference.endconference.meet.domain.com`
2. The remaining logic is also called twice with one of the runs terminating early and triggering the confusing "no muc_component specified" error.

This PR works around this by using the presence of `end_conference_component` var to distinguish between the two runs. This resolves the confusing error, but also makes it more obvious what is going on.

The downside to this approach is that the feature will not work if someone forgets to add `end_conference_component` to Virtualhost :( 

Perhaps it might have been cleaner to separate the module as we do with mod_room_metadata and mod_conference_duration, but that would mean a prosody config change while might break upgrades of existing setup?
