### PR TITLE
fix: Fixes video unmuting in case of av moderation.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1037,10 +1037,17 @@ export default {
             return;
         }
 
+        const state = APP.store.getState();
+
         if (!mute
-                && isUserInteractionRequiredForUnmute(APP.store.getState())) {
+                && isUserInteractionRequiredForUnmute(state)) {
             logger.error('Unmuting video requires user interaction');
 
+            return;
+        }
+
+        // check for A/V Moderation when trying to unmute and return early
+        if (!mute && shouldShowModeratedNotification(MEDIA_TYPE.VIDEO, state)) {
             return;
         }
 
@@ -1057,7 +1064,7 @@ export default {
             return;
         }
 
-        const localVideo = getLocalJitsiVideoTrack(APP.store.getState());
+        const localVideo = getLocalJitsiVideoTrack(state);
 
         if (!localVideo && !mute && !this.isCreatingLocalTrack) {
             const maybeShowErrorDialog = error => {


### PR DESCRIPTION
The broken use-case: 1 moderator (& 1 guest), enables video moderation. A new guest joins and tries to video unmute. A notification is shown and after clicking raise hand we actually create local track and try to unmute server-side (sending iq to jicofo and getting error not-allowed) and everything goes out of sync and when we are allowed to unmute, we send video but the bridge is not forwarding it as we are still muted in jicofo's point of view.