### PR TITLE
feat(subtitles): allow changing the transcription language for VOSK

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -479,6 +479,7 @@ export interface IConfig {
         autoCaptionOnRecord?: boolean;
         disableStartForAll?: boolean;
         enabled?: boolean;
+        autoRecognition?: boolean;
         preferredLanguage?: string;
         translationLanguages?: Array<string>;
         translationLanguagesHead?: Array<string>;

--- a/react/features/subtitles/actionTypes.ts
+++ b/react/features/subtitles/actionTypes.ts
@@ -47,6 +47,17 @@ export const UPDATE_TRANSCRIPT_MESSAGE = 'UPDATE_TRANSCRIPT_MESSAGE';
 export const UPDATE_TRANSLATION_LANGUAGE = 'UPDATE_TRANSLATION_LANGUAGE';
 
 /**
+ * The type of (redux) action which indicates that a transcript with an
+ * given message_id to be added or updated is received.
+ *
+ * {
+ *      type: UPDATE_TRANSCRIPTION_LANGUAGE,
+ *      value: string,
+ * }
+ */
+ export const UPDATE_TRANSCRIPTION_LANGUAGE = 'UPDATE_TRANSCRIPTION_LANGUAGE';
+ 
+/**
  * The type of (redux) action which indicates that the user pressed the
  * ClosedCaption button, to either enable or disable subtitles based on the
  * current state.

--- a/react/features/subtitles/actions.any.ts
+++ b/react/features/subtitles/actions.any.ts
@@ -3,6 +3,7 @@ import {
     REMOVE_TRANSCRIPT_MESSAGE,
     SET_REQUESTING_SUBTITLES,
     TOGGLE_REQUESTING_SUBTITLES,
+    UPDATE_TRANSCRIPTION_LANGUAGE,
     UPDATE_TRANSCRIPT_MESSAGE,
     UPDATE_TRANSLATION_LANGUAGE
 } from './actionTypes';
@@ -105,4 +106,20 @@ export function updateTranslationLanguage(value: string) {
         type: UPDATE_TRANSLATION_LANGUAGE,
         value
     };
+}
+
+/**
+ * Signals that the local user has selected language for the transccription.
+ *
+ * @param {string} transcriptionLanguage - The selected language for transcription.
+ * @returns {{
+*      type: UPDATE_TRANSCRIPTION_LANGUAGE,
+*      value: string
+* }}
+*/
+export function updateTranscriptionLanguage(value: string) {
+   return {
+       type: UPDATE_TRANSCRIPTION_LANGUAGE,
+       value
+   };
 }

--- a/react/features/subtitles/reducer.ts
+++ b/react/features/subtitles/reducer.ts
@@ -2,7 +2,7 @@ import ReducerRegistry from '../base/redux/ReducerRegistry';
 
 import {
     REMOVE_TRANSCRIPT_MESSAGE,
-    SET_REQUESTING_SUBTITLES, UPDATE_TRANSCRIPT_MESSAGE, UPDATE_TRANSLATION_LANGUAGE
+    SET_REQUESTING_SUBTITLES, UPDATE_TRANSCRIPT_MESSAGE, UPDATE_TRANSLATION_LANGUAGE, UPDATE_TRANSCRIPTION_LANGUAGE
 } from './actionTypes';
 
 /**
@@ -11,11 +11,13 @@ import {
 const defaultState = {
     _transcriptMessages: new Map(),
     _requestingSubtitles: false,
-    _language: 'transcribing.subtitlesOff'
+    _translationLanguage: 'transcribing.subtitlesOff',
+    _transcriptionLanguage: 'transcribing.subtitlesOff'
 };
 
 export interface ISubtitlesState {
-    _language: string;
+    _translationLanguage: string;
+    _transcriptionLanguage: string;
     _requestingSubtitles: boolean;
     _transcriptMessages: Map<string, Object>;
 }
@@ -34,7 +36,12 @@ ReducerRegistry.register<ISubtitlesState>('features/subtitles', (
     case UPDATE_TRANSLATION_LANGUAGE:
         return {
             ...state,
-            _language: action.value
+            _translationLanguage: action.value
+        };
+    case UPDATE_TRANSCRIPTION_LANGUAGE:
+        return {
+            ...state,
+            _transcriptionLanguage: action.value
         };
     case SET_REQUESTING_SUBTITLES:
         return {

--- a/react/features/transcribing/functions.ts
+++ b/react/features/transcribing/functions.ts
@@ -6,7 +6,7 @@ import JITSI_TO_BCP47_MAP from './jitsi-bcp47-map.json';
 import logger from './logger';
 import TRANSCRIBER_LANGS from './transcriber-langs.json';
 
-const DEFAULT_TRANSCRIBER_LANG = 'en-US';
+export const DEFAULT_TRANSCRIBER_LANG = 'en-US';
 
 /**
  * Determine which language to use for transcribing.
@@ -41,4 +41,41 @@ export function determineTranscriptionLanguage(config: IConfig) {
     logger.info(`Transcriber language set to ${safeBCP47Locale}`);
 
     return safeBCP47Locale;
+}
+
+
+/**
+ * Change the language chosen into the transcriber language format.
+ *
+ * @param {string} lang - language chosen.
+ * @returns {string}
+ */
+export function formatTranscriptionLanguage(lang: string) {
+    const bcp47Locale = JITSI_TO_BCP47_MAP[lang.replace('translation-languages:','') as keyof typeof JITSI_TO_BCP47_MAP]
+
+    // Check if the obtained language is supported by the transcriber
+    let safeBCP47Locale = TRANSCRIBER_LANGS[bcp47Locale as keyof typeof TRANSCRIBER_LANGS] && bcp47Locale;
+
+    if (!safeBCP47Locale) {
+        safeBCP47Locale = DEFAULT_TRANSCRIBER_LANG;
+        logger.warn(`Transcriber language ${bcp47Locale} is not supported, using default ${DEFAULT_TRANSCRIBER_LANG}`);
+    }
+
+    logger.info(`Transcriber language set to ${safeBCP47Locale}`);
+
+    return safeBCP47Locale;
+}
+
+/**
+ * Reverse the key-value pairs of JITSI_TO_BCP47_MAP.
+ *
+ * @param {Object} map - JITSI_TO_BCP47_MAP.
+ * @returns {Object}
+ */
+export const BCP47_TO_JITSI_MAP = (map) => {
+    const newMap = {}
+    for (let key of map) {
+        newMap[map[key]] = key
+    }
+    return newMap;
 }


### PR DESCRIPTION
## Problem

The way transcription works in Jitsi is that the transcription language is either the interface language or a predefined language in config. While this works for Google API because it has language auto-recognition, it doesn't work for other transcription services that don't have language auto-recognition builtin like VOSK. This means that if the animator is speaking in French VOSK will only work if we change the interface language to French. 

To solve this problem, we propose to add a parameter in the config file to specify whether the transcription service has language auto-recognition or not. And thus,  being able to handle the case where there is no language auto-recognition without affecting the normal functioning of transcription with Google API.

## Implementation

First we added a parameter to the transcription field in the config file: `autoRecognition`. By default, it is `true` in which case it the transcription service behave as usual. But if we want to use VOSK, or any transcription service with no language auto-recognition, we have to set it to `false`.

![Feature Diagram](https://i.imgur.com/2wFmH2E.png)

As you can see in the diagram above, what we want to achieve is for the moderator to choose the transcription language when activating the transcription service. Then, the other participants can choose the translation language for their own subtitles.

But, we still have the two problems: Jigasi communicate with each participant independantly and the transcription language is read only once.

Thankfully we managed to solve them:

1. We propagate the choice of the moderator: when the moderator chooses a language we save it in their local parameters and then launch the transcription service. Then once the transcription starts, the other participants retrieve the local parameters of the moderator and update their own. And the participants are then free to choose the translation language.
2. We reload the transcription service: once the moderator chooses a new transcription language, we change the transcription language and then restart the transcription service that way we can be assured that Jigasi rereads the new transcription language.

## Imperfections

While the feature allow the changing of the transcription language, because of the two problems and how we solved we are stuck with some imperfections that need to be resolved:

1. Because we propagate the moderator choice only when the moderator chooses a new transcription language, new participants who entered the meeting after that event won't have the correct transcription language. This could be solved by changing the participant behavior after their enter the conference, but this would require changing some files in the `react/base` folder.
2. Because we have to relaunch the transcription service each time the moderator chooses a new transcription language, we have a 3s delay before the transcription service restarts because that's the wait time for the transcription service to shutdown. This could be solved by changing how the transcription language is read and sent to Jigasi but I haven't found a way to do so.
