### PR TITLE
ref(participants) Remove sortedRemoteScreenshares used by legacy SS.

### DIFF
--- a/react/features/base/lastn/middleware.ts
+++ b/react/features/base/lastn/middleware.ts
@@ -5,7 +5,6 @@ import { SET_FILMSTRIP_ENABLED } from '../../filmstrip/actionTypes';
 import { SELECT_LARGE_VIDEO_PARTICIPANT } from '../../large-video/actionTypes';
 import { APP_STATE_CHANGED } from '../../mobile/background/actionTypes';
 import {
-    SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
     SET_CAR_MODE,
     SET_TILE_VIEW,
     VIRTUAL_SCREENSHARE_REMOTE_PARTICIPANTS_UPDATED
@@ -102,7 +101,6 @@ MiddlewareRegistry.register(store => next => action => {
     case PARTICIPANT_JOINED:
     case PARTICIPANT_KICKED:
     case PARTICIPANT_LEFT:
-    case SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED:
     case SELECT_LARGE_VIDEO_PARTICIPANT:
     case SET_AUDIO_ONLY:
     case SET_CAR_MODE:

--- a/react/features/base/participants/reducer.ts
+++ b/react/features/base/participants/reducer.ts
@@ -1,6 +1,3 @@
-import {
-    SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED
-} from '../../video-layout/actionTypes';
 import ReducerRegistry from '../redux/ReducerRegistry';
 import { set } from '../redux/functions';
 
@@ -74,7 +71,6 @@ const DEFAULT_STATE = {
     remote: new Map(),
     sortedRemoteVirtualScreenshareParticipants: new Map(),
     sortedRemoteParticipants: new Map(),
-    sortedRemoteScreenshares: new Map(),
     speakersList: new Map()
 };
 
@@ -89,7 +85,6 @@ export interface IParticipantsState {
     raisedHandsQueue: Array<{ id: string; raisedHandTimestamp: number; }>;
     remote: Map<string, IParticipant>;
     sortedRemoteParticipants: Map<string, string>;
-    sortedRemoteScreenshares: Map<string, string>;
     sortedRemoteVirtualScreenshareParticipants: Map<string, string>;
     speakersList: Map<string, string>;
 }
@@ -384,29 +379,6 @@ ReducerRegistry.register<IParticipantsState>('features/base/participants',
             ...state,
             raisedHandsQueue: action.queue
         };
-    }
-    case SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED: {
-        const { participantIds } = action;
-        const sortedSharesList = [];
-
-        for (const participant of participantIds) {
-            const remoteParticipant = state.remote.get(participant);
-
-            if (remoteParticipant) {
-                const displayName
-                    = _getDisplayName(state, remoteParticipant.name);
-
-                sortedSharesList.push([ participant, displayName ]);
-            }
-        }
-
-        // Keep the remote screen share list sorted alphabetically.
-        sortedSharesList.length && sortedSharesList.sort((a, b) => a[1].localeCompare(b[1]));
-
-        // @ts-ignore
-        state.sortedRemoteScreenshares = new Map(sortedSharesList);
-
-        return { ...state };
     }
     case OVERWRITE_PARTICIPANT_NAME: {
         const { id, name } = action;

--- a/react/features/video-layout/actionTypes.ts
+++ b/react/features/video-layout/actionTypes.ts
@@ -1,16 +1,4 @@
 /**
- * The type of the action which sets the list of known remote participant IDs which
- * have an active screen share.
- *
- * @returns {{
- *     type: SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
- *     participantIds: Array<string>
- * }}
- */
-export const SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED
-    = 'SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED';
-
-/**
  * The type of the action which tells whether we are in carmode.
  *
  * @returns {{

--- a/react/features/video-layout/actions.any.ts
+++ b/react/features/video-layout/actions.any.ts
@@ -1,29 +1,10 @@
 import { IStore } from '../app/types';
 
 import {
-    SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
     SET_TILE_VIEW,
     VIRTUAL_SCREENSHARE_REMOTE_PARTICIPANTS_UPDATED
 } from './actionTypes';
 import { shouldDisplayTileView } from './functions';
-
-/**
- * Creates a (redux) action which signals that the list of known remote participants
- * with screen shares has changed.
- *
- * @param {string} participantIds - The remote participants which currently have active
- * screen share streams.
- * @returns {{
- *     type: SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
- *     participantId: string
- * }}
- */
-export function setRemoteParticipantsWithScreenShare(participantIds: Array<string>) {
-    return {
-        type: SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
-        participantIds
-    };
-}
 
 /**
  * Creates a (redux) action which signals that the list of known remote virtual screen share participant ids has

--- a/react/features/video-layout/reducer.ts
+++ b/react/features/video-layout/reducer.ts
@@ -1,7 +1,6 @@
 import ReducerRegistry from '../base/redux/ReducerRegistry';
 
 import {
-    SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED,
     SET_CAR_MODE,
     SET_TILE_VIEW,
     VIRTUAL_SCREENSHARE_REMOTE_PARTICIPANTS_UPDATED
@@ -41,7 +40,6 @@ const STORE_NAME = 'features/video-layout';
 
 ReducerRegistry.register<IVideoLayoutState>(STORE_NAME, (state = DEFAULT_STATE, action): IVideoLayoutState => {
     switch (action.type) {
-    case SCREEN_SHARE_REMOTE_PARTICIPANTS_UPDATED:
     case VIRTUAL_SCREENSHARE_REMOTE_PARTICIPANTS_UPDATED:
         return {
             ...state,


### PR DESCRIPTION
The action type used in multi-stream mode is `VIRTUAL_SCREENSHARE_REMOTE_PARTICIPANTS_UPDATED` and `sortedRemoteVirtualScreenshareParticipants` has the updated list of shares. 

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
