### PR TITLE
misc(GitHub) add dev container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,11 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "16"
     }
-  }
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb" 
+  },
+  "postCreateCommand": "bash -i -c 'nvm use && npm install'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,5 @@
     "memory": "8gb",
     "storage": "32gb" 
   },
-  "postCreateCommand": "bash -i -c 'nvm use && npm install'"
+  "postCreateCommand": "bash -i -c 'nvm use && npm install && cp tsconfig.web.json tsconfig.json'"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Jitsi Meet Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "16"
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -266,7 +266,7 @@ function getDevServerConfig() {
                 }
             }
         },
-        server: 'https',
+        server: process.env.CODESPACES ? 'http' : 'https',
         static: {
             directory: process.cwd()
         }


### PR DESCRIPTION
Say you need to do a quick UI fix / test. Use a code space!

<img width="2672" alt="Screenshot 2022-12-02 at 16 41 58" src="https://user-images.githubusercontent.com/317464/205335140-aaee9bf0-1d0c-4957-8468-851714d99e76.png">

Just create one with no options, the good defaults are set.

After is has fully booted and npm is done installing all you need to do is `make dev`

<img width="2672" alt="Screenshot 2022-12-02 at 16 42 06" src="https://user-images.githubusercontent.com/317464/205335180-367768e3-1aa8-47f2-9231-9f52c7d62fdd.png">

From the ports tab (or the notification that shows up) you can open the public URL which has a redirected port.

<img width="2672" alt="Screenshot 2022-12-02 at 16 42 11" src="https://user-images.githubusercontent.com/317464/205335203-84f5c79d-785e-4496-99b8-7b553ef31c76.png">

Voila!

<img width="2672" alt="Screenshot 2022-12-02 at 16 42 16" src="https://user-images.githubusercontent.com/317464/205335214-18788bd2-5cd8-4d7c-869d-5df827077a27.png">
