### PR TITLE
ref(redux) Remove connect wrapper

### DIFF
--- a/react/features/authentication/components/native/WaitForOwnerDialog.js
+++ b/react/features/authentication/components/native/WaitForOwnerDialog.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import { cancelWaitForOwner, openLoginDialog } from '../../actions.native';
 
 /**

--- a/react/features/authentication/components/web/LoginDialog.tsx
+++ b/react/features/authentication/components/web/LoginDialog.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect as reduxConnect } from 'react-redux';
 
 // @ts-expect-error
 import { connect } from '../../../../../connection';
@@ -9,7 +10,6 @@ import { IConfig } from '../../../base/config/configType';
 import { toJid } from '../../../base/connection/functions';
 import { translate, translateToHTML } from '../../../base/i18n/functions';
 import { JitsiConnectionErrors } from '../../../base/lib-jitsi-meet';
-import { connect as reduxConnect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import Input from '../../../base/ui/components/web/Input';
 import {
@@ -26,7 +26,7 @@ interface IProps extends WithTranslation {
      * {@link JitsiConference} That needs authentication - will hold a valid
      * value in XMPP login + guest access mode.
      */
-    _conference: IJitsiConference;
+    _conference?: IJitsiConference;
 
     /**
      * The server hosts specified in the global config.
@@ -47,7 +47,7 @@ interface IProps extends WithTranslation {
      * The progress in the floating range between 0 and 1 of the authenticating
      * and upgrading the role of the local participant/user.
      */
-    _progress: number;
+    _progress?: number;
 
     /**
      * Redux store dispatch method.

--- a/react/features/authentication/components/web/WaitForOwnerDialog.tsx
+++ b/react/features/authentication/components/web/WaitForOwnerDialog.tsx
@@ -1,9 +1,9 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import { cancelWaitForOwner } from '../../actions.web';
 

--- a/react/features/base/avatar/components/Avatar.js
+++ b/react/features/base/avatar/components/Avatar.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { getParticipantById } from '../../participants';
-import { connect } from '../../redux';
 import { getAvatarColor, getInitials, isCORSAvatarURL } from '../functions';
 
 import { StatelessAvatar } from './';

--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -99,9 +99,7 @@ export interface IJitsiConference {
 export interface IConferenceState {
     authEnabled?: boolean;
     authLogin?: string;
-    authRequired?: {
-        join: Function;
-    };
+    authRequired?: IJitsiConference;
     conference?: IJitsiConference;
     conferenceTimestamp?: number;
     e2eeSupported?: boolean;

--- a/react/features/base/dialog/actions.ts
+++ b/react/features/base/dialog/actions.ts
@@ -74,7 +74,7 @@ export function openDialog(component: ComponentType<any>, componentProps?: Objec
  *     componentProps: (Object | undefined)
  * }}
  */
-export function openSheet(component: ComponentType, componentProps?: Object) {
+export function openSheet(component: ComponentType<any>, componentProps?: Object) {
     return {
         type: OPEN_SHEET,
         component,

--- a/react/features/base/dialog/components/native/AlertDialog.js
+++ b/react/features/base/dialog/components/native/AlertDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import Dialog from 'react-native-dialog';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
-import { connect } from '../../../redux';
 import { _abstractMapStateToProps } from '../../functions';
 import AbstractDialog, { type Props as AbstractProps } from '../AbstractDialog';
 import { renderHTML } from '../functions.native';

--- a/react/features/base/dialog/components/native/BottomSheet.js
+++ b/react/features/base/dialog/components/native/BottomSheet.js
@@ -1,8 +1,8 @@
 import React, { type Node, PureComponent } from 'react';
 import { SafeAreaView, ScrollView, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { SlidingView } from '../../../react';
-import { connect } from '../../../redux';
 import { hideSheet } from '../../actions';
 
 import { bottomSheetStyles as styles } from './styles';

--- a/react/features/base/dialog/components/native/ConfirmDialog.js
+++ b/react/features/base/dialog/components/native/ConfirmDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import Dialog from 'react-native-dialog';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
-import { connect } from '../../../redux';
 import AbstractDialog from '../AbstractDialog';
 import { renderHTML } from '../functions.native';
 

--- a/react/features/base/dialog/components/native/DialogContainer.js
+++ b/react/features/base/dialog/components/native/DialogContainer.js
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
 
 import { ReactionEmoji } from '../../../../reactions/components';
 import { getReactionsQueue } from '../../../../reactions/functions.any';
-import { connect } from '../../../redux';
 import AbstractDialogContainer, {
     abstractMapStateToProps
 } from '../AbstractDialogContainer';

--- a/react/features/base/dialog/components/native/InputDialog.js
+++ b/react/features/base/dialog/components/native/InputDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import Dialog from 'react-native-dialog';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../i18n';
-import { connect } from '../../../redux';
 import { _abstractMapStateToProps } from '../../functions';
 import AbstractDialog, {
     type Props as AbstractProps,

--- a/react/features/base/dialog/components/native/PageReloadDialog.tsx
+++ b/react/features/base/dialog/components/native/PageReloadDialog.tsx
@@ -4,13 +4,12 @@
 import { randomInt } from '@jitsi/js-utils/random';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
-import type { Dispatch } from 'redux';
+import { connect } from 'react-redux';
 
 import { appNavigate, reloadNow } from '../../../../app/actions.native';
-import { IReduxState } from '../../../../app/types';
+import { IReduxState, IStore } from '../../../../app/types';
 import { translate } from '../../../i18n/functions';
 import { isFatalJitsiConnectionError } from '../../../lib-jitsi-meet/functions.native';
-import { connect } from '../../../redux/functions';
 import { hideDialog } from '../../actions';
 // @ts-ignore
 import logger from '../../logger';
@@ -24,9 +23,9 @@ import ConfirmDialog from './ConfirmDialog';
  * {@link PageReloadDialog}.
  */
 interface IPageReloadDialogProps extends WithTranslation {
-    dispatch: Dispatch<any>;
+    dispatch: IStore['dispatch'];
     isNetworkFailure: boolean;
-    reason: string;
+    reason?: string;
 }
 
 /**
@@ -208,7 +207,7 @@ function mapStateToProps(state: IReduxState) {
         = connectionError && isFatalJitsiConnectionError(connectionError);
     const fatalConfigError = fatalError === configError;
 
-    const isNetworkFailure = fatalConfigError || fatalConnectionError;
+    const isNetworkFailure = Boolean(fatalConfigError || fatalConnectionError);
 
     let reason;
 

--- a/react/features/base/media/components/native/VideoTrack.js
+++ b/react/features/base/media/components/native/VideoTrack.js
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import { View } from 'react-native';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../redux';
 import AbstractVideoTrack from '../AbstractVideoTrack';
 import type { Props } from '../AbstractVideoTrack';
 

--- a/react/features/base/media/components/native/VideoTransform.tsx
+++ b/react/features/base/media/components/native/VideoTransform.tsx
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
 import { PanResponder, PixelRatio, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { type Dispatch } from 'redux';
+import { connect } from 'react-redux';
 
-import { IReduxState } from '../../../../app/types';
-import { connect } from '../../../redux/functions';
+import { IReduxState, IStore } from '../../../../app/types';
 import { ASPECT_RATIO_WIDE } from '../../../responsive-ui/constants';
 import { storeVideoTransform } from '../../actions';
 
@@ -692,7 +691,7 @@ class VideoTransform extends Component<Props, State> {
  *     _onUnmount: Function
  * }}
  */
-function _mapDispatchToProps(dispatch: Dispatch<any>) {
+function _mapDispatchToProps(dispatch: IStore['dispatch']) {
     return {
         /**
          * Dispatches actions to store the last applied transform to a video.

--- a/react/features/base/media/components/web/AudioTrack.js
+++ b/react/features/base/media/components/web/AudioTrack.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { createAudioPlayErrorEvent, createAudioPlaySuccessEvent, sendAnalytics } from '../../../../analytics';
-import { connect } from '../../../redux';
 import logger from '../../logger';
 
 /**

--- a/react/features/base/media/components/web/VideoTrack.js
+++ b/react/features/base/media/components/web/VideoTrack.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../redux';
 import AbstractVideoTrack from '../AbstractVideoTrack';
 import type { Props as AbstractVideoTrackProps } from '../AbstractVideoTrack';
 

--- a/react/features/base/participants/components/ParticipantView.native.js
+++ b/react/features/base/participants/components/ParticipantView.native.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import {
     isTrackStreamingStatusActive,
@@ -11,7 +12,7 @@ import { translate } from '../../i18n/functions';
 import VideoTrack from '../../media/components/native/VideoTrack';
 import { shouldRenderVideoTrack } from '../../media/functions';
 import { Container } from '../../react';
-import { connect, toState } from '../../redux/functions';
+import { toState } from '../../redux/functions';
 import { TestHint } from '../../testing/components';
 import { getVideoTrackByParticipant } from '../../tracks/functions';
 import { getParticipantById, getParticipantDisplayName, isSharedVideoParticipant } from '../functions';

--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -1,11 +1,11 @@
 import React, { Component, ReactNode } from 'react';
 import ReactFocusLock from 'react-focus-lock';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import DialogPortal from '../../../toolbox/components/web/DialogPortal';
 import Drawer from '../../../toolbox/components/web/Drawer';
 import JitsiPortal from '../../../toolbox/components/web/JitsiPortal';
-import { connect } from '../../redux/functions';
 import { getContextMenuStyle } from '../functions.web';
 
 /**

--- a/react/features/base/premeeting/components/web/ConnectionStatus.tsx
+++ b/react/features/base/premeeting/components/web/ConnectionStatus.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState } from '../../../../app/types';
 import { translate } from '../../../i18n/functions';
 import Icon from '../../../icons/components/Icon';
 import { IconArrowDown, IconWifi1Bar, IconWifi2Bars, IconWifi3Bars } from '../../../icons/svg';
-import { connect } from '../../../redux/functions';
 import { withPixelLineHeight } from '../../../styles/functions.web';
 import { PREJOIN_DEFAULT_CONTENT_WIDTH } from '../../../ui/components/variables';
 import { CONNECTION_TYPE } from '../../constants';
@@ -217,7 +217,7 @@ function ConnectionStatus({ connectionDetails, t, connectionType }: IProps) {
  * @param {Object} state - The redux state.
  * @returns {Object}
  */
-function mapStateToProps(state: IReduxState): Object {
+function mapStateToProps(state: IReduxState) {
     const { connectionDetails, connectionType } = getConnectionData(state);
 
     return {

--- a/react/features/base/premeeting/components/web/Preview.js
+++ b/react/features/base/premeeting/components/web/Preview.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 
 import { getDisplayName } from '../../../../base/settings';
 import { Avatar } from '../../../avatar';
 import { Video } from '../../../media';
 import { getLocalParticipant } from '../../../participants';
-import { connect } from '../../../redux';
 import { getLocalVideoTrack } from '../../../tracks';
 
 declare var APP: Object;
@@ -26,7 +26,7 @@ export type Props = {
     /**
      * The name of the user that is about to join.
      */
-     name: string,
+    name: string,
 
     /**
      * Flag signaling the visibility of camera preview.

--- a/react/features/base/react/components/web/Watermarks.js
+++ b/react/features/base/react/components/web/Watermarks.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { isVpaasMeeting } from '../../../../jaas/functions';
 import { translate } from '../../../i18n';
-import { connect } from '../../../redux';
 
 
 declare var interfaceConfig: Object;

--- a/react/features/base/redux/functions.ts
+++ b/react/features/base/redux/functions.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import { connect as reduxConnect } from 'react-redux';
 
 import { IReduxState } from '../../app/types';
 import { IStateful } from '../app/types';
@@ -25,19 +24,6 @@ export function assign<T extends Object>(target: T, source: Partial<T>): T {
     }
 
     return t;
-}
-
-/**
- * Wrapper function for the react-redux connect function to avoid having to
- * declare function types for flow, but still let flow warn for other errors.
- *
- * @param {any} mapStateToProps - Redux mapStateToProps function.
- * @param {Function?} mapDispatchToProps - Redux mapDispatchToProps function.
- * @returns {Connector}
- */
-export function connect(
-        mapStateToProps?: any, mapDispatchToProps?: Function | Object) {
-    return reduxConnect(mapStateToProps, mapDispatchToProps);
 }
 
 /**

--- a/react/features/base/settings/components/native/SettingsButton.tsx
+++ b/react/features/base/settings/components/native/SettingsButton.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable lines-around-comment */
 
+import { connect } from 'react-redux';
+
 import { IReduxState } from '../../../../app/types';
 import { translate } from '../../../../base/i18n/functions';
 import { IconGear } from '../../../../base/icons/svg';
@@ -12,7 +14,6 @@ import { navigate }
 import { screen } from '../../../../mobile/navigation/routes';
 import { SETTINGS_ENABLED } from '../../../flags/constants';
 import { getFeatureFlag } from '../../../flags/functions';
-import { connect } from '../../../redux/functions';
 
 /**
  * Implements an {@link AbstractButton} to open the carmode.

--- a/react/features/base/sounds/components/SoundCollection.js
+++ b/react/features/base/sounds/components/SoundCollection.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { Audio } from '../../media';
 import type { AudioElement } from '../../media';
-import { connect } from '../../redux';
 import { _addAudioElement, _removeAudioElement } from '../actions';
 import type { Sound } from '../reducer';
 

--- a/react/features/base/testing/components/TestConnectionInfo.js
+++ b/react/features/base/testing/components/TestConnectionInfo.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 
 import statsEmitter from '../../../connection-indicator/statsEmitter';
 import { getLocalParticipant } from '../../participants';
-import { connect } from '../../redux';
 import { isTestModeEnabled } from '../functions';
 
 import { TestHint } from './index';

--- a/react/features/base/testing/components/TestHint.android.js
+++ b/react/features/base/testing/components/TestHint.android.js
@@ -2,8 +2,7 @@
 
 import React, { Component } from 'react';
 import { Text } from 'react-native';
-
-import { connect } from '../../redux';
+import { connect } from 'react-redux';
 
 import type { TestHintProps } from './AbstractTestHint';
 import { _mapStateToProps } from './AbstractTestHint';

--- a/react/features/base/testing/components/TestHint.ios.js
+++ b/react/features/base/testing/components/TestHint.ios.js
@@ -2,8 +2,7 @@
 
 import React, { Component } from 'react';
 import { Text } from 'react-native';
-
-import { connect } from '../../redux';
+import { connect } from 'react-redux';
 
 import type { TestHintProps } from './AbstractTestHint';
 import { _mapStateToProps } from './AbstractTestHint';

--- a/react/features/base/ui/components/web/DialogContainer.tsx
+++ b/react/features/base/ui/components/web/DialogContainer.tsx
@@ -1,10 +1,10 @@
 import React, { Component, ComponentType } from 'react';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
 import { IReactionEmojiProps } from '../../../../reactions/constants';
 import JitsiPortal from '../../../../toolbox/components/web/JitsiPortal';
 import { showOverflowDrawer } from '../../../../toolbox/functions.web';
-import { connect } from '../../../redux/functions';
 
 import DialogTransition from './DialogTransition';
 
@@ -13,12 +13,12 @@ interface IProps {
     /**
      * The component to render.
      */
-    _component: ComponentType;
+    _component?: ComponentType;
 
     /**
      * The props to pass to the component that will be rendered.
      */
-    _componentProps: Object;
+    _componentProps?: Object;
 
     /**
      * Whether the overflow drawer should be used.

--- a/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
+++ b/react/features/calendar-sync/components/AddMeetingUrlButton.web.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -9,7 +10,6 @@ import {
 } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { Icon, IconPlus } from '../../base/icons';
-import { connect } from '../../base/redux';
 import Tooltip from '../../base/tooltip/components/Tooltip';
 import { updateCalendarEvent } from '../actions';
 

--- a/react/features/calendar-sync/components/CalendarList.native.js
+++ b/react/features/calendar-sync/components/CalendarList.native.js
@@ -6,10 +6,10 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { AbstractPage } from '../../base/react';
-import { connect } from '../../base/redux';
 import { openSettings } from '../../mobile/permissions';
 import { refreshCalendar } from '../actions';
 

--- a/react/features/calendar-sync/components/CalendarList.web.js
+++ b/react/features/calendar-sync/components/CalendarList.web.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import {
     createCalendarClickedEvent,
@@ -9,7 +10,6 @@ import {
 import { translate } from '../../base/i18n';
 import { Icon, IconCalendar } from '../../base/icons';
 import { AbstractPage } from '../../base/react';
-import { connect } from '../../base/redux';
 import Spinner from '../../base/ui/components/web/Spinner';
 import { SETTINGS_TABS, openSettingsDialog } from '../../settings';
 import { refreshCalendar } from '../actions';

--- a/react/features/calendar-sync/components/CalendarListContent.native.js
+++ b/react/features/calendar-sync/components/CalendarListContent.native.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import {
     createCalendarClickedEvent,
@@ -10,7 +11,6 @@ import {
 import { appNavigate } from '../../app/actions';
 import { getLocalizedDateFormatter, translate } from '../../base/i18n';
 import { NavigateSectionList } from '../../base/react';
-import { connect } from '../../base/redux';
 import { openUpdateCalendarEventDialog, refreshCalendar } from '../actions';
 
 

--- a/react/features/calendar-sync/components/CalendarListContent.web.js
+++ b/react/features/calendar-sync/components/CalendarListContent.web.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import {
     createCalendarClickedEvent,
@@ -9,7 +10,6 @@ import {
 } from '../../analytics';
 import { appNavigate } from '../../app/actions';
 import { MeetingsList } from '../../base/react';
-import { connect } from '../../base/redux';
 
 import AddMeetingUrlButton from './AddMeetingUrlButton';
 import JoinButton from './JoinButton';

--- a/react/features/calendar-sync/components/UpdateCalendarEventDialog.native.js
+++ b/react/features/calendar-sync/components/UpdateCalendarEventDialog.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
-import { connect } from '../../base/redux';
 import { updateCalendarEvent } from '../actions';
 
 type Props = {

--- a/react/features/chat/components/AbstractChatPrivacyDialog.tsx
+++ b/react/features/chat/components/AbstractChatPrivacyDialog.tsx
@@ -19,9 +19,9 @@ interface IProps extends WithTranslation {
     _onSetMessageRecipient: Function;
 
     /**
-     * The participant retrieved from Redux by the participanrID prop.
+     * The participant retrieved from Redux by the participantID prop.
      */
-    _participant: Object;
+    _participant?: IParticipant;
 
     /**
      * The message that is about to be sent.

--- a/react/features/chat/components/native/Chat.js
+++ b/react/features/chat/components/native/Chat.js
@@ -2,10 +2,10 @@
 
 import { useIsFocused } from '@react-navigation/native';
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
-import { connect } from '../../../base/redux';
 import { TabBarLabelCounter } from '../../../mobile/navigation/components/TabBarLabelCounter';
 import { closeChat } from '../../actions.native';
 import AbstractChat, {

--- a/react/features/chat/components/native/ChatButton.js
+++ b/react/features/chat/components/native/ChatButton.js
@@ -1,7 +1,8 @@
+import { connect } from 'react-redux';
+
 import { CHAT_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconChatUnread, IconMessage } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import {
     AbstractButton,
     type AbstractButtonProps

--- a/react/features/chat/components/native/ChatMessage.js
+++ b/react/features/chat/components/native/ChatMessage.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { translate } from '../../../base/i18n';
 import { Linkify } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { isGifMessage } from '../../../gifs/functions';
 import { MESSAGE_TYPE_ERROR, MESSAGE_TYPE_LOCAL } from '../../constants';
 import { replaceNonUnicodeEmojis } from '../../functions';

--- a/react/features/chat/components/native/ChatPrivacyDialog.js
+++ b/react/features/chat/components/native/ChatPrivacyDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import { AbstractChatPrivacyDialog, _mapDispatchToProps, _mapStateToProps } from '../AbstractChatPrivacyDialog';
 
 /**

--- a/react/features/chat/components/native/MessageContainer.js
+++ b/react/features/chat/components/native/MessageContainer.js
@@ -1,8 +1,8 @@
 import React, { ReactElement } from 'react';
 import { FlatList, Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractMessageContainer, { type Props as AbstractProps }
     from '../AbstractMessageContainer';
 

--- a/react/features/chat/components/native/MessageRecipient.js
+++ b/react/features/chat/components/native/MessageRecipient.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Text, TouchableHighlight, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { Icon, IconCloseLarge } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import {
     setParams
 } from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';

--- a/react/features/chat/components/native/PrivateMessageButton.js
+++ b/react/features/chat/components/native/PrivateMessageButton.js
@@ -1,8 +1,9 @@
+import { connect } from 'react-redux';
+
 import { CHAT_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMessage, IconReply } from '../../../base/icons';
 import { getParticipantById } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { handleLobbyChatInitialized, openChat } from '../../../chat/actions.native';
 import { navigate } from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';

--- a/react/features/chat/components/web/Chat.js
+++ b/react/features/chat/components/web/Chat.js
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import Tabs from '../../../base/ui/components/web/Tabs';
 import { PollsPane } from '../../../polls/components';
 import { toggleChat } from '../../actions.web';

--- a/react/features/chat/components/web/ChatButton.js
+++ b/react/features/chat/components/web/ChatButton.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconMessage } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import ChatCounter from './ChatCounter';

--- a/react/features/chat/components/web/ChatCounter.js
+++ b/react/features/chat/components/web/ChatCounter.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../base/redux';
 import { getUnreadPollCount } from '../../../polls/functions';
 import { getUnreadCount } from '../../functions';
 

--- a/react/features/chat/components/web/ChatHeader.js
+++ b/react/features/chat/components/web/ChatHeader.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { useCallback } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { Icon, IconCloseLarge } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { toggleChat } from '../../actions.web';
 
 type Props = {

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -1,11 +1,11 @@
 import React, { Component, RefObject } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../../app/types';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
 import { IconFaceSmile, IconSend } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';
 import { areSmileysDisabled } from '../../functions';

--- a/react/features/chat/components/web/ChatPrivacyDialog.tsx
+++ b/react/features/chat/components/web/ChatPrivacyDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import { AbstractChatPrivacyDialog, _mapDispatchToProps, _mapStateToProps } from '../AbstractChatPrivacyDialog';
 

--- a/react/features/chat/components/web/DisplayNameForm.tsx
+++ b/react/features/chat/components/web/DisplayNameForm.tsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';

--- a/react/features/chat/components/web/MessageRecipient.tsx
+++ b/react/features/chat/components/web/MessageRecipient.tsx
@@ -1,10 +1,10 @@
 import { Theme } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
 import { IconCloseLarge } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 import { withPixelLineHeight } from '../../../base/styles/functions.web';
 import Button from '../../../base/ui/components/web/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.any';

--- a/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.js
+++ b/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.js
@@ -2,6 +2,7 @@
 
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import {
     createChromeExtensionBannerEvent,
@@ -15,7 +16,6 @@ import {
 import { translate } from '../../base/i18n';
 import { Icon, IconCloseLarge } from '../../base/icons';
 import { browser } from '../../base/lib-jitsi-meet';
-import { connect } from '../../base/redux';
 import { isVpaasMeeting } from '../../jaas/functions';
 import logger from '../logger';
 

--- a/react/features/conference/components/native/Conference.js
+++ b/react/features/conference/components/native/Conference.js
@@ -4,12 +4,12 @@ import { useIsFocused } from '@react-navigation/native';
 import React, { useEffect } from 'react';
 import { BackHandler, NativeModules, SafeAreaView, View } from 'react-native';
 import { withSafeAreaInsets } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
 
 import { appNavigate } from '../../../app/actions';
 import { FULLSCREEN_ENABLED, PIP_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { getParticipantCount } from '../../../base/participants';
 import { Container, LoadingIndicator, TintedView } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
 import { TestConnectionInfo } from '../../../base/testing';
 import { isCalendarEnabled } from '../../../calendar-sync/functions.native';

--- a/react/features/conference/components/native/InsecureRoomNameLabel.js
+++ b/react/features/conference/components/native/InsecureRoomNameLabel.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { IconWarning } from '../../../base/icons';
 import { Label } from '../../../base/label';
-import { connect } from '../../../base/redux';
 import AbstractInsecureRoomNameLabel, { _mapStateToProps } from '../AbstractInsecureRoomNameLabel';
 
 import styles from './styles';

--- a/react/features/conference/components/native/LonelyMeetingExperience.tsx
+++ b/react/features/conference/components/native/LonelyMeetingExperience.tsx
@@ -3,6 +3,7 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 // @ts-ignore
@@ -11,7 +12,6 @@ import { translate } from '../../../base/i18n/functions';
 // @ts-ignore
 import { Icon, IconAddUser } from '../../../base/icons';
 import { getParticipantCountWithFake } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 import Button from '../../../base/ui/components/native/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';
 import { isInBreakoutRoom } from '../../../breakout-rooms/functions';
@@ -145,8 +145,8 @@ function _mapStateToProps(state: IReduxState) {
     return {
         _inviteOthersControl,
         _isInBreakoutRoom,
-        _isInviteFunctionsDisabled: !flag || disableInviteFunctions,
-        _isLonelyMeeting: conference && getParticipantCountWithFake(state) === 1
+        _isInviteFunctionsDisabled: Boolean(!flag || disableInviteFunctions),
+        _isLonelyMeeting: Boolean(conference && getParticipantCountWithFake(state) === 1)
     };
 }
 

--- a/react/features/conference/components/native/TitleBar.js
+++ b/react/features/conference/components/native/TitleBar.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { getConferenceName, getConferenceTimestamp } from '../../../base/conference/functions';
 import { CONFERENCE_TIMER_ENABLED, MEETING_NAME_ENABLED, getFeatureFlag } from '../../../base/flags';
-import { connect } from '../../../base/redux';
 import AudioDeviceToggleButton from '../../../mobile/audio-mode/components/AudioDeviceToggleButton';
 import { PictureInPictureButton } from '../../../mobile/picture-in-picture';
 import { ParticipantsPaneButton } from '../../../participants-pane/components/native';

--- a/react/features/conference/components/native/carmode/TitleBar.tsx
+++ b/react/features/conference/components/native/carmode/TitleBar.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { StyleProp, Text, View, ViewStyle } from 'react-native';
-import { useSelector } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
 import { getConferenceName } from '../../../../base/conference/functions';
@@ -10,7 +10,6 @@ import { MEETING_NAME_ENABLED } from '../../../../base/flags/constants';
 import { getFeatureFlag } from '../../../../base/flags/functions';
 import { JitsiRecordingConstants } from '../../../../base/lib-jitsi-meet';
 import { getLocalParticipant } from '../../../../base/participants/functions';
-import { connect } from '../../../../base/redux/functions';
 // @ts-ignore
 import ConnectionIndicator from '../../../../connection-indicator/components/native/ConnectionIndicator';
 // @ts-ignore

--- a/react/features/conference/components/web/Conference.js
+++ b/react/features/conference/components/web/Conference.js
@@ -2,13 +2,13 @@
 
 import _ from 'lodash';
 import React from 'react';
+import { connect as reactReduxConnect } from 'react-redux';
 
 import VideoLayout from '../../../../../modules/UI/videolayout/VideoLayout';
 import { getConferenceNameForTitle } from '../../../base/conference';
 import { connect, disconnect } from '../../../base/connection';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n';
-import { connect as reactReduxConnect } from '../../../base/redux';
 import { setColorAlpha } from '../../../base/util';
 import { Chat } from '../../../chat';
 import { MainFilmstrip, ScreenshareFilmstrip, StageFilmstrip } from '../../../filmstrip';

--- a/react/features/conference/components/web/ConferenceInfo.js
+++ b/react/features/conference/components/web/ConferenceInfo.js
@@ -3,9 +3,9 @@
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { connect } from '../../../base/redux';
 import E2EELabel from '../../../e2ee/components/E2EELabel';
 import HighlightButton from '../../../recording/components/Recording/web/HighlightButton';
 import RecordingLabel from '../../../recording/components/web/RecordingLabel';

--- a/react/features/conference/components/web/Notice.js
+++ b/react/features/conference/components/web/Notice.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 
 declare var config: Object;
 

--- a/react/features/connection-indicator/components/native/ConnectionIndicator.tsx
+++ b/react/features/connection-indicator/components/native/ConnectionIndicator.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { StyleProp, View, ViewStyle } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import { IconConnection } from '../../../base/icons/svg';
@@ -13,7 +14,6 @@ import {
 } from '../../../base/participants/functions';
 // @ts-ignore
 import BaseIndicator from '../../../base/react/components/native/BaseIndicator';
-import { connect } from '../../../base/redux/functions';
 import {
     getTrackByMediaTypeAndParticipant
 } from '../../../base/tracks/functions.native';

--- a/react/features/connection-indicator/components/web/ConnectionIndicatorContent.js
+++ b/react/features/connection-indicator/components/web/ConnectionIndicatorContent.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
 import { MEDIA_TYPE } from '../../../base/media';
 import { getLocalParticipant, getParticipantById, isScreenShareParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import {
     getTrackByMediaTypeAndParticipant,
     getVirtualScreenshareParticipantTrack

--- a/react/features/deep-linking/components/NoMobileApp.web.js
+++ b/react/features/deep-linking/components/NoMobileApp.web.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { createDeepLinkingPageEvent, sendAnalytics } from '../../analytics';
 import { IDeeplinkingConfig } from '../../base/config/configType';
-import { connect } from '../../base/redux';
 
 
 /**

--- a/react/features/desktop-picker/components/DesktopPicker.tsx
+++ b/react/features/desktop-picker/components/DesktopPicker.tsx
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IStore } from '../../app/types';
 import { hideDialog } from '../../base/dialog/actions';
 import { translate } from '../../base/i18n/functions';
-import { connect } from '../../base/redux/functions';
 import Dialog from '../../base/ui/components/web/Dialog';
 import Tabs from '../../base/ui/components/web/Tabs';
 // eslint-disable-next-line lines-around-comment

--- a/react/features/display-name/components/native/DisplayNameLabel.tsx
+++ b/react/features/display-name/components/native/DisplayNameLabel.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import {
@@ -7,7 +8,6 @@ import {
     getParticipantDisplayName,
     isScreenShareParticipant
 } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 
 // @ts-ignore
 import styles from './styles';
@@ -73,8 +73,8 @@ function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
 
     return {
         _participantName: getParticipantDisplayName(state, ownProps.participantId ?? ''),
-        _render: participant && (!participant?.local || ownProps.contained)
-            && (!participant?.fakeParticipant || isScreenShareParticipant(participant))
+        _render: Boolean(participant && (!participant?.local || ownProps.contained)
+            && (!participant?.fakeParticipant || isScreenShareParticipant(participant)))
     };
 }
 

--- a/react/features/display-name/components/native/DisplayNamePrompt.js
+++ b/react/features/display-name/components/native/DisplayNamePrompt.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { InputDialog } from '../../../base/dialog';
-import { connect } from '../../../base/redux';
 import AbstractDisplayNamePrompt from '../AbstractDisplayNamePrompt';
 
 /**

--- a/react/features/display-name/components/web/DisplayNamePrompt.tsx
+++ b/react/features/display-name/components/web/DisplayNamePrompt.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import Input from '../../../base/ui/components/web/Input';
 import AbstractDisplayNamePrompt, { IProps } from '../AbstractDisplayNamePrompt';

--- a/react/features/dynamic-branding/components/native/BrandingImageBackground.tsx
+++ b/react/features/dynamic-branding/components/native/BrandingImageBackground.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Image, ImageStyle, StyleProp, ViewStyle } from 'react-native';
 import { SvgUri } from 'react-native-svg';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 
 import styles from './styles';
 

--- a/react/features/e2ee/components/E2EESection.tsx
+++ b/react/features/e2ee/components/E2EESection.tsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { createE2EEEvent } from '../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../analytics/functions';
 import { IReduxState, IStore } from '../../app/types';
 import { translate } from '../../base/i18n/functions';
-import { connect } from '../../base/redux/functions';
 import Switch from '../../base/ui/components/web/Switch';
 import { toggleE2EE } from '../actions';
 import { MAX_MODE } from '../constants';
@@ -16,7 +16,7 @@ interface IProps extends WithTranslation {
     /**
      * The resource for the description, computed based on the maxMode and whether the switch is toggled or not.
      */
-    _descriptionResource: string;
+    _descriptionResource?: string;
 
     /**
      * Custom e2ee labels.
@@ -100,7 +100,7 @@ class E2EESection extends Component<IProps, IState> {
     render() {
         const { _descriptionResource, _enabled, _e2eeLabels, _everyoneSupportE2EE, t } = this.props;
         const { toggled } = this.state;
-        const description = _e2eeLabels?.description || t(_descriptionResource);
+        const description = _e2eeLabels?.description || t(_descriptionResource ?? '');
         const label = _e2eeLabels?.label || t('dialog.e2eeLabel');
         const warning = _e2eeLabels?.warning || t('dialog.e2eeWarning');
 
@@ -176,7 +176,7 @@ function mapStateToProps(state: IReduxState) {
         _e2eeLabels: e2eeLabels,
         _enabled: maxMode === MAX_MODE.DISABLED || e2eeEnabled,
         _toggled: e2eeEnabled,
-        _everyoneSupportE2EE: doesEveryoneSupportE2EE(state)
+        _everyoneSupportE2EE: Boolean(doesEveryoneSupportE2EE(state))
     };
 }
 

--- a/react/features/e2ee/components/ParticipantVerificationDialog.tsx
+++ b/react/features/e2ee/components/ParticipantVerificationDialog.tsx
@@ -1,11 +1,11 @@
 import { withStyles } from '@mui/styles';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../app/types';
 import { translate } from '../../base/i18n/functions';
 import { getParticipantById } from '../../base/participants/functions';
-import { connect } from '../../base/redux/functions';
 import Dialog from '../../base/ui/components/web/Dialog';
 import { participantVerified } from '../actions';
 import { ISas } from '../reducer';
@@ -16,7 +16,7 @@ interface IProps extends WithTranslation {
     dispatch: IStore['dispatch'];
     emoji: string;
     pId: string;
-    participantName: string;
+    participantName?: string;
     sas: ISas;
 }
 
@@ -31,7 +31,7 @@ const styles = () => {
     return {
         container: {
             display: 'flex',
-            flexDirection: 'column',
+            flexDirection: 'column' as const,
             margin: '16px'
         },
         row: {
@@ -39,7 +39,7 @@ const styles = () => {
             display: 'flex'
         },
         item: {
-            textAlign: 'center',
+            textAlign: 'center' as const,
             margin: '16px'
         },
         emoji: {
@@ -161,6 +161,4 @@ export function _mapStateToProps(state: IReduxState, ownProps: IProps) {
 }
 
 export default translate(connect(_mapStateToProps)(
-
-    // @ts-ignore
     withStyles(styles)(ParticipantVerificationDialog)));

--- a/react/features/embed-meeting/components/EmbedMeetingButton.js
+++ b/react/features/embed-meeting/components/EmbedMeetingButton.js
@@ -1,10 +1,11 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { openDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
 import { IconCode } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 
 import EmbedMeetingDialog from './EmbedMeetingDialog';

--- a/react/features/etherpad/components/SharedDocumentButton.native.js
+++ b/react/features/etherpad/components/SharedDocumentButton.native.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { IconShareDoc } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { navigate } from '../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../mobile/navigation/routes';

--- a/react/features/etherpad/components/SharedDocumentButton.web.js
+++ b/react/features/etherpad/components/SharedDocumentButton.web.js
@@ -1,11 +1,11 @@
 // @flow
 
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { IconShareDoc } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { toggleDocument } from '../../etherpad/actions';
 import { setOverflowMenuVisible } from '../../toolbox/actions.web';

--- a/react/features/etherpad/components/native/SharedDocument.js
+++ b/react/features/etherpad/components/native/SharedDocument.js
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
 import { LoadingIndicator } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { getSharedDocumentUrl } from '../../functions';
 
 import styles, { INDICATOR_COLOR } from './styles';

--- a/react/features/feedback/components/FeedbackButton.web.js
+++ b/react/features/feedback/components/FeedbackButton.web.js
@@ -1,10 +1,11 @@
 
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { IconFeedback } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { openFeedbackDialog } from '../actions';
 
@@ -16,7 +17,7 @@ type Props = AbstractButtonProps & {
     /**
      * The {@code JitsiConference} for the current conference.
      */
-     _conference: Object,
+    _conference: Object,
 
     /**
      * The redux {@code dispatch} function.

--- a/react/features/filmstrip/components/native/Filmstrip.js
+++ b/react/features/filmstrip/components/native/Filmstrip.js
@@ -3,10 +3,10 @@
 import React, { PureComponent } from 'react';
 import { FlatList } from 'react-native';
 import { SafeAreaView, withSafeAreaInsets } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
 
 import { getLocalParticipant } from '../../../base/participants';
 import { Platform } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui/constants';
 import { getHideSelfView } from '../../../base/settings/functions.any';
 import { isToolboxVisible } from '../../../toolbox/functions';

--- a/react/features/filmstrip/components/native/RaisedHandIndicator.js
+++ b/react/features/filmstrip/components/native/RaisedHandIndicator.js
@@ -2,10 +2,10 @@
 
 import React from 'react';
 import { View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IconRaiseHand } from '../../../base/icons';
 import { BaseIndicator } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import AbstractRaisedHandIndicator, {
     type Props as AbstractProps,
     _mapStateToProps

--- a/react/features/filmstrip/components/native/Thumbnail.js
+++ b/react/features/filmstrip/components/native/Thumbnail.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Image, View } from 'react-native';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { JitsiTrackEvents } from '../../../base/lib-jitsi-meet';
@@ -17,7 +18,6 @@ import {
 import ParticipantView from '../../../base/participants/components/ParticipantView.native';
 import { FakeParticipant } from '../../../base/participants/types';
 import { Container } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import {
     getTrackByMediaTypeAndParticipant,
     getVideoTrackByParticipant,

--- a/react/features/filmstrip/components/native/TileView.js
+++ b/react/features/filmstrip/components/native/TileView.js
@@ -7,10 +7,10 @@ import {
     TouchableWithoutFeedback
 } from 'react-native';
 import { withSafeAreaInsets } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getLocalParticipant, getParticipantCountWithFake } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { getHideSelfView } from '../../../base/settings/functions.any';
 import { setVisibleRemoteParticipants } from '../../actions.web';
 

--- a/react/features/filmstrip/components/web/AudioTracksContainer.js
+++ b/react/features/filmstrip/components/web/AudioTracksContainer.js
@@ -1,8 +1,8 @@
 /* @flow */
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { AudioTrack, MEDIA_TYPE } from '../../../base/media';
-import { connect } from '../../../base/redux';
 
 /**
  * The type of the React {@code Component} props of {@link AudioTracksContainer}.

--- a/react/features/filmstrip/components/web/Filmstrip.tsx
+++ b/react/features/filmstrip/components/web/Filmstrip.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 import { FixedSizeGrid, FixedSizeList } from 'react-window';
 
 import { ACTION_SHORTCUT_TRIGGERED, createShortcutEvent, createToolbarEvent } from '../../../analytics/AnalyticsEvents';
@@ -13,7 +14,6 @@ import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
 import Icon from '../../../base/icons/components/Icon';
 import { IconArrowDown, IconArrowUp } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 import { getHideSelfView } from '../../../base/settings/functions.any';
 import { showToolbox } from '../../../toolbox/actions.web';
 import { isButtonEnabled, isToolboxVisible } from '../../../toolbox/functions.web';
@@ -67,7 +67,7 @@ interface IProps extends WithTranslation {
     /**
      * The current layout of the filmstrip.
      */
-    _currentLayout: string;
+    _currentLayout?: string;
 
     /**
      * Whether or not to hide the self view.
@@ -167,7 +167,7 @@ interface IProps extends WithTranslation {
     /**
      * The height of the top panel (user resized).
      */
-    _topPanelHeight?: number;
+    _topPanelHeight?: number | null;
 
     /**
      * The max height of the top panel.
@@ -182,7 +182,7 @@ interface IProps extends WithTranslation {
     /**
      * The width of the vertical filmstrip (user resized).
      */
-    _verticalFilmstripWidth?: number;
+    _verticalFilmstripWidth?: number | null;
 
     /**
      * Whether or not the vertical filmstrip should have a background color.
@@ -922,7 +922,7 @@ function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
         _mainFilmstripVisible: visible,
         _maxFilmstripWidth: clientWidth - MIN_STAGE_VIEW_WIDTH,
         _maxTopPanelHeight: clientHeight - MIN_STAGE_VIEW_HEIGHT,
-        _remoteParticipantsLength: _remoteParticipants?.length,
+        _remoteParticipantsLength: _remoteParticipants?.length ?? 0,
         _topPanelHeight: topPanelHeight.current,
         _topPanelMaxHeight: topPanelHeight.current || TOP_FILMSTRIP_HEIGHT,
         _topPanelVisible,

--- a/react/features/filmstrip/components/web/MainFilmstrip.js
+++ b/react/features/filmstrip/components/web/MainFilmstrip.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { getToolbarButtons } from '../../../base/config';
 import { isMobileBrowser } from '../../../base/environment/utils';
-import { connect } from '../../../base/redux';
 import { LAYOUTS, getCurrentLayout } from '../../../video-layout';
 import {
     ASPECT_RATIO_BREAKPOINT,

--- a/react/features/filmstrip/components/web/ScreenshareFilmstrip.js
+++ b/react/features/filmstrip/components/web/ScreenshareFilmstrip.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../base/redux';
 import { LAYOUTS, LAYOUT_CLASSNAMES, getCurrentLayout } from '../../../video-layout';
 import {
     FILMSTRIP_TYPE

--- a/react/features/filmstrip/components/web/StageFilmstrip.js
+++ b/react/features/filmstrip/components/web/StageFilmstrip.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { getToolbarButtons } from '../../../base/config';
 import { isMobileBrowser } from '../../../base/environment/utils';
-import { connect } from '../../../base/redux';
 import { LAYOUTS, LAYOUT_CLASSNAMES, getCurrentLayout } from '../../../video-layout';
 import {
     ASPECT_RATIO_BREAKPOINT,

--- a/react/features/filmstrip/components/web/StatusIndicators.js
+++ b/react/features/filmstrip/components/web/StatusIndicators.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { MEDIA_TYPE } from '../../../base/media';
 import {
@@ -8,7 +9,6 @@ import {
     getParticipantByIdOrUndefined,
     isScreenShareParticipantById
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import {
     getVideoTrackByParticipant,
     isLocalTrackMuted,

--- a/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
+++ b/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.js
@@ -6,6 +6,7 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import { connect } from 'react-redux';
 
 import { AlertDialog, openDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
@@ -19,7 +20,6 @@ import {
 } from '../../../../base/icons';
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
 import { AvatarListItem, type Item } from '../../../../base/react';
-import { connect } from '../../../../base/redux';
 import BaseTheme from '../../../../base/ui/components/BaseTheme.native';
 import Input from '../../../../base/ui/components/native/Input';
 import HeaderNavigationButton

--- a/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.tsx
+++ b/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable lines-around-comment */
 import React, { useEffect } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { createInviteDialogEvent } from '../../../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../../../analytics/functions';
@@ -8,7 +9,6 @@ import { IReduxState } from '../../../../app/types';
 import { getInviteURL } from '../../../../base/connection/functions';
 import { translate } from '../../../../base/i18n/functions';
 import { JitsiRecordingConstants } from '../../../../base/lib-jitsi-meet';
-import { connect } from '../../../../base/redux/functions';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 import { StatusCode } from '../../../../base/util/uri';
 import { isDynamicBrandingDataLoaded } from '../../../../dynamic-branding/functions.any';
@@ -68,7 +68,7 @@ interface IProps extends WithTranslation {
     /**
      * An alternate app name to be displayed in the email subject.
      */
-    _inviteAppName?: string;
+    _inviteAppName?: string | null;
 
     /**
      * Whether or not invite contacts should be visible.
@@ -88,12 +88,12 @@ interface IProps extends WithTranslation {
     /**
      * The current known URL for a live stream in progress.
      */
-    _liveStreamViewURL: string;
+    _liveStreamViewURL?: string;
 
     /**
      * The default phone number.
      */
-    _phoneNumber?: string;
+    _phoneNumber?: string | null;
 
     /**
      * Whether or not url sharing button should be visible.

--- a/react/features/invite/components/add-people-dialog/web/InviteButton.js
+++ b/react/features/invite/components/add-people-dialog/web/InviteButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../../analytics';
 import { translate } from '../../../../base/i18n';
 import { IconAddUser } from '../../../../base/icons';
-import { connect } from '../../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../../base/toolbox/components';
 import { beginAddPeople } from '../../../actions.any';
 

--- a/react/features/invite/components/add-people-dialog/web/InviteContactsForm.js
+++ b/react/features/invite/components/add-people-dialog/web/InviteContactsForm.js
@@ -2,13 +2,13 @@
 
 import InlineMessage from '@atlaskit/inline-message';
 import React from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { Avatar } from '../../../../base/avatar';
 import { translate } from '../../../../base/i18n';
 import { Icon, IconPhoneRinging } from '../../../../base/icons';
 import { MultiSelectAutocomplete } from '../../../../base/react';
-import { connect } from '../../../../base/redux';
 import { isVpaasMeeting } from '../../../../jaas/functions';
 import { hideAddPeopleDialog } from '../../../actions';
 import { INVITE_TYPES } from '../../../constants';

--- a/react/features/invite/components/callee-info/CalleeInfo.js
+++ b/react/features/invite/components/callee-info/CalleeInfo.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { MEDIA_TYPE } from '../../../base/media';
@@ -10,7 +11,6 @@ import {
     getRemoteParticipants
 } from '../../../base/participants';
 import { Container, Text } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { isLocalTrackMuted } from '../../../base/tracks';
 import { CALLING, PresenceLabel } from '../../../presence-status';
 

--- a/react/features/invite/components/callee-info/CalleeInfoContainer.js
+++ b/react/features/invite/components/callee-info/CalleeInfoContainer.js
@@ -1,8 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-
-import { connect } from '../../../base/redux';
+import { connect } from 'react-redux';
 
 import CalleeInfo from './CalleeInfo';
 
@@ -49,7 +48,7 @@ class CalleeInfoContainer extends Component<Props> {
  *     _calleeInfoVisible: boolean
  * }}
  */
-function _mapStateToProps(state: Object): Object {
+function _mapStateToProps(state: Object) {
     return {
         /**
          * The indicator which determines whether {@code CalleeInfo} is to be

--- a/react/features/invite/components/dial-in-summary/native/DialInSummary.js
+++ b/react/features/invite/components/dial-in-summary/native/DialInSummary.js
@@ -3,13 +3,13 @@
 import React, { PureComponent } from 'react';
 import { Linking, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 
 import { openDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
 import { LoadingIndicator } from '../../../../base/react';
-import { connect } from '../../../../base/redux';
 import { getDialInfoPageURLForURIString } from '../../../functions';
 
 import DialInSummaryErrorDialog from './DialInSummaryErrorDialog';

--- a/react/features/invite/components/dial-in-summary/native/DialInSummaryErrorDialog.js
+++ b/react/features/invite/components/dial-in-summary/native/DialInSummaryErrorDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { AlertDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 
 /**
  * Dialog to inform the user that we couldn't fetch the dial-in info page.

--- a/react/features/keyboard-shortcuts/components/web/KeyboardShortcutsButton.js
+++ b/react/features/keyboard-shortcuts/components/web/KeyboardShortcutsButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
 import { IconShortcuts } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { openSettingsDialog } from '../../../settings/actions';
 import { SETTINGS_TABS } from '../../../settings/constants';

--- a/react/features/large-video/components/LargeVideo.native.js
+++ b/react/features/large-video/components/LargeVideo.native.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
 import ParticipantView from '../../base/participants/components/ParticipantView.native';
 import { getParticipantById, isLocalScreenshareParticipant } from '../../base/participants/functions';
-import { connect } from '../../base/redux';
 import {
     getVideoTrackByParticipant,
     isLocalVideoTrackDesktop,

--- a/react/features/large-video/components/LargeVideo.web.js
+++ b/react/features/large-video/components/LargeVideo.web.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import VideoLayout from '../../../../modules/UI/videolayout/VideoLayout';
 import { VIDEO_TYPE } from '../../base/media';
 import { getLocalParticipant } from '../../base/participants';
 import { Watermarks } from '../../base/react';
-import { connect } from '../../base/redux';
 import { getHideSelfView } from '../../base/settings/functions.any';
 import { getVideoTrackByParticipant } from '../../base/tracks';
 import { setColorAlpha } from '../../base/util';

--- a/react/features/large-video/components/LargeVideoBackground.web.js
+++ b/react/features/large-video/components/LargeVideoBackground.web.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../base/redux';
 import { shouldDisplayTileView } from '../../video-layout';
 
 /**
@@ -24,7 +24,7 @@ export const ORIENTATION = {
  */
 type Props = {
 
-   /**
+    /**
      * Whether or not the layout should change to support tile view mode.
      *
      * @protected
@@ -230,17 +230,17 @@ export class LargeVideoBackground extends Component<Props> {
             height: canvasHeight,
             width: canvasWidth
         } = this._canvasEl;
-        const cavnasContext = this._canvasEl.getContext('2d');
+        const canvasContext = this._canvasEl.getContext('2d');
 
         if (this.props.orientationFit === ORIENTATION.LANDSCAPE) {
             const heightScaledToFit = (canvasWidth / videoWidth) * videoHeight;
 
-            cavnasContext.drawImage(
+            canvasContext.drawImage(
                 videoElement, 0, 0, canvasWidth, heightScaledToFit);
         } else {
             const widthScaledToFit = (canvasHeight / videoHeight) * videoWidth;
 
-            cavnasContext.drawImage(
+            canvasContext.drawImage(
                 videoElement, 0, 0, widthScaledToFit, canvasHeight);
         }
     }

--- a/react/features/lobby/components/AbstractLobbyScreen.js
+++ b/react/features/lobby/components/AbstractLobbyScreen.js
@@ -437,7 +437,7 @@ export default class AbstractLobbyScreen<P: Props = Props> extends PureComponent
  * @param {Object} state - The Redux state.
  * @returns {Props}
  */
-export function _mapStateToProps(state: Object): $Shape<Props> {
+export function _mapStateToProps(state: Object) {
     const localParticipant = getLocalParticipant(state);
     const participantId = localParticipant?.id;
     const inviteEnabledFlag = getFeatureFlag(state, INVITE_ENABLED, true);

--- a/react/features/lobby/components/native/LobbyChatScreen.js
+++ b/react/features/lobby/components/native/LobbyChatScreen.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
-import { connect } from '../../../base/redux';
 import ChatInputBar from '../../../chat/components/native/ChatInputBar';
 import MessageContainer from '../../../chat/components/native/MessageContainer';
 import AbstractLobbyScreen, {

--- a/react/features/lobby/components/native/LobbyScreen.js
+++ b/react/features/lobby/components/native/LobbyScreen.js
@@ -1,11 +1,11 @@
 import React, { ReactElement } from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { getConferenceName } from '../../../base/conference/functions';
 import { translate } from '../../../base/i18n';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
 import { LoadingIndicator } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_NARROW } from '../../../base/responsive-ui';
 import BaseTheme from '../../../base/ui/components/BaseTheme.native';
 import Button from '../../../base/ui/components/native/Button';

--- a/react/features/lobby/components/web/LobbyScreen.js
+++ b/react/features/lobby/components/web/LobbyScreen.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { Icon, IconCloseLarge } from '../../../base/icons';
 import { PreMeetingScreen } from '../../../base/premeeting';
 import { LoadingIndicator } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';
 import ChatInput from '../../../chat/components/web/ChatInput';

--- a/react/features/lobby/components/web/LobbySection.tsx
+++ b/react/features/lobby/components/web/LobbySection.tsx
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import { getSecurityUiConfig } from '../../../base/config/functions.any';
 import { translate } from '../../../base/i18n/functions';
 import { isLocalParticipantModerator } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 import Switch from '../../../base/ui/components/web/Switch';
 import { isInBreakoutRoom } from '../../../breakout-rooms/functions';
 import { toggleLobbyMode } from '../../actions';
@@ -125,7 +125,7 @@ class LobbySection extends PureComponent<IProps, IState> {
  * @param {Object} state - The Redux state.
  * @returns {IProps}
  */
-function mapStateToProps(state: IReduxState): Partial<IProps> {
+function mapStateToProps(state: IReduxState) {
     const { conference } = state['features/base/conference'];
     const { hideLobbyButton } = getSecurityUiConfig(state);
 

--- a/react/features/mobile/audio-mode/components/AudioDeviceToggleButton.js
+++ b/react/features/mobile/audio-mode/components/AudioDeviceToggleButton.js
@@ -1,9 +1,9 @@
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { openSheet } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { IconVolumeUp } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import AudioRoutePickerDialog from './AudioRoutePickerDialog';

--- a/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
+++ b/react/features/mobile/audio-mode/components/AudioRoutePickerDialog.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import { NativeModules, Text, TouchableHighlight, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { BottomSheet, hideSheet } from '../../../base/dialog';
 import { bottomSheetStyles } from '../../../base/dialog/components/native/styles';
@@ -13,7 +14,6 @@ import {
     IconPhoneRinging,
     IconVolumeUp
 } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import BaseTheme from '../../../base/ui/components/BaseTheme.native';
 
 import styles from './styles';

--- a/react/features/mobile/navigation/components/RootNavigationContainer.tsx
+++ b/react/features/mobile/navigation/components/RootNavigationContainer.tsx
@@ -4,9 +4,9 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React, { useCallback } from 'react';
 import { StatusBar } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 // @ts-ignore
 import DialInSummary from '../../../invite/components/dial-in-summary/native/DialInSummary';
 import Prejoin from '../../../prejoin/components/native/Prejoin';

--- a/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
+++ b/react/features/mobile/picture-in-picture/components/PictureInPictureButton.js
@@ -1,11 +1,11 @@
 // @flow
 
 import { NativeModules, Platform } from 'react-native';
+import { connect } from 'react-redux';
 
 import { PIP_ENABLED, PIP_WHILE_SCREEN_SHARING_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconArrowDown } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions';
 import { enterPictureInPicture } from '../actions';
@@ -62,7 +62,7 @@ class PictureInPictureButton extends AbstractButton<Props, *> {
  *     _enabled: boolean
  * }}
  */
-function _mapStateToProps(state): Object {
+function _mapStateToProps(state) {
     const pipEnabled = Boolean(getFeatureFlag(state, PIP_ENABLED));
     const pipWhileScreenSharingEnabled = getFeatureFlag(state, PIP_WHILE_SCREEN_SHARING_ENABLED, false);
 

--- a/react/features/no-audio-signal/components/DialInLink.js
+++ b/react/features/no-audio-signal/components/DialInLink.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
-import { connect } from '../../base/redux';
 import { getDialInfoPageURL, shouldDisplayDialIn } from '../../invite';
 
 /**

--- a/react/features/noise-suppression/components/NoiseSuppressionButton.tsx
+++ b/react/features/noise-suppression/components/NoiseSuppressionButton.tsx
@@ -1,10 +1,11 @@
+import { connect } from 'react-redux';
+
 import { IReduxState } from '../../app/types';
 import { translate } from '../../base/i18n/functions';
 import {
     IconNoiseSuppressionOff,
     IconNoiseSuppressionOn
 } from '../../base/icons/svg';
-import { connect } from '../../base/redux/functions';
 import {
     AbstractButton,
     type AbstractButtonProps
@@ -69,7 +70,7 @@ class NoiseSuppressionButton extends AbstractButton<Props, any, any> {
  * @private
  * @returns {Props}
  */
-function _mapStateToProps(state: IReduxState): Object {
+function _mapStateToProps(state: IReduxState) {
     return {
         _isNoiseSuppressionEnabled: isNoiseSuppressionEnabled(state)
     };

--- a/react/features/notifications/components/native/NotificationsContainer.tsx
+++ b/react/features/notifications/components/native/NotificationsContainer.tsx
@@ -4,9 +4,9 @@ import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { Platform } from 'react-native';
 import { Edge, SafeAreaView } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 import { hideNotification } from '../../actions';
 import { areThereNotifications } from '../../functions';
 import NotificationsTransition from '../NotificationsTransition';

--- a/react/features/notifications/components/web/NotificationsContainer.tsx
+++ b/react/features/notifications/components/web/NotificationsContainer.tsx
@@ -2,9 +2,9 @@ import { withStyles } from '@mui/styles';
 import clsx from 'clsx';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 import { hideNotification } from '../../actions';
 import { areThereNotifications } from '../../functions';
 import { INotificationProps } from '../../types';

--- a/react/features/overlay/components/web/OverlayContainer.tsx
+++ b/react/features/overlay/components/web/OverlayContainer.tsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 import { getOverlayToRender } from '../../functions.web';
 
 

--- a/react/features/overlay/components/web/PageReloadOverlay.js
+++ b/react/features/overlay/components/web/PageReloadOverlay.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 
 import AbstractPageReloadOverlay, {
     type Props,

--- a/react/features/overlay/components/web/ReloadButton.js
+++ b/react/features/overlay/components/web/ReloadButton.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { reloadNow } from '../../../app/actions';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 
 /**
  * The type of the React {@code Component} props of {@link ReloadButton}.
@@ -63,7 +63,7 @@ class ReloadButton extends Component<Props> {
  * @private
  * @returns {Object}
  */
-function _mapDispatchToProps(dispatch: Function): Object {
+function _mapDispatchToProps(dispatch: Function) {
     return {
         /**
          * Dispatches the redux action to reload the page.

--- a/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
+++ b/react/features/overlay/components/web/UserMediaPermissionsOverlay.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate, translateToHTML } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 
 import AbstractUserMediaPermissionsOverlay, { abstractMapStateToProps }
     from './AbstractUserMediaPermissionsOverlay';
@@ -96,7 +96,7 @@ class UserMediaPermissionsOverlay extends AbstractUserMediaPermissionsOverlay {
  * @param {Object} ownProps - The props passed to the component.
  * @returns {Object}
  */
-function mapStateToProps(state): Object {
+function mapStateToProps(state) {
     const { premeetingBackground } = state['features/dynamic-branding'];
 
     return {

--- a/react/features/participants-pane/components/native/MeetingParticipantItem.js
+++ b/react/features/participants-pane/components/native/MeetingParticipantItem.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import {
@@ -9,7 +10,6 @@ import {
     isParticipantModerator
 } from '../../../base/participants';
 import { FakeParticipant } from '../../../base/participants/types';
-import { connect } from '../../../base/redux';
 import {
     isParticipantAudioMuted,
     isParticipantVideoMuted

--- a/react/features/participants-pane/components/native/MeetingParticipantList.tsx
+++ b/react/features/participants-pane/components/native/MeetingParticipantList.tsx
@@ -3,6 +3,7 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { FlatList, Text } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
@@ -13,7 +14,6 @@ import {
     getParticipantCountWithFake,
     getRemoteParticipants
 } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 import Button from '../../../base/ui/components/native/Button';
 import Input from '../../../base/ui/components/native/Input';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';

--- a/react/features/participants-pane/components/native/ParticipantsPaneButton.js
+++ b/react/features/participants-pane/components/native/ParticipantsPaneButton.js
@@ -1,10 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
 import { IconUsers } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { navigate }
     from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';

--- a/react/features/participants-pane/components/native/RoomParticipantMenu.tsx
+++ b/react/features/participants-pane/components/native/RoomParticipantMenu.tsx
@@ -2,6 +2,7 @@
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 // @ts-ignore
@@ -11,7 +12,6 @@ import { BottomSheet, hideSheet } from '../../../base/dialog';
 // @ts-ignore
 import { bottomSheetStyles } from '../../../base/dialog/components/native/styles';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import { getBreakoutRooms } from '../../../breakout-rooms/functions';
 // @ts-ignore
 import SendToBreakoutRoom from '../../../video-menu/components/native/SendToBreakoutRoom';

--- a/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantContextMenu.js
@@ -1,12 +1,12 @@
 // @flow
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import {
     getLocalParticipant,
     getParticipantByIdOrUndefined
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import FakeParticipantContextMenu from '../../../video-menu/components/web/FakeParticipantContextMenu';
 import ParticipantContextMenu from '../../../video-menu/components/web/ParticipantContextMenu';
 
@@ -122,7 +122,7 @@ class MeetingParticipantContextMenu extends Component<Props> {
  * @private
  * @returns {Props}
  */
-function _mapStateToProps(state, ownProps): Object {
+function _mapStateToProps(state, ownProps) {
     const { participantID, overflowDrawer, drawerParticipant } = ownProps;
     const { ownerId } = state['features/shared-video'];
     const localParticipantId = getLocalParticipant(state).id;

--- a/react/features/participants-pane/components/web/MeetingParticipantItem.js
+++ b/react/features/participants-pane/components/web/MeetingParticipantItem.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { useCallback, useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 
 import { JitsiTrackEvents } from '../../../base/lib-jitsi-meet';
 import { MEDIA_TYPE } from '../../../base/media';
@@ -11,7 +12,6 @@ import {
     hasRaisedHand,
     isParticipantModerator
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import {
     getLocalAudioTrack,
     getTrackByMediaTypeAndParticipant,
@@ -294,7 +294,7 @@ function MeetingParticipantItem({
  * @private
  * @returns {Props}
  */
-function _mapStateToProps(state, ownProps): Object {
+function _mapStateToProps(state, ownProps) {
     const { participantID, searchString } = ownProps;
     const { ownerId } = state['features/shared-video'];
     const localParticipantId = getLocalParticipant(state).id;

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable lines-around-comment */
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState } from '../../../app/types';
@@ -10,7 +10,6 @@ import participantsPaneTheme from '../../../base/components/themes/participantsP
 import { isToolbarButtonEnabled } from '../../../base/config/functions.web';
 import { MEDIA_TYPE } from '../../../base/media/constants';
 import { getParticipantById, isScreenShareParticipant } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 import { withPixelLineHeight } from '../../../base/styles/functions.web';
 import Input from '../../../base/ui/components/web/Input';
 import useContextMenu from '../../../base/ui/hooks/useContextMenu.web';
@@ -173,7 +172,7 @@ function MeetingParticipants({
  * @private
  * @returns {IProps}
  */
-function _mapStateToProps(state: IReduxState): Object {
+function _mapStateToProps(state: IReduxState) {
     let sortedParticipantIds: any = getSortedParticipantIds(state);
 
     // Filter out the virtual screenshare participants since we do not want them to be displayed as separate

--- a/react/features/participants-pane/components/web/ParticipantsPaneButton.js
+++ b/react/features/participants-pane/components/web/ParticipantsPaneButton.js
@@ -1,9 +1,9 @@
 // @flow
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconUsers } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import ParticipantsCounter from './ParticipantsCounter';

--- a/react/features/prejoin/components/web/Prejoin.tsx
+++ b/react/features/prejoin/components/web/Prejoin.tsx
@@ -1,6 +1,7 @@
 import InlineDialog from '@atlaskit/inline-dialog';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 // eslint-disable-next-line lines-around-comment
@@ -13,7 +14,6 @@ import { isVideoMutedByUser } from '../../../base/media/functions';
 import { getLocalParticipant } from '../../../base/participants/functions';
 import ActionButton from '../../../base/premeeting/components/web/ActionButton';
 import PreMeetingScreen from '../../../base/premeeting/components/web/PreMeetingScreen';
-import { connect } from '../../../base/redux/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import { getDisplayName } from '../../../base/settings/functions.web';
 import { getLocalJitsiVideoTrack } from '../../../base/tracks/functions.web';
@@ -66,7 +66,7 @@ interface IProps extends WithTranslation {
     /**
      * Whether conference join is in progress.
      */
-    joiningInProgress: boolean;
+    joiningInProgress?: boolean;
 
     /**
      * The name of the user that is about to join.
@@ -76,7 +76,7 @@ interface IProps extends WithTranslation {
     /**
      * Local participant id.
      */
-    participantId: string;
+    participantId?: string;
 
     /**
      * The prejoin config.

--- a/react/features/prejoin/components/web/PrejoinThirdParty.js
+++ b/react/features/prejoin/components/web/PrejoinThirdParty.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { isVideoMutedByUser } from '../../../base/media';
 import { PreMeetingScreen } from '../../../base/premeeting';
-import { connect } from '../../../base/redux';
 import { getLocalJitsiVideoTrack } from '../../../base/tracks';
 import { isDeviceStatusVisible } from '../../functions';
 
@@ -14,7 +14,7 @@ type Props = {
     /**
      * Indicates the className that needs to be applied.
     */
-     className: string,
+    className: string,
 
     /**
      * Flag signaling if the device status is visible or not.
@@ -75,7 +75,7 @@ class PrejoinThirdParty extends Component<Props> {
  * @param {Object} ownProps - The props passed to the component.
  * @returns {Object}
  */
-function mapStateToProps(state): Object {
+function mapStateToProps(state) {
     return {
         deviceStatusVisible: isDeviceStatusVisible(state),
         showCameraPreview: !isVideoMutedByUser(state),

--- a/react/features/prejoin/components/web/country-picker/CountryPicker.js
+++ b/react/features/prejoin/components/web/country-picker/CountryPicker.js
@@ -2,8 +2,8 @@
 
 import InlineDialog from '@atlaskit/inline-dialog';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../../base/redux';
 import { setDialOutCountry, setDialOutNumber } from '../../../actions.web';
 import { getDialOutCountry, getDialOutNumber } from '../../../functions';
 import { getCountryFromDialCodeText } from '../../../utils';

--- a/react/features/prejoin/components/web/dialogs/JoinByPhoneDialog.js
+++ b/react/features/prejoin/components/web/dialogs/JoinByPhoneDialog.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../../base/redux';
 import {
     getConferenceId,
     getDefaultDialInNumber,
@@ -228,7 +228,7 @@ class JoinByPhoneDialog extends PureComponent<Props, State> {
  * @param {Object} state - The redux state.
  * @returns {Object}
  */
-function mapStateToProps(state): Object {
+function mapStateToProps(state) {
     return {
         dialInNumber: getDefaultDialInNumber(state),
         dialOutNumber: getFullDialOutNumber(state),

--- a/react/features/prejoin/components/web/preview/DeviceStatus.tsx
+++ b/react/features/prejoin/components/web/preview/DeviceStatus.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState } from '../../../../app/types';
 import { translate } from '../../../../base/i18n/functions';
-import { connect } from '../../../../base/redux/functions';
 import { withPixelLineHeight } from '../../../../base/styles/functions.web';
 import {
     getDeviceStatusText,

--- a/react/features/presence-status/components/PresenceLabel.js
+++ b/react/features/presence-status/components/PresenceLabel.js
@@ -1,11 +1,11 @@
 /* @flow */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { getParticipantById } from '../../base/participants';
 import { Text } from '../../base/react';
-import { connect } from '../../base/redux';
 import { STATUS_TO_I18N_KEY } from '../constants';
 import { presenceStatusDisabled } from '../functions';
 

--- a/react/features/reactions/components/native/RaiseHandButton.js
+++ b/react/features/reactions/components/native/RaiseHandButton.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import { Text } from 'react-native-paper';
+import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 
 import {
@@ -15,7 +16,6 @@ import {
     hasRaisedHand,
     raiseHand
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { type AbstractButtonProps } from '../../../base/toolbox/components';
 import Button from '../../../base/ui/components/native/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';

--- a/react/features/reactions/components/native/ReactionMenuDialog.js
+++ b/react/features/reactions/components/native/ReactionMenuDialog.js
@@ -2,11 +2,11 @@
 
 import React, { PureComponent } from 'react';
 import { SafeAreaView, TouchableWithoutFeedback, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { hideDialog, isDialogOpen } from '../../../base/dialog';
 import { getParticipantCount } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import type { StyleType } from '../../../base/styles';
 
 import ReactionMenu from './ReactionMenu';

--- a/react/features/reactions/components/native/ReactionsMenuButton.js
+++ b/react/features/reactions/components/native/ReactionsMenuButton.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 
 import { isDialogOpen, openDialog } from '../../../base/dialog';
@@ -9,7 +10,6 @@ import { IconRaiseHand } from '../../../base/icons';
 import {
     getLocalParticipant, hasRaisedHand
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import ReactionMenuDialog from './ReactionMenuDialog';

--- a/react/features/reactions/components/web/RaiseHandButton.js
+++ b/react/features/reactions/components/web/RaiseHandButton.js
@@ -1,7 +1,8 @@
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconRaiseHand } from '../../../base/icons';
 import { getLocalParticipant, hasRaisedHand } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 

--- a/react/features/reactions/components/web/ReactionsMenuButton.tsx
+++ b/react/features/reactions/components/web/ReactionsMenuButton.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback } from 'react';
 import { WithTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
 import { IconArrowUp } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 // eslint-disable-next-line lines-around-comment
 // @ts-ignore
 import ToolboxButtonWithIconPopup from '../../../base/toolbox/components/web/ToolboxButtonWithIconPopup';

--- a/react/features/recent-list/components/DeleteItemButton.native.js
+++ b/react/features/recent-list/components/DeleteItemButton.native.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../base/i18n';
 import { IconTrash } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { deleteRecentListEntry } from '../actions';
 

--- a/react/features/recent-list/components/RecentList.native.js
+++ b/react/features/recent-list/components/RecentList.native.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { TouchableWithoutFeedback, View } from 'react-native';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getDefaultURL } from '../../app/functions';
 import { openSheet } from '../../base/dialog/actions';
 import { translate } from '../../base/i18n';
 import { NavigateSectionList, type Section } from '../../base/react';
-import { connect } from '../../base/redux';
 import styles from '../../welcome/components/styles';
 import { isRecentListEnabled, toDisplayableList } from '../functions';
 

--- a/react/features/recent-list/components/RecentList.web.js
+++ b/react/features/recent-list/components/RecentList.web.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../base/i18n';
 import { MeetingsList } from '../../base/react';
-import { connect } from '../../base/redux';
 import { deleteRecentListEntry } from '../actions';
 import { isRecentListEnabled, toDisplayableList } from '../functions';
 

--- a/react/features/recent-list/components/RecentListItemMenu.native.js
+++ b/react/features/recent-list/components/RecentListItemMenu.native.js
@@ -1,10 +1,10 @@
 import React, { PureComponent } from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { BottomSheet, hideSheet } from '../../base/dialog';
 import { bottomSheetStyles } from '../../base/dialog/components/native/styles';
 import { type Item } from '../../base/react/Types';
-import { connect } from '../../base/redux';
 
 import DeleteItemButton from './DeleteItemButton.native';
 import ShowDialInInfoButton from './ShowDialInInfoButton.native';

--- a/react/features/recent-list/components/ShowDialInInfoButton.native.js
+++ b/react/features/recent-list/components/ShowDialInInfoButton.native.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../base/i18n';
 import { IconInfoCircle } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { navigateRoot } from '../../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../../mobile/navigation/routes';

--- a/react/features/recording/components/LiveStream/native/GoogleSigninForm.js
+++ b/react/features/recording/components/LiveStream/native/GoogleSigninForm.js
@@ -2,10 +2,10 @@
 
 import React, { Component } from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 import {
     GOOGLE_API_STATES,

--- a/react/features/recording/components/LiveStream/native/LiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/native/LiveStreamButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { openDialog } from '../../../../base/dialog';
 import { LIVE_STREAMING_ENABLED, getFeatureFlag } from '../../../../base/flags';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { navigate }
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../../mobile/navigation/routes';

--- a/react/features/recording/components/LiveStream/native/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/native/StartLiveStreamDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
-import { connect } from '../../../../base/redux';
 import { googleApi } from '../../../../google-api';
 import HeaderNavigationButton
     from '../../../../mobile/navigation/components/HeaderNavigationButton';

--- a/react/features/recording/components/LiveStream/native/StopLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/native/StopLiveStreamDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import AbstractStopLiveStreamDialog, {
     _mapStateToProps
 } from '../AbstractStopLiveStreamDialog';

--- a/react/features/recording/components/LiveStream/native/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyForm.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Linking, Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 import Button from '../../../../base/ui/components/native/Button';
 import Input from '../../../../base/ui/components/native/Input';

--- a/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
+++ b/react/features/recording/components/LiveStream/native/StreamKeyPicker.js
@@ -8,10 +8,10 @@ import {
     TouchableOpacity,
     View
 } from 'react-native';
+import { connect } from 'react-redux';
 
 import { _abstractMapStateToProps } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { StyleType } from '../../../../base/styles';
 import { YOUTUBE_LIVE_DASHBOARD_URL } from '../constants';
 

--- a/react/features/recording/components/LiveStream/web/LiveStreamButton.js
+++ b/react/features/recording/components/LiveStream/web/LiveStreamButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { getToolbarButtons } from '../../../../base/config';
 import { openDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import AbstractLiveStreamButton, {
     type Props,
     _mapStateToProps as _abstractMapStateToProps

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 import Spinner from '../../../../base/ui/components/web/Spinner';
 import {

--- a/react/features/recording/components/LiveStream/web/StopLiveStreamDialog.js
+++ b/react/features/recording/components/LiveStream/web/StopLiveStreamDialog.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 import AbstractStopLiveStreamDialog, {
     _mapStateToProps

--- a/react/features/recording/components/LiveStream/web/StreamKeyForm.js
+++ b/react/features/recording/components/LiveStream/web/StreamKeyForm.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import Input from '../../../../base/ui/components/web/Input';
 import AbstractStreamKeyForm, {
     type Props, _mapStateToProps

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -9,6 +9,7 @@ import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
 import { setVideoMuted } from '../../../base/media/actions';
 import { stopLocalVideoRecording } from '../../actions';
 import { getActiveSession } from '../../functions';
+import { ISessionData } from '../../reducer';
 
 import LocalRecordingManager from './LocalRecordingManager';
 
@@ -21,12 +22,12 @@ export interface IProps extends WithTranslation {
     /**
      * The {@code JitsiConference} for the current conference.
      */
-    _conference: IJitsiConference;
+    _conference?: IJitsiConference;
 
     /**
      * The redux representation of the recording session to be stopped.
      */
-    _fileRecordingSession: Object;
+    _fileRecordingSession?: ISessionData;
 
     /**
      * Whether the recording is a local recording or not.

--- a/react/features/recording/components/Recording/native/HighlightButton.js
+++ b/react/features/recording/components/Recording/native/HighlightButton.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../../base/i18n';
 import { IconHighlight } from '../../../../base/icons';
 import { Label } from '../../../../base/label';
-import { connect } from '../../../../base/redux';
 import BaseTheme from '../../../../base/ui/components/BaseTheme';
 import AbstractHighlightButton, {
     type Props as AbstractProps,

--- a/react/features/recording/components/Recording/native/RecordButton.js
+++ b/react/features/recording/components/Recording/native/RecordButton.js
@@ -1,11 +1,11 @@
 // @flow
 
 import { Platform } from 'react-native';
+import { connect } from 'react-redux';
 
 import { openDialog } from '../../../../base/dialog';
 import { IOS_RECORDING_ENABLED, RECORDING_ENABLED, getFeatureFlag } from '../../../../base/flags';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { navigate }
     from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../../mobile/navigation/routes';

--- a/react/features/recording/components/Recording/native/StartRecordingDialog.js
+++ b/react/features/recording/components/Recording/native/StartRecordingDialog.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
-import { connect } from '../../../../base/redux';
 import HeaderNavigationButton
     from '../../../../mobile/navigation/components/HeaderNavigationButton';
 import { goBack } from

--- a/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
@@ -2,11 +2,11 @@
 import React from 'react';
 import { Image, View } from 'react-native';
 import { Text } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n/functions';
 // @ts-ignore
 import { LoadingIndicator } from '../../../../base/react';
-import { connect } from '../../../../base/redux/functions';
 import Button from '../../../../base/ui/components/native/Button';
 import Switch from '../../../../base/ui/components/native/Switch';
 import { BUTTON_TYPES } from '../../../../base/ui/constants.native';

--- a/react/features/recording/components/Recording/native/StopRecordingDialog.js
+++ b/react/features/recording/components/Recording/native/StopRecordingDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import AbstractStopRecordingDialog, {
     type Props,
     _mapStateToProps

--- a/react/features/recording/components/Recording/web/HighlightButton.tsx
+++ b/react/features/recording/components/Recording/web/HighlightButton.tsx
@@ -1,6 +1,7 @@
 import { Theme } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import React from 'react';
+import { connect } from 'react-redux';
 
 // @ts-ignore
 import { StartRecordingDialog } from '../..';
@@ -9,7 +10,6 @@ import { translate } from '../../../../base/i18n/functions';
 import { IconHighlight } from '../../../../base/icons/svg';
 import { MEET_FEATURES } from '../../../../base/jwt/constants';
 import Label from '../../../../base/label/components/web/Label';
-import { connect } from '../../../../base/redux/functions';
 import Tooltip from '../../../../base/tooltip/components/Tooltip';
 import BaseTheme from '../../../../base/ui/components/BaseTheme.web';
 import { maybeShowPremiumFeatureDialog } from '../../../../jaas/actions';
@@ -55,7 +55,7 @@ interface IState {
 const styles = (theme: Theme) => {
     return {
         container: {
-            position: 'relative'
+            position: 'relative' as const
         },
         disabled: {
             background: theme.palette.text02
@@ -67,13 +67,13 @@ const styles = (theme: Theme) => {
             backgroundColor: theme.palette.field02,
             borderRadius: '6px',
             boxShadow: '0px 6px 20px rgba(0, 0, 0, 0.25)',
-            boxSizing: 'border-box',
+            boxSizing: 'border-box' as const,
             color: theme.palette.uiBackground,
             fontSize: '14px',
             fontWeight: '400',
             left: '4px',
             padding: '16px',
-            position: 'absolute',
+            position: 'absolute' as const,
             top: '32px',
             width: 320
         },

--- a/react/features/recording/components/Recording/web/RecordButton.js
+++ b/react/features/recording/components/Recording/web/RecordButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { getToolbarButtons } from '../../../../base/config';
 import { openDialog } from '../../../../base/dialog';
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import AbstractRecordButton, {
     type Props,
     _mapStateToProps as _abstractMapStateToProps
@@ -47,7 +48,7 @@ class RecordingButton extends AbstractRecordButton<Props> {
  *     visible: boolean
  * }}
  */
-export function _mapStateToProps(state: Object, ownProps: Props): Object {
+export function _mapStateToProps(state: Object, ownProps: Props) {
     const abstractProps = _abstractMapStateToProps(state, ownProps);
     const toolbarButtons = getToolbarButtons(state);
     const visible = toolbarButtons.includes('recording') && abstractProps.visible;

--- a/react/features/recording/components/Recording/web/StartRecordingDialog.js
+++ b/react/features/recording/components/Recording/web/StartRecordingDialog.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 import { toggleScreenshotCaptureSummary } from '../../../../screenshot-capture';
 import { isScreenshotCaptureEnabled } from '../../../../screenshot-capture/functions';

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable lines-around-comment  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n/functions';
 import {
@@ -9,7 +10,6 @@ import {
     Text
     // @ts-ignore
 } from '../../../../base/react';
-import { connect } from '../../../../base/redux/functions';
 import Button from '../../../../base/ui/components/web/Button';
 import Switch from '../../../../base/ui/components/web/Switch';
 import { BUTTON_TYPES } from '../../../../base/ui/constants.web';

--- a/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
+++ b/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../../base/i18n/functions';
-import { connect } from '../../../../base/redux/functions';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 // eslint-disable-next-line lines-around-comment
 // @ts-ignore

--- a/react/features/recording/components/native/RecordingExpandedLabel.js
+++ b/react/features/recording/components/native/RecordingExpandedLabel.js
@@ -1,12 +1,13 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import {
     type Props as AbstractProps,
     ExpandedLabel
 } from '../../../base/label';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { connect } from '../../../base/redux';
 import { getSessionStatusToShow } from '../../functions';
 
 type Props = AbstractProps & {

--- a/react/features/recording/components/native/RecordingLabel.js
+++ b/react/features/recording/components/native/RecordingLabel.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { Label } from '../../../base/label';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { connect } from '../../../base/redux';
 import AbstractRecordingLabel, {
     _mapStateToProps
 } from '../AbstractRecordingLabel';

--- a/react/features/recording/components/web/RecordingLabel.tsx
+++ b/react/features/recording/components/web/RecordingLabel.tsx
@@ -1,12 +1,12 @@
 import { Theme } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
 import { IconRecord, IconSites } from '../../../base/icons/svg';
 import Label from '../../../base/label/components/web/Label';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { connect } from '../../../base/redux/functions';
 import Tooltip from '../../../base/tooltip/components/Tooltip';
 import AbstractRecordingLabel, {
     _mapStateToProps

--- a/react/features/recording/components/web/RecordingLimitNotificationDescription.js
+++ b/react/features/recording/components/web/RecordingLimitNotificationDescription.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate, translateToHTML } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 
 /**
  * The type of the React {@code Component} props of {@link RecordingLimitNotificationDescription}.
@@ -62,7 +62,7 @@ function RecordingLimitNotificationDescription(props: Props) {
 
 
 /**
- * Maps part of the Redix state to the props of this component.
+ * Maps part of the Redux state to the props of this component.
  *
  * @param {Object} state - The Redux state.
  * @returns {Props}

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -16,7 +16,7 @@ const DEFAULT_STATE = {
     sessionDatas: []
 };
 
-interface ISessionData {
+export interface ISessionData {
     error?: Error;
     id?: string;
     initiator?: { getId: Function; };

--- a/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
+++ b/react/features/remote-control/components/RemoteControlAuthorizationDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { getParticipantById } from '../../base/participants';
-import { connect } from '../../base/redux';
 import { getLocalVideoTrack } from '../../base/tracks';
 import Dialog from '../../base/ui/components/web/Dialog';
 import { deny, grant } from '../actions';

--- a/react/features/room-lock/components/PasswordRequiredPrompt.native.js
+++ b/react/features/room-lock/components/PasswordRequiredPrompt.native.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { setPassword } from '../../base/conference';
 import { InputDialog } from '../../base/dialog';
-import { connect } from '../../base/redux';
 import { _cancelPasswordRequiredPrompt } from '../actions';
 
 /**

--- a/react/features/screen-share/components/web/ShareAudioButton.js
+++ b/react/features/screen-share/components/web/ShareAudioButton.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
@@ -7,7 +8,6 @@ import {
     IconVolumeOff,
     IconVolumeUp
 } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import {
     AbstractButton,
     type AbstractButtonProps
@@ -72,7 +72,7 @@ class ShareAudioButton extends AbstractButton<Props, *> {
  * @private
  * @returns {Props}
  */
-function _mapStateToProps(state: Object): $Shape<Props> {
+function _mapStateToProps(state: Object) {
 
     return {
         _isAudioOnlySharing: isAudioOnlySharing(state)

--- a/react/features/screen-share/components/web/ShareAudioDialog.tsx
+++ b/react/features/screen-share/components/web/ShareAudioDialog.tsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import { shouldHideShareAudioHelper } from '../../../base/settings/functions.web';
 import { toggleScreensharing } from '../../../base/tracks/actions.web';
@@ -105,10 +105,10 @@ class ShareAudioDialog extends Component<IProps> {
  * @private
  * @returns {IProps}
  */
-function _mapStateToProps(state: IReduxState): Partial<IProps> {
+function _mapStateToProps(state: IReduxState) {
 
     return {
-        _shouldHideShareAudioHelper: shouldHideShareAudioHelper(state)
+        _shouldHideShareAudioHelper: Boolean(shouldHideShareAudioHelper(state))
     };
 }
 

--- a/react/features/screen-share/components/web/ShareScreenWarningDialog.tsx
+++ b/react/features/screen-share/components/web/ShareScreenWarningDialog.tsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import { toggleScreensharing } from '../../../base/tracks/actions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 

--- a/react/features/security/components/security-dialog/native/SecurityDialog.js
+++ b/react/features/security/components/security-dialog/native/SecurityDialog.js
@@ -3,6 +3,7 @@ import {
     Text,
     View
 } from 'react-native';
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { getSecurityUiConfig } from '../../../../base/config/functions.any';
@@ -10,7 +11,6 @@ import { MEETING_PASSWORD_ENABLED, getFeatureFlag } from '../../../../base/flags
 import { translate } from '../../../../base/i18n';
 import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
 import { isLocalParticipantModerator } from '../../../../base/participants';
-import { connect } from '../../../../base/redux';
 import Button from '../../../../base/ui/components/native/Button';
 import Input from '../../../../base/ui/components/native/Input';
 import Switch from '../../../../base/ui/components/native/Switch';

--- a/react/features/security/components/security-dialog/native/SecurityDialogButton.js
+++ b/react/features/security/components/security-dialog/native/SecurityDialogButton.js
@@ -1,7 +1,8 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { navigate } from '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../../mobile/navigation/routes';
 import AbstractSecurityDialogButton, {

--- a/react/features/security/components/security-dialog/web/PasswordForm.tsx
+++ b/react/features/security/components/security-dialog/web/PasswordForm.tsx
@@ -19,7 +19,7 @@ interface IProps extends WithTranslation {
      * The value for how the conference is locked (or undefined if not locked)
      * as defined by room-lock constants.
      */
-    locked: string;
+    locked?: string;
 
     /**
      * Callback to invoke when the local participant is submitting a password
@@ -30,7 +30,7 @@ interface IProps extends WithTranslation {
     /**
      * The current known password for the JitsiConference.
      */
-    password: string;
+    password?: string;
 
     /**
      * The number of digits to be used in the password.

--- a/react/features/security/components/security-dialog/web/PasswordSection.tsx
+++ b/react/features/security/components/security-dialog/web/PasswordSection.tsx
@@ -35,12 +35,12 @@ interface IProps extends WithTranslation {
      * The value for how the conference is locked (or undefined if not locked)
      * as defined by room-lock constants.
      */
-    locked: string;
+    locked?: string;
 
     /**
      * The current known password for the JitsiConference.
      */
-    password: string;
+    password?: string;
 
     /**
      * Whether or not to show the password in editing mode.
@@ -165,7 +165,7 @@ function PasswordSection({
      * @returns {void}
      */
     function onPasswordCopy() {
-        copyText(password);
+        copyText(password ?? '');
     }
 
     /**

--- a/react/features/security/components/security-dialog/web/SecurityDialog.tsx
+++ b/react/features/security/components/security-dialog/web/SecurityDialog.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable lines-around-comment */
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
 import { setPassword as setPass } from '../../../../base/conference/actions';
+import { IJitsiConference } from '../../../../base/conference/reducer';
 import { getSecurityUiConfig } from '../../../../base/config/functions.any';
 import { isLocalParticipantModerator } from '../../../../base/participants/functions';
-import { connect } from '../../../../base/redux/functions';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 // @ts-ignore
 import { E2EESection } from '../../../../e2ee/components';
@@ -36,7 +37,7 @@ interface IProps {
      * The JitsiConference for which to display a lock state and change the
      * password.
      */
-    _conference: Object;
+    _conference?: IJitsiConference;
 
     /**
      * Whether to hide the lobby password section.
@@ -47,12 +48,12 @@ interface IProps {
      * The value for how the conference is locked (or undefined if not locked)
      * as defined by room-lock constants.
      */
-    _locked: string;
+    _locked?: string;
 
     /**
      * The current known password for the JitsiConference.
      */
-    _password: string;
+    _password?: string;
 
     /**
      * The number of digits to be used in the password.
@@ -152,7 +153,7 @@ function mapStateToProps(state: IReduxState) {
     const showE2ee = Boolean(e2eeSupported) && isLocalParticipantModerator(state);
 
     return {
-        _buttonsWithNotifyClick: buttonsWithNotifyClick,
+        _buttonsWithNotifyClick: buttonsWithNotifyClick ?? [],
         _canEditPassword: isLocalParticipantModerator(state),
         _conference: conference,
         _dialIn: state['features/invite'],

--- a/react/features/security/components/security-dialog/web/SecurityDialogButton.js
+++ b/react/features/security/components/security-dialog/web/SecurityDialogButton.js
@@ -1,7 +1,8 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../../base/i18n';
-import { connect } from '../../../../base/redux';
 import { toggleSecurityDialog } from '../../../actions';
 import AbstractSecurityDialogButton, {
     type Props as AbstractSecurityDialogButtonProps,

--- a/react/features/settings/components/native/SettingsView.tsx
+++ b/react/features/settings/components/native/SettingsView.tsx
@@ -13,6 +13,7 @@ import {
     View
 } from 'react-native';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 
 import { getDefaultURL } from '../../../app/functions.native';
@@ -24,7 +25,6 @@ import { translate } from '../../../base/i18n/functions';
 // @ts-ignore
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
 import { getLocalParticipant } from '../../../base/participants/functions';
-import { connect } from '../../../base/redux/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import Button from '../../../base/ui/components/native/Button';
 import Input from '../../../base/ui/components/native/Input';
@@ -52,52 +52,52 @@ interface IState {
     /**
      * State variable for the disable call integration switch.
      */
-    disableCallIntegration: boolean;
+    disableCallIntegration?: boolean;
 
     /**
      * State variable for the disable crash reporting switch.
      */
-    disableCrashReporting: boolean;
+    disableCrashReporting?: boolean;
 
     /**
      * State variable for the disable p2p switch.
      */
-    disableP2P: boolean;
+    disableP2P?: boolean;
 
     /**
      * Whether the self view is disabled or not.
      */
-    disableSelfView: boolean;
+    disableSelfView?: boolean;
 
     /**
      * State variable for the display name field.
      */
-    displayName: string;
+    displayName?: string;
 
     /**
      * State variable for the email field.
      */
-    email: string;
+    email?: string;
 
     /**
      * State variable for the server URL field.
      */
-    serverURL: string;
+    serverURL?: string;
 
     /**
      * State variable for start car mode.
      */
-    startCarMode: boolean;
+    startCarMode?: boolean;
 
     /**
      * State variable for the start with audio muted switch.
      */
-    startWithAudioMuted: boolean;
+    startWithAudioMuted?: boolean;
 
     /**
      * State variable for the start with video muted switch.
      */
-    startWithVideoMuted: boolean;
+    startWithVideoMuted?: boolean;
 }
 
 /**
@@ -118,7 +118,7 @@ interface IProps extends WithTranslation {
     /**
      * The ID of the local participant.
      */
-    _localParticipantId: string;
+    _localParticipantId?: string;
 
     /**
      * The default URL for when there is no custom URL set in the settings.
@@ -138,16 +138,16 @@ interface IProps extends WithTranslation {
      * The current settings object.
      */
     _settings: {
-        disableCallIntegration: boolean;
-        disableCrashReporting: boolean;
-        disableP2P: boolean;
-        disableSelfView: boolean;
-        displayName: string;
-        email: string;
-        serverURL: string;
-        startCarMode: boolean;
-        startWithAudioMuted: boolean;
-        startWithVideoMuted: boolean;
+        disableCallIntegration?: boolean;
+        disableCrashReporting?: boolean;
+        disableP2P?: boolean;
+        disableSelfView?: boolean;
+        displayName?: string;
+        email?: string;
+        serverURL?: string;
+        startCarMode?: boolean;
+        startWithAudioMuted?: boolean;
+        startWithVideoMuted?: boolean;
     };
 
     /**
@@ -155,7 +155,7 @@ interface IProps extends WithTranslation {
      *
      * @protected
      */
-    _visible: boolean;
+    _visible?: boolean;
 
     /**
      * Add bottom padding to the screen.
@@ -305,7 +305,7 @@ class SettingsView extends Component<IProps, IState> {
                             onChange = { this._onChangeDisplayName }
                             placeholder = { t('settingsView.displayNamePlaceholderText') }
                             textContentType = { 'name' } // iOS only
-                            value = { displayName } />
+                            value = { displayName ?? '' } />
                         {/* @ts-ignore */}
                         <Divider style = { styles.fieldSeparator } />
                         <Input
@@ -317,7 +317,7 @@ class SettingsView extends Component<IProps, IState> {
                             onChange = { this._onChangeEmail }
                             placeholder = { t('settingsView.emailPlaceholderText') }
                             textContentType = { 'emailAddress' } // iOS only
-                            value = { email } />
+                            value = { email ?? '' } />
                     </FormSection>
                     {/* @ts-ignore */}
                     <FormSection
@@ -333,12 +333,12 @@ class SettingsView extends Component<IProps, IState> {
                             onChange = { this._onChangeServerURL }
                             placeholder = { this.props._serverURL }
                             textContentType = { 'URL' } // iOS only
-                            value = { serverURL } />
+                            value = { serverURL ?? '' } />
                         {/* @ts-ignore */}
                         <Divider style = { styles.fieldSeparator } />
                         <FormRow label = 'settingsView.startCarModeInLowBandwidthMode'>
                             <Switch
-                                checked = { startCarMode }
+                                checked = { Boolean(startCarMode) }
                                 // @ts-ignore
                                 onChange = { this._onStartCarmodeInLowBandwidthMode } />
                         </FormRow>
@@ -347,7 +347,7 @@ class SettingsView extends Component<IProps, IState> {
                         <FormRow
                             label = 'settingsView.startWithAudioMuted'>
                             <Switch
-                                checked = { startWithAudioMuted }
+                                checked = { Boolean(startWithAudioMuted) }
                                 // @ts-ignore
                                 onChange = { this._onStartAudioMutedChange } />
                         </FormRow>
@@ -355,7 +355,7 @@ class SettingsView extends Component<IProps, IState> {
                         <Divider style = { styles.fieldSeparator } />
                         <FormRow label = 'settingsView.startWithVideoMuted'>
                             <Switch
-                                checked = { startWithVideoMuted }
+                                checked = { Boolean(startWithVideoMuted) }
                                 // @ts-ignore
                                 onChange = { this._onStartVideoMutedChange } />
                         </FormRow>
@@ -363,7 +363,7 @@ class SettingsView extends Component<IProps, IState> {
                         <Divider style = { styles.fieldSeparator } />
                         <FormRow label = 'videothumbnail.hideSelfView'>
                             <Switch
-                                checked = { disableSelfView }
+                                checked = { Boolean(disableSelfView) }
                                 // @ts-ignore
                                 onChange = { this._onDisableSelfView } />
                         </FormRow>
@@ -413,7 +413,7 @@ class SettingsView extends Component<IProps, IState> {
                                 <FormRow
                                     label = 'settingsView.disableCallIntegration'>
                                     <Switch
-                                        checked = { disableCallIntegration }
+                                        checked = { Boolean(disableCallIntegration) }
                                         // @ts-ignore
                                         onChange = { this._onDisableCallIntegration } />
                                 </FormRow>
@@ -424,7 +424,7 @@ class SettingsView extends Component<IProps, IState> {
                         <FormRow
                             label = 'settingsView.disableP2P'>
                             <Switch
-                                checked = { disableP2P }
+                                checked = { Boolean(disableP2P) }
                                 // @ts-ignore
                                 onChange = { this._onDisableP2P } />
                         </FormRow>
@@ -435,7 +435,7 @@ class SettingsView extends Component<IProps, IState> {
                                 fieldSeparator = { true }
                                 label = 'settingsView.disableCrashReporting'>
                                 <Switch
-                                    checked = { disableCrashReporting }
+                                    checked = { Boolean(disableCrashReporting) }
                                     // @ts-ignore
                                     onChange = { this._onDisableCrashReporting } />
                             </FormRow>
@@ -652,7 +652,7 @@ class SettingsView extends Component<IProps, IState> {
     _processServerURL(hideOnSuccess: boolean) {
         // @ts-ignore
         const { serverURL } = this.props._settings;
-        const normalizedURL = normalizeUserInputURL(serverURL);
+        const normalizedURL = normalizeUserInputURL(serverURL ?? '');
 
         if (normalizedURL === null) {
             this._showURLAlert();

--- a/react/features/settings/components/web/LogoutDialog.tsx
+++ b/react/features/settings/components/web/LogoutDialog.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 
 /**

--- a/react/features/settings/components/web/SettingsButton.js
+++ b/react/features/settings/components/web/SettingsButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
 import { IconGear } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { openSettingsDialog } from '../../actions';
 import { SETTINGS_TABS } from '../../constants';

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import { withStyles } from '@mui/styles';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import {
@@ -13,7 +14,6 @@ import {
     IconVideo,
     IconVolumeUp
 } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 import DialogWithTabs, { IDialogTab } from '../../../base/ui/components/web/DialogWithTabs';
 import { isCalendarEnabled } from '../../../calendar-sync/functions.web';
 import { submitAudioDeviceSelectionTab, submitVideoDeviceSelectionTab } from '../../../device-selection/actions.web';

--- a/react/features/shared-video/components/native/SharedVideo.js
+++ b/react/features/shared-video/components/native/SharedVideo.js
@@ -2,9 +2,9 @@
 
 import React, { Component } from 'react';
 import { View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { getLocalParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { ASPECT_RATIO_WIDE } from '../../../base/responsive-ui';
 import { setToolboxVisible } from '../../../toolbox/actions';
 

--- a/react/features/shared-video/components/native/SharedVideoButton.js
+++ b/react/features/shared-video/components/native/SharedVideoButton.js
@@ -1,12 +1,12 @@
 // @flow
 
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { VIDEO_SHARE_BUTTON_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconPlay } from '../../../base/icons';
 import { getLocalParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { toggleSharedVideo } from '../../actions.native';
 import { isSharingStatus } from '../../functions';

--- a/react/features/shared-video/components/native/SharedVideoDialog.js
+++ b/react/features/shared-video/components/native/SharedVideoDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { InputDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractSharedVideoDialog from '../AbstractSharedVideoDialog';
 
 /**

--- a/react/features/shared-video/components/native/VideoManager.js
+++ b/react/features/shared-video/components/native/VideoManager.js
@@ -1,8 +1,8 @@
 import Logger from '@jitsi/logger';
 import React from 'react';
 import Video from 'react-native-video';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../base/redux';
 import { PLAYBACK_STATUSES } from '../../constants';
 
 import AbstractVideoManager, {

--- a/react/features/shared-video/components/native/YoutubeVideoManager.js
+++ b/react/features/shared-video/components/native/YoutubeVideoManager.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Video from 'react-native-youtube-iframe';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../base/redux';
 import { PLAYBACK_STATUSES } from '../../constants';
 
 import AbstractVideoManager, {

--- a/react/features/shared-video/components/web/AbstractVideoManager.js
+++ b/react/features/shared-video/components/web/AbstractVideoManager.js
@@ -399,7 +399,7 @@ export default AbstractVideoManager;
  * @param {Object} state - The Redux state.
  * @returns {Props}
  */
-export function _mapStateToProps(state: Object): $Shape<Props> {
+export function _mapStateToProps(state: Object) {
     const { ownerId, status, time, videoUrl, muted } = state['features/shared-video'];
     const localParticipant = getLocalParticipant(state);
     const _isLocalAudioMuted = isLocalTrackMuted(state['features/base/tracks'], MEDIA_TYPE.AUDIO);

--- a/react/features/shared-video/components/web/SharedVideo.js
+++ b/react/features/shared-video/components/web/SharedVideo.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import Filmstrip from '../../../../../modules/UI/videolayout/Filmstrip';
 import { getLocalParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { getVerticalViewMaxWidth } from '../../../filmstrip/functions.web';
 import { getToolboxHeight } from '../../../toolbox/functions.web';
 

--- a/react/features/shared-video/components/web/SharedVideoButton.js
+++ b/react/features/shared-video/components/web/SharedVideoButton.js
@@ -1,10 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import { translate } from '../../../base/i18n';
 import { IconPlay } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import {
     AbstractButton,
     type AbstractButtonProps
@@ -92,7 +92,7 @@ class SharedVideoButton extends AbstractButton<Props, *> {
  * @private
  * @returns {Props}
  */
-function _mapStateToProps(state): Object {
+function _mapStateToProps(state) {
     const {
         disabled: sharedVideoBtnDisabled,
         status: sharedVideoStatus

--- a/react/features/shared-video/components/web/SharedVideoDialog.tsx
+++ b/react/features/shared-video/components/web/SharedVideoDialog.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { hideDialog } from '../../../base/dialog/actions';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import Input from '../../../base/ui/components/web/Input';
 import AbstractSharedVideoDialog from '../AbstractSharedVideoDialog';

--- a/react/features/shared-video/components/web/VideoManager.js
+++ b/react/features/shared-video/components/web/VideoManager.js
@@ -1,6 +1,6 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
-import { connect } from '../../../base/redux';
 import { PLAYBACK_STATUSES } from '../../constants';
 
 import AbstractVideoManager, {

--- a/react/features/shared-video/components/web/YoutubeVideoManager.js
+++ b/react/features/shared-video/components/web/YoutubeVideoManager.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-invalid-this */
 import React from 'react';
+import { connect } from 'react-redux';
 import YouTube from 'react-youtube';
 
-import { connect } from '../../../base/redux';
 import { PLAYBACK_STATUSES } from '../../constants';
 
 import AbstractVideoManager, {

--- a/react/features/speaker-stats/components/native/SpeakerStatsButton.js
+++ b/react/features/speaker-stats/components/native/SpeakerStatsButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { SPEAKERSTATS_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import { navigate } from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../mobile/navigation/routes';
 import AbstractSpeakerStatsButton from '../AbstractSpeakerStatsButton';

--- a/react/features/speaker-stats/components/web/SpeakerStatsButton.tsx
+++ b/react/features/speaker-stats/components/web/SpeakerStatsButton.tsx
@@ -1,8 +1,9 @@
+import { connect } from 'react-redux';
+
 import { createToolbarEvent } from '../../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../../analytics/functions';
 import { openDialog } from '../../../base/dialog/actions';
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import AbstractSpeakerStatsButton from '../AbstractSpeakerStatsButton';
 
 import SpeakerStats from './SpeakerStats';

--- a/react/features/subtitles/components/Captions.native.js
+++ b/react/features/subtitles/components/Captions.native.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { Container, Text } from '../../base/react';
-import { connect } from '../../base/redux';
 
 import {
     AbstractCaptions,

--- a/react/features/subtitles/components/Captions.web.js
+++ b/react/features/subtitles/components/Captions.web.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { getLocalParticipant } from '../../base/participants';
-import { connect } from '../../base/redux';
 import { getLargeVideoParticipant } from '../../large-video/functions';
 import { isLayoutTileView } from '../../video-layout';
 

--- a/react/features/subtitles/components/ClosedCaptionButton.native.js
+++ b/react/features/subtitles/components/ClosedCaptionButton.native.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { CLOSE_CAPTIONS_ENABLED, getFeatureFlag } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { IconSubtitles } from '../../base/icons';
-import { connect } from '../../base/redux';
 
 import {
     AbstractClosedCaptionButton,

--- a/react/features/subtitles/components/ClosedCaptionButton.web.js
+++ b/react/features/subtitles/components/ClosedCaptionButton.web.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../base/i18n';
 import { IconSubtitles } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { toggleLanguageSelectorDialog } from '../actions';
 
 import {

--- a/react/features/subtitles/components/LanguageSelectorDialog.web.tsx
+++ b/react/features/subtitles/components/LanguageSelectorDialog.web.tsx
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 import React, { useCallback, useEffect, useState } from 'react';
 import { WithTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState } from '../../app/types';
@@ -9,7 +9,6 @@ import { IReduxState } from '../../app/types';
 // @ts-ignore
 import { TRANSLATION_LANGUAGES, TRANSLATION_LANGUAGES_HEAD } from '../../base/i18n';
 import { translate, translateToHTML } from '../../base/i18n/functions';
-import { connect } from '../../base/redux/functions';
 import Dialog from '../../base/ui/components/web/Dialog';
 import { openSettingsDialog } from '../../settings/actions';
 import { SETTINGS_TABS } from '../../settings/constants';

--- a/react/features/toolbox/components/AudioMuteButton.js
+++ b/react/features/toolbox/components/AudioMuteButton.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import {
     ACTION_SHORTCUT_TRIGGERED,
     AUDIO_MUTE,
@@ -9,7 +11,6 @@ import {
 import { AUDIO_MUTE_BUTTON_ENABLED, getFeatureFlag } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { MEDIA_TYPE } from '../../base/media';
-import { connect } from '../../base/redux';
 import { AbstractAudioMuteButton, AbstractButton } from '../../base/toolbox/components';
 import type { AbstractButtonProps } from '../../base/toolbox/components';
 import { isLocalTrackMuted } from '../../base/tracks';
@@ -157,7 +158,7 @@ class AudioMuteButton extends AbstractAudioMuteButton<Props, *> {
  *     _disabled: boolean
  * }}
  */
-function _mapStateToProps(state): Object {
+function _mapStateToProps(state) {
     const _audioMuted = isLocalTrackMuted(state['features/base/tracks'], MEDIA_TYPE.AUDIO);
     const _disabled = isAudioMuteButtonDisabled(state);
     const enabledFlag = getFeatureFlag(state, AUDIO_MUTE_BUTTON_ENABLED, true);

--- a/react/features/toolbox/components/DownloadButton.js
+++ b/react/features/toolbox/components/DownloadButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { translate } from '../../base/i18n';
 import { IconDownload } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { openURLInBrowser } from '../../base/util';
 

--- a/react/features/toolbox/components/HangupButton.js
+++ b/react/features/toolbox/components/HangupButton.js
@@ -1,11 +1,11 @@
 // @flow
 
 import _ from 'lodash';
+import { connect } from 'react-redux';
 
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { leaveConference } from '../../base/conference/actions';
 import { translate } from '../../base/i18n';
-import { connect } from '../../base/redux';
 import { AbstractHangupButton } from '../../base/toolbox/components';
 import type { AbstractButtonProps } from '../../base/toolbox/components';
 

--- a/react/features/toolbox/components/HelpButton.js
+++ b/react/features/toolbox/components/HelpButton.js
@@ -1,10 +1,11 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../analytics';
 import { HELP_BUTTON_ENABLED, getFeatureFlag } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { IconHelp } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { openURLInBrowser } from '../../base/util';
 

--- a/react/features/toolbox/components/VideoMuteButton.js
+++ b/react/features/toolbox/components/VideoMuteButton.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import {
     ACTION_SHORTCUT_TRIGGERED,
     VIDEO_MUTE,
@@ -9,7 +11,6 @@ import {
 import { VIDEO_MUTE_BUTTON_ENABLED, getFeatureFlag } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { MEDIA_TYPE } from '../../base/media';
-import { connect } from '../../base/redux';
 import { AbstractButton, AbstractVideoMuteButton } from '../../base/toolbox/components';
 import type { AbstractButtonProps } from '../../base/toolbox/components';
 import { isLocalTrackMuted } from '../../base/tracks';
@@ -160,7 +161,7 @@ class VideoMuteButton extends AbstractVideoMuteButton<Props, *> {
  *     _videoMuted: boolean
  * }}
  */
-function _mapStateToProps(state): Object {
+function _mapStateToProps(state) {
     const tracks = state['features/base/tracks'];
     const enabledFlag = getFeatureFlag(state, VIDEO_MUTE_BUTTON_ENABLED, true);
 

--- a/react/features/toolbox/components/native/AudioOnlyButton.js
+++ b/react/features/toolbox/components/native/AudioOnlyButton.js
@@ -1,10 +1,11 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { setAudioOnly, toggleAudioOnly } from '../../../base/audio-only';
 import { AUDIO_ONLY_BUTTON_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconAudioOnly, IconAudioOnlyOff } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import {
     navigate

--- a/react/features/toolbox/components/native/LinkToSalesforceButton.js
+++ b/react/features/toolbox/components/native/LinkToSalesforceButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
 import { IconCloudUpload } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { navigate }
     from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';

--- a/react/features/toolbox/components/native/OpenCarmodeButton.tsx
+++ b/react/features/toolbox/components/native/OpenCarmodeButton.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable lines-around-comment */
+import { connect } from 'react-redux';
+
 import { IReduxState } from '../../../app/types';
 import { CAR_MODE_ENABLED } from '../../../base/flags/constants';
 import { getFeatureFlag } from '../../../base/flags/functions';
 import { translate } from '../../../base/i18n/functions';
 import { IconCar } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 // @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { navigate }
@@ -12,6 +13,7 @@ import { navigate }
     from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 // @ts-ignore
 import { screen } from '../../../mobile/navigation/routes';
+/* eslint-enable lines-around-comment */
 
 /**
  * Implements an {@link AbstractButton} to open the carmode.
@@ -48,5 +50,6 @@ function _mapStateToProps(state: IReduxState, ownProps: AbstractButtonProps): Ob
         visible
     };
 }
+
 // @ts-ignore
 export default translate(connect(_mapStateToProps)(OpenCarmodeButton));

--- a/react/features/toolbox/components/native/OverflowMenu.js
+++ b/react/features/toolbox/components/native/OverflowMenu.js
@@ -2,10 +2,10 @@
 
 import React, { PureComponent } from 'react';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { BottomSheet, hideSheet } from '../../../base/dialog';
 import { bottomSheetStyles } from '../../../base/dialog/components/native/styles';
-import { connect } from '../../../base/redux';
 import SettingsButton from '../../../base/settings/components/native/SettingsButton';
 import { SharedDocumentButton } from '../../../etherpad';
 import { ReactionMenu } from '../../../reactions/components';

--- a/react/features/toolbox/components/native/OverflowMenuButton.js
+++ b/react/features/toolbox/components/native/OverflowMenuButton.js
@@ -1,8 +1,9 @@
+import { connect } from 'react-redux';
+
 import { openSheet } from '../../../base/dialog';
 import { OVERFLOW_MENU_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconDotsHorizontal } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import OverflowMenu from './OverflowMenu';

--- a/react/features/toolbox/components/native/RaiseHandButton.js
+++ b/react/features/toolbox/components/native/RaiseHandButton.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 
 import {
@@ -14,7 +15,6 @@ import {
     hasRaisedHand,
     raiseHand
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 /**

--- a/react/features/toolbox/components/native/ScreenSharingAndroidButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingAndroidButton.js
@@ -1,12 +1,13 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import {
     ANDROID_SCREENSHARING_ENABLED,
     getFeatureFlag
 } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconScreenshare } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isLocalVideoTrackDesktop, toggleScreensharing } from '../../../base/tracks';
 

--- a/react/features/toolbox/components/native/ScreenSharingButton.tsx
+++ b/react/features/toolbox/components/native/ScreenSharingButton.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable lines-around-comment */
 import React from 'react';
 import { Platform } from 'react-native';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { connect } from '../../../base/redux/functions';
 // @ts-ignore
 import { isDesktopShareButtonDisabled } from '../../functions.native';
 

--- a/react/features/toolbox/components/native/ScreenSharingIosButton.js
+++ b/react/features/toolbox/components/native/ScreenSharingIosButton.js
@@ -3,11 +3,11 @@
 import React from 'react';
 import { NativeModules, Platform, findNodeHandle } from 'react-native';
 import { ScreenCapturePickerView } from 'react-native-webrtc';
+import { connect } from 'react-redux';
 
 import { IOS_SCREENSHARING_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconScreenshare } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isLocalVideoTrackDesktop } from '../../../base/tracks';
 

--- a/react/features/toolbox/components/native/ToggleCameraButton.js
+++ b/react/features/toolbox/components/native/ToggleCameraButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconCameraRefresh } from '../../../base/icons';
 import { MEDIA_TYPE, toggleCameraFacingMode } from '../../../base/media';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isLocalTrackMuted } from '../../../base/tracks';
 

--- a/react/features/toolbox/components/native/ToggleSelfViewButton.js
+++ b/react/features/toolbox/components/native/ToggleSelfViewButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconAudioOnlyOff } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { updateSettings } from '../../../base/settings';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 

--- a/react/features/toolbox/components/native/Toolbox.js
+++ b/react/features/toolbox/components/native/Toolbox.js
@@ -3,10 +3,10 @@
 import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
 
 import { ColorSchemeRegistry } from '../../../base/color-scheme';
 import { Platform } from '../../../base/react';
-import { connect } from '../../../base/redux';
 import { StyleType } from '../../../base/styles';
 import { ChatButton } from '../../../chat';
 import { ReactionsMenuButton } from '../../../reactions/components';

--- a/react/features/toolbox/components/web/AudioSettingsButton.js
+++ b/react/features/toolbox/components/web/AudioSettingsButton.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n';
 import { IconArrowUp } from '../../../base/icons';
 import JitsiMeetJS from '../../../base/lib-jitsi-meet/_';
-import { connect } from '../../../base/redux';
 import { ToolboxButtonWithIcon } from '../../../base/toolbox/components';
 import { AudioSettingsPopup, toggleAudioSettings } from '../../../settings';
 import { getAudioSettingsVisibility } from '../../../settings/functions';
@@ -18,12 +18,12 @@ type Props = {
     /**
      * The button's key.
      */
-     buttonKey?: string,
+    buttonKey?: string,
 
     /**
      * External handler for click action.
      */
-     handleClick: Function,
+    handleClick: Function,
 
     /**
      * Indicates whether audio permissions have been granted or denied.

--- a/react/features/toolbox/components/web/FullscreenButton.js
+++ b/react/features/toolbox/components/web/FullscreenButton.js
@@ -1,16 +1,17 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconEnterFullscreen, IconExitFullscreen } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 type Props = AbstractButtonProps & {
 
-  /**
-   * Whether or not the app is currently in full screen.
-   */
-   _fullScreen: boolean,
+    /**
+    * Whether or not the app is currently in full screen.
+    */
+    _fullScreen: boolean,
 };
 
 /**

--- a/react/features/toolbox/components/web/LinkToSalesforceButton.js
+++ b/react/features/toolbox/components/web/LinkToSalesforceButton.js
@@ -1,17 +1,18 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { openDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { IconCloudUpload } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { SalesforceLinkDialog } from '../../../salesforce/components';
 
 /**
  * The type of the React {@code Component} props of {@link LinkToSalesforce}.
  */
- type Props = AbstractButtonProps & {
+type Props = AbstractButtonProps & {
 
     /**
      * The redux {@code dispatch} function.

--- a/react/features/toolbox/components/web/ProfileButton.js
+++ b/react/features/toolbox/components/web/ProfileButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createToolbarEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
 import { getLocalParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { SETTINGS_TABS, openSettingsDialog } from '../../../settings';
 
@@ -22,12 +23,12 @@ type Props = AbstractButtonProps & {
     /**
      * The redux representation of the local participant.
      */
-     _localParticipant: Object,
+    _localParticipant: Object,
 
-     /**
+    /**
       * Whether the button support clicking or not.
       */
-     _unclickable: boolean,
+    _unclickable: boolean,
 
     /**
      * The redux {@code dispatch} function.

--- a/react/features/toolbox/components/web/ProfileButtonAvatar.js
+++ b/react/features/toolbox/components/web/ProfileButtonAvatar.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { translate } from '../../../base/i18n';
 import { getLocalParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 
 /**
  * The type of the React {@code Component} props of

--- a/react/features/toolbox/components/web/ShareDesktopButton.js
+++ b/react/features/toolbox/components/web/ShareDesktopButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconScreenshare, IconStopScreenshare } from '../../../base/icons';
 import JitsiMeetJS from '../../../base/lib-jitsi-meet/_';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isScreenVideoShared } from '../../../screen-share/functions';
 import { isDesktopShareButtonDisabled } from '../../functions';

--- a/react/features/toolbox/components/web/ToggleCameraButton.js
+++ b/react/features/toolbox/components/web/ToggleCameraButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconCameraRefresh } from '../../../base/icons';
 import { MEDIA_TYPE } from '../../../base/media';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isLocalTrackMuted, isToggleCameraEnabled, toggleCamera } from '../../../base/tracks';
 import { setOverflowMenuVisible } from '../../actions.web';
@@ -66,7 +67,7 @@ class ToggleCameraButton extends AbstractButton<Props, any> {
  * @param {Object} state - The Redux state.
  * @returns {Props}
  */
-function mapStateToProps(state): Object {
+function mapStateToProps(state) {
     const { enabled: audioOnly } = state['features/base/audio-only'];
     const tracks = state['features/base/tracks'];
 

--- a/react/features/toolbox/components/web/VideoSettingsButton.js
+++ b/react/features/toolbox/components/web/VideoSettingsButton.js
@@ -1,11 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n';
 import { IconArrowUp } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { ToolboxButtonWithIcon } from '../../../base/toolbox/components';
 import { getLocalJitsiVideoTrack } from '../../../base/tracks';
 import { VideoSettingsPopup, toggleVideoSettings } from '../../../settings';
@@ -19,7 +19,7 @@ type Props = {
     /**
      * The button's key.
      */
-     buttonKey?: string,
+    buttonKey?: string,
 
     /**
      * External handler for click action.

--- a/react/features/transcribing/components/TranscribingLabel.native.js
+++ b/react/features/transcribing/components/TranscribingLabel.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { Label } from '../../base/label';
-import { connect } from '../../base/redux';
 
 import { type Props, _mapStateToProps } from './AbstractTranscribingLabel';
 

--- a/react/features/video-layout/components/TileViewButton.js
+++ b/react/features/video-layout/components/TileViewButton.js
@@ -1,5 +1,5 @@
 // @flow
-import { batch } from 'react-redux';
+import { batch, connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import {
@@ -9,7 +9,6 @@ import {
 import { TILE_VIEW_ENABLED, getFeatureFlag } from '../../base/flags';
 import { translate } from '../../base/i18n';
 import { IconTileView } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../base/toolbox/components';
 import { setOverflowMenuVisible } from '../../toolbox/actions';
 import { setTileView } from '../actions';

--- a/react/features/video-menu/components/AbstractGrantModeratorDialog.ts
+++ b/react/features/video-menu/components/AbstractGrantModeratorDialog.ts
@@ -22,7 +22,7 @@ interface IProps extends WithTranslation {
     /**
      * The name of the remote participant to be granted moderator rights.
      */
-    participantName: string;
+    participantName?: string;
 }
 
 /**

--- a/react/features/video-menu/components/AbstractMuteEveryoneDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteEveryoneDialog.ts
@@ -16,16 +16,16 @@ import AbstractMuteRemoteParticipantDialog, {
  * {@link AbstractMuteEveryoneDialog}.
  */
 export type Props = AbstractProps & WithTranslation & {
-    content: string;
+    content?: string;
     exclude: Array<string>;
-    isAudioModerationEnabled: boolean;
-    isModerationSupported: boolean;
+    isAudioModerationEnabled?: boolean;
+    isModerationSupported?: boolean;
     showAdvancedModerationToggle: boolean;
     title: string;
 };
 
 interface IState {
-    audioModerationEnabled: boolean;
+    audioModerationEnabled?: boolean;
     content: string;
 }
 

--- a/react/features/video-menu/components/AbstractMuteEveryonesVideoDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteEveryonesVideoDialog.ts
@@ -8,7 +8,7 @@ import { getLocalParticipant, getParticipantDisplayName } from '../../base/parti
 import { muteAllParticipants } from '../actions';
 
 import AbstractMuteRemoteParticipantsVideoDialog, {
-    type Props as AbstractProps
+    type IProps as AbstractProps
 } from './AbstractMuteRemoteParticipantsVideoDialog';
 
 /**
@@ -16,17 +16,17 @@ import AbstractMuteRemoteParticipantsVideoDialog, {
  * {@link AbstractMuteEveryonesVideoDialog}.
  */
 export type Props = AbstractProps & WithTranslation & {
-    content: string;
+    content?: string;
     exclude: Array<string>;
-    isModerationSupported: boolean;
-    isVideoModerationEnabled: boolean;
+    isModerationSupported?: boolean;
+    isVideoModerationEnabled?: boolean;
     showAdvancedModerationToggle: boolean;
     title: string;
 };
 
 interface IState {
     content: string;
-    moderationEnabled: boolean;
+    moderationEnabled?: boolean;
 }
 
 /**

--- a/react/features/video-menu/components/AbstractMuteRemoteParticipantsVideoDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteRemoteParticipantsVideoDialog.ts
@@ -1,4 +1,5 @@
 import { Component } from 'react';
+import { WithTranslation } from 'react-i18next';
 
 import { IReduxState } from '../../app/types';
 import { rejectParticipantVideo } from '../../av-moderation/actions';
@@ -10,7 +11,7 @@ import { muteRemote } from '../actions';
  * The type of the React {@code Component} props of
  * {@link AbstractMuteRemoteParticipantsVideoDialog}.
  */
-export type Props = {
+export interface IProps extends WithTranslation {
 
     /**
      * The Redux dispatch function.
@@ -26,19 +27,14 @@ export type Props = {
      * The ID of the remote participant to be muted.
      */
     participantID: string;
-
-    /**
-     * Function to translate i18n labels.
-     */
-    t: Function;
-};
+}
 
 /**
  * Abstract dialog to confirm a remote participant video ute action.
  *
  * @augments Component
  */
-export default class AbstractMuteRemoteParticipantsVideoDialog<P extends Props = Props, State=void>
+export default class AbstractMuteRemoteParticipantsVideoDialog<P extends IProps = IProps, State=any>
     extends Component<P, State> {
     /**
      * Initializes a new {@code AbstractMuteRemoteParticipantsVideoDialog} instance.

--- a/react/features/video-menu/components/native/AskUnmuteButton.js
+++ b/react/features/video-menu/components/native/AskUnmuteButton.js
@@ -1,12 +1,13 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { approveParticipant } from '../../../av-moderation/actions';
 import { isSupported } from '../../../av-moderation/functions';
 import { translate } from '../../../base/i18n';
 import { IconMic, IconVideo } from '../../../base/icons';
 import { MEDIA_TYPE } from '../../../base/media';
 import { getParticipantById, isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { isForceMuted } from '../../../participants-pane/functions';
 

--- a/react/features/video-menu/components/native/ConnectionStatusButton.js
+++ b/react/features/video-menu/components/native/ConnectionStatusButton.js
@@ -1,7 +1,8 @@
+import { connect } from 'react-redux';
+
 import { openSheet } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
 import { IconInfoCircle } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 
 import ConnectionStatusComponent from './ConnectionStatusComponent';

--- a/react/features/video-menu/components/native/ConnectionStatusComponent.tsx
+++ b/react/features/video-menu/components/native/ConnectionStatusComponent.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable lines-around-comment */
 
 import React, { PureComponent } from 'react';
+import { WithTranslation } from 'react-i18next';
 import { Text, View } from 'react-native';
 import { withTheme } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 // @ts-ignore
@@ -18,7 +20,6 @@ import { MEDIA_TYPE } from '../../../base/media/constants';
 import { getParticipantDisplayName } from '../../../base/participants/functions';
 // @ts-ignore
 import BaseIndicator from '../../../base/react/components/native/BaseIndicator';
-import { connect } from '../../../base/redux/functions';
 import {
     getTrackByMediaTypeAndParticipant
 } from '../../../base/tracks/functions.native';
@@ -57,7 +58,7 @@ const CONNECTION_QUALITY = [
     }
 ];
 
-type IProps = {
+interface IProps extends WithTranslation {
 
     /**
      * Whether this participant's connection is inactive.
@@ -90,15 +91,10 @@ type IProps = {
     participantID: string;
 
     /**
-     * The function to be used to translate i18n labels.
-     */
-    t: Function;
-
-    /**
      * Theme used for styles.
      */
     theme: any;
-};
+}
 
 /**
  * The type of the React {@code Component} state of {@link ConnectionStatusComponent}.
@@ -484,5 +480,4 @@ function _mapStateToProps(state: IReduxState, ownProps: IProps) {
     };
 }
 
-// @ts-ignore
 export default translate(connect(_mapStateToProps)(withTheme(ConnectionStatusComponent)));

--- a/react/features/video-menu/components/native/GrantModeratorButton.js
+++ b/react/features/video-menu/components/native/GrantModeratorButton.js
@@ -1,7 +1,8 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractGrantModeratorButton, {
     _mapStateToProps
 } from '../AbstractGrantModeratorButton';

--- a/react/features/video-menu/components/native/GrantModeratorDialog.js
+++ b/react/features/video-menu/components/native/GrantModeratorDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractGrantModeratorDialog, { abstractMapStateToProps }
     from '../AbstractGrantModeratorDialog';
 

--- a/react/features/video-menu/components/native/KickButton.js
+++ b/react/features/video-menu/components/native/KickButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import AbstractKickButton from '../AbstractKickButton';
 
 /**

--- a/react/features/video-menu/components/native/KickRemoteParticipantDialog.js
+++ b/react/features/video-menu/components/native/KickRemoteParticipantDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractKickRemoteParticipantDialog
     from '../AbstractKickRemoteParticipantDialog';
 

--- a/react/features/video-menu/components/native/LocalVideoMenu.js
+++ b/react/features/video-menu/components/native/LocalVideoMenu.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { BottomSheet } from '../../../base/dialog';
@@ -9,7 +10,6 @@ import {
     getLocalParticipant,
     getParticipantDisplayName
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import ToggleSelfViewButton from '../../../toolbox/components/native/ToggleSelfViewButton';
 
 import ConnectionStatusButton from './ConnectionStatusButton';

--- a/react/features/video-menu/components/native/MuteButton.js
+++ b/react/features/video-menu/components/native/MuteButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import AbstractMuteButton, { _mapStateToProps as _abstractMapStateToProps } from '../AbstractMuteButton';
 
 /**

--- a/react/features/video-menu/components/native/MuteEveryoneDialog.js
+++ b/react/features/video-menu/components/native/MuteEveryoneDialog.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Dialog from 'react-native-dialog';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractMuteEveryoneDialog, {
     type Props,
     abstractMapStateToProps as _mapStateToProps } from '../AbstractMuteEveryoneDialog';

--- a/react/features/video-menu/components/native/MuteEveryoneElseButton.js
+++ b/react/features/video-menu/components/native/MuteEveryoneElseButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import AbstractMuteEveryoneElseButton from '../AbstractMuteEveryoneElseButton';
 
 /**

--- a/react/features/video-menu/components/native/MuteEveryonesVideoDialog.js
+++ b/react/features/video-menu/components/native/MuteEveryonesVideoDialog.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import Dialog from 'react-native-dialog';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractMuteEveryonesVideoDialog, {
     type Props,
     abstractMapStateToProps as _mapStateToProps } from '../AbstractMuteEveryonesVideoDialog';

--- a/react/features/video-menu/components/native/MuteRemoteParticipantsVideoDialog.js
+++ b/react/features/video-menu/components/native/MuteRemoteParticipantsVideoDialog.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { ConfirmDialog } from '../../../base/dialog';
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import AbstractMuteRemoteParticipantsVideoDialog, {
     abstractMapStateToProps
 } from '../AbstractMuteRemoteParticipantsVideoDialog';

--- a/react/features/video-menu/components/native/MuteVideoButton.js
+++ b/react/features/video-menu/components/native/MuteVideoButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import AbstractMuteVideoButton, { _mapStateToProps as _abstractMapStateToProps } from '../AbstractMuteVideoButton';
 
 /**

--- a/react/features/video-menu/components/native/PinButton.js
+++ b/react/features/video-menu/components/native/PinButton.js
@@ -1,9 +1,10 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../../base/i18n';
 import { IconEnlarge } from '../../../base/icons';
 import { pinParticipant } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { shouldDisplayTileView } from '../../../video-layout/functions';
 

--- a/react/features/video-menu/components/native/RemoteVideoMenu.js
+++ b/react/features/video-menu/components/native/RemoteVideoMenu.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Text, View } from 'react-native';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { BottomSheet, hideSheet } from '../../../base/dialog';
@@ -12,7 +13,6 @@ import {
     getParticipantDisplayName,
     isLocalParticipantModerator
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { getBreakoutRooms, getCurrentRoomId } from '../../../breakout-rooms/functions';
 import PrivateMessageButton from '../../../chat/components/native/PrivateMessageButton';
 import ConnectionStatusButton from '../native/ConnectionStatusButton';

--- a/react/features/video-menu/components/native/SendToBreakoutRoom.js
+++ b/react/features/video-menu/components/native/SendToBreakoutRoom.js
@@ -1,10 +1,11 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { createBreakoutRoomsEvent, sendAnalytics } from '../../../analytics';
 import { translate } from '../../../base/i18n';
 import { IconRingGroup } from '../../../base/icons';
 import { isLocalParticipantModerator } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';
 import { sendParticipantToRoom } from '../../../breakout-rooms/actions';
 

--- a/react/features/video-menu/components/native/SharedVideoMenu.js
+++ b/react/features/video-menu/components/native/SharedVideoMenu.js
@@ -3,6 +3,7 @@
 import React, { PureComponent } from 'react';
 import { Text, View } from 'react-native';
 import { Divider } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { Avatar } from '../../../base/avatar';
 import { BottomSheet, hideSheet } from '../../../base/dialog';
@@ -11,7 +12,6 @@ import {
     getParticipantById,
     getParticipantDisplayName
 } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import { SharedVideoButton } from '../../../shared-video/components';
 
 import styles from './styles';

--- a/react/features/video-menu/components/native/VolumeSlider.js
+++ b/react/features/video-menu/components/native/VolumeSlider.js
@@ -5,9 +5,9 @@ import _ from 'lodash';
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
 import { withTheme } from 'react-native-paper';
+import { connect } from 'react-redux';
 
 import { Icon, IconVolumeUp } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import { setVolume } from '../../../participants-pane/actions.native';
 import { VOLUME_SLIDER_SCALE } from '../../constants';
 

--- a/react/features/video-menu/components/web/ConnectionStatusButton.js
+++ b/react/features/video-menu/components/web/ConnectionStatusButton.js
@@ -1,9 +1,9 @@
 // @flow
 import React, { useCallback } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconInfoCircle } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { renderConnectionStatus } from '../../actions.web';
 

--- a/react/features/video-menu/components/web/FlipLocalVideoButton.js
+++ b/react/features/video-menu/components/web/FlipLocalVideoButton.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import { updateSettings } from '../../../base/settings';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 

--- a/react/features/video-menu/components/web/GrantModeratorButton.js
+++ b/react/features/video-menu/components/web/GrantModeratorButton.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconModerator } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractGrantModeratorButton, {
     type Props,

--- a/react/features/video-menu/components/web/GrantModeratorDialog.tsx
+++ b/react/features/video-menu/components/web/GrantModeratorDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import AbstractGrantModeratorDialog, { abstractMapStateToProps } from '../AbstractGrantModeratorDialog';
 

--- a/react/features/video-menu/components/web/HideSelfViewVideoButton.js
+++ b/react/features/video-menu/components/web/HideSelfViewVideoButton.js
@@ -1,9 +1,9 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
-import { connect } from '../../../base/redux';
 import { getHideSelfView, updateSettings } from '../../../base/settings';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 

--- a/react/features/video-menu/components/web/KickButton.js
+++ b/react/features/video-menu/components/web/KickButton.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconUserDeleted } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractKickButton, {
     type Props

--- a/react/features/video-menu/components/web/KickRemoteParticipantDialog.tsx
+++ b/react/features/video-menu/components/web/KickRemoteParticipantDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import AbstractKickRemoteParticipantDialog from '../AbstractKickRemoteParticipantDialog';
 

--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
@@ -220,7 +220,6 @@ class LocalVideoMenuTriggerButton extends Component<IProps> {
                     id = 'local-video-menu-trigger'
                     onPopoverClose = { this._onPopoverClose }
                     onPopoverOpen = { this._onPopoverOpen }
-                    overflowDrawer = { _overflowDrawer }
                     position = { _menuPosition }
                     visible = { popoverVisible }>
                     {buttonVisible && !isMobileBrowser() && (

--- a/react/features/video-menu/components/web/MuteButton.js
+++ b/react/features/video-menu/components/web/MuteButton.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconMicSlash } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractMuteButton, {
     type Props,

--- a/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import Switch from '../../../base/ui/components/web/Switch';
 import AbstractMuteEveryoneDialog, { type Props, abstractMapStateToProps }

--- a/react/features/video-menu/components/web/MuteEveryoneElseButton.js
+++ b/react/features/video-menu/components/web/MuteEveryoneElseButton.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconMicSlash } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractMuteEveryoneElseButton, {
     type Props

--- a/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.js
+++ b/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconVideoOff } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractMuteEveryoneElsesVideoButton, {
     type Props

--- a/react/features/video-menu/components/web/MuteEveryonesVideoDialog.tsx
+++ b/react/features/video-menu/components/web/MuteEveryonesVideoDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import Switch from '../../../base/ui/components/web/Switch';
 import AbstractMuteEveryonesVideoDialog, { type Props, abstractMapStateToProps }

--- a/react/features/video-menu/components/web/MuteRemoteParticipantsVideoDialog.tsx
+++ b/react/features/video-menu/components/web/MuteRemoteParticipantsVideoDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';
-import { connect } from '../../../base/redux/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
 import AbstractMuteRemoteParticipantsVideoDialog, {
     abstractMapStateToProps
@@ -37,5 +37,4 @@ class MuteRemoteParticipantsVideoDialog extends AbstractMuteRemoteParticipantsVi
     }
 }
 
-// @ts-ignore
 export default translate(connect(abstractMapStateToProps)(MuteRemoteParticipantsVideoDialog));

--- a/react/features/video-menu/components/web/MuteVideoButton.js
+++ b/react/features/video-menu/components/web/MuteVideoButton.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n';
 import { IconVideoOff } from '../../../base/icons';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import AbstractMuteVideoButton, {
     type Props,

--- a/react/features/video-menu/components/web/PrivateMessageMenuButton.js
+++ b/react/features/video-menu/components/web/PrivateMessageMenuButton.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import { CHAT_ENABLED, getFeatureFlag } from '../../../base/flags';
 import { translate } from '../../../base/i18n';
 import { IconMessage } from '../../../base/icons';
 import { getParticipantById } from '../../../base/participants';
-import { connect } from '../../../base/redux';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { openChat } from '../../../chat/actions.web';
 import {
@@ -85,7 +85,7 @@ class PrivateMessageMenuButton extends Component<Props> {
  * @param {Props} ownProps - The own props of the component.
  * @returns {Props}
  */
-function _mapStateToProps(state: Object, ownProps: Props): $Shape<Props> {
+function _mapStateToProps(state: Object, ownProps: Props) {
     const enabled = getFeatureFlag(state, CHAT_ENABLED, true);
     const { visible = enabled } = ownProps;
 

--- a/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.tsx
+++ b/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.tsx
@@ -48,11 +48,6 @@ interface IProps extends WithTranslation {
     _menuPosition: string;
 
     /**
-     * Whether to display the Popover as a drawer.
-     */
-    _overflowDrawer: boolean;
-
-    /**
      * Participant reference.
      */
     _participant: IParticipant;
@@ -165,7 +160,6 @@ class RemoteVideoMenuTriggerButton extends Component<IProps> {
     render() {
         const {
             _disabled,
-            _overflowDrawer,
             _showConnectionInfo,
             _participantDisplayName,
             buttonVisible,
@@ -194,7 +188,6 @@ class RemoteVideoMenuTriggerButton extends Component<IProps> {
                 id = 'remote-video-menu-trigger'
                 onPopoverClose = { this._onPopoverClose }
                 onPopoverOpen = { this._onPopoverOpen }
-                overflowDrawer = { _overflowDrawer }
                 position = { this.props._menuPosition }
                 visible = { popoverVisible }>
                 { buttonVisible && !_disabled && (
@@ -287,7 +280,6 @@ function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
     const { active, controller } = state['features/remote-control'];
     const { requestedParticipant, controlled } = controller;
     const activeParticipant = requestedParticipant || controlled;
-    const { overflowDrawer } = state['features/toolbox'];
     const { showConnectionInfo } = state['features/base/connection'];
     const { remoteVideoMenu } = state['features/base/config'];
     const { ownerId } = state['features/shared-video'];
@@ -323,7 +315,6 @@ function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
         _disabled: Boolean(remoteVideoMenu?.disabled),
         _localVideoOwner: Boolean(ownerId === localParticipantId),
         _menuPosition,
-        _overflowDrawer: overflowDrawer,
         _participant: participant ?? { id: '' },
         _participantDisplayName: _participantDisplayName ?? '',
         _remoteControlState,

--- a/react/features/video-quality/components/VideoQualityLabel.native.js
+++ b/react/features/video-quality/components/VideoQualityLabel.native.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { translate } from '../../base/i18n';
 import { Label } from '../../base/label';
-import { connect } from '../../base/redux';
 import { type StyleType, combineStyles } from '../../base/styles';
 
 import AbstractVideoQualityLabel, {

--- a/react/features/video-quality/components/VideoQualityLabel.web.js
+++ b/react/features/video-quality/components/VideoQualityLabel.web.js
@@ -1,13 +1,13 @@
 // @flow
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { openDialog } from '../../base/dialog';
 import { translate } from '../../base/i18n';
 import { IconPerformance } from '../../base/icons';
 import { Label } from '../../base/label';
 import { COLORS } from '../../base/label/constants';
-import { connect } from '../../base/redux';
 import Tooltip from '../../base/tooltip/components/Tooltip';
 import { shouldDisplayTileView } from '../../video-layout';
 

--- a/react/features/video-quality/components/VideoQualitySlider.web.tsx
+++ b/react/features/video-quality/components/VideoQualitySlider.web.tsx
@@ -3,6 +3,7 @@ import { withStyles } from '@mui/styles';
 import clsx from 'clsx';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
 
 import { createToolbarEvent } from '../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../analytics/functions';
@@ -11,7 +12,6 @@ import { setAudioOnly } from '../../base/audio-only/actions';
 import { translate } from '../../base/i18n/functions';
 import { setLastN } from '../../base/lastn/actions';
 import { getLastNForQualityLevel } from '../../base/lastn/functions';
-import { connect } from '../../base/redux/functions';
 import { withPixelLineHeight } from '../../base/styles/functions.web';
 import { setPreferredVideoQuality } from '../actions';
 import { DEFAULT_LAST_N, VIDEO_QUALITY_LEVELS } from '../constants';
@@ -55,12 +55,12 @@ interface IProps extends WithTranslation {
     /**
      * The channelLastN value configured for the conference.
      */
-    _channelLastN: number;
+    _channelLastN?: number;
 
     /**
      * Whether or not the conference is in peer to peer mode.
      */
-    _p2p: Boolean;
+    _p2p?: Object;
 
     /**
      * The currently configured maximum quality resolution to be sent and

--- a/react/features/virtual-background/components/VideoBackgroundButton.js
+++ b/react/features/virtual-background/components/VideoBackgroundButton.js
@@ -1,8 +1,9 @@
 // @flow
 
+import { connect } from 'react-redux';
+
 import { translate } from '../../base/i18n';
 import { IconImage } from '../../base/icons';
-import { connect } from '../../base/redux';
 import { AbstractButton } from '../../base/toolbox/components';
 import type { AbstractButtonProps } from '../../base/toolbox/components';
 import { openSettingsDialog } from '../../settings/actions';

--- a/react/features/welcome/components/WelcomePage.native.js
+++ b/react/features/welcome/components/WelcomePage.native.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Animated, SafeAreaView, TouchableHighlight, View } from 'react-native';
+import { connect } from 'react-redux';
 
 import { getName } from '../../app/functions';
 import { translate } from '../../base/i18n';
 import { Icon, IconWarning } from '../../base/icons';
 import { LoadingIndicator, Text } from '../../base/react';
-import { connect } from '../../base/redux';
 import BaseTheme from '../../base/ui/components/BaseTheme.native';
 import Button from '../../base/ui/components/native/Button';
 import Input from '../../base/ui/components/native/Input';

--- a/react/features/welcome/components/WelcomePage.web.js
+++ b/react/features/welcome/components/WelcomePage.web.js
@@ -1,12 +1,12 @@
 /* global interfaceConfig */
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { isMobileBrowser } from '../../base/environment/utils';
 import { translate, translateToHTML } from '../../base/i18n';
 import { Icon, IconWarning } from '../../base/icons';
 import { Watermarks } from '../../base/react';
-import { connect } from '../../base/redux';
 import { CalendarList } from '../../calendar-sync';
 import { RecentList } from '../../recent-list';
 import { SETTINGS_TABS, SettingsButton } from '../../settings';

--- a/react/features/whiteboard/components/web/WhiteboardButton.tsx
+++ b/react/features/whiteboard/components/web/WhiteboardButton.tsx
@@ -1,7 +1,8 @@
+import { connect } from 'react-redux';
+
 import { IReduxState, IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
 import { IconWhiteboard, IconWhiteboardHide } from '../../../base/icons/svg';
-import { connect } from '../../../base/redux/functions';
 // eslint-disable-next-line lines-around-comment
 // @ts-ignore
 import { AbstractButton, type AbstractButtonProps } from '../../../base/toolbox/components';


### PR DESCRIPTION
Remove the wrapper function and fix some TS errors that were hidden because of it.

The connect wrapper causes the following TS issues (because TS does not recognize the function):
- TS does not compare the return type of the `mapStateToProps` to the Props interface
- TS requires any parent component to provide all the props (even the ones from `mapStateToProps`)
