### PR TITLE
fix(video-quality) Add pinned participants to selectedSources.

### DIFF
--- a/react/features/video-quality/subscriber.ts
+++ b/react/features/video-quality/subscriber.ts
@@ -463,7 +463,17 @@ function _updateReceiverVideoConstraints({ getState }: IStore) {
         }
 
         if (getCurrentLayout(state) === LAYOUTS.STAGE_FILMSTRIP_VIEW && activeParticipantsSources.length > 0) {
-            const onStageSources = [ ...activeParticipantsSources ];
+            const selectedSources: string[] = [];
+            const onStageSources: string[] = [];
+
+            // If more than one video source is pinned to the stage filmstrip, they need to be added to the
+            // 'selectedSources' so that the bridge can allocate bandwidth for all the sources as opposed to doing
+            // greedy allocation for the sources (which happens when they are added to 'onStageSources').
+            if (activeParticipantsSources.length > 1) {
+                selectedSources.push(...activeParticipantsSources);
+            } else {
+                onStageSources.push(activeParticipantsSources[0]);
+            }
 
             activeParticipantsSources.forEach(sourceName => {
                 const isScreenSharing = remoteScreenShares.includes(sourceName);
@@ -485,6 +495,7 @@ function _updateReceiverVideoConstraints({ getState }: IStore) {
             }
 
             receiverConstraints.onStageSources = onStageSources;
+            receiverConstraints.selectedSources = selectedSources;
         } else if (largeVideoSourceName) {
             let quality = VIDEO_QUALITY_UNLIMITED;
 


### PR DESCRIPTION
When mulltiple videos are pinned to the stage filmstrip, the expectation is that the bridge will forward all the videos even if they are of lower quality. For this, the video sources need to be added to selectedSources instead of onStageSources.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
