### PR TITLE
ParticipantsCounter badge Style Changed

### DIFF
--- a/react/features/participants-pane/components/web/ParticipantsCounter.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsCounter.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles()(theme => {
             right: '-4px',
             top: '-3px',
             textAlign: 'center',
-            paddingTop: '2px'
+            paddingTop: '1px'
         }
     };
 });

--- a/react/features/participants-pane/components/web/ParticipantsCounter.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsCounter.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles()(theme => {
             right: '-4px',
             top: '-3px',
             textAlign: 'center',
-            paddingTop: '1px'
+            padding: '1px'
         }
     };
 });


### PR DESCRIPTION
Before (Badge is not circular)

<img width="220" alt="219693716-3d8debca-d128-4141-a426-d440edbaefb8" src="https://user-images.githubusercontent.com/123248648/219720179-2e3467e3-ca2d-43ed-a584-f31ed6871495.png">

changed the padding top from '2px' to '1px' to make the badge circular.

After

<img width="219" alt="219693814-2c4e615c-1682-4825-8754-a01314a9a4d2" src="https://user-images.githubusercontent.com/123248648/219720553-6ccc2b23-1b28-4ec5-bd3e-1c4fc05d421c.png">
