### PR TITLE
fix(participants) don't treat Jigasi like a fake participant

### DIFF
--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -32,7 +32,7 @@ const AVATAR_CHECKED_URLS = new Map();
 /* eslint-disable arrow-body-style, no-unused-vars */
 const AVATAR_CHECKER_FUNCTIONS = [
     (participant: IParticipant) => {
-        return isJigasiParticipant(participant) ? JIGASI_PARTICIPANT_ICON : null;
+        return participant?.isJigasi ? JIGASI_PARTICIPANT_ICON : null;
     },
     (participant: IParticipant) => {
         return isWhiteboardParticipant(participant) ? WHITEBOARD_PARTICIPANT_ICON : null;
@@ -279,16 +279,6 @@ export function getVirtualScreenshareParticipantOwnerId(id: string) {
  */
 export function getFakeParticipants(stateful: IStateful) {
     return toState(stateful)['features/base/participants'].fakeParticipants;
-}
-
-/**
- * Returns whether the fake participant is Jigasi.
- *
- * @param {IParticipant|undefined} participant - The participant entity.
- * @returns {boolean} - True if it's a Jigasi participant.
- */
-function isJigasiParticipant(participant?: IParticipant): boolean {
-    return participant?.fakeParticipant === FakeParticipant.Jigasi;
 }
 
 /**

--- a/react/features/base/participants/middleware.ts
+++ b/react/features/base/participants/middleware.ts
@@ -80,7 +80,7 @@ import {
 } from './functions';
 import logger from './logger';
 import { PARTICIPANT_JOINED_FILE, PARTICIPANT_LEFT_FILE } from './sounds';
-import { FakeParticipant, IJitsiParticipant } from './types';
+import { IJitsiParticipant } from './types';
 
 import './subscriber';
 
@@ -438,7 +438,7 @@ StateListenerRegistry.register(
                     store.dispatch(participantUpdated({
                         conference,
                         id: participant.getId(),
-                        fakeParticipant: value ? FakeParticipant.Jigasi : undefined
+                        isJigasi: value
                     })),
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 'features_screen-sharing': (participant: IJitsiParticipant, value: string) =>

--- a/react/features/base/participants/types.ts
+++ b/react/features/base/participants/types.ts
@@ -1,5 +1,4 @@
 export enum FakeParticipant {
-    Jigasi = 'Jigasi',
     LocalScreenShare = 'LocalScreenShare',
     RemoteScreenShare = 'RemoteScreenShare',
     SharedVideo = 'SharedVideo',
@@ -21,6 +20,7 @@ export interface IParticipant {
     };
     getId?: Function;
     id: string;
+    isJigasi?: boolean;
     isReplaced?: boolean;
     isReplacing?: number;
     jwtId?: string;


### PR DESCRIPTION
We only really want to know if a participant is Jigasi for displaying a specific icon, for all other intents and purposes it's a normal participant.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
