### PR TITLE
chore(deps): bumped rtcstats 9.5.0 -> 9.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@jitsi/js-utils": "2.0.5",
         "@jitsi/logger": "2.0.0",
         "@jitsi/rnnoise-wasm": "0.1.0",
-        "@jitsi/rtcstats": "9.5.0",
+        "@jitsi/rtcstats": "9.5.1",
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.10.2",
@@ -3780,9 +3780,9 @@
       "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
     },
     "node_modules/@jitsi/rtcstats": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.0.tgz",
-      "integrity": "sha512-jKB+1IzKuqynA2etmWAA4uDFF0oAFUZWxRq+m+rOt8FfBp6pXojWbWA7xblcjxerj/3njGc8nEQbcK9qck1How==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
+      "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
       "dependencies": {
         "@jitsi/js-utils": "^2.0.0",
         "sdp": "^3.0.3",
@@ -23208,9 +23208,9 @@
       "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
     },
     "@jitsi/rtcstats": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.0.tgz",
-      "integrity": "sha512-jKB+1IzKuqynA2etmWAA4uDFF0oAFUZWxRq+m+rOt8FfBp6pXojWbWA7xblcjxerj/3njGc8nEQbcK9qck1How==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
+      "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
       "requires": {
         "@jitsi/js-utils": "^2.0.0",
         "sdp": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@jitsi/js-utils": "2.0.5",
     "@jitsi/logger": "2.0.0",
     "@jitsi/rnnoise-wasm": "0.1.0",
-    "@jitsi/rtcstats": "9.5.0",
+    "@jitsi/rtcstats": "9.5.1",
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.10.2",


### PR DESCRIPTION
Bumping rtcstats dependency to version 9.5.1 to include fixes throwing exceptions when SDP logging is turned on.