### PR TITLE
fix(dialog): cancel hide timeout on openDialog

### DIFF
--- a/react/features/base/ui/components/web/Dialog.tsx
+++ b/react/features/base/ui/components/web/Dialog.tsx
@@ -190,6 +190,7 @@ interface IDialogProps {
     children?: React.ReactNode;
     className?: string;
     description?: string;
+    disableAutoHideOnSubmit?: boolean;
     disableBackdropClose?: boolean;
     disableEnter?: boolean;
     hideCloseButton?: boolean;
@@ -211,6 +212,7 @@ const Dialog = ({
     children,
     className,
     description,
+    disableAutoHideOnSubmit = false,
     disableBackdropClose,
     hideCloseButton,
     disableEnter,
@@ -232,7 +234,7 @@ const Dialog = ({
     }, [ onCancel ]);
 
     const submit = useCallback(() => {
-        dispatch(hideDialog());
+        !disableAutoHideOnSubmit && dispatch(hideDialog());
         onSubmit?.();
     }, [ onSubmit ]);
 

--- a/react/features/base/ui/components/web/DialogTransition.tsx
+++ b/react/features/base/ui/components/web/DialogTransition.tsx
@@ -2,18 +2,29 @@ import React, { ReactElement, useEffect, useState } from 'react';
 
 export const DialogTransitionContext = React.createContext({ isUnmounting: false });
 
+type TimeoutType = ReturnType<typeof setTimeout>;
+
 const DialogTransition = ({ children }: { children: ReactElement | null; }) => {
     const [ childrenToRender, setChildrenToRender ] = useState(children);
     const [ isUnmounting, setIsUnmounting ] = useState(false);
+    const [ timeoutID, setTimeoutID ] = useState<TimeoutType | undefined>(undefined);
 
     useEffect(() => {
         if (children === null) {
             setIsUnmounting(true);
-            setTimeout(() => {
-                setChildrenToRender(children);
-                setIsUnmounting(false);
-            }, 150);
+            if (typeof timeoutID === 'undefined') {
+                setTimeoutID(setTimeout(() => {
+                    setChildrenToRender(children);
+                    setIsUnmounting(false);
+                    setTimeoutID(undefined);
+                }, 150));
+            }
         } else {
+            if (typeof timeoutID !== 'undefined') {
+                clearTimeout(timeoutID);
+                setTimeoutID(undefined);
+                setIsUnmounting(false);
+            }
             setChildrenToRender(children);
         }
     }, [ children ]);

--- a/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
+++ b/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from 'react';
 
-import { hideDialog } from '../../base/dialog/actions';
 import { translate } from '../../base/i18n';
 import { getParticipantById } from '../../base/participants';
 import { connect } from '../../base/redux';
@@ -138,7 +137,6 @@ class RemoteControlAuthorizationDialog extends Component<Props> {
     _onSubmit() {
         const { dispatch, participantId } = this.props;
 
-        dispatch(hideDialog());
         dispatch(grant(participantId));
 
         return false;

--- a/react/features/shared-video/components/web/SharedVideoDialog.tsx
+++ b/react/features/shared-video/components/web/SharedVideoDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { hideDialog } from '../../../base/dialog/actions';
 import { translate } from '../../../base/i18n/functions';
 import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
@@ -52,7 +53,9 @@ class SharedVideoDialog extends AbstractSharedVideoDialog<any> {
     _onSubmitValue() {
         const result = super._onSetVideoLink(this.state.value);
 
-        if (!result) {
+        if (result) {
+            this.props.dispatch(hideDialog());
+        } else {
             this.setState({
                 error: true
             });
@@ -72,6 +75,7 @@ class SharedVideoDialog extends AbstractSharedVideoDialog<any> {
 
         return (
             <Dialog
+                disableAutoHideOnSubmit = { true }
                 ok = {{
                     disabled: this.state.okDisabled,
                     translationKey: 'dialog.Share'


### PR DESCRIPTION
Since we unmount the dialog after a timeout because of an animation we
need to cancel the timeout in case we need to render new dialog.
Otherwise the actual hiding can be executed after we render the new
dialog.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
