### PR TITLE
fix: stop ticking timer resizing its container

### DIFF
--- a/css/_subject.scss
+++ b/css/_subject.scss
@@ -73,6 +73,7 @@
     min-width: 34px;
     padding: 0 8px;
     height: 28px;
+    font-variant-numeric: tabular-nums;
 
     @media (max-width: 300px) {
         display: none;


### PR DESCRIPTION
Use "monospace" digits in the `.subject-timer`. 

Given fonts that support this, the browser renders '1' and '8' at the same width.

The effect is that the ticking seconds stop resizing the timer on screen: ":21" and ":22"  take up the same space instead of wobbling 1+ pixel.

Before:

https://user-images.githubusercontent.com/59080/212181023-5b78419a-aa76-412a-a3f9-e5fab2f2f340.mov


After:

https://user-images.githubusercontent.com/59080/212181034-5785ea78-05fa-4ac5-a693-7869d82c66a5.mov

