### PR TITLE
Adding additional parameter to iframe in order to link to the Jitsi mobile application

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -393,7 +393,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);
-        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads';
+        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads\
+         allow-top-navigation-by-user-activation';
         this._frame.setAttribute('allowFullScreen', 'true');
         this._frame.style.border = 0;
 

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -393,8 +393,14 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);
-        this._frame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-downloads\
-         allow-top-navigation-by-user-activation';
+        this._frame.sandbox = [
+            'allow-scripts',
+            'allow-same-origin',
+            'allow-popups',
+            'allow-forms',
+            'allow-downloads',
+            'allow-top-navigation-by-user-activation'
+        ].join(' ');
         this._frame.setAttribute('allowFullScreen', 'true');
         this._frame.style.border = 0;
 


### PR DESCRIPTION
Solves #12948

- added parameter to iframe allowing linking to the Jitsi mobile app with user interaction

Currently users will hit an error when trying to click on the button to go to the mobile app when clicking within an iframe.
