### PR TITLE
fix: breakout rooms with non-ascii room names

### DIFF
--- a/resources/prosody-plugins/mod_jitsi_session.lua
+++ b/resources/prosody-plugins/mod_jitsi_session.lua
@@ -3,7 +3,6 @@
 module:set_global();
 
 local formdecode = require "util.http".formdecode;
-local urlencode = require "util.http".urlencode;
 
 -- Extract the following parameters from the URL and set them in the session:
 -- * previd: for session resumption
@@ -22,8 +21,8 @@ function init_session(event)
         session.customusername = query and params.customusername or nil;
 
         -- The room name and optional prefix from the web query
-        session.jitsi_web_query_room = urlencode(params.room);
-        session.jitsi_web_query_prefix = urlencode(params.prefix) or "";
+        session.jitsi_web_query_room = params.room;
+        session.jitsi_web_query_prefix = params.prefix or "";
     end
 end
 


### PR DESCRIPTION
Somewhere along a double encoding for the room names occurred, thus
currently moderation does not work for rooms names which contain non-
ascii charaters like ä etc.

This essentially reverts a6bc51cff1566a8afb5cb29eb74a72da89fc74e5

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
