### PR TITLE
Added horizonatal scroll bar to read the device name

### DIFF
--- a/css/_audio-preview.scss
+++ b/css/_audio-preview.scss
@@ -6,7 +6,7 @@
         border-radius: 3px;
         font-size: 14px;
         line-height: 24px;
-        max-height: 456px;
+        max-height: 80vh;
         overflow: auto;
         width: 300px;
         &-ul {
@@ -59,9 +59,8 @@
             color: #fff;
             display: inline-block;
             line-height: 24px;
-            text-overflow: ellipsis;
             max-width: 213px;
-            overflow: hidden;
+            overflow-x: scroll;
             white-space: nowrap;
         }
     }


### PR DESCRIPTION
I have added the scroll bar to read the whole audio device name. I also restricted the window size(height) which after adding 4 or 5 audio devices going outside the window. 

