### PR TITLE
Changes initialPositionInSuperView constant to variable.

### DIFF
--- a/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
+++ b/ios/sdk/src/picture-in-picture/PiPViewCoordinator.swift
@@ -46,7 +46,7 @@ public class PiPViewCoordinator {
         }
     }
 
-    public let initialPositionInSuperView: Position = .lowerRightCorner
+    public var initialPositionInSuperView: Position = .lowerRightCorner
 
     // Unused. Remove on the next major release.
     @available(*, deprecated, message: "The PiP window size is now fixed to 150px.")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Currently, when using PiP mode, the initial position (`initialPositionInSuperView`) cannot be changed, which is a regression compared to the previous behaviour.

Fixes #12446
