### PR TITLE
fix: Returns source names only for existing participants.

### DIFF
--- a/react/features/base/participants/subscriber.ts
+++ b/react/features/base/participants/subscriber.ts
@@ -10,7 +10,11 @@ import { VIDEO_TYPE } from '../media/constants';
 import StateListenerRegistry from '../redux/StateListenerRegistry';
 
 import { createVirtualScreenshareParticipant, participantLeft } from './actions';
-import { getRemoteScreensharesBasedOnPresence } from './functions';
+import {
+    getParticipantById,
+    getRemoteScreensharesBasedOnPresence,
+    getVirtualScreenshareParticipantOwnerId
+} from './functions';
 import { FakeParticipant } from './types';
 
 StateListenerRegistry.register(
@@ -76,7 +80,7 @@ function _updateScreenshareParticipants(store: IStore): void {
 
             if (track.local) {
                 newLocalSceenshareSourceName = sourceName;
-            } else {
+            } else if (getParticipantById(state, getVirtualScreenshareParticipantOwnerId(sourceName))) {
                 acc.push(sourceName);
             }
         }


### PR DESCRIPTION
There are cases when participant is left and still we receive a track added. In this occasions for screensharing sources a virtual participant is created for non-existing participant.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
