### PR TITLE
Added text-align in toolbar-button-with-badge

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -73,7 +73,7 @@
 .toolbar-button-with-badge {
     display: inline-block;
     position: relative;
-
+    text-align: center;
     .badge-round {
         bottom: -5px;
         font-size: 12px;


### PR DESCRIPTION
Participants Number in the badge was not in center when screen screen is small. Added text-align: center to center it.
