### PR TITLE
fix(lang) update Spanish translation

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -838,7 +838,7 @@
         "selectCamera": "Cámara",
         "selectMic": "Micrófono",
         "sounds": "Sonidos",
-        "speakers": "Parlantes",
+        "speakers": "Altavoces",
         "startAudioMuted": "Todos inician silenciados",
         "startVideoMuted": "Todos inician con cámara desactivada",
         "talkWhileMuted": "Hablar en silencio",


### PR DESCRIPTION
"Parlantes" is not the right translation for "Speakers" in Spanish when referring to the usual electronic audio output device (at least in the non-Latin-American Spanish variants).
Note that the singular "Altavoz" was already correct.