### PR TITLE
fix(useVideoStream): a crash after GUM failure

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1455,7 +1455,7 @@ export default {
 
                 logger.debug(`useVideoStream: Replacing ${oldTrack} with ${newTrack}`);
 
-                if (oldTrack === newTrack) {
+                if (oldTrack === newTrack || (!oldTrack && !newTrack)) {
                     resolve();
                     onFinish();
 


### PR DESCRIPTION
Fixes a crash which happens after GUM fails without any track previosuly created.

Steps to reproduce:

1. Join a meeting without camera.
2. Disable camera access permissions in the browser.
3. Try to use the camera button.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
