### PR TITLE
feat(conference, toolbox): removed pointer events from parent views

### DIFF
--- a/react/features/conference/components/native/TitleBar.js
+++ b/react/features/conference/components/native/TitleBar.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { getConferenceName, getConferenceTimestamp } from '../../../base/conference/functions';
@@ -62,8 +62,7 @@ const TitleBar = (props: Props) => {
     }
 
     return (
-        <TouchableOpacity
-            activeOpacity = { 1 }
+        <View
             style = { styles.titleBarWrapper }>
             <View style = { styles.pipButtonContainer }>
                 <PictureInPictureButton styles = { styles.pipButton } />
@@ -99,7 +98,7 @@ const TitleBar = (props: Props) => {
             <View style = { styles.titleBarButtonContainer }>
                 <ParticipantsPaneButton styles = { styles.titleBarButton } />
             </View>
-        </TouchableOpacity>
+        </View>
     );
 };
 

--- a/react/features/conference/components/native/carmode/TitleBar.tsx
+++ b/react/features/conference/components/native/carmode/TitleBar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable lines-around-comment */
 
 import React from 'react';
-import { StyleProp, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { StyleProp, Text, View, ViewStyle } from 'react-native';
 import { connect, useSelector } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
@@ -47,8 +47,7 @@ const TitleBar = (props: IProps): JSX.Element => {
     const localParticipantId = localParticipant?.id;
 
     return (
-        <TouchableOpacity
-            activeOpacity = { 1 }
+        <View
             style = { styles.titleBarWrapper as StyleProp<ViewStyle> }>
             <View
                 pointerEvents = 'box-none'
@@ -76,7 +75,7 @@ const TitleBar = (props: IProps): JSX.Element => {
                     </View>
                 }
             </View>
-        </TouchableOpacity>
+        </View>
     );
 };
 

--- a/react/features/toolbox/components/native/Toolbox.js
+++ b/react/features/toolbox/components/native/Toolbox.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect } from 'react-redux';
 
@@ -92,8 +92,7 @@ function Toolbox(props: Props) {
     }
 
     return (
-        <TouchableOpacity
-            activeOpacity = { 1 }
+        <View
             style = { styles.toolboxContainer }>
             <SafeAreaView
                 accessibilityRole = 'toolbar'
@@ -135,7 +134,7 @@ function Toolbox(props: Props) {
                         styles = { hangupButtonStyles } />
                 }
             </SafeAreaView>
-        </TouchableOpacity>
+        </View>
     );
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Rethink #13158 

We used to apply pointerEvents, 'box-none', to parent views, this means subviews can be targeted by touch events.