### PR TITLE
fix: Raised hand state (#12671)

### DIFF
--- a/react/features/base/participants/middleware.ts
+++ b/react/features/base/participants/middleware.ts
@@ -249,7 +249,7 @@ MiddlewareRegistry.register(store => next => action => {
 
     case RAISE_HAND_UPDATED: {
         const { participant } = action;
-        let queue = getRaiseHandsQueue(store.getState());
+        let queue = [ ...getRaiseHandsQueue(store.getState()) ];
 
         if (participant.raisedHandTimestamp) {
             queue.push({


### PR DESCRIPTION
I'm not expert in react, but here is a proposition for a fix for https://github.com/jitsi/jitsi-meet/issues/12671.

Work with a copy of the raiseHandsQueue array instead of a reference in participants middleware as the array is modified in participants reducer.

Tested with jitsi-meet-sdk-samples, the bug was not reproductible.