### PR TITLE
fix(webhid, external_api) webhid error showing up in iframe

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -389,7 +389,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow = 'camera; microphone; display-capture; autoplay; clipboard-write';
+        this._frame.allow = 'camera; microphone; display-capture; autoplay; clipboard-write; hid';
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);


### PR DESCRIPTION
By using a sample JaaS example for the IframeApi, there was an error that showed up in the logs on chrome related to webhid.
![image](https://user-images.githubusercontent.com/109954554/229112942-d23e0cb9-2048-4cd1-9f8a-0db18afdeea9.png)
This is due to the permissions policy in the iframe https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy. By adding hid it will solve this issue and the error won't show up anymore instead this will be the log: `[features/hid] <D4.listenToConnectedHid>:  No hid device found.` 
This error only appears on chrome and other browsers that support webhid, safari for example won't have this problem.


