### PR TITLE
fix(prosody) fix matching rooms with unicode names

### DIFF
--- a/resources/prosody-plugins/mod_av_moderation_component.lua
+++ b/resources/prosody-plugins/mod_av_moderation_component.lua
@@ -1,4 +1,4 @@
-local get_room_by_name_and_subdomain = module:require 'util'.get_room_by_name_and_subdomain;
+local get_room_from_session = module:require 'util'.get_room_from_session;
 local is_healthcheck_room = module:require 'util'.is_healthcheck_room;
 local internal_room_jid_match_rewrite = module:require "util".internal_room_jid_match_rewrite;
 local room_jid_match_rewrite = module:require "util".room_jid_match_rewrite;
@@ -129,7 +129,7 @@ function on_message(event)
 
     if moderation_command then
         -- get room name with tenant and find room
-        local room = get_room_by_name_and_subdomain(session.jitsi_web_query_room, session.jitsi_web_query_prefix);
+        local room = get_room_from_session(session);
 
         if not room then
             module:log('warn', 'No room found found for %s/%s',

--- a/resources/prosody-plugins/mod_end_conference.lua
+++ b/resources/prosody-plugins/mod_end_conference.lua
@@ -9,7 +9,7 @@
 -- Component "endconference.jitmeet.example.com" "end_conference"
 --     muc_component = muc.jitmeet.example.com
 --
-local get_room_by_name_and_subdomain = module:require 'util'.get_room_by_name_and_subdomain;
+local get_room_from_session = module:require 'util'.get_room_from_session;
 
 local END_CONFERENCE_REASON = 'The meeting has been terminated';
 
@@ -51,7 +51,7 @@ function on_message(event)
 
     if moderation_command then
         -- get room name with tenant and find room
-        local room = get_room_by_name_and_subdomain(session.jitsi_web_query_room, session.jitsi_web_query_prefix);
+        local room = get_room_from_session(session);
 
         if not room then
             module:log('warn', 'No room found found for %s/%s',

--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -31,6 +31,7 @@ local st = require 'util.stanza';
 local uuid_gen = require 'util.uuid'.generate;
 
 local util = module:require 'util';
+local get_room_from_session = util.get_room_from_session;
 local internal_room_jid_match_rewrite = util.internal_room_jid_match_rewrite;
 local is_healthcheck_room = util.is_healthcheck_room;
 
@@ -253,7 +254,7 @@ function on_message(event)
     end
 
     -- get room name with tenant and find room
-    local room = get_room_by_name_and_subdomain(session.jitsi_web_query_room, session.jitsi_web_query_prefix);
+    local room = get_room_from_session(session);
 
     if not room then
         module:log('warn', 'No room found found for %s/%s',

--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -42,7 +42,7 @@ local NOTIFY_LOBBY_ACCESS_GRANTED = 'LOBBY-ACCESS-GRANTED';
 local NOTIFY_LOBBY_ACCESS_DENIED = 'LOBBY-ACCESS-DENIED';
 
 local util = module:require "util";
-local get_room_by_name_and_subdomain = util.get_room_by_name_and_subdomain;
+local get_room_from_session = util.get_room_from_session;
 local is_healthcheck_room = util.is_healthcheck_room;
 local presence_check_status = util.presence_check_status;
 
@@ -263,7 +263,7 @@ function process_lobby_muc_loaded(lobby_muc, host_module)
         if node == LOBBY_IDENTITY_TYPE
             and session.jitsi_web_query_room
             and check_display_name_required then
-            local room = get_room_by_name_and_subdomain(session.jitsi_web_query_room, session.jitsi_web_query_prefix);
+            local room = get_room_from_session(session);
 
             if room and room._data.lobbyroom then
                 reply:tag('feature', { var = DISPLAY_NAME_REQUIRED_FEATURE }):up();

--- a/resources/prosody-plugins/mod_muc_poltergeist.lua
+++ b/resources/prosody-plugins/mod_muc_poltergeist.lua
@@ -1,5 +1,6 @@
 local bare = require "util.jid".bare;
 local get_room_by_name_and_subdomain = module:require "util".get_room_by_name_and_subdomain;
+local get_room_from_session = module:require "util".get_room_from_session;
 local jid = require "util.jid";
 local neturl = require "net.url";
 local parse = neturl.parseQuery;
@@ -92,9 +93,7 @@ end
 prosody.events.add_handler("pre-jitsi-authentication", function(session)
 
     if (session.jitsi_meet_context_user) then
-        local room = get_room_by_name_and_subdomain(
-            session.jitsi_web_query_room,
-            session.jitsi_web_query_prefix);
+        local room = get_room_from_session(session);
 
         if (not room) then
             return nil;

--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -1,3 +1,4 @@
+local urlencode = require "util.http".urldecode;
 local jid = require "util.jid";
 local timer = require "util.timer";
 local http = require "net.http";
@@ -110,6 +111,20 @@ function get_room_from_jid(room_jid)
             return
         end
     end
+end
+
+-- Returns the room if available.
+-- @param s the current session.
+-- @return returns room if found or nil
+function get_room_from_session(s)
+    if not s or not s.jitsi_web_query_room then
+        return nil;
+    end
+
+    local room_name = urldecode(s.jitsi_web_query_room);
+    local subdomain = urldecode(s.jitsi_web_query_prefix);
+
+    return get_room_by_name_and_subdomain(room_name, subdomain);
 end
 
 -- Returns the room if available, work and in multidomain mode
@@ -362,6 +377,7 @@ return {
     is_feature_allowed = is_feature_allowed;
     is_healthcheck_room = is_healthcheck_room;
     get_room_from_jid = get_room_from_jid;
+    get_room_from_session = get_room_from_session;
     get_room_by_name_and_subdomain = get_room_by_name_and_subdomain;
     async_handler_wrapper = async_handler_wrapper;
     presence_check_status = presence_check_status;


### PR DESCRIPTION
When the room is attached to the session we urlencode() it, so we need to decode it when we search for it.

Since most of the times we are looking for the room associated with the current session I'm introducing a new helper: get_room_from_session, which given a session object extracts the room and subdomain, urldecode()'s them and then finds the matching room.

Fixes: https://github.com/jitsi/jitsi-meet/issues/12607

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
