### PR TITLE
Small height screen fixes

### DIFF
--- a/react/features/base/ui/components/web/ContextMenu.tsx
+++ b/react/features/base/ui/components/web/ContextMenu.tsx
@@ -7,6 +7,7 @@ import JitsiPortal from '../../../../toolbox/components/web/JitsiPortal';
 import { showOverflowDrawer } from '../../../../toolbox/functions.web';
 import participantsPaneTheme from '../../../components/themes/participantsPaneTheme.json';
 import { withPixelLineHeight } from '../../../styles/functions.web';
+import { spacing } from '../../Tokens';
 
 /**
  * Get a style property from a style declaration as a float.
@@ -184,9 +185,22 @@ const ContextMenu = ({
             && offsetTarget.offsetParent instanceof HTMLElement
         ) {
             const { current: container } = containerRef;
+
+            // make sure the max height is not set
+            // @ts-ignore
+            container.style.maxHeight = null;
             const { offsetTop, offsetParent: { offsetHeight, scrollTop } } = offsetTarget;
-            const outerHeight = getComputedOuterHeight(container);
-            const height = Math.min(MAX_HEIGHT, outerHeight);
+            let outerHeight = getComputedOuterHeight(container);
+            let height = Math.min(MAX_HEIGHT, outerHeight);
+
+            if (offsetTop + height > offsetHeight + scrollTop && height > offsetTop) {
+                // top offset and + padding + border
+                container.style.maxHeight = `${offsetTop - ((spacing[2] * 2) + 2)}px`;
+            }
+
+            // get the height after style changes
+            outerHeight = getComputedOuterHeight(container);
+            height = Math.min(MAX_HEIGHT, outerHeight);
 
             container.style.top = offsetTop + height > offsetHeight + scrollTop
                 ? `${offsetTop - outerHeight}`

--- a/react/features/virtual-background/components/UploadImageButton.tsx
+++ b/react/features/virtual-background/components/UploadImageButton.tsx
@@ -41,7 +41,10 @@ interface IProps extends WithTranslation {
 const useStyles = makeStyles()(theme => {
     return {
         addBackground: {
-            marginRight: theme.spacing(2)
+            marginRight: theme.spacing(2),
+            '& svg': {
+                fill: '#669aec !important'
+            }
         },
         button: {
             display: 'none'

--- a/react/features/virtual-background/components/VirtualBackgroundDialog.tsx
+++ b/react/features/virtual-background/components/VirtualBackgroundDialog.tsx
@@ -256,7 +256,7 @@ const useStyles = makeStyles()(theme => {
             }
         },
         dialogMarginTop: {
-            marginTop: '44px'
+            marginTop: '8px'
         },
         virtualBackgroundLoading: {
             overflow: 'hidden',


### PR DESCRIPTION
Before context menu
<img width="317" alt="Screenshot 2023-02-15 at 16 52 32" src="https://user-images.githubusercontent.com/57035818/219062859-20f8e842-2c8a-487e-ae3e-29878a35e712.png">
After
<img width="313" alt="Screenshot 2023-02-15 at 16 52 51" src="https://user-images.githubusercontent.com/57035818/219062922-52a64340-450b-4abb-b738-1fcffd336dc7.png">


Before select background dialog
<img width="625" alt="Screenshot 2023-02-15 at 16 53 27" src="https://user-images.githubusercontent.com/57035818/219063071-921a5aff-da1c-4a84-8f35-851e959d6cf6.png">
After
<img width="629" alt="Screenshot 2023-02-15 at 16 53 14" src="https://user-images.githubusercontent.com/57035818/219063039-59787898-50d1-4766-a9a0-9a4edbfb78a7.png">

if you merge this please rebase the commits do not squash them!
Peace ✌️