### PR TITLE
fix(toolbox): consistent color for hangup buttons

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -135,11 +135,11 @@
 }
 
 .hangup-menu-button {
-    background-color: $hangupMenuButtonColor;
+    background-color: $hangupColor;
 
     @media (hover: hover) and (pointer: fine) {
         &:hover {
-            background-color: $hangupMenuButtonHoverColor;
+            background-color: $hangupHoverColor;
         }
     }
 

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -6,8 +6,6 @@
 $baseFontFamily: -apple-system, BlinkMacSystemFont, 'open_sanslight', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 $hangupColor:#DD3849;
 $hangupHoverColor: #F25363;
-$hangupMenuButtonColor:#0056E0;;
-$hangupMenuButtonHoverColor: #246FE5;
 
 /**
  * Size variables.


### PR DESCRIPTION
Use same color for hangup button and hangup menu button (https://github.com/jitsi/jitsi-meet/pull/12850#issuecomment-1413442663).

