### PR TITLE
feat(thumbnail,filmstrip) - remove tint from owner screenshare participants

### DIFF
--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -268,6 +268,22 @@ export function getVirtualScreenshareParticipantOwnerId(id: string) {
 }
 
 /**
+ * Returns owner participant IDs of the virtual screenshares participant.
+ *
+ * @param {(Function|Object)} stateful - The (whole) redux state, or redux's.
+ * @returns {(string[])}
+ */
+export function getVirtualScreenshareParticipantOwnerIds(stateful: IStateful) {
+    const virtualScreenshareParticipants = toState(stateful)['features/base/participants']
+        .sortedRemoteVirtualScreenshareParticipants;
+
+    const virtualScreenshareParticipantIds = Array.from(virtualScreenshareParticipants.keys())
+        .map(id => getVirtualScreenshareParticipantOwnerId(id));
+
+    return virtualScreenshareParticipantIds;
+}
+
+/**
  * Returns the Map with fake participants.
  *
  * @param {(Function|Object)} stateful - The (whole) redux state, or redux's

--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -268,29 +268,6 @@ export function getVirtualScreenshareParticipantOwnerId(id: string) {
 }
 
 /**
- * Returns owner participant IDs of the virtual screenshares participant.
- *
- * @param {(Function|Object)} stateful - The (whole) redux state, or redux's.
- * @returns {(string[])}
- */
-export function getVirtualScreenshareParticipantOwnerIds(stateful: IStateful) {
-    const virtualScreenshareParticipants = toState(stateful)['features/base/participants']
-        .sortedRemoteVirtualScreenshareParticipants ?? new Map();
-
-    const virtualScreenshareParticipantIds = Array.from(virtualScreenshareParticipants.keys())
-        .map(id => getVirtualScreenshareParticipantOwnerId(id));
-    const localScreenShareParticipantId = getLocalScreenShareParticipant(stateful)?.id;
-
-    if (localScreenShareParticipantId) {
-        return [
-            ...virtualScreenshareParticipantIds,
-            getVirtualScreenshareParticipantOwnerId(localScreenShareParticipantId) ];
-    }
-
-    return virtualScreenshareParticipantIds;
-}
-
-/**
  * Returns the Map with fake participants.
  *
  * @param {(Function|Object)} stateful - The (whole) redux state, or redux's

--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -275,10 +275,17 @@ export function getVirtualScreenshareParticipantOwnerId(id: string) {
  */
 export function getVirtualScreenshareParticipantOwnerIds(stateful: IStateful) {
     const virtualScreenshareParticipants = toState(stateful)['features/base/participants']
-        .sortedRemoteVirtualScreenshareParticipants;
+        .sortedRemoteVirtualScreenshareParticipants ?? new Map();
 
     const virtualScreenshareParticipantIds = Array.from(virtualScreenshareParticipants.keys())
         .map(id => getVirtualScreenshareParticipantOwnerId(id));
+    const localScreenShareParticipantId = getLocalScreenShareParticipant(stateful)?.id;
+
+    if (localScreenShareParticipantId) {
+        return [
+            ...virtualScreenshareParticipantIds,
+            getVirtualScreenshareParticipantOwnerId(localScreenShareParticipantId) ];
+    }
 
     return virtualScreenshareParticipantIds;
 }

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -20,7 +20,7 @@ import { pinParticipant } from '../../../base/participants/actions';
 import {
     getLocalParticipant,
     getParticipantByIdOrUndefined,
-    getVirtualScreenshareParticipantOwnerIds,
+    getScreenshareParticipantIds,
     hasRaisedHand,
     isLocalScreenshareParticipant,
     isScreenShareParticipant,
@@ -1288,13 +1288,14 @@ function _mapStateToProps(state: IReduxState, ownProps: any): Object {
     const participantId = isLocal ? getLocalParticipant(state)?.id : participantID;
     const isActiveParticipant = activeParticipants.find((pId: string) => pId === participantId);
     const participantCurrentlyOnLargeVideo = state['features/large-video']?.participantId === id;
-    const virtualScreenshareParticipantOwnerIds = getVirtualScreenshareParticipantOwnerIds(state);
+    const screenshareParticipantIds = getScreenshareParticipantIds(state);
+
     const shouldDisplayTintBackground
         = _currentLayout !== LAYOUTS.TILE_VIEW && filmstripType === FILMSTRIP_TYPE.MAIN
         && (isActiveParticipant || participantCurrentlyOnLargeVideo)
 
         // skip showing tint for owner participants that are screensharing.
-        && !virtualScreenshareParticipantOwnerIds.includes(id);
+        && !screenshareParticipantIds.includes(id);
 
     return {
         _audioTrack,

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -20,6 +20,7 @@ import { pinParticipant } from '../../../base/participants/actions';
 import {
     getLocalParticipant,
     getParticipantByIdOrUndefined,
+    getVirtualScreenshareParticipantOwnerIds,
     hasRaisedHand,
     isLocalScreenshareParticipant,
     isScreenShareParticipant,
@@ -1287,9 +1288,13 @@ function _mapStateToProps(state: IReduxState, ownProps: any): Object {
     const participantId = isLocal ? getLocalParticipant(state)?.id : participantID;
     const isActiveParticipant = activeParticipants.find((pId: string) => pId === participantId);
     const participantCurrentlyOnLargeVideo = state['features/large-video']?.participantId === id;
+    const virtualScreenshareParticipantOwnerIds = getVirtualScreenshareParticipantOwnerIds(state);
     const shouldDisplayTintBackground
         = _currentLayout !== LAYOUTS.TILE_VIEW && filmstripType === FILMSTRIP_TYPE.MAIN
-        && (isActiveParticipant || participantCurrentlyOnLargeVideo);
+        && (isActiveParticipant || participantCurrentlyOnLargeVideo)
+
+        // skip showing tint for owner participants that are screensharing.
+        && !virtualScreenshareParticipantOwnerIds.includes(id);
 
     return {
         _audioTrack,


### PR DESCRIPTION
- remove tint on thumbnail if the participant is sharing the screen, in order to be visible for the others and see who is sharing the screen.