### PR TITLE
Fixed the issue of Audio devices pop-over menu is to small #12595

### DIFF
--- a/css/_audio-preview.scss
+++ b/css/_audio-preview.scss
@@ -7,7 +7,7 @@
         margin-bottom: 4px;
         max-height: calc(100vh - 100px);
         overflow: auto;
-        width: 300px;
+        width: 60vw;
 
         &-ul {
             margin:0;
@@ -38,7 +38,7 @@
             }
 
             .audio-preview-entry-text {
-                max-width: 178px;
+                max-width: 40vw;
                 margin-right: 0;
             }
         }


### PR DESCRIPTION

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
The audio devices pop up menu had a fixed width of 300 px which made it difficult to see the full name of the microphone.  Made the suitable changes and fixed the issue. The new width is set to 60vh for the box and 40vh for the text , so that now the full name of microphones can be read.

Closes https://github.com/jitsi/jitsi-meet/issues/12595