### PR TITLE
feat: Sends the statisticsDisplayName to rtcstats.

### DIFF
--- a/react/features/rtcstats/functions.ts
+++ b/react/features/rtcstats/functions.ts
@@ -68,11 +68,15 @@ export function connectAndSendIdentity({ getState, dispatch }: IStore, identity:
             // This is done in order to facilitate queries based on different conference configurations.
             // e.g. Find all RTCPeerConnections that connect to a specific shard or were created in a
             // conference with a specific version.
-            // XXX(george): we also want to be able to correlate between rtcstats and callstats, so we're
-            // appending the callstats user name (if it exists) to the display name.
-            const displayName = options.statisticsId
-                || options.statisticsDisplayName
-                || jitsiLocalStorage.getItem('callStatsUserName');
+            let displayName = jitsiLocalStorage.getItem('callStatsUserName');
+
+            if (options.statisticsId || options.statisticsDisplayName) {
+                if (options.statisticsId && options.statisticsDisplayName) {
+                    displayName = `${options.statisticsDisplayName} (${options.statisticsId})`;
+                } else {
+                    displayName = options.statisticsId || options.statisticsDisplayName;
+                }
+            }
 
             RTCStats.sendIdentityData({
                 ...getAmplitudeIdentity(),


### PR DESCRIPTION
The previous code was copy/pasted from some other part of the app and didn't include the statisticsDisplayName in the rtcstats display name. This PR fixes the issue.