### PR TITLE
fix(a11y) make keyboard nav to audio/video settings work better:

### DIFF
--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -1,4 +1,5 @@
 import React, { Component, ReactNode } from 'react';
+import ReactFocusLock from 'react-focus-lock';
 
 import { IReduxState } from '../../../app/types';
 // eslint-disable-next-line lines-around-comment
@@ -33,6 +34,11 @@ interface IProps {
      * Whether displaying of the popover should be prevented.
      */
     disablePopover?: boolean;
+
+    /**
+     * Whether to use trap keyboard focus in the popover when its visible or not.
+     */
+    focusTrap: boolean;
 
     /**
      * An id attribute to apply to the root of the {@code Popover}
@@ -222,7 +228,11 @@ class Popover extends Component<IProps, IState> {
                         getRef = { this._setContextMenuRef }
                         setSize = { this._setContextMenuStyle }
                         style = { this.state.contextMenuStyle }>
-                        {this._renderContent()}
+                        {this.props.focusTrap && this.props.trigger === 'click' ? (
+                            <ReactFocusLock returnFocus = { true }>
+                                {this._renderContent()}
+                            </ReactFocusLock>
+                        ) : this._renderContent()}
                     </DialogPortal>
                 )}
                 { children }

--- a/react/features/settings/components/web/audio/AudioSettingsContent.js
+++ b/react/features/settings/components/web/audio/AudioSettingsContent.js
@@ -106,7 +106,6 @@ class AudioSettingsContent extends Component<Props, State> {
 
         this._onMicrophoneEntryClick = this._onMicrophoneEntryClick.bind(this);
         this._onSpeakerEntryClick = this._onSpeakerEntryClick.bind(this);
-        this._onEscClick = this._onEscClick.bind(this);
         this._audioContentRef = React.createRef();
 
         this.state = {
@@ -119,21 +118,6 @@ class AudioSettingsContent extends Component<Props, State> {
                 };
             })
         };
-    }
-    _onEscClick: (KeyboardEvent) => void;
-
-    /**
-     * Click handler for the speaker entries.
-     *
-     * @param {KeyboardEvent} event - Esc key click to close the popup.
-     * @returns {void}
-     */
-    _onEscClick(event) {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            event.stopPropagation();
-            this._audioContentRef.current.style.display = 'none';
-        }
     }
 
     _onMicrophoneEntryClick: (string) => void;
@@ -304,7 +288,6 @@ class AudioSettingsContent extends Component<Props, State> {
                     aria-labelledby = 'audio-settings-button'
                     className = 'audio-preview-content'
                     id = 'audio-settings-dialog'
-                    onKeyDown = { this._onEscClick }
                     ref = { this._audioContentRef }
                     role = 'menu'
                     tabIndex = { -1 }>

--- a/react/features/settings/components/web/audio/AudioSettingsPopup.js
+++ b/react/features/settings/components/web/audio/AudioSettingsPopup.js
@@ -76,6 +76,7 @@ function AudioSettingsPopup({
                     outputDevices = { outputDevices }
                     setAudioInputDevice = { setAudioInputDevice }
                     setAudioOutputDevice = { setAudioOutputDevice } /> }
+                focusTrap = { true }
                 onPopoverClose = { onClose }
                 position = { popupPlacement }
                 trigger = 'click'

--- a/react/features/settings/components/web/video/VideoSettingsContent.js
+++ b/react/features/settings/components/web/video/VideoSettingsContent.js
@@ -70,7 +70,6 @@ class VideoSettingsContent extends Component<Props, State> {
      */
     constructor(props) {
         super(props);
-        this._onEscClick = this._onEscClick.bind(this);
         this._videoContentRef = React.createRef();
 
         this.state = {
@@ -78,21 +77,6 @@ class VideoSettingsContent extends Component<Props, State> {
                 jitsiTrack: null
             })
         };
-    }
-    _onEscClick: (KeyboardEvent) => void;
-
-    /**
-     * Click handler for the video entries.
-     *
-     * @param {KeyboardEvent} event - Esc key click to close the popup.
-     * @returns {void}
-     */
-    _onEscClick(event) {
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            event.stopPropagation();
-            this._videoContentRef.current.style.display = 'none';
-        }
     }
 
     /**
@@ -249,7 +233,6 @@ class VideoSettingsContent extends Component<Props, State> {
                 aria-labelledby = 'video-settings-button'
                 className = 'video-preview-container'
                 id = 'video-settings-dialog'
-                onKeyDown = { this._onEscClick }
                 ref = { this._videoContentRef }
                 role = 'radiogroup'
                 tabIndex = '-1'>

--- a/react/features/settings/components/web/video/VideoSettingsPopup.js
+++ b/react/features/settings/components/web/video/VideoSettingsPopup.js
@@ -63,6 +63,7 @@ function VideoSettingsPopup({
                     setVideoInputDevice = { setVideoInputDevice }
                     toggleVideoSettings = { onClose }
                     videoDeviceIds = { videoDeviceIds } /> }
+                focusTrap = { true }
                 onPopoverClose = { onClose }
                 position = { popupPlacement }
                 trigger = 'click'


### PR DESCRIPTION
- first, there was an issue with AudioSettingsContent/VideoSettingsContent escape key handling. It made their popover content have a "display: none" instead of letting the other components handle it as usual, meaning, deleting the DOM node. So, when using the keyboard, the app was sometimes in weird states where it seemed the popover was closed, while it was actually opened, but with a "display: none". Removing custom esc handlers in these components fix this.

- second, going from the Audio/Video settings button, to the Audio/Video settings Content panel, with a keyboard, was difficult. This is because focus wasn't updated after showing the content panel. So, before this commit, I could open the content panel via keyboard, but I had to tab to the very end of the body to access its content via keyboard (to access the portal created). Now, we use a focus trap to directly focus the content, like a usual dialog, and put back the focus were it was when we close the content.
This behavior is enabled via a change in the Popover component, behind a new `focusTrap` prop that you must set, to avoid setting it as default and having weird side-effects in other parts of the code.


Here is the behavior before the fix:

https://user-images.githubusercontent.com/221253/205709533-0c35b8cc-5f9e-4c55-bf49-4e2f1ed12f47.mp4

Here it is after:


https://user-images.githubusercontent.com/221253/205709563-7b197982-61f3-4df0-9537-0e41e79caa1b.mp4


This is part of the work to globally improve a11y on Jitsi Meet: https://github.com/jitsi/jitsi-meet/issues/12379