### PR TITLE
fix(breakout-room, rn): joining room

### DIFF
--- a/react/features/base/conference/actions.ts
+++ b/react/features/base/conference/actions.ts
@@ -501,7 +501,7 @@ export function conferenceWillLeave(conference: IJitsiConference) {
  * from Redux.
  * @returns {Function}
  */
-export function createConference(overrideRoom?: string) {
+export function createConference(overrideRoom?: string | String) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const { connection, locationURL } = state['features/base/connection'];

--- a/react/features/breakout-rooms/actions.ts
+++ b/react/features/breakout-rooms/actions.ts
@@ -215,9 +215,7 @@ export function moveToRoom(roomId?: string) {
             }
 
             dispatch(clearNotifications());
-
-            // dispatch(setRoom(_roomId));
-            dispatch(createConference(_roomId?.toString()));
+            dispatch(createConference(_roomId));
             dispatch(setAudioMuted(audio.muted));
             dispatch(setVideoMuted(Boolean(video.muted)));
             dispatch(createDesiredLocalTracks());


### PR DESCRIPTION
Joining breakout rooms is broken on mobile clients 22.7.0 and newer. This reverts the regression introduced by https://github.com/jitsi/jitsi-meet/commit/2a321d6b1fdc4f5fc6009e628a18d9e5435c1b39#diff-520fc45db467a4bacc01e090dec8b5131c22597eb4d604552dbce5f1ae88a7b9R225, while making a small adjustment to pass the TypeScript check.