### PR TITLE
fix: Drops jicofo-authuser as we use hardcoded value.

### DIFF
--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -44,12 +44,7 @@ case "$1" in
         fi
         JVB_SECRET="$RET"
 
-        db_get jicofo/jicofo-authuser
-        if [ -z "$RET" ] ; then
-            db_input critical jicofo/jicofo-authuser || true
-            db_go
-        fi
-        JICOFO_AUTH_USER="$RET"
+        JICOFO_AUTH_USER="focus"
 
         db_get jicofo/jicofo-authpassword
         if [ -z "$RET" ] ; then

--- a/debian/jitsi-meet-prosody.templates
+++ b/debian/jitsi-meet-prosody.templates
@@ -13,12 +13,6 @@ Type: password
 _Description: Jitsi Videobridge Component secret:
  The secret used by Jitsi Videobridge to connect to xmpp server as component.
 
-Template: jicofo/jicofo-authuser
-Type: string
-Default: focus
-_Description: Jicofo username:
- The jicofo needs an authenticated admin user to connect to xmpp server.
-
 Template: jicofo/jicofo-authpassword
 Type: password
 _Description: Jicofo user password:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
