### PR TITLE
fix: get the current conference

### DIFF
--- a/react/features/base/participants/actions.ts
+++ b/react/features/base/participants/actions.ts
@@ -477,18 +477,19 @@ export function participantMutedUs(participant: any, track: any) {
 /**
  * Action to create a virtual screenshare participant.
  *
- * @param {(string)} sourceName - JitsiTrack instance.
- * @param {(boolean)} local - JitsiTrack instance.
+ * @param {(string)} sourceName - The source name of the JitsiTrack instance.
+ * @param {(boolean)} local - Whether it's a local or remote participant.
+ * @param {JitsiConference} conference - The conference instance for which the participant is to be created.
  * @returns {Function}
  */
-export function createVirtualScreenshareParticipant(sourceName: string, local: boolean) {
+export function createVirtualScreenshareParticipant(sourceName: string, local: boolean, conference: any) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const ownerId = getVirtualScreenshareParticipantOwnerId(sourceName);
         const ownerName = getParticipantDisplayName(state, ownerId);
 
         dispatch(participantJoined({
-            conference: state['features/base/conference'].conference,
+            conference,
             fakeParticipant: local ? FakeParticipant.LocalScreenShare : FakeParticipant.RemoteScreenShare,
             id: sourceName,
             name: ownerName

--- a/react/features/base/participants/subscriber.ts
+++ b/react/features/base/participants/subscriber.ts
@@ -46,7 +46,7 @@ function _updateScreenshareParticipants({ getState, dispatch }: IStore) {
 
     if (getMultipleVideoSendingSupportFeatureFlag(state)) {
         if (!localScreenShare && newLocalSceenshareSourceName) {
-            dispatch(createVirtualScreenshareParticipant(newLocalSceenshareSourceName, true));
+            dispatch(createVirtualScreenshareParticipant(newLocalSceenshareSourceName, true, conference));
         }
 
         if (localScreenShare && !newLocalSceenshareSourceName) {
@@ -68,7 +68,7 @@ function _updateScreenshareParticipants({ getState, dispatch }: IStore) {
     }
 
     if (addedScreenshareSourceNames.length) {
-        addedScreenshareSourceNames.forEach(id => dispatch(createVirtualScreenshareParticipant(id, false)));
-
+        addedScreenshareSourceNames.forEach(id => dispatch(
+            createVirtualScreenshareParticipant(id, false, conference)));
     }
 }


### PR DESCRIPTION
state['features/base/conference'].conference is not the right way to get the current conference. See getCurrentConference selector - it accounts for joining and other states.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
