### PR TITLE
fix(audio-only) Fix an issue where 'startAudioOnly' in config is not applied to web clients.

### DIFF
--- a/react/features/base/media/middleware.any.js
+++ b/react/features/base/media/middleware.any.js
@@ -273,7 +273,10 @@ function _setRoom({ dispatch, getState }, next, action) {
                     // The following don't have complications around whether
                     // they are defined or not:
                     jwt: false,
-                    settings: true
+
+                    // We need to look for 'startAudioOnly' in settings only for react native clients. Otherwise, the
+                    // default value from ISettingsState (false) will override the value set in config for web clients.
+                    settings: typeof APP === 'undefined'
                 }));
 
     sendAnalytics(createStartAudioOnlyEvent(audioOnly));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
