### PR TITLE
fix(toolbox): do not show hangup menu for non-moderators

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -24,7 +24,8 @@ import {
 } from '../../../base/participants/actions';
 import {
     getLocalParticipant,
-    hasRaisedHand
+    hasRaisedHand,
+    isLocalParticipantModerator
 } from '../../../base/participants/functions';
 import { connect } from '../../../base/redux/functions';
 import { getLocalVideoTrack } from '../../../base/tracks/functions';
@@ -1518,7 +1519,7 @@ class Toolbox extends Component<IProps> {
 function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
     const { conference } = state['features/base/conference'];
     const { isNarrowLayout } = state['features/base/responsive-ui'];
-    const endConferenceSupported = conference?.isEndConferenceSupported();
+    const endConferenceSupported = conference?.isEndConferenceSupported() && isLocalParticipantModerator(state);
 
     const {
         buttonsWithNotifyClick,


### PR DESCRIPTION
endConferenceSupported check now also takes into account moderator status.

Ref: https://community.jitsi.org/t/end-conference-unnecessary-dialog-for-non-moderator/120873?u=shawn