### PR TITLE
Fix iFrame top navigation in external API

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -392,7 +392,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);
-        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads';
+        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads allow-top-navigation-by-user-activation';
         this._frame.setAttribute('allowFullScreen', 'true');
         this._frame.style.border = 0;
 

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -392,7 +392,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);
-        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads allow-top-navigation-by-user-activation';
+        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads ' +
+                              'allow-top-navigation-by-user-activation';
         this._frame.setAttribute('allowFullScreen', 'true');
         this._frame.style.border = 0;
 


### PR DESCRIPTION
Add allow-top-navigation-by-user-activation iFrame sandbox flag to externalAPI. This fixes unclickable navigation buttons displayed on mobile browsers, i.e. "Join this meeting using the app", "Download the app".