### PR TITLE
fix(rn) temporarily disable P2P

### DIFF
--- a/react/features/base/config/middleware.ts
+++ b/react/features/base/config/middleware.ts
@@ -2,7 +2,6 @@ import { AnyAction } from 'redux';
 
 import { IStore } from '../../app/types';
 import { getFeatureFlag } from '../flags/functions';
-import Platform from '../react/Platform';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import { updateSettings } from '../settings/actions';
 
@@ -53,7 +52,9 @@ function _setConfig({ dispatch, getState }: IStore, next: Function, action: AnyA
     const settings = state['features/base/settings'];
     const config: IConfig = {};
 
-    if (Platform.OS !== 'android' && typeof settings.disableP2P !== 'undefined') {
+    // FIXME: P2P is currently temporality disabled on mobile.
+    // eslint-disable-next-line no-constant-condition
+    if (false && typeof settings.disableP2P !== 'undefined') {
         config.p2p = { enabled: !settings.disableP2P };
     }
 

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 
 import { CONFERENCE_INFO } from '../../conference/components/constants';
-import Platform from '../react/Platform';
 import ReducerRegistry from '../redux/ReducerRegistry';
 import { equals } from '../redux/functions';
 
@@ -52,8 +51,8 @@ const INITIAL_RN_STATE: IConfig = {
     // than requiring this override here...
 
     p2p: {
-        // Temporarily disable P2P on Android while we sort out some (codec?) issues.
-        ...(Platform.OS === 'android' ? { enabled: false } : {}), // eslint-disable-line no-extra-parens
+        // Temporarily disable P2P on mobile while we sort out some (codec?) issues.
+        enabled: false,
         disabledCodec: 'vp9',
         preferredCodec: 'h264'
     },


### PR DESCRIPTION
We're getting some no-video problems after the migration to Unified Plan (before it was only working for same plan clients FWIW).

It was already disabled on Android, so the same in iOS while we figure this out.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
