### PR TITLE
fix(ios) avoid getting duplicated SDK events

### DIFF
--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -40,19 +40,10 @@ static NSString *const PiPEnabledFeatureFlag = @"pip.enabled";
 
 #pragma mark Initializers
 
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        [self initWithXXX];
-    }
-
-    return self;
-}
-
 - (instancetype)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
-        [self initWithXXX];
+        [self doInitialize];
     }
 
     return self;
@@ -61,7 +52,7 @@ static NSString *const PiPEnabledFeatureFlag = @"pip.enabled";
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self initWithXXX];
+        [self doInitialize];
     }
 
     return self;
@@ -71,9 +62,9 @@ static NSString *const PiPEnabledFeatureFlag = @"pip.enabled";
  * Internal initialization:
  *
  * - sets the background color
- * - initializes the external API scope
+ * - registers necessary observers
  */
-- (void)initWithXXX {
+- (void)doInitialize {
     // Set a background color which is in accord with the JavaScript and Android
     // parts of the application and causes less perceived visual flicker than
     // the default background color.


### PR DESCRIPTION
UIView has 2 designated initializers: initWithFrame and initWithCoder, which means either of them is going to be called, whatever the constructor.

THus overriding init will cause creating new (and unnecessary) observers.

Ref: https://community.jitsi.org/t/duplicate-delegate-calls/121051/6
Fixes: https://github.com/jitsi/jitsi-meet/issues/12892

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
