### PR TITLE
fix(config): Remove unused config values.

### DIFF
--- a/config.js
+++ b/config.js
@@ -79,11 +79,6 @@ var config = {
         // This is useful when the client runs on a host with limited resources.
         // noAutoPlayVideo: false,
 
-        // Whether to use fake constraints (height: 99999, width: 99999) when calling getDisplayMedia on
-        // Chromium based browsers. This is intended as a workaround for
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=1056311
-        // setScreenSharingResolutionConstraints: true,
-
         // Enable callstats only for a percentage of users.
         // This takes a value between 0 and 100 which determines the probability for
         // the callstats to be enabled.

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -481,12 +481,10 @@ export interface IConfig {
     subject?: string;
     testing?: {
         callStatsThreshold?: number;
-        capScreenshareBitrate?: number;
         disableE2EE?: boolean;
         mobileXmppWsThreshold?: number;
         noAutoPlayVideo?: boolean;
         p2pTestMode?: boolean;
-        setScreenSharingResolutionConstraints?: boolean;
         testMode?: boolean;
     };
     tileView?: {


### PR DESCRIPTION
capScreenshareBitrate and setScreenSharingResolutionConstraints are no longer valid.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
