### PR TITLE
fix(build) drop unused file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,7 @@ deploy-appbundle:
 
 deploy-lib-jitsi-meet:
 	cp \
-		$(LIBJITSIMEET_DIR)/dist/umd/lib-jitsi-meet.min.js \
-		$(LIBJITSIMEET_DIR)/dist/umd/lib-jitsi-meet.min.map \
-		$(LIBJITSIMEET_DIR)/dist/umd/lib-jitsi-meet.e2ee-worker.js \
-		$(LIBJITSIMEET_DIR)/modules/browser/capabilities.json \
+		$(LIBJITSIMEET_DIR)/dist/umd/lib-jitsi-meet.* \
 		$(DEPLOY_DIR)
 
 deploy-olm:


### PR DESCRIPTION
Also generalize the lib-jitsi-meet files rule so it can also work with development (unminimized) builds.

Depends on: https://github.com/jitsi/lib-jitsi-meet/pull/2234