### PR TITLE
fix: Reinitialize rtcstats when the config changes

### DIFF
--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -125,7 +125,9 @@ class RTCStats {
                 eventCallback: this.handleRtcstatsEvent.bind(this)
             };
 
-            rtcstatsInit(this, rtcstatsOptions);
+            const statsEntryCallback = { statsEntry: this.statsEntry.bind(this) };
+
+            rtcstatsInit(statsEntryCallback, rtcstatsOptions);
             this.isPeerConnectionWrapped = true;
         }
         this.options = options;

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -75,6 +75,19 @@ class RTCStats {
     }
 
     /**
+     * Wrapper method for the underlying trace object to be used as a static reference from inside the wrapped
+     * PeerConnection.
+     *
+     * @param {any[]} data - the stats entry to send to the rtcstats endpoint.
+     * @returns {void}
+     */
+    statsEntry(...data) {
+        if (this.trace) {
+            this.trace.statsEntry(data);
+        }
+    }
+
+    /**
      * Initialize the rtcstats components. First off we initialize the trace, which is a wrapped websocket
      * that does the actual communication with the server. Secondly, the rtcstats component is initialized,
      * it overwrites GUM and PeerConnection global functions and adds a proxy over them used to capture stats.
@@ -112,7 +125,7 @@ class RTCStats {
                 eventCallback: this.handleRtcstatsEvent.bind(this)
             };
 
-            rtcstatsInit(this.trace, rtcstatsOptions);
+            rtcstatsInit(this, rtcstatsOptions);
             this.isPeerConnectionWrapped = true;
         }
         this.options = options;

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -82,9 +82,7 @@ class RTCStats {
      * @returns {void}
      */
     statsEntry(...data) {
-        if (this.trace) {
-            this.trace.statsEntry(data);
-        }
+        this.trace?.statsEntry(data);
     }
 
     /**

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -70,6 +70,8 @@ class RTCStats {
 
             if (newOptions.meetingFqn && newOptions.endpoint) {
                 this.init(newOptions);
+            } else {
+                logger.warn('RTCStats is enabled but it has not been configured.');
             }
         }
     }
@@ -78,10 +80,10 @@ class RTCStats {
      * Wrapper method for the underlying trace object to be used as a static reference from inside the wrapped
      * PeerConnection.
      *
-     * @param {any[]} data - the stats entry to send to the rtcstats endpoint.
+     * @param {any[]} data - The stats entry to send to the rtcstats endpoint.
      * @returns {void}
      */
-    statsEntry(...data) {
+    statsEntry(...data: any[]) {
         this.trace?.statsEntry(data);
     }
 

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -116,7 +116,6 @@ class RTCStats {
 
         this.trace = traceInit(traceOptions);
         if (!this.isPeerConnectionWrapped) {
-            // FIXME we cannot unwrap the peer connection, so this has to be done once.
             const rtcstatsOptions = {
                 connectionFilter,
                 pollInterval,
@@ -149,8 +148,6 @@ class RTCStats {
      */
     reset() {
         delete this.options;
-
-        // FIXME unwrap the peer connection.
 
         if (this.trace) {
             this.trace.close();

--- a/react/features/rtcstats/middleware.ts
+++ b/react/features/rtcstats/middleware.ts
@@ -41,7 +41,7 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
 
     switch (action.type) {
     case LIB_WILL_INIT: {
-        if (isRtcstatsEnabled(state) && !RTCStats.isInitialized()) {
+        if (isRtcstatsEnabled(state)) {
             // RTCStats "proxies" WebRTC functions such as GUM and RTCPeerConnection by rewriting the global
             // window functions. Because lib-jitsi-meet uses references to those functions that are taken on
             // init, we need to add these proxies before it initializes, otherwise lib-jitsi-meet will use the
@@ -54,7 +54,8 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
 
                 // Initialize but don't connect to the rtcstats server wss, as it will start sending data for all
                 // media calls made even before the conference started.
-                RTCStats.init({
+
+                RTCStats.maybeInit({
                     endpoint: analytics?.rtcstatsEndpoint,
                     meetingFqn: extractFqnFromPath(state),
                     useLegacy,
@@ -64,6 +65,8 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
             } catch (error) {
                 logger.error('Failed to initialize RTCStats: ', error);
             }
+        } else {
+            RTCStats.reset();
         }
         break;
     }


### PR DESCRIPTION
The mobile app does not exit after the user has left the meeting. This means we need to re-initialize rtcstats every time a user joins a call to be sure we are using the correct deployment information.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
