### PR TITLE
Use focus-visible for some focus styles to fix a11y issues

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -90,7 +90,7 @@ body.welcome-page {
                     font-size: 14px;
                     padding-left: 10px;
 
-                    &:focus {
+                    &.focus-visible {
                         outline: auto 2px #005fcc;
                     }
                 }

--- a/react/features/base/ui/components/web/Button.tsx
+++ b/react/features/base/ui/components/web/Button.tsx
@@ -69,7 +69,7 @@ const useStyles = makeStyles()(theme => {
                 backgroundColor: theme.palette.action01Active
             },
 
-            '&:focus': {
+            '&.focus-visible': {
                 outline: 0,
                 boxShadow: `0px 0px 0px 2px ${theme.palette.focus01}`
             },

--- a/react/features/base/ui/components/web/ClickableIcon.tsx
+++ b/react/features/base/ui/components/web/ClickableIcon.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles()(theme => {
                 backgroundColor: theme.palette.ui02
             },
 
-            '&:focus': {
+            '&.focus-visible': {
                 outline: 0,
                 boxShadow: `0px 0px 0px 2px ${theme.palette.focus01}`
             },

--- a/react/features/base/ui/components/web/ContextMenuItem.tsx
+++ b/react/features/base/ui/components/web/ContextMenuItem.tsx
@@ -102,7 +102,7 @@ const useStyles = makeStyles()(theme => {
                 backgroundColor: theme.palette.ui03
             },
 
-            '&:focus': {
+            '&.focus-visible': {
                 boxShadow: `inset 0 0 0 2px ${theme.palette.action01Hover}`
             }
         },

--- a/react/features/base/ui/components/web/Dialog.tsx
+++ b/react/features/base/ui/components/web/Dialog.tsx
@@ -23,12 +23,6 @@ const useStyles = makeStyles()(theme => {
             justifyContent: 'space-between'
         },
 
-        closeIcon: {
-            '&:focus': {
-                boxShadow: 'none'
-            }
-        },
-
         title: {
             color: theme.palette.text01,
             ...withPixelLineHeight(theme.typography.heading5),
@@ -138,7 +132,6 @@ const Dialog = ({
                 {!hideCloseButton && (
                     <ClickableIcon
                         accessibilityLabel = { t('dialog.close') }
-                        className = { classes.closeIcon }
                         icon = { IconCloseLarge }
                         id = 'modal-header-close-button'
                         onClick = { onClose } />

--- a/react/features/base/ui/components/web/DialogWithTabs.tsx
+++ b/react/features/base/ui/components/web/DialogWithTabs.tsx
@@ -112,12 +112,6 @@ const useStyles = makeStyles()(theme => {
             }
         },
 
-        closeIcon: {
-            '&:focus': {
-                boxShadow: 'none'
-            }
-        },
-
         content: {
             flexGrow: 1,
             overflowY: 'auto',
@@ -258,7 +252,6 @@ const DialogWithTabs = ({
     const closeIcon = useMemo(() => (
         <ClickableIcon
             accessibilityLabel = { t('dialog.close') }
-            className = { classes.closeIcon }
             icon = { IconCloseLarge }
             id = 'modal-header-close-button'
             onClick = { onClose } />
@@ -298,7 +291,6 @@ const DialogWithTabs = ({
                             <span className = { classes.backContainer }>
                                 <ClickableIcon
                                     accessibilityLabel = { t('dialog.Back') }
-                                    className = { classes.closeIcon }
                                     icon = { IconArrowBack }
                                     id = 'modal-header-back-button'
                                     onClick = { back } />

--- a/react/features/base/ui/components/web/Tabs.tsx
+++ b/react/features/base/ui/components/web/Tabs.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles()(theme => {
                 borderColor: theme.palette.ui10
             },
 
-            '&:focus': {
+            '&.focus-visible': {
                 outline: 0,
                 boxShadow: `0px 0px 0px 2px ${theme.palette.focus01}`,
                 border: 0,

--- a/react/features/video-quality/components/Slider.web.tsx
+++ b/react/features/video-quality/components/Slider.web.tsx
@@ -94,7 +94,7 @@ const useStyles = makeStyles()(theme => {
                 top: 0,
                 width: '100%',
 
-                '&:focus': {
+                '&.focus-visible': {
                     // override global styles in order to use our own color
                     outline: 'none !important',
 


### PR DESCRIPTION
_Related to https://github.com/jitsi/jitsi-meet/issues/12379_

This takes advantage of the `:focus-visible` polyfill that is already used in the app.

For focus styles that we know we only want to trigger when using the keyboard, use the `.focus-visible` class instead the `:focus` pseudo class.

This allows us to [stop hiding focus styles on dialog close buttons](https://github.com/jitsi/jitsi-meet/commit/a00b534767aaf26fba5199365eff6d039da46a10), something that was not great when navigating via keyboard.


See the new behavior in video, first when using keyboard, then when using the mouse:

https://user-images.githubusercontent.com/221253/221629521-c20a20a0-7ca8-4eb6-a742-1a7477886593.mp4

