### PR TITLE
Convert tabs to spaces in mixed formatted prosody plugins

### DIFF
--- a/resources/prosody-plugins/luajwtjitsi.lib.lua
+++ b/resources/prosody-plugins/luajwtjitsi.lib.lua
@@ -10,13 +10,13 @@ local pkey   = require 'openssl.pkey'
 -- @param algo The digest algorithm to user when generating the signature: sha256, sha384, or sha512.
 -- @return The signature or nil and an error message.
 local function signRS (data, key, algo)
-	local privkey = pkey.new(key)
-	if privkey == nil then
-		return nil, 'Not a private PEM key'
-	else
-		local datadigest = digest.new(algo):update(data)
-		return privkey:sign(datadigest)
-	end
+    local privkey = pkey.new(key)
+    if privkey == nil then
+        return nil, 'Not a private PEM key'
+    else
+        local datadigest = digest.new(algo):update(data)
+        return privkey:sign(datadigest)
+    end
 end
 
 -- Verifies an RSA signature on the data.
@@ -26,82 +26,82 @@ end
 -- @param algo The digest algorithm to user when generating the signature: sha256, sha384, or sha512.
 -- @return True if the signature is valid, false otherwise. Also returns false if the key is invalid.
 local function verifyRS (data, signature, key, algo)
-	local pubkey = pkey.new(key)
-	if pubkey == nil then
-		return false
-	end
+    local pubkey = pkey.new(key)
+    if pubkey == nil then
+        return false
+    end
 
-	local datadigest = digest.new(algo):update(data)
-	return pubkey:verify(signature, datadigest)
+    local datadigest = digest.new(algo):update(data)
+    return pubkey:verify(signature, datadigest)
 end
 
 local alg_sign = {
-	['HS256'] = function(data, key) return hmac.new(key, 'sha256'):final(data) end,
-	['HS384'] = function(data, key) return hmac.new(key, 'sha384'):final(data) end,
-	['HS512'] = function(data, key) return hmac.new(key, 'sha512'):final(data) end,
-	['RS256'] = function(data, key) return signRS(data, key, 'sha256') end,
-	['RS384'] = function(data, key) return signRS(data, key, 'sha384') end,
-	['RS512'] = function(data, key) return signRS(data, key, 'sha512') end
+    ['HS256'] = function(data, key) return hmac.new(key, 'sha256'):final(data) end,
+    ['HS384'] = function(data, key) return hmac.new(key, 'sha384'):final(data) end,
+    ['HS512'] = function(data, key) return hmac.new(key, 'sha512'):final(data) end,
+    ['RS256'] = function(data, key) return signRS(data, key, 'sha256') end,
+    ['RS384'] = function(data, key) return signRS(data, key, 'sha384') end,
+    ['RS512'] = function(data, key) return signRS(data, key, 'sha512') end
 }
 
 local alg_verify = {
-	['HS256'] = function(data, signature, key) return signature == alg_sign['HS256'](data, key) end,
-	['HS384'] = function(data, signature, key) return signature == alg_sign['HS384'](data, key) end,
-	['HS512'] = function(data, signature, key) return signature == alg_sign['HS512'](data, key) end,
-	['RS256'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha256') end,
-	['RS384'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha384') end,
-	['RS512'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha512') end
+    ['HS256'] = function(data, signature, key) return signature == alg_sign['HS256'](data, key) end,
+    ['HS384'] = function(data, signature, key) return signature == alg_sign['HS384'](data, key) end,
+    ['HS512'] = function(data, signature, key) return signature == alg_sign['HS512'](data, key) end,
+    ['RS256'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha256') end,
+    ['RS384'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha384') end,
+    ['RS512'] = function(data, signature, key) return verifyRS(data, signature, key, 'sha512') end
 }
 
 -- Splits a token into segments, separated by '.'.
 -- @param token The full token to be split.
 -- @return A table of segments.
 local function split_token(token)
-	local segments={}
-  for str in string.gmatch(token, "([^\\.]+)") do
-    table.insert(segments, str)
-  end
-  return segments
+    local segments={}
+    for str in string.gmatch(token, "([^\\.]+)") do
+        table.insert(segments, str)
+    end
+    return segments
 end
 
 -- Parses a JWT token into it's header, body, and signature.
 -- @param token The JWT token to be parsed.
 -- @return A JSON header and body represented as a table, and a signature.
 local function parse_token(token)
-	local segments=split_token(token)
-  if #segments ~= 3 then
-		return nil, nil, nil, "Invalid token"
-	end
+    local segments=split_token(token)
+    if #segments ~= 3 then
+        return nil, nil, nil, "Invalid token"
+    end
 
-	local header, err = cjson_safe.decode(basexx.from_url64(segments[1]))
-	if err then
-		return nil, nil, nil, "Invalid header"
-	end
+    local header, err = cjson_safe.decode(basexx.from_url64(segments[1]))
+    if err then
+        return nil, nil, nil, "Invalid header"
+    end
 
-	local body, err = cjson_safe.decode(basexx.from_url64(segments[2]))
-	if err then
-		return nil, nil, nil, "Invalid body"
-	end
+    local body, err = cjson_safe.decode(basexx.from_url64(segments[2]))
+    if err then
+        return nil, nil, nil, "Invalid body"
+    end
 
-	local sig, err = basexx.from_url64(segments[3])
-	if err then
-		return nil, nil, nil, "Invalid signature"
-	end
+    local sig, err = basexx.from_url64(segments[3])
+    if err then
+        return nil, nil, nil, "Invalid signature"
+    end
 
-	return header, body, sig
+    return header, body, sig
 end
 
 -- Removes the signature from a JWT token.
 -- @param token A JWT token.
 -- @return The token without its signature.
 local function strip_signature(token)
-	local segments=split_token(token)
-  if #segments ~= 3 then
-		return nil, nil, nil, "Invalid token"
-	end
+    local segments=split_token(token)
+    if #segments ~= 3 then
+        return nil, nil, nil, "Invalid token"
+    end
 
-	table.remove(segments)
-	return table.concat(segments, ".")
+    table.remove(segments)
+    return table.concat(segments, ".")
 end
 
 -- Verifies that a claim is in a list of allowed claims. Allowed claims can be exact values, or the
@@ -110,16 +110,16 @@ end
 -- @param acceptedClaims A table of accepted claims.
 -- @return True if the claim was allowed, false otherwise.
 local function verify_claim(claim, acceptedClaims)
-  for i, accepted in ipairs(acceptedClaims) do
-    if accepted == '*' then
-      return true;
+    for i, accepted in ipairs(acceptedClaims) do
+        if accepted == '*' then
+            return true;
+        end
+        if claim == accepted then
+            return true;
+        end
     end
-    if claim == accepted then
-      return true;
-    end
-  end
 
-  return false;
+    return false;
 end
 
 local M = {}
@@ -131,44 +131,44 @@ local M = {}
 -- @param header Additional values to put in the JWT header.
 -- @param The resulting JWT token, or nil and an error message.
 function M.encode(data, key, alg, header)
-	if type(data) ~= 'table' then return nil, "Argument #1 must be table" end
-	if type(key) ~= 'string' then return nil, "Argument #2 must be string" end
+    if type(data) ~= 'table' then return nil, "Argument #1 must be table" end
+    if type(key) ~= 'string' then return nil, "Argument #2 must be string" end
 
-	alg = alg or "HS256"
+    alg = alg or "HS256"
 
-	if not alg_sign[alg] then
-		return nil, "Algorithm not supported"
-	end
+    if not alg_sign[alg] then
+        return nil, "Algorithm not supported"
+    end
 
-	header = header or {}
+    header = header or {}
 
-	header['typ'] = 'JWT'
-	header['alg'] = alg
+    header['typ'] = 'JWT'
+    header['alg'] = alg
 
-	local headerEncoded, err = cjson_safe.encode(header)
-	if headerEncoded == nil then
-		return nil, err
-	end
+    local headerEncoded, err = cjson_safe.encode(header)
+    if headerEncoded == nil then
+        return nil, err
+    end
 
-	local dataEncoded, err = cjson_safe.encode(data)
-	if dataEncoded == nil then
-		return nil, err
-	end
+    local dataEncoded, err = cjson_safe.encode(data)
+    if dataEncoded == nil then
+        return nil, err
+    end
 
-	local segments = {
-		basexx.to_url64(headerEncoded),
-		basexx.to_url64(dataEncoded)
-	}
+    local segments = {
+        basexx.to_url64(headerEncoded),
+        basexx.to_url64(dataEncoded)
+    }
 
-	local signing_input = table.concat(segments, ".")
-	local signature, error = alg_sign[alg](signing_input, key)
-	if signature == nil then
-		return nil, error
-	end
+    local signing_input = table.concat(segments, ".")
+    local signature, error = alg_sign[alg](signing_input, key)
+    if signature == nil then
+        return nil, error
+    end
 
-	segments[#segments+1] = basexx.to_url64(signature)
+    segments[#segments+1] = basexx.to_url64(signature)
 
-	return table.concat(segments, ".")
+    return table.concat(segments, ".")
 end
 
 -- Verify that the token is valid, and if it is return the decoded JSON payload data.
@@ -182,78 +182,77 @@ end
 --     be checked against this list.
 -- @return A table representing the JSON body of the token, or nil and an error message.
 function M.verify(token, expectedAlgo, key, acceptedIssuers, acceptedAudiences)
-	if type(token) ~= 'string' then return nil, "token argument must be string" end
-	if type(expectedAlgo) ~= 'string' then return nil, "algorithm argument must be string" end
-	if type(key) ~= 'string' then return nil, "key argument must be string" end
-	if acceptedIssuers ~= nil and type(acceptedIssuers) ~= 'table' then
-		return nil, "acceptedIssuers argument must be table"
-	end
-	if acceptedAudiences ~= nil and type(acceptedAudiences) ~= 'table' then
-		return nil, "acceptedAudiences argument must be table"
-	end
-
-	if not alg_verify[expectedAlgo] then
-		return nil, "Algorithm not supported"
-	end
-
-	local header, body, sig, err = parse_token(token)
-	if err ~= nil then
-		return nil, err
-	end
-
-	-- Validate header
-	if not header.typ or header.typ ~= "JWT" then
-		return nil, "Invalid typ"
-	end
-
-	if not header.alg or header.alg ~= expectedAlgo then
-		return nil, "Invalid or incorrect alg"
-	end
-
-	-- Validate signature
-	if not alg_verify[expectedAlgo](strip_signature(token), sig, key) then
-		return nil, 'Invalid signature'
-	end
-
-	-- Validate body
-	if body.exp and type(body.exp) ~= "number" then
-		return nil, "exp must be number"
-	end
-
-	if body.nbf and type(body.nbf) ~= "number" then
-		return nil, "nbf must be number"
-	end
-
-
-	if body.exp and os.time() >= body.exp then
-		return nil, "Not acceptable by exp"
-	end
-
-	if body.nbf and os.time() < body.nbf then
-		return nil, "Not acceptable by nbf"
-	end
-
-	if acceptedIssuers ~= nil then
-		local issClaim = body.iss;
-		if issClaim == nil then
-        return nil, "'iss' claim is missing";
+    if type(token) ~= 'string' then return nil, "token argument must be string" end
+    if type(expectedAlgo) ~= 'string' then return nil, "algorithm argument must be string" end
+    if type(key) ~= 'string' then return nil, "key argument must be string" end
+    if acceptedIssuers ~= nil and type(acceptedIssuers) ~= 'table' then
+        return nil, "acceptedIssuers argument must be table"
     end
-    if not verify_claim(issClaim, acceptedIssuers) then
-    	return nil, "invalid 'iss' claim";
+    if acceptedAudiences ~= nil and type(acceptedAudiences) ~= 'table' then
+        return nil, "acceptedAudiences argument must be table"
     end
-	end
 
-	if acceptedAudiences ~= nil then
-		local audClaim = body.aud;
-		if audClaim == nil then
-        return nil, "'aud' claim is missing";
+    if not alg_verify[expectedAlgo] then
+        return nil, "Algorithm not supported"
     end
-    if not verify_claim(audClaim, acceptedAudiences) then
-    	return nil, "invalid 'aud' claim";
-    end
-	end
 
-	return body
+    local header, body, sig, err = parse_token(token)
+    if err ~= nil then
+        return nil, err
+    end
+
+    -- Validate header
+    if not header.typ or header.typ ~= "JWT" then
+        return nil, "Invalid typ"
+    end
+
+    if not header.alg or header.alg ~= expectedAlgo then
+        return nil, "Invalid or incorrect alg"
+    end
+
+    -- Validate signature
+    if not alg_verify[expectedAlgo](strip_signature(token), sig, key) then
+        return nil, 'Invalid signature'
+    end
+
+    -- Validate body
+    if body.exp and type(body.exp) ~= "number" then
+        return nil, "exp must be number"
+    end
+
+    if body.nbf and type(body.nbf) ~= "number" then
+        return nil, "nbf must be number"
+    end
+
+    if body.exp and os.time() >= body.exp then
+        return nil, "Not acceptable by exp"
+    end
+
+    if body.nbf and os.time() < body.nbf then
+        return nil, "Not acceptable by nbf"
+    end
+
+    if acceptedIssuers ~= nil then
+        local issClaim = body.iss;
+        if issClaim == nil then
+            return nil, "'iss' claim is missing";
+        end
+        if not verify_claim(issClaim, acceptedIssuers) then
+            return nil, "invalid 'iss' claim";
+        end
+    end
+
+    if acceptedAudiences ~= nil then
+        local audClaim = body.aud;
+        if audClaim == nil then
+            return nil, "'aud' claim is missing";
+        end
+        if not verify_claim(audClaim, acceptedAudiences) then
+            return nil, "invalid 'aud' claim";
+        end
+    end
+
+    return body
 end
 
 return M

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -22,10 +22,10 @@ local host = module.host;
 
 -- Extract 'token' param from URL when session is created
 function init_session(event)
-	local session, request = event.session, event.request;
-	local query = request.url.query;
+    local session, request = event.session, event.request;
+    local query = request.url.query;
 
-	if query ~= nil then
+    if query ~= nil then
         local params = formdecode(query);
 
         -- The following fields are filled in the session, by extracting them
@@ -41,32 +41,32 @@ module:hook_global("bosh-session", init_session);
 module:hook_global("websocket-session", init_session);
 
 function provider.test_password(username, password)
-	return nil, "Password based auth not supported";
+    return nil, "Password based auth not supported";
 end
 
 function provider.get_password(username)
-	return nil;
+    return nil;
 end
 
 function provider.set_password(username, password)
-	return nil, "Set password not supported";
+    return nil, "Set password not supported";
 end
 
 function provider.user_exists(username)
-	return nil;
+    return nil;
 end
 
 function provider.create_user(username, password)
-	return nil;
+    return nil;
 end
 
 function provider.delete_user(username)
-	return nil;
+    return nil;
 end
 
 function provider.get_sasl_handler(session)
 
-	local function get_username_from_token(self, message)
+    local function get_username_from_token(self, message)
 
         -- retrieve custom public key from server and save it on the session
         local pre_event_result = prosody.events.fire_event("pre-jitsi-authentication-fetch-key", session);
@@ -102,7 +102,7 @@ function provider.get_sasl_handler(session)
                     self.username = session1.username;
                     break;
                 end
-        	end
+            end
         else
             self.username = message;
         end
@@ -116,28 +116,28 @@ function provider.get_sasl_handler(session)
         end
 
         return res;
-	end
+    end
 
-	return new_sasl(host, { anonymous = get_username_from_token });
+    return new_sasl(host, { anonymous = get_username_from_token });
 end
 
 module:provides("auth", provider);
 
 local function anonymous(self, message)
 
-	local username = generate_uuid();
+    local username = generate_uuid();
 
-	-- This calls the handler created in 'provider.get_sasl_handler(session)'
-	local result, err, msg = self.profile.anonymous(self, username, self.realm);
+    -- This calls the handler created in 'provider.get_sasl_handler(session)'
+    local result, err, msg = self.profile.anonymous(self, username, self.realm);
 
-	if result == true then
-		if (self.username == nil) then
-			self.username = username;
-		end
-		return "success";
-	else
-		return "failure", err, msg;
-	end
+    if result == true then
+        if (self.username == nil) then
+            self.username = username;
+        end
+        return "success";
+    else
+        return "failure", err, msg;
+    end
 end
 
 sasl.registerMechanism("ANONYMOUS", {"anonymous"}, anonymous);

--- a/resources/prosody-plugins/mod_client_proxy.lua
+++ b/resources/prosody-plugins/mod_client_proxy.lua
@@ -1,5 +1,5 @@
 if module:get_host_type() ~= "component" then
-	error("proxy_component should be loaded as component", 0);
+    error("proxy_component should be loaded as component", 0);
 end
 
 local jid_split = require "util.jid".split;
@@ -14,172 +14,172 @@ sessions = array{};
 local sessions = sessions;
 
 local function handle_target_presence(stanza)
-	local type = stanza.attr.type;
-	module:log("debug", "received presence from destination: %s", type)
-	local _, _, resource = jid_split(stanza.attr.from);
-	if type == "error" then
-		-- drop all known sessions
-		for k in pairs(sessions) do
-			sessions[k] = nil
-		end
-		module:log(
-			"debug",
-			"received error presence, dropping all target sessions",
-			resource
-		)
-	elseif type == "unavailable" then
-		for k in pairs(sessions) do
-			if sessions[k] == resource then
-				sessions[k] = nil
-				module:log(
-					"debug",
-					"dropped target session: %s",
-					resource
-				)
-				break
-			end
-		end
-	elseif not type then
-		-- available
-		local found = false;
-		for k in pairs(sessions) do
-			if sessions[k] == resource then
-				found = true;
-				break
-			end
-		end
-		if not found then
-			module:log(
-				"debug",
-				"registered new target session: %s",
-				resource
-			)
-			sessions:push(resource)
-		end
-	end
+    local type = stanza.attr.type;
+    module:log("debug", "received presence from destination: %s", type)
+    local _, _, resource = jid_split(stanza.attr.from);
+    if type == "error" then
+        -- drop all known sessions
+        for k in pairs(sessions) do
+            sessions[k] = nil
+        end
+        module:log(
+            "debug",
+            "received error presence, dropping all target sessions",
+            resource
+        )
+    elseif type == "unavailable" then
+        for k in pairs(sessions) do
+            if sessions[k] == resource then
+                sessions[k] = nil
+                module:log(
+                    "debug",
+                    "dropped target session: %s",
+                    resource
+                )
+                break
+            end
+        end
+    elseif not type then
+        -- available
+        local found = false;
+        for k in pairs(sessions) do
+            if sessions[k] == resource then
+                found = true;
+                break
+            end
+        end
+        if not found then
+            module:log(
+                "debug",
+                "registered new target session: %s",
+                resource
+            )
+            sessions:push(resource)
+        end
+    end
 end
 
 local function handle_from_target(stanza)
-	local type = stanza.attr.type
-	module:log(
-		"debug",
-		"non-presence stanza from target: name = %s, type = %s",
-		stanza.name,
-		type
-	)
-	if stanza.name == "iq" then
-		if type == "error" or type == "result" then
-			-- de-NAT message
-			local _, _, denatted_to_unprepped = jid_split(stanza.attr.to);
-			local denatted_to = jid_prep(denatted_to_unprepped);
-			if not denatted_to then
-				module:log(
-					"debug",
-					"cannot de-NAT stanza, invalid to: %s",
-					denatted_to_unprepped
-				)
-				return
-			end
-			local denatted_from = module:get_host();
+    local type = stanza.attr.type
+    module:log(
+        "debug",
+        "non-presence stanza from target: name = %s, type = %s",
+        stanza.name,
+        type
+    )
+    if stanza.name == "iq" then
+        if type == "error" or type == "result" then
+            -- de-NAT message
+            local _, _, denatted_to_unprepped = jid_split(stanza.attr.to);
+            local denatted_to = jid_prep(denatted_to_unprepped);
+            if not denatted_to then
+                module:log(
+                    "debug",
+                    "cannot de-NAT stanza, invalid to: %s",
+                    denatted_to_unprepped
+                )
+                return
+            end
+            local denatted_from = module:get_host();
 
-			module:log(
-				"debug",
-				"de-NAT-ed stanza: from: %s -> %s, to: %s -> %s",
-				stanza.attr.from,
-				denatted_from,
-				stanza.attr.to,
-				denatted_to
-			)
+            module:log(
+                "debug",
+                "de-NAT-ed stanza: from: %s -> %s, to: %s -> %s",
+                stanza.attr.from,
+                denatted_from,
+                stanza.attr.to,
+                denatted_to
+            )
 
-			stanza.attr.from = denatted_from
-			stanza.attr.to = denatted_to
+            stanza.attr.from = denatted_from
+            stanza.attr.to = denatted_to
 
-			module:send(stanza)
-		else
-			-- FIXME: we don’t support NATing outbund requests atm.
-			module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
-		end
-	elseif stanza.name == "message" then
-		-- not implemented yet, we need a way to ensure that routing doesn’t
-		-- break
-		module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
-	end
+            module:send(stanza)
+        else
+            -- FIXME: we don’t support NATing outbund requests atm.
+            module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
+        end
+    elseif stanza.name == "message" then
+        -- not implemented yet, we need a way to ensure that routing doesn’t
+        -- break
+        module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
+    end
 end
 
 local function handle_to_target(stanza)
-	local type = stanza.attr.type;
-	module:log(
-		"debug",
-		"stanza to target: name = %s, type = %s",
-		stanza.name, type
-	)
-	if stanza.name == "presence" then
-		if type ~= "error" then
-			module:send(st.error_reply(stanza, "cancel", "bad-request"))
-			return
-		end
-	elseif stanza.name == "iq" then
-		if type == "get" or type == "set" then
-			if #sessions == 0 then
-				-- no sessions available to send to
-				module:log("debug", "no sessions to send to!")
-				module:send(st.error_reply(stanza, "cancel", "service-unavailable"))
-				return
-			end
+    local type = stanza.attr.type;
+    module:log(
+        "debug",
+        "stanza to target: name = %s, type = %s",
+        stanza.name, type
+    )
+    if stanza.name == "presence" then
+        if type ~= "error" then
+            module:send(st.error_reply(stanza, "cancel", "bad-request"))
+            return
+        end
+    elseif stanza.name == "iq" then
+        if type == "get" or type == "set" then
+            if #sessions == 0 then
+                -- no sessions available to send to
+                module:log("debug", "no sessions to send to!")
+                module:send(st.error_reply(stanza, "cancel", "service-unavailable"))
+                return
+            end
 
-			-- find a target session
-			local target_session = sessions:random()
-			local target = target_address .. "/" .. target_session
+            -- find a target session
+            local target_session = sessions:random()
+            local target = target_address .. "/" .. target_session
 
-			-- encode sender JID in resource
-			local natted_from = module:get_host() .. "/" .. stanza.attr.from;
+            -- encode sender JID in resource
+            local natted_from = module:get_host() .. "/" .. stanza.attr.from;
 
-			module:log(
-				"debug",
-				"NAT-ed stanza: from: %s -> %s, to: %s -> %s",
-				stanza.attr.from,
-				natted_from,
-				stanza.attr.to,
-				target
-			)
+            module:log(
+                "debug",
+                "NAT-ed stanza: from: %s -> %s, to: %s -> %s",
+                stanza.attr.from,
+                natted_from,
+                stanza.attr.to,
+                target
+            )
 
-			stanza.attr.from = natted_from
-			stanza.attr.to = target
+            stanza.attr.from = natted_from
+            stanza.attr.to = target
 
-			module:send(stanza)
-		end
-		-- FIXME: handle and forward result/error correctly
-	elseif stanza.name == "message" then
-		-- not implemented yet, we need a way to ensure that routing doesn’t
-		-- break
-		module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
-	end
+            module:send(stanza)
+        end
+        -- FIXME: handle and forward result/error correctly
+    elseif stanza.name == "message" then
+        -- not implemented yet, we need a way to ensure that routing doesn’t
+        -- break
+        module:send(st.error_reply(stanza, "cancel", "feature-not-implemented"))
+    end
 end
 
 local function stanza_handler(event)
-	local origin, stanza = event.origin, event.stanza
-	module:log("debug", "received stanza from %s session", origin.type)
+    local origin, stanza = event.origin, event.stanza
+    module:log("debug", "received stanza from %s session", origin.type)
 
-	local bare_from = jid_bare(stanza.attr.from);
-	local _, _, to = jid_split(stanza.attr.to);
-	if bare_from == target_address then
-		-- from our target, to whom?
-		if not to then
-			-- directly to component
-			if stanza.name == "presence" then
-				handle_target_presence(stanza)
-			else
-				module:send(st.error_reply(stanza, "cancel", "bad-request"))
-				return true
-			end
-		else
-			-- to someone else
-			handle_from_target(stanza)
-		end
-	else
-		handle_to_target(stanza)
-	end
-	return true
+    local bare_from = jid_bare(stanza.attr.from);
+    local _, _, to = jid_split(stanza.attr.to);
+    if bare_from == target_address then
+        -- from our target, to whom?
+        if not to then
+            -- directly to component
+            if stanza.name == "presence" then
+                handle_target_presence(stanza)
+            else
+                module:send(st.error_reply(stanza, "cancel", "bad-request"))
+                return true
+            end
+        else
+            -- to someone else
+            handle_from_target(stanza)
+        end
+    else
+        handle_to_target(stanza)
+    end
+    return true
 end
 
 module:hook("iq/bare", stanza_handler, -1);
@@ -195,8 +195,8 @@ module:hook("presence/host", stanza_handler, -1);
 module:log("debug", "loaded proxy on %s", module:get_host())
 
 subscription_request = st.presence({
-	type = "subscribe",
-	to = target_address,
-	from = module:get_host()}
+    type = "subscribe",
+    to = target_address,
+    from = module:get_host()}
 )
 module:send(subscription_request)

--- a/resources/prosody-plugins/mod_external_services.lua
+++ b/resources/prosody-plugins/mod_external_services.lua
@@ -18,206 +18,206 @@ local access = module:get_option_set("external_service_access", {});
 
 -- https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
 local function behave_turn_rest_credentials(srv, item, secret)
-	local ttl = default_ttl;
-	if type(item.ttl) == "number" then
-		ttl = item.ttl;
-	end
-	local expires = srv.expires or os.time() + ttl;
-	local username;
-	if type(item.username) == "string" then
-		username = string.format("%d:%s", expires, item.username);
-	else
-		username = string.format("%d", expires);
-	end
-	srv.username = username;
-	srv.password = base64.encode(hashes.hmac_sha1(secret, srv.username));
+    local ttl = default_ttl;
+    if type(item.ttl) == "number" then
+        ttl = item.ttl;
+    end
+    local expires = srv.expires or os.time() + ttl;
+    local username;
+    if type(item.username) == "string" then
+        username = string.format("%d:%s", expires, item.username);
+    else
+        username = string.format("%d", expires);
+    end
+    srv.username = username;
+    srv.password = base64.encode(hashes.hmac_sha1(secret, srv.username));
 end
 
 local algorithms = {
-	turn = behave_turn_rest_credentials;
+    turn = behave_turn_rest_credentials;
 }
 
 -- filter config into well-defined service records
 local function prepare(item)
-	if type(item) ~= "table" then
-		module:log("error", "Service definition is not a table: %q", item);
-		return nil;
-	end
+    if type(item) ~= "table" then
+        module:log("error", "Service definition is not a table: %q", item);
+        return nil;
+    end
 
-	local srv = {
-		type = nil;
-		transport = nil;
-		host = default_host;
-		port = default_port;
-		username = nil;
-		password = nil;
-		restricted = nil;
-		expires = nil;
-	};
+    local srv = {
+        type = nil;
+        transport = nil;
+        host = default_host;
+        port = default_port;
+        username = nil;
+        password = nil;
+        restricted = nil;
+        expires = nil;
+    };
 
-	if type(item.type) == "string" then
-		srv.type = item.type;
-	else
-		module:log("error", "Service missing mandatory 'type' field: %q", item);
-		return nil;
-	end
-	if type(item.transport) == "string" then
-		srv.transport = item.transport;
-	end
-	if type(item.host) == "string" then
-		srv.host = item.host;
-	end
-	if type(item.port) == "number" then
-		srv.port = item.port;
-	end
-	if type(item.username) == "string" then
-		srv.username = item.username;
-	end
-	if type(item.password) == "string" then
-		srv.password = item.password;
-		srv.restricted = true;
-	end
-	if item.restricted == true then
-		srv.restricted = true;
-	end
-	if type(item.expires) == "number" then
-		srv.expires = item.expires;
-	elseif type(item.ttl) == "number" then
-		srv.expires = os.time() + item.ttl;
-	end
-	if (item.secret == true and default_secret) or type(item.secret) == "string" then
-		local secret_cb = item.credentials_cb or algorithms[item.algorithm] or algorithms[srv.type];
-		local secret = item.secret;
-		if secret == true then
-			secret = default_secret;
-		end
-		if secret_cb then
-			secret_cb(srv, item, secret);
-			srv.restricted = true;
-		end
-	end
-	return srv;
+    if type(item.type) == "string" then
+        srv.type = item.type;
+    else
+        module:log("error", "Service missing mandatory 'type' field: %q", item);
+        return nil;
+    end
+    if type(item.transport) == "string" then
+        srv.transport = item.transport;
+    end
+    if type(item.host) == "string" then
+        srv.host = item.host;
+    end
+    if type(item.port) == "number" then
+        srv.port = item.port;
+    end
+    if type(item.username) == "string" then
+        srv.username = item.username;
+    end
+    if type(item.password) == "string" then
+        srv.password = item.password;
+        srv.restricted = true;
+    end
+    if item.restricted == true then
+        srv.restricted = true;
+    end
+    if type(item.expires) == "number" then
+        srv.expires = item.expires;
+    elseif type(item.ttl) == "number" then
+        srv.expires = os.time() + item.ttl;
+    end
+    if (item.secret == true and default_secret) or type(item.secret) == "string" then
+        local secret_cb = item.credentials_cb or algorithms[item.algorithm] or algorithms[srv.type];
+        local secret = item.secret;
+        if secret == true then
+            secret = default_secret;
+        end
+        if secret_cb then
+            secret_cb(srv, item, secret);
+            srv.restricted = true;
+        end
+    end
+    return srv;
 end
 
 function module.load()
-	-- Trigger errors on startup
-	local services = configured_services / prepare;
-	if #services == 0 then
-		module:log("warn", "No services configured or all had errors");
-	end
+    -- Trigger errors on startup
+    local services = configured_services / prepare;
+    if #services == 0 then
+        module:log("warn", "No services configured or all had errors");
+    end
 end
 
 -- Ensure only valid items are added in events
 local services_mt = {
-	__index = getmetatable(array()).__index;
-	__newindex = function (self, i, v)
-		rawset(self, i, assert(prepare(v), "Invalid service entry added"));
-	end;
+    __index = getmetatable(array()).__index;
+    __newindex = function (self, i, v)
+        rawset(self, i, assert(prepare(v), "Invalid service entry added"));
+    end;
 }
 
 function get_services()
-	local extras = module:get_host_items("external_service");
-	local services = ( configured_services + extras ) / prepare;
+    local extras = module:get_host_items("external_service");
+    local services = ( configured_services + extras ) / prepare;
 
-	setmetatable(services, services_mt);
+    setmetatable(services, services_mt);
 
-	return services;
+    return services;
 end
 
 function services_xml(services, name, namespace)
-	local reply = st.stanza(name or "services", { xmlns = namespace or "urn:xmpp:extdisco:2" });
+    local reply = st.stanza(name or "services", { xmlns = namespace or "urn:xmpp:extdisco:2" });
 
-	for _, srv in ipairs(services) do
-		reply:tag("service", {
-				type = srv.type;
-				transport = srv.transport;
-				host = srv.host;
-				port = srv.port and string.format("%d", srv.port) or nil;
-				username = srv.username;
-				password = srv.password;
-				expires = srv.expires and dt.datetime(srv.expires) or nil;
-				restricted = srv.restricted and "1" or nil;
-			}):up();
-	end
+    for _, srv in ipairs(services) do
+        reply:tag("service", {
+                type = srv.type;
+                transport = srv.transport;
+                host = srv.host;
+                port = srv.port and string.format("%d", srv.port) or nil;
+                username = srv.username;
+                password = srv.password;
+                expires = srv.expires and dt.datetime(srv.expires) or nil;
+                restricted = srv.restricted and "1" or nil;
+            }):up();
+    end
 
-	return reply;
+    return reply;
 end
 
 local function handle_services(event)
-	local origin, stanza = event.origin, event.stanza;
-	local action = stanza.tags[1];
+    local origin, stanza = event.origin, event.stanza;
+    local action = stanza.tags[1];
 
-	local user_bare = jid.bare(stanza.attr.from);
-	local user_host = jid.host(user_bare);
-	if not ((access:empty() and origin.type == "c2s") or access:contains(user_bare) or access:contains(user_host)) then
-		origin.send(st.error_reply(stanza, "auth", "forbidden"));
-		return true;
-	end
+    local user_bare = jid.bare(stanza.attr.from);
+    local user_host = jid.host(user_bare);
+    if not ((access:empty() and origin.type == "c2s") or access:contains(user_bare) or access:contains(user_host)) then
+        origin.send(st.error_reply(stanza, "auth", "forbidden"));
+        return true;
+    end
 
-	local services = get_services();
+    local services = get_services();
 
-	local requested_type = action.attr.type;
-	if requested_type then
-		services:filter(function(item)
-			return item.type == requested_type;
-		end);
-	end
+    local requested_type = action.attr.type;
+    if requested_type then
+        services:filter(function(item)
+            return item.type == requested_type;
+        end);
+    end
 
-	module:fire_event("external_service/services", {
-			origin = origin;
-			stanza = stanza;
-			requested_type = requested_type;
-			services = services;
-		});
+    module:fire_event("external_service/services", {
+            origin = origin;
+            stanza = stanza;
+            requested_type = requested_type;
+            services = services;
+        });
 
-	local reply = st.reply(stanza):add_child(services_xml(services, action.name, action.attr.xmlns));
+    local reply = st.reply(stanza):add_child(services_xml(services, action.name, action.attr.xmlns));
 
-	origin.send(reply);
-	return true;
+    origin.send(reply);
+    return true;
 end
 
 local function handle_credentials(event)
-	local origin, stanza = event.origin, event.stanza;
-	local action = stanza.tags[1];
+    local origin, stanza = event.origin, event.stanza;
+    local action = stanza.tags[1];
 
-	if origin.type ~= "c2s" then
-		origin.send(st.error_reply(stanza, "auth", "forbidden", "The 'port' and 'type' attributes are required."));
-		return true;
-	end
+    if origin.type ~= "c2s" then
+        origin.send(st.error_reply(stanza, "auth", "forbidden", "The 'port' and 'type' attributes are required."));
+        return true;
+    end
 
-	local services = get_services();
-	services:filter(function (item)
-		return item.restricted;
-	end)
+    local services = get_services();
+    services:filter(function (item)
+        return item.restricted;
+    end)
 
-	local requested_credentials = set.new();
-	for service in action:childtags("service") do
-		if not service.attr.type or not service.attr.host then
-			origin.send(st.error_reply(stanza, "modify", "bad-request"));
-			return true;
-		end
+    local requested_credentials = set.new();
+    for service in action:childtags("service") do
+        if not service.attr.type or not service.attr.host then
+            origin.send(st.error_reply(stanza, "modify", "bad-request"));
+            return true;
+        end
 
-		requested_credentials:add(string.format("%s:%s:%d", service.attr.type, service.attr.host,
-			tonumber(service.attr.port) or 0));
-	end
+        requested_credentials:add(string.format("%s:%s:%d", service.attr.type, service.attr.host,
+            tonumber(service.attr.port) or 0));
+    end
 
-	module:fire_event("external_service/credentials", {
-			origin = origin;
-			stanza = stanza;
-			requested_credentials = requested_credentials;
-			services = services;
-		});
+    module:fire_event("external_service/credentials", {
+            origin = origin;
+            stanza = stanza;
+            requested_credentials = requested_credentials;
+            services = services;
+        });
 
-	services:filter(function (srv)
-		local port_key = string.format("%s:%s:%d", srv.type, srv.host, srv.port or 0);
-		local portless_key = string.format("%s:%s:%d", srv.type, srv.host, 0);
-		return requested_credentials:contains(port_key) or requested_credentials:contains(portless_key);
-	end);
+    services:filter(function (srv)
+        local port_key = string.format("%s:%s:%d", srv.type, srv.host, srv.port or 0);
+        local portless_key = string.format("%s:%s:%d", srv.type, srv.host, 0);
+        return requested_credentials:contains(port_key) or requested_credentials:contains(portless_key);
+    end);
 
-	local reply = st.reply(stanza):add_child(services_xml(services, action.name, action.attr.xmlns));
+    local reply = st.reply(stanza):add_child(services_xml(services, action.name, action.attr.xmlns));
 
-	origin.send(reply);
-	return true;
+    origin.send(reply);
+    return true;
 end
 
 -- XEP-0215 v0.7

--- a/resources/prosody-plugins/mod_limits_exception.lua
+++ b/resources/prosody-plugins/mod_limits_exception.lua
@@ -2,7 +2,7 @@
 local have_async = pcall(require, 'util.async');
 
 if not have_async then
-	return;
+    return;
 end
 
 local unlimited_jids = module:get_option_inherited_set("unlimited_jids", {});
@@ -11,22 +11,22 @@ local unlimited_jids = module:get_option_inherited_set("unlimited_jids", {});
 local unlimited_stanza_size_limit = module:get_option_number("unlimited_size", 10*1024*1024);
 
 if unlimited_jids:empty() then
-	return;
+    return;
 end
 
 module:hook("authentication-success", function (event)
-	local session = event.session;
-	local jid = session.username .. "@" .. session.host;
-	if unlimited_jids:contains(jid) then
-		if session.conn and session.conn.setlimit then
-			session.conn:setlimit(0);
-		elseif session.throttle then
-			session.throttle = nil;
-		end
+    local session = event.session;
+    local jid = session.username .. "@" .. session.host;
+    if unlimited_jids:contains(jid) then
+        if session.conn and session.conn.setlimit then
+            session.conn:setlimit(0);
+        elseif session.throttle then
+            session.throttle = nil;
+        end
 
-		if unlimited_stanza_size_limit and session.stream.set_stanza_size_limit then
-			module:log('info', 'Setting stanza size limits for %s to %s', jid, unlimited_stanza_size_limit)
-			session.stream:set_stanza_size_limit(unlimited_stanza_size_limit);
-		end
-	end
+        if unlimited_stanza_size_limit and session.stream.set_stanza_size_limit then
+            module:log('info', 'Setting stanza size limits for %s to %s', jid, unlimited_stanza_size_limit)
+            session.stream:set_stanza_size_limit(unlimited_stanza_size_limit);
+        end
+    end
 end);

--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -64,7 +64,7 @@ local main_rooms_map = {};
 function get_main_room_jid(room_jid)
     local _, host = jid_split(room_jid);
 
-	return
+    return
         host == main_muc_component_config
         and room_jid
         or main_rooms_map[room_jid];

--- a/resources/prosody-plugins/mod_muc_max_occupants.lua
+++ b/resources/prosody-plugins/mod_muc_max_occupants.lua
@@ -13,60 +13,60 @@ local whitelist = module:get_option_set("muc_access_whitelist");
 local MAX_OCCUPANTS = module:get_option_number("muc_max_occupants", -1);
 
 local function count_keys(t)
-  return it.count(it.keys(t));
+    return it.count(it.keys(t));
 end
 
 local function check_for_max_occupants(event)
-  local room, origin, stanza = event.room, event.origin, event.stanza;
-  local user, domain, res = split_jid(stanza.attr.from);
+    local room, origin, stanza = event.room, event.origin, event.stanza;
+    local user, domain, res = split_jid(stanza.attr.from);
 
-  if is_healthcheck_room(room.jid) then
-    return;
-  end
+    if is_healthcheck_room(room.jid) then
+        return;
+    end
 
-  --no user object means no way to check for max occupants
-  if user == nil then
-    return
-  end
-  -- If we're a whitelisted user joining the room, don't bother checking the max
-  -- occupants.
-  if whitelist and whitelist:contains(domain) or whitelist:contains(user..'@'..domain) then
-    return;
-  end
+    --no user object means no way to check for max occupants
+    if user == nil then
+        return
+    end
+    -- If we're a whitelisted user joining the room, don't bother checking the max
+    -- occupants.
+    if whitelist and whitelist:contains(domain) or whitelist:contains(user..'@'..domain) then
+        return;
+    end
 
-	if room and not room._jid_nick[stanza.attr.from] then
+    if room and not room._jid_nick[stanza.attr.from] then
         local max_occupants_by_room = event.room._data.max_occupants;
-		local count = count_keys(room._occupants);
+        local count = count_keys(room._occupants);
         -- if no of occupants limit is set per room basis use
         -- that settings otherwise use the global one
         local slots = max_occupants_by_room or MAX_OCCUPANTS;
 
-		-- If there is no whitelist, just check the count.
-		if not whitelist and count >= slots then
-			module:log("info", "Attempt to enter a maxed out MUC");
-			origin.send(st.error_reply(stanza, "cancel", "service-unavailable"));
-			return true;
-		end
+        -- If there is no whitelist, just check the count.
+        if not whitelist and count >= slots then
+            module:log("info", "Attempt to enter a maxed out MUC");
+            origin.send(st.error_reply(stanza, "cancel", "service-unavailable"));
+            return true;
+        end
 
-		-- TODO: Are Prosody hooks atomic, or is this a race condition?
-		-- For each person in the room that's not on the whitelist, subtract one
-		-- from the count.
-		for _, occupant in room:each_occupant() do
-			user, domain, res = split_jid(occupant.bare_jid);
-			if not whitelist:contains(domain) and not whitelist:contains(user..'@'..domain) then
-				slots = slots - 1
-			end
-		end
+        -- TODO: Are Prosody hooks atomic, or is this a race condition?
+        -- For each person in the room that's not on the whitelist, subtract one
+        -- from the count.
+        for _, occupant in room:each_occupant() do
+            user, domain, res = split_jid(occupant.bare_jid);
+            if not whitelist:contains(domain) and not whitelist:contains(user..'@'..domain) then
+                slots = slots - 1
+            end
+        end
 
-		-- If the room is full (<0 slots left), error out.
-		if slots <= 0 then
-			module:log("info", "Attempt to enter a maxed out MUC");
-			origin.send(st.error_reply(stanza, "cancel", "service-unavailable"));
-			return true;
-		end
-	end
+        -- If the room is full (<0 slots left), error out.
+        if slots <= 0 then
+            module:log("info", "Attempt to enter a maxed out MUC");
+            origin.send(st.error_reply(stanza, "cancel", "service-unavailable"));
+            return true;
+        end
+    end
 end
 
 if MAX_OCCUPANTS > 0 then
-	module:hook("muc-occupant-pre-join", check_for_max_occupants, 10);
+    module:hook("muc-occupant-pre-join", check_for_max_occupants, 10);
 end

--- a/resources/prosody-plugins/mod_muc_size.lua
+++ b/resources/prosody-plugins/mod_muc_size.lua
@@ -82,9 +82,9 @@ function handle_get_room_size(event)
         return { status_code = 400; };
     end
 
-	local params = parse(event.request.url.query);
-	local room_name = params["room"];
-	local domain_name = params["domain"];
+    local params = parse(event.request.url.query);
+    local room_name = params["room"];
+    local domain_name = params["domain"];
     local subdomain = params["subdomain"];
 
     local room_address
@@ -98,28 +98,28 @@ function handle_get_room_size(event)
         return { status_code = 403; };
     end
 
-	local room = get_room_from_jid(room_address);
-	local participant_count = 0;
+    local room = get_room_from_jid(room_address);
+    local participant_count = 0;
 
-	log("debug", "Querying room %s", tostring(room_address));
+    log("debug", "Querying room %s", tostring(room_address));
 
-	if room then
-		local occupants = room._occupants;
-		if occupants then
-			participant_count = iterators.count(room:each_occupant());
-		end
-		log("debug",
+    if room then
+        local occupants = room._occupants;
+        if occupants then
+            participant_count = iterators.count(room:each_occupant());
+        end
+        log("debug",
             "there are %s occupants in room", tostring(participant_count));
-	else
-		log("debug", "no such room exists");
-		return { status_code = 404; };
-	end
+    else
+        log("debug", "no such room exists");
+        return { status_code = 404; };
+    end
 
-	if participant_count > 1 then
-		participant_count = participant_count - 1;
-	end
+    if participant_count > 1 then
+        participant_count = participant_count - 1;
+    end
 
-	return { status_code = 200; body = [[{"participants":]]..participant_count..[[}]] };
+    return { status_code = 200; body = [[{"participants":]]..participant_count..[[}]] };
 end
 
 --- Handles request for retrieving the room participants details
@@ -130,9 +130,9 @@ function handle_get_room (event)
         return { status_code = 400; };
     end
 
-	local params = parse(event.request.url.query);
-	local room_name = params["room"];
-	local domain_name = params["domain"];
+    local params = parse(event.request.url.query);
+    local room_name = params["room"];
+    local domain_name = params["domain"];
     local subdomain = params["subdomain"];
     local room_address
         = jid.join(room_name, muc_domain_prefix.."."..domain_name);
@@ -145,53 +145,53 @@ function handle_get_room (event)
         return { status_code = 403; };
     end
 
-	local room = get_room_from_jid(room_address);
-	local participant_count = 0;
-	local occupants_json = array();
+    local room = get_room_from_jid(room_address);
+    local participant_count = 0;
+    local occupants_json = array();
 
-	log("debug", "Querying room %s", tostring(room_address));
+    log("debug", "Querying room %s", tostring(room_address));
 
-	if room then
-		local occupants = room._occupants;
-		if occupants then
-			participant_count = iterators.count(room:each_occupant());
-			for _, occupant in room:each_occupant() do
-			    -- filter focus as we keep it as hidden participant
-			    if string.sub(occupant.nick,-string.len("/focus"))~="/focus" then
-				    for _, pr in occupant:each_session() do
-					local nick = pr:get_child_text("nick", "http://jabber.org/protocol/nick") or "";
-					local email = pr:get_child_text("email") or "";
-					occupants_json:push({
-					    jid = tostring(occupant.nick),
-					    email = tostring(email),
-					    display_name = tostring(nick)});
-				    end
-			    end
-			end
-		end
-		log("debug",
+    if room then
+        local occupants = room._occupants;
+        if occupants then
+            participant_count = iterators.count(room:each_occupant());
+            for _, occupant in room:each_occupant() do
+                -- filter focus as we keep it as hidden participant
+                if string.sub(occupant.nick,-string.len("/focus"))~="/focus" then
+                    for _, pr in occupant:each_session() do
+                        local nick = pr:get_child_text("nick", "http://jabber.org/protocol/nick") or "";
+                        local email = pr:get_child_text("email") or "";
+                        occupants_json:push({
+                            jid = tostring(occupant.nick),
+                            email = tostring(email),
+                            display_name = tostring(nick)});
+                    end
+                end
+            end
+        end
+        log("debug",
             "there are %s occupants in room", tostring(participant_count));
-	else
-		log("debug", "no such room exists");
-		return { status_code = 404; };
-	end
+    else
+        log("debug", "no such room exists");
+        return { status_code = 404; };
+    end
 
-	if participant_count > 1 then
-		participant_count = participant_count - 1;
-	end
+    if participant_count > 1 then
+        participant_count = participant_count - 1;
+    end
 
-	return { status_code = 200; body = json.encode(occupants_json); };
+    return { status_code = 200; body = json.encode(occupants_json); };
 end;
 
 function module.load()
     module:depends("http");
-	module:provides("http", {
-		default_path = "/";
-		route = {
-			["GET room-size"] = function (event) return async_handler_wrapper(event,handle_get_room_size) end;
-			["GET sessions"] = function () return tostring(it.count(it.keys(prosody.full_sessions))); end;
-			["GET room"] = function (event) return async_handler_wrapper(event,handle_get_room) end;
-		};
-	});
+    module:provides("http", {
+        default_path = "/";
+        route = {
+            ["GET room-size"] = function (event) return async_handler_wrapper(event,handle_get_room_size) end;
+            ["GET sessions"] = function () return tostring(it.count(it.keys(prosody.full_sessions))); end;
+            ["GET room"] = function (event) return async_handler_wrapper(event,handle_get_room) end;
+        };
+    });
 end
 

--- a/resources/prosody-plugins/mod_poltergeist_component.lua
+++ b/resources/prosody-plugins/mod_poltergeist_component.lua
@@ -3,12 +3,12 @@ local st = require "util.stanza";
 -- A component which we use to receive all stanzas for the created poltergeists
 -- replays with error if an iq is sent
 function no_action()
-	return true;
+    return true;
 end
 
 function error_reply(event)
-	module:send(st.error_reply(event.stanza, "cancel", "service-unavailable"));
-	return true;
+    module:send(st.error_reply(event.stanza, "cancel", "service-unavailable"));
+    return true;
 end
 
 module:hook("presence/host", no_action);

--- a/resources/prosody-plugins/mod_roster_command.lua
+++ b/resources/prosody-plugins/mod_roster_command.lua
@@ -10,8 +10,8 @@
 -----------------------------------------------------------
 
 if module.host ~= "*" then
-	module:log("error", "Do not load this module in Prosody, for correct usage see: https://modules.prosody.im/mod_roster_command.html");
-	return;
+    module:log("error", "Do not load this module in Prosody, for correct usage see: https://modules.prosody.im/mod_roster_command.html");
+    return;
 end
 
 
@@ -30,136 +30,136 @@ local warn = require"util.prosodyctl".show_warning;
 -- Make a *one-way* subscription. User will see when contact is online,
 -- contact will not see when user is online.
 function subscribe(user_jid, contact_jid)
-	local user_username, user_host = jid.split(user_jid);
-	local contact_username, contact_host = jid.split(contact_jid);
-	if not hosts[user_host] then
-		warn("The host '%s' is not configured for this server.", user_host);
-		return;
-	end
-	if hosts[user_host].users.name == "null" then
-		storagemanager.initialize_host(user_host);
-		usermanager.initialize_host(user_host);
-	end
-	-- Update user's roster to say subscription request is pending. Bare hosts (e.g. components) don't have rosters.
-    if user_username ~= nil then
-	    rostermanager.set_contact_pending_out(user_username, user_host, contact_jid);
+    local user_username, user_host = jid.split(user_jid);
+    local contact_username, contact_host = jid.split(contact_jid);
+    if not hosts[user_host] then
+        warn("The host '%s' is not configured for this server.", user_host);
+        return;
     end
-	if hosts[contact_host] then
-		if contact_host ~= user_host and hosts[contact_host].users.name == "null" then
-			storagemanager.initialize_host(contact_host);
-			usermanager.initialize_host(contact_host);
-		end
-		-- Update contact's roster to say subscription request is pending...
-		rostermanager.set_contact_pending_in(contact_username, contact_host, user_jid);
-		-- Update contact's roster to say subscription request approved...
-		rostermanager.subscribed(contact_username, contact_host, user_jid);
-		-- Update user's roster to say subscription request approved. Bare hosts (e.g. components) don't have rosters.
-        if user_username ~= nil then
-		    rostermanager.process_inbound_subscription_approval(user_username, user_host, contact_jid);
+    if hosts[user_host].users.name == "null" then
+        storagemanager.initialize_host(user_host);
+        usermanager.initialize_host(user_host);
+    end
+    -- Update user's roster to say subscription request is pending. Bare hosts (e.g. components) don't have rosters.
+    if user_username ~= nil then
+        rostermanager.set_contact_pending_out(user_username, user_host, contact_jid);
+    end
+    if hosts[contact_host] then
+        if contact_host ~= user_host and hosts[contact_host].users.name == "null" then
+            storagemanager.initialize_host(contact_host);
+            usermanager.initialize_host(contact_host);
         end
-	end
+        -- Update contact's roster to say subscription request is pending...
+        rostermanager.set_contact_pending_in(contact_username, contact_host, user_jid);
+        -- Update contact's roster to say subscription request approved...
+        rostermanager.subscribed(contact_username, contact_host, user_jid);
+        -- Update user's roster to say subscription request approved. Bare hosts (e.g. components) don't have rosters.
+        if user_username ~= nil then
+            rostermanager.process_inbound_subscription_approval(user_username, user_host, contact_jid);
+        end
+    end
 end
 
 -- Make a mutual subscription between jid1 and jid2. Each JID will see
 -- when the other one is online.
 function subscribe_both(jid1, jid2)
-	subscribe(jid1, jid2);
-	subscribe(jid2, jid1);
+    subscribe(jid1, jid2);
+    subscribe(jid2, jid1);
 end
 
 -- Unsubscribes user from contact (not contact from user, if subscribed).
 function unsubscribe(user_jid, contact_jid)
-	local user_username, user_host = jid.split(user_jid);
-	local contact_username, contact_host = jid.split(contact_jid);
-	if not hosts[user_host] then
-		warn("The host '%s' is not configured for this server.", user_host);
-		return;
-	end
-	if hosts[user_host].users.name == "null" then
-		storagemanager.initialize_host(user_host);
-		usermanager.initialize_host(user_host);
-	end
-	-- Update user's roster to say subscription is cancelled...
-	rostermanager.unsubscribe(user_username, user_host, contact_jid);
-	if hosts[contact_host] then
-		if contact_host ~= user_host and hosts[contact_host].users.name == "null" then
-			storagemanager.initialize_host(contact_host);
-			usermanager.initialize_host(contact_host);
-		end
-		-- Update contact's roster to say subscription is cancelled...
-		rostermanager.unsubscribed(contact_username, contact_host, user_jid);
-	end
+    local user_username, user_host = jid.split(user_jid);
+    local contact_username, contact_host = jid.split(contact_jid);
+    if not hosts[user_host] then
+        warn("The host '%s' is not configured for this server.", user_host);
+        return;
+    end
+    if hosts[user_host].users.name == "null" then
+        storagemanager.initialize_host(user_host);
+        usermanager.initialize_host(user_host);
+    end
+    -- Update user's roster to say subscription is cancelled...
+    rostermanager.unsubscribe(user_username, user_host, contact_jid);
+    if hosts[contact_host] then
+        if contact_host ~= user_host and hosts[contact_host].users.name == "null" then
+            storagemanager.initialize_host(contact_host);
+            usermanager.initialize_host(contact_host);
+        end
+        -- Update contact's roster to say subscription is cancelled...
+        rostermanager.unsubscribed(contact_username, contact_host, user_jid);
+    end
 end
 
 -- Cancel any subscription in either direction.
 function unsubscribe_both(jid1, jid2)
-	unsubscribe(jid1, jid2);
-	unsubscribe(jid2, jid1);
+    unsubscribe(jid1, jid2);
+    unsubscribe(jid2, jid1);
 end
 
 -- Set the name shown and group used in the contact list
 function rename(user_jid, contact_jid, contact_nick, contact_group)
-	local user_username, user_host = jid.split(user_jid);
-	if not hosts[user_host] then
-		warn("The host '%s' is not configured for this server.", user_host);
-		return;
-	end
-	if hosts[user_host].users.name == "null" then
-		storagemanager.initialize_host(user_host);
-		usermanager.initialize_host(user_host);
-	end
+    local user_username, user_host = jid.split(user_jid);
+    if not hosts[user_host] then
+        warn("The host '%s' is not configured for this server.", user_host);
+        return;
+    end
+    if hosts[user_host].users.name == "null" then
+        storagemanager.initialize_host(user_host);
+        usermanager.initialize_host(user_host);
+    end
 
-	-- Load user's roster and find the contact
-	local roster = rostermanager.load_roster(user_username, user_host);
-	local item = roster[contact_jid];
-	if item then
-		if contact_nick then
-			item.name = contact_nick;
-		end
-		if contact_group then
-			item.groups = {}; -- Remove from all current groups
-			item.groups[contact_group] = true;
-		end
-		rostermanager.save_roster(user_username, user_host, roster);
-	end
+    -- Load user's roster and find the contact
+    local roster = rostermanager.load_roster(user_username, user_host);
+    local item = roster[contact_jid];
+    if item then
+        if contact_nick then
+            item.name = contact_nick;
+        end
+        if contact_group then
+            item.groups = {}; -- Remove from all current groups
+            item.groups[contact_group] = true;
+        end
+        rostermanager.save_roster(user_username, user_host, roster);
+    end
 end
 
 function remove(user_jid, contact_jid)
-	unsubscribe_both(user_jid, contact_jid);
-	local user_username, user_host = jid.split(user_jid);
-	local roster = rostermanager.load_roster(user_username, user_host);
-	roster[contact_jid] = nil;
-	rostermanager.save_roster(user_username, user_host, roster);
+    unsubscribe_both(user_jid, contact_jid);
+    local user_username, user_host = jid.split(user_jid);
+    local roster = rostermanager.load_roster(user_username, user_host);
+    roster[contact_jid] = nil;
+    rostermanager.save_roster(user_username, user_host, roster);
 end
 
 function module.command(arg)
-	local command = arg[1];
-	if not command then
-		warn("Valid subcommands: (un)subscribe(_both) | rename");
-		return 0;
-	end
-	table.remove(arg, 1);
-	if command == "subscribe" then
-		subscribe(arg[1], arg[2]);
-		return 0;
-	elseif command == "subscribe_both" then
-		subscribe_both(arg[1], arg[2]);
-		return 0;
-	elseif command == "unsubscribe" then
-		unsubscribe(arg[1], arg[2]);
-		return 0;
-	elseif command == "unsubscribe_both" then
-		unsubscribe_both(arg[1], arg[2]);
-		return 0;
-	elseif command == "remove" then
-		remove(arg[1], arg[2]);
-		return 0;
-	elseif command == "rename" then
-		rename(arg[1], arg[2], arg[3], arg[4]);
-		return 0;
-	else
-		warn("Unknown command: %s", command);
-		return 1;
-	end
-	return 0;
+    local command = arg[1];
+    if not command then
+        warn("Valid subcommands: (un)subscribe(_both) | rename");
+        return 0;
+    end
+    table.remove(arg, 1);
+    if command == "subscribe" then
+        subscribe(arg[1], arg[2]);
+        return 0;
+    elseif command == "subscribe_both" then
+        subscribe_both(arg[1], arg[2]);
+        return 0;
+    elseif command == "unsubscribe" then
+        unsubscribe(arg[1], arg[2]);
+        return 0;
+    elseif command == "unsubscribe_both" then
+        unsubscribe_both(arg[1], arg[2]);
+        return 0;
+    elseif command == "remove" then
+        remove(arg[1], arg[2]);
+        return 0;
+    elseif command == "rename" then
+        rename(arg[1], arg[2], arg[3], arg[4]);
+        return 0;
+    else
+        warn("Unknown command: %s", command);
+        return 1;
+    end
+    return 0;
 end

--- a/resources/prosody-plugins/mod_s2s_whitelist.lua
+++ b/resources/prosody-plugins/mod_s2s_whitelist.lua
@@ -4,17 +4,17 @@ local st = require "util.stanza";
 local whitelist = module:get_option_inherited_set("s2s_whitelist", {});
 
 module:hook("route/remote", function (event)
-	if not whitelist:contains(event.to_host) then
-		module:send(st.error_reply(event.stanza, "cancel", "not-allowed", "Communication with this domain is restricted"));
-		return true;
-	end
+    if not whitelist:contains(event.to_host) then
+        module:send(st.error_reply(event.stanza, "cancel", "not-allowed", "Communication with this domain is restricted"));
+        return true;
+    end
 end, 100);
 
 module:hook("s2s-stream-features", function (event)
-	if not whitelist:contains(event.origin.from_host) then
-		event.origin:close({
-			condition = "policy-violation";
-			text = "Communication with this domain is restricted";
-		});
-	end
+    if not whitelist:contains(event.origin.from_host) then
+        event.origin:close({
+            condition = "policy-violation";
+            text = "Communication with this domain is restricted";
+        });
+    end
 end, 1000);

--- a/resources/prosody-plugins/mod_s2soutinjection.lua
+++ b/resources/prosody-plugins/mod_s2soutinjection.lua
@@ -63,7 +63,7 @@ function proxy_listener.register_outgoing(conn, session)
 end
 
 function proxy_listener.ondisconnect(conn, err)
-	sessions[conn]  = nil;
+	sessions[conn] = nil;
 end
 
 module:hook("route/remote", function(event)

--- a/resources/prosody-plugins/mod_s2soutinjection.lua
+++ b/resources/prosody-plugins/mod_s2soutinjection.lua
@@ -19,72 +19,71 @@ local injected = module:get_option("s2s_connect_overrides");
 local proxy_listener = { default_port = nil, default_mode = "*a", default_interface = "*" };
 
 function proxy_listener.onconnect(conn)
-	local session = sessions[conn];
+    local session = sessions[conn];
 
-	-- Now the real s2s listener can take over the connection.
-	local listener = portmanager.get_service("s2s").listener;
+    -- Now the real s2s listener can take over the connection.
+    local listener = portmanager.get_service("s2s").listener;
 
-	local log = session.log;
+    local log = session.log;
 
-	local filter = initialize_filters(session);
+    local filter = initialize_filters(session);
 
-	session.version = 1;
+    session.version = 1;
 
-	session.sends2s = function (t)
-		log("debug", "sending (s2s over proxy): %s", (t.top_tag and t:top_tag()) or t:match("^[^>]*>?"));
-		if t.name then
-			t = filter("stanzas/out", t);
-		end
-		if t then
-			t = filter("bytes/out", tostring(t));
-			if t then
-				return conn:write(tostring(t));
-			end
-		end
-	end
+    session.sends2s = function (t)
+        log("debug", "sending (s2s over proxy): %s", (t.top_tag and t:top_tag()) or t:match("^[^>]*>?"));
+        if t.name then
+            t = filter("stanzas/out", t);
+        end
+        if t then
+            t = filter("bytes/out", tostring(t));
+            if t then
+                return conn:write(tostring(t));
+            end
+        end
+    end
 
-	session.open_stream = function ()
-		session.sends2s(st.stanza("stream:stream", {
-			xmlns='jabber:server', ["xmlns:db"]='jabber:server:dialback',
-			["xmlns:stream"]='http://etherx.jabber.org/streams',
-			from=session.from_host, to=session.to_host, version='1.0', ["xml:lang"]='en'}):top_tag());
-	end
+    session.open_stream = function ()
+        session.sends2s(st.stanza("stream:stream", {
+            xmlns='jabber:server', ["xmlns:db"]='jabber:server:dialback',
+            ["xmlns:stream"]='http://etherx.jabber.org/streams',
+            from=session.from_host, to=session.to_host, version='1.0', ["xml:lang"]='en'}):top_tag());
+    end
 
-	conn.setlistener(conn, listener);
+    conn.setlistener(conn, listener);
 
-	listener.register_outgoing(conn, session);
+    listener.register_outgoing(conn, session);
 
-	listener.onconnect(conn);
+    listener.onconnect(conn);
 end
 
 function proxy_listener.register_outgoing(conn, session)
-	session.direction = "outgoing";
-	sessions[conn] = session;
+    session.direction = "outgoing";
+    sessions[conn] = session;
 end
 
 function proxy_listener.ondisconnect(conn, err)
-	sessions[conn] = nil;
+    sessions[conn] = nil;
 end
 
 module:hook("route/remote", function(event)
-	local from_host, to_host, stanza = event.from_host, event.to_host, event.stanza;
-	local inject = injected and injected[to_host];
-	if not inject then return end
-	module:log("debug", "opening a new outgoing connection for this stanza");
-	local host_session = new_outgoing(from_host, to_host);
+    local from_host, to_host, stanza = event.from_host, event.to_host, event.stanza;
+    local inject = injected and injected[to_host];
+    if not inject then return end
+    module:log("debug", "opening a new outgoing connection for this stanza");
+    local host_session = new_outgoing(from_host, to_host);
 
-	-- Store in buffer
-	host_session.bounce_sendq = bounce_sendq;
-	host_session.sendq = { {tostring(stanza), stanza.attr.type ~= "error" and stanza.attr.type ~= "result" and st.reply(stanza)} };
-	host_session.log("debug", "stanza [%s] queued until connection complete", tostring(stanza.name));
+    -- Store in buffer
+    host_session.bounce_sendq = bounce_sendq;
+    host_session.sendq = { {tostring(stanza), stanza.attr.type ~= "error" and stanza.attr.type ~= "result" and st.reply(stanza)} };
+    host_session.log("debug", "stanza [%s] queued until connection complete", tostring(stanza.name));
 
-	local host, port = inject[1] or inject, tonumber(inject[2]) or 5269;
+    local host, port = inject[1] or inject, tonumber(inject[2]) or 5269;
 
-	local conn = addclient(host, port, proxy_listener, "*a");
+    local conn = addclient(host, port, proxy_listener, "*a");
 
-	proxy_listener.register_outgoing(conn, host_session);
+    proxy_listener.register_outgoing(conn, host_session);
 
-	host_session.conn = conn;
-	return true;
+    host_session.conn = conn;
+    return true;
 end, -2);
-

--- a/resources/prosody-plugins/mod_secure_interfaces.lua
+++ b/resources/prosody-plugins/mod_secure_interfaces.lua
@@ -2,19 +2,19 @@
 local secure_interfaces = module:get_option_set("secure_interfaces", { "127.0.0.1", "::1" });
 
 module:hook("stream-features", function (event)
-	local session = event.origin;
-	if session.type ~= "c2s_unauthed" then return; end
-	local socket = session.conn:socket();
-	if not socket.getsockname then
-		module:log("debug", "Unable to determine local address of incoming connection");
-		return;
-	end
-	local localip = socket:getsockname();
-	if secure_interfaces:contains(localip) then
-		module:log("debug", "Marking session from %s to %s as secure", session.ip or "[?]", localip);
-		session.secure = true;
-		session.conn.starttls = false;
-	else
-		module:log("debug", "Not marking session from %s to %s as secure", session.ip or "[?]", localip);
-	end
+    local session = event.origin;
+    if session.type ~= "c2s_unauthed" then return; end
+    local socket = session.conn:socket();
+    if not socket.getsockname then
+        module:log("debug", "Unable to determine local address of incoming connection");
+        return;
+    end
+    local localip = socket:getsockname();
+    if secure_interfaces:contains(localip) then
+        module:log("debug", "Marking session from %s to %s as secure", session.ip or "[?]", localip);
+        session.secure = true;
+        session.conn.starttls = false;
+    else
+        module:log("debug", "Not marking session from %s to %s as secure", session.ip or "[?]", localip);
+    end
 end, 2500);

--- a/resources/prosody-plugins/mod_smacks.lua
+++ b/resources/prosody-plugins/mod_smacks.lua
@@ -13,7 +13,7 @@
 
 local st = require "util.stanza";
 local dep = require "util.dependencies";
-local cache = dep.softreq("util.cache");	-- only available in prosody 0.10+
+local cache = dep.softreq("util.cache");    -- only available in prosody 0.10+
 local uuid_generate = require "util.uuid".generate;
 local jid = require "util.jid";
 
@@ -52,352 +52,352 @@ assert(max_old_sessions > 0, "smacks_max_old_sessions must be greater than 0");
 local c2s_sessions = module:shared("/*/c2s/sessions");
 
 local function init_session_cache(max_entries, evict_callback)
-	-- old prosody version < 0.10 (no limiting at all!)
-	if not cache then
-		local store = {};
-		return {
-			get = function(user, key)
-				if not user then return nil; end
-				if not key then return nil; end
-				return store[key];
-			end;
-			set = function(user, key, value)
-				if not user then return nil; end
-				if not key then return nil; end
-				store[key] = value;
-			end;
-		};
-	end
+    -- old prosody version < 0.10 (no limiting at all!)
+    if not cache then
+        local store = {};
+        return {
+            get = function(user, key)
+                if not user then return nil; end
+                if not key then return nil; end
+                return store[key];
+            end;
+            set = function(user, key, value)
+                if not user then return nil; end
+                if not key then return nil; end
+                store[key] = value;
+            end;
+        };
+    end
 
-	-- use per user limited cache for prosody >= 0.10
-	local stores = {};
-	return {
-			get = function(user, key)
-				if not user then return nil; end
-				if not key then return nil; end
-				if not stores[user] then
-					stores[user] = cache.new(max_entries, evict_callback);
-				end
-				return stores[user]:get(key);
-			end;
-			set = function(user, key, value)
-				if not user then return nil; end
-				if not key then return nil; end
-				if not stores[user] then stores[user] = cache.new(max_entries, evict_callback); end
-				stores[user]:set(key, value);
-				-- remove empty caches completely
-				if not stores[user]:count() then stores[user] = nil; end
-			end;
-		};
+    -- use per user limited cache for prosody >= 0.10
+    local stores = {};
+    return {
+            get = function(user, key)
+                if not user then return nil; end
+                if not key then return nil; end
+                if not stores[user] then
+                    stores[user] = cache.new(max_entries, evict_callback);
+                end
+                return stores[user]:get(key);
+            end;
+            set = function(user, key, value)
+                if not user then return nil; end
+                if not key then return nil; end
+                if not stores[user] then stores[user] = cache.new(max_entries, evict_callback); end
+                stores[user]:set(key, value);
+                -- remove empty caches completely
+                if not stores[user]:count() then stores[user] = nil; end
+            end;
+        };
 end
 local old_session_registry = init_session_cache(max_old_sessions, nil);
 local session_registry = init_session_cache(max_hibernated_sessions, function(resumption_token, session)
-	if session.destroyed then return true; end		-- destroyed session can always be removed from cache
-	session.log("warn", "User has too much hibernated sessions, removing oldest session (token: %s)", resumption_token);
-	-- store old session's h values on force delete
-	-- save only actual h value and username/host (for security)
-	old_session_registry.set(session.username, resumption_token, {
-		h = session.handled_stanza_count,
-		username = session.username,
-		host = session.host
-	});
-	return true;	-- allow session to be removed from full cache to make room for new one
+    if session.destroyed then return true; end        -- destroyed session can always be removed from cache
+    session.log("warn", "User has too much hibernated sessions, removing oldest session (token: %s)", resumption_token);
+    -- store old session's h values on force delete
+    -- save only actual h value and username/host (for security)
+    old_session_registry.set(session.username, resumption_token, {
+        h = session.handled_stanza_count,
+        username = session.username,
+        host = session.host
+    });
+    return true;    -- allow session to be removed from full cache to make room for new one
 end);
 
 local function stoppable_timer(delay, callback)
-	local stopped = false;
-	local timer = module:add_timer(delay, function (t)
-		if stopped then return; end
-		return callback(t);
-	end);
-	if timer and timer.stop then return timer; end		-- new prosody api includes stop() function
-	return {
-		stop = function(self) stopped = true end;
-		timer;
-	};
+    local stopped = false;
+    local timer = module:add_timer(delay, function (t)
+        if stopped then return; end
+        return callback(t);
+    end);
+    if timer and timer.stop then return timer; end        -- new prosody api includes stop() function
+    return {
+        stop = function(self) stopped = true end;
+        timer;
+    };
 end
 
 local function delayed_ack_function(session, stanza)
-	-- fire event only if configured to do so and our session is not already hibernated or destroyed
-	if delayed_ack_timeout > 0 and session.awaiting_ack
-	and not session.hibernating and not session.destroyed then
-		session.log("debug", "Firing event 'smacks-ack-delayed', queue = %d",
-			session.outgoing_stanza_queue and #session.outgoing_stanza_queue or 0);
-		module:fire_event("smacks-ack-delayed", {origin = session, queue = session.outgoing_stanza_queue, stanza = stanza});
-	end
-	session.delayed_ack_timer = nil;
+    -- fire event only if configured to do so and our session is not already hibernated or destroyed
+    if delayed_ack_timeout > 0 and session.awaiting_ack
+    and not session.hibernating and not session.destroyed then
+        session.log("debug", "Firing event 'smacks-ack-delayed', queue = %d",
+            session.outgoing_stanza_queue and #session.outgoing_stanza_queue or 0);
+        module:fire_event("smacks-ack-delayed", {origin = session, queue = session.outgoing_stanza_queue, stanza = stanza});
+    end
+    session.delayed_ack_timer = nil;
 end
 
 local function can_do_smacks(session, advertise_only)
-	if session.smacks then return false, "unexpected-request", "Stream management is already enabled"; end
+    if session.smacks then return false, "unexpected-request", "Stream management is already enabled"; end
 
-	local session_type = session.type;
-	if session.username then
-		if not(advertise_only) and not(session.resource) then -- Fail unless we're only advertising sm
-			return false, "unexpected-request", "Client must bind a resource before enabling stream management";
-		end
-		return true;
-	elseif s2s_smacks and (session_type == "s2sin" or session_type == "s2sout") then
-		return true;
-	end
-	return false, "service-unavailable", "Stream management is not available for this stream";
+    local session_type = session.type;
+    if session.username then
+        if not(advertise_only) and not(session.resource) then -- Fail unless we're only advertising sm
+            return false, "unexpected-request", "Client must bind a resource before enabling stream management";
+        end
+        return true;
+    elseif s2s_smacks and (session_type == "s2sin" or session_type == "s2sout") then
+        return true;
+    end
+    return false, "service-unavailable", "Stream management is not available for this stream";
 end
 
 module:hook("stream-features",
-		function (event)
-			if can_do_smacks(event.origin, true) then
-				event.features:tag("sm", sm2_attr):tag("optional"):up():up();
-				event.features:tag("sm", sm3_attr):tag("optional"):up():up();
-			end
-		end);
+    function (event)
+        if can_do_smacks(event.origin, true) then
+            event.features:tag("sm", sm2_attr):tag("optional"):up():up();
+            event.features:tag("sm", sm3_attr):tag("optional"):up():up();
+        end
+    end);
 
 module:hook("s2s-stream-features",
-		function (event)
-			if can_do_smacks(event.origin, true) then
-				event.features:tag("sm", sm2_attr):tag("optional"):up():up();
-				event.features:tag("sm", sm3_attr):tag("optional"):up():up();
-			end
-		end);
+    function (event)
+        if can_do_smacks(event.origin, true) then
+            event.features:tag("sm", sm2_attr):tag("optional"):up():up();
+            event.features:tag("sm", sm3_attr):tag("optional"):up():up();
+        end
+    end);
 
 local function request_ack_if_needed(session, force, reason, stanza)
-	local queue = session.outgoing_stanza_queue;
-	local expected_h = session.last_acknowledged_stanza + #queue;
-	-- session.log("debug", "*** SMACKS(1) ***: awaiting_ack=%s, hibernating=%s", tostring(session.awaiting_ack), tostring(session.hibernating));
-	if session.awaiting_ack == nil and not session.hibernating then
-		local max_unacked = max_unacked_stanzas;
-		if session.state == "inactive" then
-			max_unacked = max_inactive_unacked_stanzas;
-		end
-		-- this check of last_requested_h prevents ack-loops if missbehaving clients report wrong
-		-- stanza counts. it is set when an <r> is really sent (e.g. inside timer), preventing any
-		-- further requests until a higher h-value would be expected.
-		-- session.log("debug", "*** SMACKS(2) ***: #queue=%s, max_unacked_stanzas=%s, expected_h=%s, last_requested_h=%s", tostring(#queue), tostring(max_unacked_stanzas), tostring(expected_h), tostring(session.last_requested_h));
-		if (#queue > max_unacked and expected_h ~= session.last_requested_h) or force then
-			session.log("debug", "Queuing <r> (in a moment) from %s - #queue=%d", reason, #queue);
-			session.awaiting_ack = false;
-			session.awaiting_ack_timer = stoppable_timer(1e-06, function ()
-				-- session.log("debug", "*** SMACKS(3) ***: awaiting_ack=%s, hibernating=%s", tostring(session.awaiting_ack), tostring(session.hibernating));
-				-- only request ack if needed and our session is not already hibernated or destroyed
-				if not session.awaiting_ack and not session.hibernating and not session.destroyed then
-					session.log("debug", "Sending <r> (inside timer, before send) from %s - #queue=%d", reason, #queue);
-					(session.sends2s or session.send)(st.stanza("r", { xmlns = session.smacks }))
-					if session.destroyed then return end -- sending something can trigger destruction
-					session.awaiting_ack = true;
-					-- expected_h could be lower than this expression e.g. more stanzas added to the queue meanwhile)
-					session.last_requested_h = session.last_acknowledged_stanza + #queue;
-					session.log("debug", "Sending <r> (inside timer, after send) from %s - #queue=%d", reason, #queue);
-					if not session.delayed_ack_timer then
-						session.delayed_ack_timer = stoppable_timer(delayed_ack_timeout, function()
-							delayed_ack_function(session, nil);		-- we don't know if this is the only new stanza in the queue
-						end);
-					end
-				end
-			end);
-		end
-	end
+    local queue = session.outgoing_stanza_queue;
+    local expected_h = session.last_acknowledged_stanza + #queue;
+    -- session.log("debug", "*** SMACKS(1) ***: awaiting_ack=%s, hibernating=%s", tostring(session.awaiting_ack), tostring(session.hibernating));
+    if session.awaiting_ack == nil and not session.hibernating then
+        local max_unacked = max_unacked_stanzas;
+        if session.state == "inactive" then
+            max_unacked = max_inactive_unacked_stanzas;
+        end
+        -- this check of last_requested_h prevents ack-loops if missbehaving clients report wrong
+        -- stanza counts. it is set when an <r> is really sent (e.g. inside timer), preventing any
+        -- further requests until a higher h-value would be expected.
+        -- session.log("debug", "*** SMACKS(2) ***: #queue=%s, max_unacked_stanzas=%s, expected_h=%s, last_requested_h=%s", tostring(#queue), tostring(max_unacked_stanzas), tostring(expected_h), tostring(session.last_requested_h));
+        if (#queue > max_unacked and expected_h ~= session.last_requested_h) or force then
+            session.log("debug", "Queuing <r> (in a moment) from %s - #queue=%d", reason, #queue);
+            session.awaiting_ack = false;
+            session.awaiting_ack_timer = stoppable_timer(1e-06, function ()
+                -- session.log("debug", "*** SMACKS(3) ***: awaiting_ack=%s, hibernating=%s", tostring(session.awaiting_ack), tostring(session.hibernating));
+                -- only request ack if needed and our session is not already hibernated or destroyed
+                if not session.awaiting_ack and not session.hibernating and not session.destroyed then
+                    session.log("debug", "Sending <r> (inside timer, before send) from %s - #queue=%d", reason, #queue);
+                    (session.sends2s or session.send)(st.stanza("r", { xmlns = session.smacks }))
+                    if session.destroyed then return end -- sending something can trigger destruction
+                    session.awaiting_ack = true;
+                    -- expected_h could be lower than this expression e.g. more stanzas added to the queue meanwhile)
+                    session.last_requested_h = session.last_acknowledged_stanza + #queue;
+                    session.log("debug", "Sending <r> (inside timer, after send) from %s - #queue=%d", reason, #queue);
+                    if not session.delayed_ack_timer then
+                        session.delayed_ack_timer = stoppable_timer(delayed_ack_timeout, function()
+                            delayed_ack_function(session, nil);        -- we don't know if this is the only new stanza in the queue
+                        end);
+                    end
+                end
+            end);
+        end
+    end
 
-	-- Trigger "smacks-ack-delayed"-event if we added new (ackable) stanzas to the outgoing queue
-	-- and there isn't already a timer for this event running.
-	-- If we wouldn't do this, stanzas added to the queue after the first "smacks-ack-delayed"-event
-	-- would not trigger this event (again).
-	if #queue > max_unacked_stanzas and session.awaiting_ack and session.delayed_ack_timer == nil then
-		session.log("debug", "Calling delayed_ack_function directly (still waiting for ack)");
-		delayed_ack_function(session, stanza);		-- this is the only new stanza in the queue --> provide it to other modules
-	end
+    -- Trigger "smacks-ack-delayed"-event if we added new (ackable) stanzas to the outgoing queue
+    -- and there isn't already a timer for this event running.
+    -- If we wouldn't do this, stanzas added to the queue after the first "smacks-ack-delayed"-event
+    -- would not trigger this event (again).
+    if #queue > max_unacked_stanzas and session.awaiting_ack and session.delayed_ack_timer == nil then
+        session.log("debug", "Calling delayed_ack_function directly (still waiting for ack)");
+        delayed_ack_function(session, stanza);        -- this is the only new stanza in the queue --> provide it to other modules
+    end
 end
 
 local function outgoing_stanza_filter(stanza, session)
-	-- XXX: Normally you wouldn't have to check the xmlns for a stanza as it's
-	-- supposed to be nil.
-	-- However, when using mod_smacks with mod_websocket, then mod_websocket's
-	-- stanzas/out filter can get called before this one and adds the xmlns.
-	local is_stanza = stanza.attr and
-		(not stanza.attr.xmlns or stanza.attr.xmlns == 'jabber:client')
-		and not stanza.name:find":";
+    -- XXX: Normally you wouldn't have to check the xmlns for a stanza as it's
+    -- supposed to be nil.
+    -- However, when using mod_smacks with mod_websocket, then mod_websocket's
+    -- stanzas/out filter can get called before this one and adds the xmlns.
+    local is_stanza = stanza.attr and
+        (not stanza.attr.xmlns or stanza.attr.xmlns == 'jabber:client')
+        and not stanza.name:find":";
 
-	if is_stanza and not stanza._cached then
-		local queue = session.outgoing_stanza_queue;
-		local cached_stanza = st.clone(stanza);
-		cached_stanza._cached = true;
+    if is_stanza and not stanza._cached then
+        local queue = session.outgoing_stanza_queue;
+        local cached_stanza = st.clone(stanza);
+        cached_stanza._cached = true;
 
-		if cached_stanza and cached_stanza.name ~= "iq" and cached_stanza:get_child("delay", xmlns_delay) == nil then
-			cached_stanza = cached_stanza:tag("delay", {
-				xmlns = xmlns_delay,
-				from = jid.bare(session.full_jid or session.host),
-				stamp = datetime.datetime()
-			});
-		end
+        if cached_stanza and cached_stanza.name ~= "iq" and cached_stanza:get_child("delay", xmlns_delay) == nil then
+            cached_stanza = cached_stanza:tag("delay", {
+                xmlns = xmlns_delay,
+                from = jid.bare(session.full_jid or session.host),
+                stamp = datetime.datetime()
+            });
+        end
 
-		queue[#queue+1] = cached_stanza;
-		if session.hibernating then
-			session.log("debug", "hibernating since %s, stanza queued", datetime.datetime(session.hibernating));
-			module:fire_event("smacks-hibernation-stanza-queued", {origin = session, queue = queue, stanza = cached_stanza});
-			return nil;
-		end
-		request_ack_if_needed(session, false, "outgoing_stanza_filter", stanza);
-	end
-	return stanza;
+        queue[#queue+1] = cached_stanza;
+        if session.hibernating then
+            session.log("debug", "hibernating since %s, stanza queued", datetime.datetime(session.hibernating));
+            module:fire_event("smacks-hibernation-stanza-queued", {origin = session, queue = queue, stanza = cached_stanza});
+            return nil;
+        end
+        request_ack_if_needed(session, false, "outgoing_stanza_filter", stanza);
+    end
+    return stanza;
 end
 
 local function count_incoming_stanzas(stanza, session)
-	if not stanza.attr.xmlns then
-		session.handled_stanza_count = session.handled_stanza_count + 1;
-		session.log("debug", "Handled %d incoming stanzas", session.handled_stanza_count);
-	end
-	return stanza;
+    if not stanza.attr.xmlns then
+        session.handled_stanza_count = session.handled_stanza_count + 1;
+        session.log("debug", "Handled %d incoming stanzas", session.handled_stanza_count);
+    end
+    return stanza;
 end
 
 local function wrap_session_out(session, resume)
-	if not resume then
-		session.outgoing_stanza_queue = {};
-		session.last_acknowledged_stanza = 0;
-	end
+    if not resume then
+        session.outgoing_stanza_queue = {};
+        session.last_acknowledged_stanza = 0;
+    end
 
-	add_filter(session, "stanzas/out", outgoing_stanza_filter, -999);
+    add_filter(session, "stanzas/out", outgoing_stanza_filter, -999);
 
-	local session_close = session.close;
-	function session.close(...)
-		if session.resumption_token then
-			session_registry.set(session.username, session.resumption_token, nil);
-			old_session_registry.set(session.username, session.resumption_token, nil);
-			session.resumption_token = nil;
-		end
-		-- send out last ack as per revision 1.5.2 of XEP-0198
-		if session.smacks and session.conn then
-			(session.sends2s or session.send)(st.stanza("a", { xmlns = session.smacks, h = string.format("%d", session.handled_stanza_count) }));
-		end
-		return session_close(...);
-	end
-	return session;
+    local session_close = session.close;
+    function session.close(...)
+        if session.resumption_token then
+            session_registry.set(session.username, session.resumption_token, nil);
+            old_session_registry.set(session.username, session.resumption_token, nil);
+            session.resumption_token = nil;
+        end
+        -- send out last ack as per revision 1.5.2 of XEP-0198
+        if session.smacks and session.conn then
+            (session.sends2s or session.send)(st.stanza("a", { xmlns = session.smacks, h = string.format("%d", session.handled_stanza_count) }));
+        end
+        return session_close(...);
+    end
+    return session;
 end
 
 local function wrap_session_in(session, resume)
-	if not resume then
-		session.handled_stanza_count = 0;
-	end
-	add_filter(session, "stanzas/in", count_incoming_stanzas, 999);
+    if not resume then
+        session.handled_stanza_count = 0;
+    end
+    add_filter(session, "stanzas/in", count_incoming_stanzas, 999);
 
-	return session;
+    return session;
 end
 
 local function wrap_session(session, resume)
-	wrap_session_out(session, resume);
-	wrap_session_in(session, resume);
-	return session;
+    wrap_session_out(session, resume);
+    wrap_session_in(session, resume);
+    return session;
 end
 
 function handle_enable(session, stanza, xmlns_sm)
-	local ok, err, err_text = can_do_smacks(session);
-	if not ok then
-		session.log("warn", "Failed to enable smacks: %s", err_text); -- TODO: XEP doesn't say we can send error text, should it?
-		(session.sends2s or session.send)(st.stanza("failed", { xmlns = xmlns_sm }):tag(err, { xmlns = xmlns_errors}));
-		return true;
-	end
+    local ok, err, err_text = can_do_smacks(session);
+    if not ok then
+        session.log("warn", "Failed to enable smacks: %s", err_text); -- TODO: XEP doesn't say we can send error text, should it?
+        (session.sends2s or session.send)(st.stanza("failed", { xmlns = xmlns_sm }):tag(err, { xmlns = xmlns_errors}));
+        return true;
+    end
 
-	module:log("debug", "Enabling stream management");
-	session.smacks = xmlns_sm;
+    module:log("debug", "Enabling stream management");
+    session.smacks = xmlns_sm;
 
-	wrap_session(session, false);
+    wrap_session(session, false);
 
-	local resume_token;
-	local resume = stanza.attr.resume;
-	if resume == "true" or resume == "1" then
-		resume_token = uuid_generate();
-		session_registry.set(session.username, resume_token, session);
-		session.resumption_token = resume_token;
-	end
-	(session.sends2s or session.send)(st.stanza("enabled", { xmlns = xmlns_sm, id = resume_token, resume = resume, max = tostring(resume_timeout) }));
-	return true;
+    local resume_token;
+    local resume = stanza.attr.resume;
+    if resume == "true" or resume == "1" then
+        resume_token = uuid_generate();
+        session_registry.set(session.username, resume_token, session);
+        session.resumption_token = resume_token;
+    end
+    (session.sends2s or session.send)(st.stanza("enabled", { xmlns = xmlns_sm, id = resume_token, resume = resume, max = tostring(resume_timeout) }));
+    return true;
 end
 module:hook_stanza(xmlns_sm2, "enable", function (session, stanza) return handle_enable(session, stanza, xmlns_sm2); end, 100);
 module:hook_stanza(xmlns_sm3, "enable", function (session, stanza) return handle_enable(session, stanza, xmlns_sm3); end, 100);
 
 module:hook_stanza("http://etherx.jabber.org/streams", "features",
-		function (session, stanza)
-			stoppable_timer(1e-6, function ()
-				if can_do_smacks(session) then
-					if stanza:get_child("sm", xmlns_sm3) then
-						session.sends2s(st.stanza("enable", sm3_attr));
-						session.smacks = xmlns_sm3;
-					elseif stanza:get_child("sm", xmlns_sm2) then
-						session.sends2s(st.stanza("enable", sm2_attr));
-						session.smacks = xmlns_sm2;
-					else
-						return;
-					end
-					wrap_session_out(session, false);
-				end
-			end);
-		end);
+    function (session, stanza)
+        stoppable_timer(1e-6, function ()
+            if can_do_smacks(session) then
+                if stanza:get_child("sm", xmlns_sm3) then
+                    session.sends2s(st.stanza("enable", sm3_attr));
+                    session.smacks = xmlns_sm3;
+                elseif stanza:get_child("sm", xmlns_sm2) then
+                    session.sends2s(st.stanza("enable", sm2_attr));
+                    session.smacks = xmlns_sm2;
+                else
+                    return;
+                end
+                wrap_session_out(session, false);
+            end
+        end);
+    end);
 
 function handle_enabled(session, stanza, xmlns_sm)
-	module:log("debug", "Enabling stream management");
-	session.smacks = xmlns_sm;
+    module:log("debug", "Enabling stream management");
+    session.smacks = xmlns_sm;
 
-	wrap_session_in(session, false);
+    wrap_session_in(session, false);
 
-	-- FIXME Resume?
+    -- FIXME Resume?
 
-	return true;
+    return true;
 end
 module:hook_stanza(xmlns_sm2, "enabled", function (session, stanza) return handle_enabled(session, stanza, xmlns_sm2); end, 100);
 module:hook_stanza(xmlns_sm3, "enabled", function (session, stanza) return handle_enabled(session, stanza, xmlns_sm3); end, 100);
 
 function handle_r(origin, stanza, xmlns_sm)
-	if not origin.smacks then
-		module:log("debug", "Received ack request from non-smack-enabled session");
-		return;
-	end
-	module:log("debug", "Received ack request, acking for %d", origin.handled_stanza_count);
-	-- Reply with <a>
-	(origin.sends2s or origin.send)(st.stanza("a", { xmlns = xmlns_sm, h = string.format("%d", origin.handled_stanza_count) }));
-	-- piggyback our own ack request if needed (see request_ack_if_needed() for explanation of last_requested_h)
-	local expected_h = origin.last_acknowledged_stanza + #origin.outgoing_stanza_queue;
-	if #origin.outgoing_stanza_queue > 0 and expected_h ~= origin.last_requested_h then
-		request_ack_if_needed(origin, true, "piggybacked by handle_r", nil);
-	end
-	return true;
+    if not origin.smacks then
+        module:log("debug", "Received ack request from non-smack-enabled session");
+        return;
+    end
+    module:log("debug", "Received ack request, acking for %d", origin.handled_stanza_count);
+    -- Reply with <a>
+    (origin.sends2s or origin.send)(st.stanza("a", { xmlns = xmlns_sm, h = string.format("%d", origin.handled_stanza_count) }));
+    -- piggyback our own ack request if needed (see request_ack_if_needed() for explanation of last_requested_h)
+    local expected_h = origin.last_acknowledged_stanza + #origin.outgoing_stanza_queue;
+    if #origin.outgoing_stanza_queue > 0 and expected_h ~= origin.last_requested_h then
+        request_ack_if_needed(origin, true, "piggybacked by handle_r", nil);
+    end
+    return true;
 end
 module:hook_stanza(xmlns_sm2, "r", function (origin, stanza) return handle_r(origin, stanza, xmlns_sm2); end);
 module:hook_stanza(xmlns_sm3, "r", function (origin, stanza) return handle_r(origin, stanza, xmlns_sm3); end);
 
 function handle_a(origin, stanza)
-	if not origin.smacks then return; end
-	origin.awaiting_ack = nil;
-	if origin.awaiting_ack_timer then
-		origin.awaiting_ack_timer:stop();
-	end
-	if origin.delayed_ack_timer then
-		origin.delayed_ack_timer:stop();
-		origin.delayed_ack_timer = nil;
-	end
-	-- Remove handled stanzas from outgoing_stanza_queue
-	-- origin.log("debug", "ACK: h=%s, last=%s", stanza.attr.h or "", origin.last_acknowledged_stanza or "");
-	local h = tonumber(stanza.attr.h);
-	if not h then
-		origin:close{ condition = "invalid-xml"; text = "Missing or invalid 'h' attribute"; };
-		return;
-	end
-	local handled_stanza_count = h-origin.last_acknowledged_stanza;
-	local queue = origin.outgoing_stanza_queue;
-	if handled_stanza_count > #queue then
-		origin.log("warn", "The client says it handled %d new stanzas, but we only sent %d :)",
-			handled_stanza_count, #queue);
-		origin.log("debug", "Client h: %d, our h: %d", tonumber(stanza.attr.h), origin.last_acknowledged_stanza);
-		for i=1,#queue do
-			origin.log("debug", "Q item %d: %s", i, tostring(queue[i]));
-		end
-	end
+    if not origin.smacks then return; end
+    origin.awaiting_ack = nil;
+    if origin.awaiting_ack_timer then
+        origin.awaiting_ack_timer:stop();
+    end
+    if origin.delayed_ack_timer then
+        origin.delayed_ack_timer:stop();
+        origin.delayed_ack_timer = nil;
+    end
+    -- Remove handled stanzas from outgoing_stanza_queue
+    -- origin.log("debug", "ACK: h=%s, last=%s", stanza.attr.h or "", origin.last_acknowledged_stanza or "");
+    local h = tonumber(stanza.attr.h);
+    if not h then
+        origin:close{ condition = "invalid-xml"; text = "Missing or invalid 'h' attribute"; };
+        return;
+    end
+    local handled_stanza_count = h-origin.last_acknowledged_stanza;
+    local queue = origin.outgoing_stanza_queue;
+    if handled_stanza_count > #queue then
+        origin.log("warn", "The client says it handled %d new stanzas, but we only sent %d :)",
+            handled_stanza_count, #queue);
+        origin.log("debug", "Client h: %d, our h: %d", tonumber(stanza.attr.h), origin.last_acknowledged_stanza);
+        for i=1,#queue do
+            origin.log("debug", "Q item %d: %s", i, tostring(queue[i]));
+        end
+    end
 
-	for i=1,math_min(handled_stanza_count,#queue) do
-		local handled_stanza = t_remove(origin.outgoing_stanza_queue, 1);
-		module:fire_event("delivery/success", { session = origin, stanza = handled_stanza });
-	end
+    for i=1,math_min(handled_stanza_count,#queue) do
+        local handled_stanza = t_remove(origin.outgoing_stanza_queue, 1);
+        module:fire_event("delivery/success", { session = origin, stanza = handled_stanza });
+    end
 
-	origin.log("debug", "#queue = %d", #queue);
-	origin.last_acknowledged_stanza = origin.last_acknowledged_stanza + handled_stanza_count;
-	request_ack_if_needed(origin, false, "handle_a", nil)
-	return true;
+    origin.log("debug", "#queue = %d", #queue);
+    origin.last_acknowledged_stanza = origin.last_acknowledged_stanza + handled_stanza_count;
+    request_ack_if_needed(origin, false, "handle_a", nil)
+    return true;
 end
 module:hook_stanza(xmlns_sm2, "a", handle_a);
 module:hook_stanza(xmlns_sm3, "a", handle_a);
@@ -408,275 +408,275 @@ module:hook_stanza(xmlns_sm3, "a", handle_a);
 -- on stanzas
 
 local function handle_unacked_stanzas(session)
-	local queue = session.outgoing_stanza_queue;
-	local error_attr = { type = "cancel" };
-	if #queue > 0 then
-		session.outgoing_stanza_queue = {};
-		for i=1,#queue do
-			if not module:fire_event("delivery/failure", { session = session, stanza = queue[i] }) then
-				if queue[i].attr.type ~= "error" then
-					local reply = st.reply(queue[i]);
-					if reply.attr.to ~= session.full_jid then
-						reply.attr.type = "error";
-						reply:tag("error", error_attr)
-							:tag("recipient-unavailable", {xmlns = "urn:ietf:params:xml:ns:xmpp-stanzas"});
-						core_process_stanza(session, reply);
-					end
-				end
-			end
-		end
-	end
+    local queue = session.outgoing_stanza_queue;
+    local error_attr = { type = "cancel" };
+    if #queue > 0 then
+        session.outgoing_stanza_queue = {};
+        for i=1,#queue do
+            if not module:fire_event("delivery/failure", { session = session, stanza = queue[i] }) then
+                if queue[i].attr.type ~= "error" then
+                    local reply = st.reply(queue[i]);
+                    if reply.attr.to ~= session.full_jid then
+                        reply.attr.type = "error";
+                        reply:tag("error", error_attr)
+                            :tag("recipient-unavailable", {xmlns = "urn:ietf:params:xml:ns:xmpp-stanzas"});
+                        core_process_stanza(session, reply);
+                    end
+                end
+            end
+        end
+    end
 end
 
 -- don't send delivery errors for messages which will be delivered by mam later on
 -- check if stanza was archived --> this will allow us to send back errors for stanzas not archived
 -- because the user configured the server to do so ("no-archive"-setting for one special contact for example)
 local function get_stanza_id(stanza, by_jid)
-	for tag in stanza:childtags("stanza-id", "urn:xmpp:sid:0") do
-		if tag.attr.by == by_jid then
-			return tag.attr.id;
-		end
-	end
-	return nil;
+    for tag in stanza:childtags("stanza-id", "urn:xmpp:sid:0") do
+        if tag.attr.by == by_jid then
+            return tag.attr.id;
+        end
+    end
+    return nil;
 end
 module:hook("delivery/failure", function(event)
-	local session, stanza = event.session, event.stanza;
-	-- Only deal with authenticated (c2s) sessions
-	if session.username then
-		if stanza.name == "message" and stanza.attr.xmlns == nil and
-				( stanza.attr.type == "chat" or ( stanza.attr.type or "normal" ) == "normal" ) then
-			-- don't store messages in offline store if they are mam results
-			local mam_result = stanza:get_child("result", xmlns_mam2);
-			if mam_result ~= nil then
-				return true;		-- stanza already "handled", don't send an error and don't add it to offline storage
-			end
-			-- do nothing here for normal messages and don't send out "message delivery errors",
-			-- because messages are already in MAM at this point (no need to frighten users)
-			local stanza_id = get_stanza_id(stanza, jid.bare(session.full_jid));
-			if session.mam_requested and stanza_id ~= nil then
-				session.log("debug", "mod_smacks delivery/failure returning true for mam-handled stanza: mam-archive-id=%s", tostring(stanza_id));
-				return true;		-- stanza handled, don't send an error
-			end
-			-- store message in offline store, if this client does not use mam *and* was the last client online
-			local sessions = prosody.hosts[module.host].sessions[session.username] and
-					prosody.hosts[module.host].sessions[session.username].sessions or nil;
-			if sessions and next(sessions) == session.resource and next(sessions, session.resource) == nil then
-				local ok = module:fire_event("message/offline/handle", { origin = session, stanza = stanza } );
-				session.log("debug", "mod_smacks delivery/failuere returning %s for offline-handled stanza", tostring(ok));
-				return ok;			-- if stanza was handled, don't send an error
-			end
-		end
-	end
+    local session, stanza = event.session, event.stanza;
+    -- Only deal with authenticated (c2s) sessions
+    if session.username then
+        if stanza.name == "message" and stanza.attr.xmlns == nil and
+                ( stanza.attr.type == "chat" or ( stanza.attr.type or "normal" ) == "normal" ) then
+            -- don't store messages in offline store if they are mam results
+            local mam_result = stanza:get_child("result", xmlns_mam2);
+            if mam_result ~= nil then
+                return true;        -- stanza already "handled", don't send an error and don't add it to offline storage
+            end
+            -- do nothing here for normal messages and don't send out "message delivery errors",
+            -- because messages are already in MAM at this point (no need to frighten users)
+            local stanza_id = get_stanza_id(stanza, jid.bare(session.full_jid));
+            if session.mam_requested and stanza_id ~= nil then
+                session.log("debug", "mod_smacks delivery/failure returning true for mam-handled stanza: mam-archive-id=%s", tostring(stanza_id));
+                return true;        -- stanza handled, don't send an error
+            end
+            -- store message in offline store, if this client does not use mam *and* was the last client online
+            local sessions = prosody.hosts[module.host].sessions[session.username] and
+                prosody.hosts[module.host].sessions[session.username].sessions or nil;
+            if sessions and next(sessions) == session.resource and next(sessions, session.resource) == nil then
+                local ok = module:fire_event("message/offline/handle", { origin = session, stanza = stanza } );
+                session.log("debug", "mod_smacks delivery/failuere returning %s for offline-handled stanza", tostring(ok));
+                return ok;            -- if stanza was handled, don't send an error
+            end
+        end
+    end
 end);
 
 module:hook("pre-resource-unbind", function (event)
-	local session, err = event.session, event.error;
-	if session.smacks then
-		if not session.resumption_token then
-			local queue = session.outgoing_stanza_queue;
-			if #queue > 0 then
-				session.log("debug", "Destroying session with %d unacked stanzas", #queue);
-				handle_unacked_stanzas(session);
-			end
-		else
-			session.log("debug", "mod_smacks hibernating session for up to %d seconds", resume_timeout);
-			local hibernate_time = os_time(); -- Track the time we went into hibernation
-			session.hibernating = hibernate_time;
-			local resumption_token = session.resumption_token;
-			module:fire_event("smacks-hibernation-start", {origin = session, queue = session.outgoing_stanza_queue});
-			timer.add_task(resume_timeout, function ()
-				session.log("debug", "mod_smacks hibernation timeout reached...");
-				-- We need to check the current resumption token for this resource
-				-- matches the smacks session this timer is for in case it changed
-				-- (for example, the client may have bound a new resource and
-				-- started a new smacks session, or not be using smacks)
-				local curr_session = full_sessions[session.full_jid];
-				if session.destroyed then
-					session.log("debug", "The session has already been destroyed");
-				elseif curr_session and curr_session.resumption_token == resumption_token
-				-- Check the hibernate time still matches what we think it is,
-				-- otherwise the session resumed and re-hibernated.
-				and session.hibernating == hibernate_time then
-					-- wait longer if the timeout isn't reached because push was enabled for this session
-					-- session.first_hibernated_push is the starting point for hibernation timeouts of those push enabled clients
-					-- wait for an additional resume_timeout seconds if no push occurred since hibernation at all
-					local current_time = os_time();
-					local timeout_start = math_max(session.hibernating, session.first_hibernated_push or session.hibernating);
-					if session.push_identifier ~= nil and not session.first_hibernated_push then
-						session.log("debug", "No push happened since hibernation started, hibernating session for up to %d extra seconds", resume_timeout);
-						return resume_timeout;
-					end
-					if session.push_identifier ~= nil and current_time-timeout_start < resume_timeout then
-						session.log("debug", "A push happened since hibernation started, hibernating session for up to %d extra seconds", resume_timeout-(current_time-timeout_start));
-						return resume_timeout-(current_time-timeout_start);		-- time left to wait
-					end
-					session.log("debug", "Destroying session for hibernating too long");
-					session_registry.set(session.username, session.resumption_token, nil);
-					-- save only actual h value and username/host (for security)
-					old_session_registry.set(session.username, session.resumption_token, {
-						h = session.handled_stanza_count,
-						username = session.username,
-						host = session.host
-					});
-					session.resumption_token = nil;
-					sessionmanager.destroy_session(session);
-				else
-					session.log("debug", "Session resumed before hibernation timeout, all is well")
-				end
-			end);
-			return true; -- Postpone destruction for now
-		end
-	end
+    local session, err = event.session, event.error;
+    if session.smacks then
+        if not session.resumption_token then
+            local queue = session.outgoing_stanza_queue;
+            if #queue > 0 then
+                session.log("debug", "Destroying session with %d unacked stanzas", #queue);
+                handle_unacked_stanzas(session);
+            end
+        else
+            session.log("debug", "mod_smacks hibernating session for up to %d seconds", resume_timeout);
+            local hibernate_time = os_time(); -- Track the time we went into hibernation
+            session.hibernating = hibernate_time;
+            local resumption_token = session.resumption_token;
+            module:fire_event("smacks-hibernation-start", {origin = session, queue = session.outgoing_stanza_queue});
+            timer.add_task(resume_timeout, function ()
+                session.log("debug", "mod_smacks hibernation timeout reached...");
+                -- We need to check the current resumption token for this resource
+                -- matches the smacks session this timer is for in case it changed
+                -- (for example, the client may have bound a new resource and
+                -- started a new smacks session, or not be using smacks)
+                local curr_session = full_sessions[session.full_jid];
+                if session.destroyed then
+                    session.log("debug", "The session has already been destroyed");
+                elseif curr_session and curr_session.resumption_token == resumption_token
+                -- Check the hibernate time still matches what we think it is,
+                -- otherwise the session resumed and re-hibernated.
+                and session.hibernating == hibernate_time then
+                    -- wait longer if the timeout isn't reached because push was enabled for this session
+                    -- session.first_hibernated_push is the starting point for hibernation timeouts of those push enabled clients
+                    -- wait for an additional resume_timeout seconds if no push occurred since hibernation at all
+                    local current_time = os_time();
+                    local timeout_start = math_max(session.hibernating, session.first_hibernated_push or session.hibernating);
+                    if session.push_identifier ~= nil and not session.first_hibernated_push then
+                        session.log("debug", "No push happened since hibernation started, hibernating session for up to %d extra seconds", resume_timeout);
+                        return resume_timeout;
+                    end
+                    if session.push_identifier ~= nil and current_time-timeout_start < resume_timeout then
+                        session.log("debug", "A push happened since hibernation started, hibernating session for up to %d extra seconds", resume_timeout-(current_time-timeout_start));
+                        return resume_timeout-(current_time-timeout_start);        -- time left to wait
+                    end
+                    session.log("debug", "Destroying session for hibernating too long");
+                    session_registry.set(session.username, session.resumption_token, nil);
+                    -- save only actual h value and username/host (for security)
+                    old_session_registry.set(session.username, session.resumption_token, {
+                        h = session.handled_stanza_count,
+                        username = session.username,
+                        host = session.host
+                    });
+                    session.resumption_token = nil;
+                    sessionmanager.destroy_session(session);
+                else
+                    session.log("debug", "Session resumed before hibernation timeout, all is well")
+                end
+            end);
+            return true; -- Postpone destruction for now
+        end
+    end
 end);
 
 local function handle_s2s_destroyed(event)
-	local session = event.session;
-	local queue = session.outgoing_stanza_queue;
-	if queue and #queue > 0 then
-		session.log("warn", "Destroying session with %d unacked stanzas", #queue);
-		if s2s_resend then
-			for i = 1, #queue do
-				module:send(queue[i]);
-			end
-			session.outgoing_stanza_queue = nil;
-		else
-			handle_unacked_stanzas(session);
-		end
-	end
+    local session = event.session;
+    local queue = session.outgoing_stanza_queue;
+    if queue and #queue > 0 then
+        session.log("warn", "Destroying session with %d unacked stanzas", #queue);
+        if s2s_resend then
+            for i = 1, #queue do
+                module:send(queue[i]);
+            end
+            session.outgoing_stanza_queue = nil;
+        else
+            handle_unacked_stanzas(session);
+        end
+    end
 end
 
 module:hook("s2sout-destroyed", handle_s2s_destroyed);
 module:hook("s2sin-destroyed", handle_s2s_destroyed);
 
 local function get_session_id(session)
-	return session.id or (tostring(session):match("[a-f0-9]+$"));
+    return session.id or (tostring(session):match("[a-f0-9]+$"));
 end
 
 function handle_resume(session, stanza, xmlns_sm)
-	if session.full_jid then
-		session.log("warn", "Tried to resume after resource binding");
-		session.send(st.stanza("failed", { xmlns = xmlns_sm })
-			:tag("unexpected-request", { xmlns = xmlns_errors })
-		);
-		return true;
-	end
+    if session.full_jid then
+        session.log("warn", "Tried to resume after resource binding");
+        session.send(st.stanza("failed", { xmlns = xmlns_sm })
+            :tag("unexpected-request", { xmlns = xmlns_errors })
+        );
+        return true;
+    end
 
-	local id = stanza.attr.previd;
-	local original_session = session_registry.get(session.username, id);
-	if not original_session then
-		session.log("debug", "Tried to resume non-existent session with id %s", id);
-		local old_session = old_session_registry.get(session.username, id);
-		if old_session and session.username == old_session.username
-		and session.host == old_session.host
-		and old_session.h then
-			session.send(st.stanza("failed", { xmlns = xmlns_sm, h = string.format("%d", old_session.h) })
-				:tag("item-not-found", { xmlns = xmlns_errors })
-			);
-		else
-			session.send(st.stanza("failed", { xmlns = xmlns_sm })
-				:tag("item-not-found", { xmlns = xmlns_errors })
-			);
-		end;
-	elseif session.username == original_session.username
-	and session.host == original_session.host then
-		session.log("debug", "mod_smacks resuming existing session %s...", get_session_id(original_session));
-		original_session.log("debug", "mod_smacks session resumed from %s...", get_session_id(session));
-		-- TODO: All this should move to sessionmanager (e.g. session:replace(new_session))
-		if original_session.conn then
-			original_session.log("debug", "mod_smacks closing an old connection for this session");
-			local conn = original_session.conn;
-			c2s_sessions[conn] = nil;
-			conn:close();
-		end
-		local migrated_session_log = session.log;
-		original_session.ip = session.ip;
-		original_session.conn = session.conn;
-		original_session.send = session.send;
-		original_session.close = session.close;
-		original_session.filter = session.filter;
-		original_session.filter.session = original_session;
-		original_session.filters = session.filters;
-		original_session.stream = session.stream;
-		original_session.secure = session.secure;
-		original_session.hibernating = nil;
-		session.log = original_session.log;
-		session.type = original_session.type;
-		wrap_session(original_session, true);
-		-- Inform xmppstream of the new session (passed to its callbacks)
-		original_session.stream:set_session(original_session);
-		-- Similar for connlisteners
-		c2s_sessions[session.conn] = original_session;
+    local id = stanza.attr.previd;
+    local original_session = session_registry.get(session.username, id);
+    if not original_session then
+        session.log("debug", "Tried to resume non-existent session with id %s", id);
+        local old_session = old_session_registry.get(session.username, id);
+        if old_session and session.username == old_session.username
+        and session.host == old_session.host
+        and old_session.h then
+            session.send(st.stanza("failed", { xmlns = xmlns_sm, h = string.format("%d", old_session.h) })
+                :tag("item-not-found", { xmlns = xmlns_errors })
+            );
+        else
+            session.send(st.stanza("failed", { xmlns = xmlns_sm })
+                :tag("item-not-found", { xmlns = xmlns_errors })
+            );
+        end;
+    elseif session.username == original_session.username
+    and session.host == original_session.host then
+        session.log("debug", "mod_smacks resuming existing session %s...", get_session_id(original_session));
+        original_session.log("debug", "mod_smacks session resumed from %s...", get_session_id(session));
+        -- TODO: All this should move to sessionmanager (e.g. session:replace(new_session))
+        if original_session.conn then
+            original_session.log("debug", "mod_smacks closing an old connection for this session");
+            local conn = original_session.conn;
+            c2s_sessions[conn] = nil;
+            conn:close();
+        end
+        local migrated_session_log = session.log;
+        original_session.ip = session.ip;
+        original_session.conn = session.conn;
+        original_session.send = session.send;
+        original_session.close = session.close;
+        original_session.filter = session.filter;
+        original_session.filter.session = original_session;
+        original_session.filters = session.filters;
+        original_session.stream = session.stream;
+        original_session.secure = session.secure;
+        original_session.hibernating = nil;
+        session.log = original_session.log;
+        session.type = original_session.type;
+        wrap_session(original_session, true);
+        -- Inform xmppstream of the new session (passed to its callbacks)
+        original_session.stream:set_session(original_session);
+        -- Similar for connlisteners
+        c2s_sessions[session.conn] = original_session;
 
-		original_session.send(st.stanza("resumed", { xmlns = xmlns_sm,
-			h = string.format("%d", original_session.handled_stanza_count), previd = id }));
+        original_session.send(st.stanza("resumed", { xmlns = xmlns_sm,
+            h = string.format("%d", original_session.handled_stanza_count), previd = id }));
 
-		-- Fake an <a> with the h of the <resume/> from the client
-		original_session:dispatch_stanza(st.stanza("a", { xmlns = xmlns_sm,
-			h = stanza.attr.h }));
+        -- Fake an <a> with the h of the <resume/> from the client
+        original_session:dispatch_stanza(st.stanza("a", { xmlns = xmlns_sm,
+            h = stanza.attr.h }));
 
-		-- Ok, we need to re-send any stanzas that the client didn't see
-		-- ...they are what is now left in the outgoing stanza queue
-		-- We have to use the send of "session" because we don't want to add our resent stanzas
-		-- to the outgoing queue again
-		local queue = original_session.outgoing_stanza_queue;
-		session.log("debug", "resending all unacked stanzas that are still queued after resume, #queue = %d", #queue);
-		for i=1,#queue do
-			session.send(queue[i]);
-		end
-		session.log("debug", "all stanzas resent, now disabling send() in this migrated session, #queue = %d", #queue);
-		function session.send(stanza)
-			migrated_session_log("error", "Tried to send stanza on old session migrated by smacks resume (maybe there is a bug?): %s", tostring(stanza));
-			return false;
-		end
-		module:fire_event("smacks-hibernation-end", {origin = session, resumed = original_session, queue = queue});
-		request_ack_if_needed(original_session, true, "handle_resume", nil);
-	else
-		module:log("warn", "Client %s@%s[%s] tried to resume stream for %s@%s[%s]",
-			session.username or "?", session.host or "?", session.type,
-			original_session.username or "?", original_session.host or "?", original_session.type);
-		session.send(st.stanza("failed", { xmlns = xmlns_sm })
-			:tag("not-authorized", { xmlns = xmlns_errors }));
-	end
-	return true;
+        -- Ok, we need to re-send any stanzas that the client didn't see
+        -- ...they are what is now left in the outgoing stanza queue
+        -- We have to use the send of "session" because we don't want to add our resent stanzas
+        -- to the outgoing queue again
+        local queue = original_session.outgoing_stanza_queue;
+        session.log("debug", "resending all unacked stanzas that are still queued after resume, #queue = %d", #queue);
+        for i=1,#queue do
+            session.send(queue[i]);
+        end
+        session.log("debug", "all stanzas resent, now disabling send() in this migrated session, #queue = %d", #queue);
+        function session.send(stanza)
+            migrated_session_log("error", "Tried to send stanza on old session migrated by smacks resume (maybe there is a bug?): %s", tostring(stanza));
+            return false;
+        end
+        module:fire_event("smacks-hibernation-end", {origin = session, resumed = original_session, queue = queue});
+        request_ack_if_needed(original_session, true, "handle_resume", nil);
+    else
+        module:log("warn", "Client %s@%s[%s] tried to resume stream for %s@%s[%s]",
+            session.username or "?", session.host or "?", session.type,
+            original_session.username or "?", original_session.host or "?", original_session.type);
+        session.send(st.stanza("failed", { xmlns = xmlns_sm })
+            :tag("not-authorized", { xmlns = xmlns_errors }));
+    end
+    return true;
 end
 module:hook_stanza(xmlns_sm2, "resume", function (session, stanza) return handle_resume(session, stanza, xmlns_sm2); end);
 module:hook_stanza(xmlns_sm3, "resume", function (session, stanza) return handle_resume(session, stanza, xmlns_sm3); end);
 
 module:hook("csi-client-active", function (event)
-	if event.origin.smacks then
-		request_ack_if_needed(event.origin, true, "csi-active", nil);
-	end
+    if event.origin.smacks then
+        request_ack_if_needed(event.origin, true, "csi-active", nil);
+    end
 end);
 
 module:hook("csi-flushing", function (event)
-	if event.session.smacks then
-		request_ack_if_needed(event.session, true, "csi-active", nil);
-	end
+    if event.session.smacks then
+        request_ack_if_needed(event.session, true, "csi-active", nil);
+    end
 end);
 
 local function handle_read_timeout(event)
-	local session = event.session;
-	if session.smacks then
-		if session.awaiting_ack then
-			if session.awaiting_ack_timer then
-				session.awaiting_ack_timer:stop();
-			end
-			if session.delayed_ack_timer then
-				session.delayed_ack_timer:stop();
-				session.delayed_ack_timer = nil;
-			end
-			return false; -- Kick the session
-		end
-		session.log("debug", "Sending <r> (read timeout)");
-		(session.sends2s or session.send)(st.stanza("r", { xmlns = session.smacks }));
-		session.awaiting_ack = true;
-		if not session.delayed_ack_timer then
-			session.delayed_ack_timer = stoppable_timer(delayed_ack_timeout, function()
-				delayed_ack_function(session, nil);
-			end);
-		end
-		return true;
-	end
+    local session = event.session;
+    if session.smacks then
+        if session.awaiting_ack then
+            if session.awaiting_ack_timer then
+                session.awaiting_ack_timer:stop();
+            end
+            if session.delayed_ack_timer then
+                session.delayed_ack_timer:stop();
+                session.delayed_ack_timer = nil;
+            end
+            return false; -- Kick the session
+        end
+        session.log("debug", "Sending <r> (read timeout)");
+        (session.sends2s or session.send)(st.stanza("r", { xmlns = session.smacks }));
+        session.awaiting_ack = true;
+        if not session.delayed_ack_timer then
+            session.delayed_ack_timer = stoppable_timer(delayed_ack_timeout, function()
+                delayed_ack_function(session, nil);
+            end);
+        end
+        return true;
+    end
 end
 
 module:hook("s2s-read-timeout", handle_read_timeout);

--- a/resources/prosody-plugins/mod_smacks.lua
+++ b/resources/prosody-plugins/mod_smacks.lua
@@ -165,7 +165,7 @@ local function request_ack_if_needed(session, force, reason, stanza)
 	-- session.log("debug", "*** SMACKS(1) ***: awaiting_ack=%s, hibernating=%s", tostring(session.awaiting_ack), tostring(session.hibernating));
 	if session.awaiting_ack == nil and not session.hibernating then
 		local max_unacked = max_unacked_stanzas;
-		if session.state == "inactive"  then
+		if session.state == "inactive" then
 			max_unacked = max_inactive_unacked_stanzas;
 		end
 		-- this check of last_requested_h prevents ack-loops if missbehaving clients report wrong

--- a/resources/prosody-plugins/mod_token_verification.lua
+++ b/resources/prosody-plugins/mod_token_verification.lua
@@ -13,16 +13,16 @@ end
 
 local parentHostName = string.gmatch(tostring(host), "%w+.(%w.+)")();
 if parentHostName == nil then
-	log("error", "Failed to start - unable to get parent hostname");
-	return;
+    log("error", "Failed to start - unable to get parent hostname");
+    return;
 end
 
 local parentCtx = module:context(parentHostName);
 if parentCtx == nil then
-	log("error",
-		"Failed to start - unable to get parent context for host: %s",
-		tostring(parentHostName));
-	return;
+    log("error",
+        "Failed to start - unable to get parent context for host: %s",
+        tostring(parentHostName));
+    return;
 end
 
 local token_util = module:require "token/util".new(parentCtx);
@@ -33,9 +33,9 @@ if token_util == nil then
 end
 
 log("debug",
-	"%s - starting MUC token verifier app_id: %s app_secret: %s allow empty: %s",
-	tostring(host), tostring(token_util.appId), tostring(token_util.appSecret),
-	tostring(token_util.allowEmptyToken));
+    "%s - starting MUC token verifier app_id: %s app_secret: %s allow empty: %s",
+    tostring(host), tostring(token_util.appId), tostring(token_util.appSecret),
+    tostring(token_util.allowEmptyToken));
 
 -- option to disable room modification (sending muc config form) for guest that do not provide token
 local require_token_for_moderation;
@@ -46,16 +46,16 @@ load_config();
 
 -- verify user and whether he is allowed to join a room based on the token information
 local function verify_user(session, stanza)
-	log("debug", "Session token: %s, session room: %s",
-		tostring(session.auth_token),
-		tostring(session.jitsi_meet_room));
+    log("debug", "Session token: %s, session room: %s",
+        tostring(session.auth_token),
+        tostring(session.jitsi_meet_room));
 
-	-- token not required for admin users
-	local user_jid = stanza.attr.from;
-	if is_admin(user_jid) then
-		log("debug", "Token not required from admin user: %s", user_jid);
-		return true;
-	end
+    -- token not required for admin users
+    local user_jid = stanza.attr.from;
+    if is_admin(user_jid) then
+        log("debug", "Token not required from admin user: %s", user_jid);
+        return true;
+    end
 
     log("debug",
         "Will verify token for user: %s, room: %s ", user_jid, stanza.attr.to);
@@ -67,22 +67,22 @@ local function verify_user(session, stanza)
                 stanza, "cancel", "not-allowed", "Room and token mismatched"));
         return false; -- we need to just return non nil
     end
-	log("debug",
+    log("debug",
         "allowed: %s to enter/create room: %s", user_jid, stanza.attr.to);
     return true;
 end
 
 module:hook("muc-room-pre-create", function(event)
-	local origin, stanza = event.origin, event.stanza;
-	log("debug", "pre create: %s %s", tostring(origin), tostring(stanza));
+    local origin, stanza = event.origin, event.stanza;
+    log("debug", "pre create: %s %s", tostring(origin), tostring(stanza));
     if not verify_user(origin, stanza) then
         return true; -- Returning any value other than nil will halt processing of the event
     end
 end, 99);
 
 module:hook("muc-occupant-pre-join", function(event)
-	local origin, room, stanza = event.origin, event.room, event.stanza;
-	log("debug", "pre join: %s %s", tostring(room), tostring(stanza));
+    local origin, room, stanza = event.origin, event.room, event.stanza;
+    log("debug", "pre join: %s %s", tostring(room), tostring(stanza));
     if not verify_user(origin, stanza) then
         return true; -- Returning any value other than nil will halt processing of the event
     end

--- a/resources/prosody-plugins/mod_turncredentials.lua
+++ b/resources/prosody-plugins/mod_turncredentials.lua
@@ -33,7 +33,6 @@ function random(arr)
     return arr[index];
 end
 
-
 module:hook_global("config-reloaded", function()
     module:log("debug", "config-reloaded")
     secret = module:get_option_string("turncredentials_secret");
@@ -59,8 +58,8 @@ module:hook("iq-get/host/urn:xmpp:extdisco:1:services", function(event)
         elseif item.type == "turn" or item.type == "turns" then
             local turn = {}
             -- turn items need host, port (defaults to 3478),
-	          -- transport (defaults to udp)
-	          -- username, password, ttl
+            -- transport (defaults to udp)
+            -- username, password, ttl
             turn.type = item.type;
             turn.port = tostring(item.port);
             turn.transport = item.transport;


### PR DESCRIPTION
- Convert tabs to spaces in mixed formatted prosody plugins to improve readability.
- Convert tabs to spaces in some plugins (_even they are not fixed formatted_) to match the common format