### PR TITLE
Participants badge style fix

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -82,6 +82,7 @@
         pointer-events: none;
         position: absolute;
         right: -5px;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
Issue : https://github.com/jitsi/jitsi-meet/issues/12878

This happens on smaller machines, the fix/hack I have added it to align the text to centre

Before fix -
![image](https://user-images.githubusercontent.com/44804981/217736201-36e56901-b912-4018-9f70-7c3410cec787.png)

After fix - 
![image](https://user-images.githubusercontent.com/44804981/217736389-28ef27ff-a97d-4111-914d-7f2f31c7b692.png)

