### PR TITLE
fix(filmstrip): scroll

### DIFF
--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -351,11 +351,11 @@ export function isWhiteboardParticipant(participant?: IParticipant): boolean {
  * features/base/participants.
  * @returns {number}
  */
-export function getRemoteParticipantCount(stateful: IStateful) {
+export function getRemoteParticipantCountWithFake(stateful: IStateful) {
     const state = toState(stateful);
     const participantsState = state['features/base/participants'];
 
-    return participantsState.remote.size - participantsState.sortedRemoteVirtualScreenshareParticipants.size;
+    return participantsState.remote.size;
 }
 
 /**

--- a/react/features/filmstrip/actions.web.ts
+++ b/react/features/filmstrip/actions.web.ts
@@ -3,7 +3,7 @@ import { pinParticipant } from '../base/participants/actions';
 import {
     getLocalParticipant,
     getParticipantById,
-    getRemoteParticipantCount
+    getRemoteParticipantCountWithFake
 } from '../base/participants/functions';
 import { shouldHideSelfView } from '../base/settings/functions.web';
 import { getMaxColumnCount } from '../video-layout/functions.web';
@@ -149,7 +149,7 @@ export function setVerticalViewDimensions() {
         const disableSelfView = shouldHideSelfView(state);
         const resizableFilmstrip = isFilmstripResizable(state);
         const _verticalViewGrid = showGridInVerticalView(state);
-        const numberOfRemoteParticipants = getRemoteParticipantCount(state);
+        const numberOfRemoteParticipants = getRemoteParticipantCountWithFake(state);
         const { localScreenShare } = state['features/base/participants'];
 
         let gridView = {};
@@ -261,7 +261,7 @@ export function setHorizontalViewDimensions() {
             = clientWidth - (disableSelfView ? 0 : thumbnails?.local?.width) - HORIZONTAL_FILMSTRIP_MARGIN;
         const remoteVideosContainerHeight
             = thumbnails?.local?.height + TILE_VERTICAL_MARGIN + STAGE_VIEW_THUMBNAIL_VERTICAL_BORDER + SCROLL_SIZE;
-        const numberOfRemoteParticipants = getRemoteParticipantCount(state);
+        const numberOfRemoteParticipants = getRemoteParticipantCountWithFake(state);
         const hasScroll
             = remoteVideosContainerHeight
                 < (thumbnails?.remote.width + TILE_HORIZONTAL_MARGIN) * numberOfRemoteParticipants;


### PR DESCRIPTION
Add SS tiles to the number of participants in scroll calculations. This
fixes an issue where the scroll is not displayed if there is a SS tile
and only part of 1 tile is overflowing.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
