### PR TITLE
Fix: updated checkbox size to look as expected for small screen

### DIFF
--- a/react/features/base/ui/components/web/Checkbox.tsx
+++ b/react/features/base/ui/components/web/Checkbox.tsx
@@ -164,7 +164,7 @@ const Checkbox = ({
                 <Icon
                     className = 'checkmark'
                     color = { disabled ? theme.palette.icon03 : theme.palette.icon01 }
-                    size = { 18 }
+                    size = { "80%" }
                     src = { IconCheck } />
             </label>
             <label>{label}</label>


### PR DESCRIPTION
closes https://github.com/jitsi/jitsi-meet/issues/12887

For small screens, the checkbox goes out of alignment. By setting the size to 80%, the checkbox looks as expected.