### PR TITLE
fix: Fixes muc rate limit to fire occupant-pre-join.

### DIFF
--- a/resources/prosody-plugins/mod_muc_rate_limit.lua
+++ b/resources/prosody-plugins/mod_muc_rate_limit.lua
@@ -83,7 +83,7 @@ module:hook("muc-occupant-pre-join", function (event)
     -- skipping events we had produced and clear our flag
     if stanza.delayed_join_skip == true then
         event.stanza.delayed_join_skip = nil;
-        return false;
+        return nil;
     end
 
     local throttle = room.join_rate_throttle;
@@ -101,7 +101,7 @@ module:hook("muc-occupant-pre-join", function (event)
 
         if not add_item_to_queue(room.join_rate_presence_queue, event, room, stanza.attr.from) then
             -- let's not stop processing the event
-            return false;
+            return nil;
         end
 
         if not room.join_rate_queue_timer then


### PR DESCRIPTION
If any handler returns a value (that isn't nil) then processing will halt and that value will be returned.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
