### PR TITLE
Fixed style of participant badge

### DIFF
--- a/react/features/participants-pane/components/web/ParticipantsCounter.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsCounter.tsx
@@ -9,18 +9,18 @@ const useStyles = makeStyles()(theme => {
     return {
         badge: {
             backgroundColor: theme.palette.ui03,
-            borderRadius: '12px',
+            borderRadius: '100%',
             height: '16px',
             minWidth: '16px',
             color: theme.palette.text01,
             ...withPixelLineHeight(theme.typography.labelBold),
-	    lineHeight: '20px',
             pointerEvents: 'none',
             position: 'absolute',
             right: '-4px',
             top: '-3px',
-	    textAlign: 'center',
-	    padding: '2px'
+            textAlign: 'center',
+            boxSizing: 'border-box',
+            paddingTop: '2px'
         }
     };
 });

--- a/react/features/participants-pane/components/web/ParticipantsCounter.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsCounter.tsx
@@ -9,15 +9,18 @@ const useStyles = makeStyles()(theme => {
     return {
         badge: {
             backgroundColor: theme.palette.ui03,
-            borderRadius: '100%',
+            borderRadius: '12px',
             height: '16px',
-            width: '16px',
+            minWidth: '16px',
             color: theme.palette.text01,
             ...withPixelLineHeight(theme.typography.labelBold),
+	    lineHeight: '20px',
             pointerEvents: 'none',
             position: 'absolute',
             right: '-4px',
-            top: '-3px'
+            top: '-3px',
+	    textAlign: 'center',
+	    padding: '2px'
         }
     };
 });


### PR DESCRIPTION
close issue: https://github.com/jitsi/jitsi-meet/issues/12878

This occurs when the screen width and height become smaller than 368 x 619 or badge number become two or more digits, causing the badge value to overflow the badge container. To address this issue, I made the badge more responsive for larger numbers and smaller devices.


Before: 
![Screenshot from 2023-02-07 23-05-17](https://user-images.githubusercontent.com/57032769/217356396-8171b5bc-886c-40ea-9e3a-b8a09893330d.png)

After fix:
![Screenshot from 2023-02-08 00-13-11](https://user-images.githubusercontent.com/57032769/217356479-fb5cc2a0-da6d-485f-83af-3d8d1fe42008.png)
