### PR TITLE
fix(desktop-picker): Populate list of desktop app windows to share

### DIFF
--- a/react/features/desktop-picker/components/DesktopPicker.tsx
+++ b/react/features/desktop-picker/components/DesktopPicker.tsx
@@ -358,7 +358,7 @@ class DesktopPicker extends PureComponent<IProps, IState> {
                 type => {
                     return {
                         accessibilityLabel: t(TAB_LABELS[type as keyof typeof TAB_LABELS]),
-                        id: `${type}-tab`,
+                        id: `${type}`,
                         controlsId: `${type}-panel`,
                         label: t(TAB_LABELS[type as keyof typeof TAB_LABELS])
                     };
@@ -369,7 +369,7 @@ class DesktopPicker extends PureComponent<IProps, IState> {
                 accessibilityLabel = { t('dialog.sharingTabs') }
                 className = 'desktop-picker-tabs-container'
                 onChange = { this._onTabSelected }
-                selected = { `${this.state.selectedTab}-tab` }
+                selected = { `${this.state.selectedTab}` }
                 tabs = { tabs } />);
     }
 


### PR DESCRIPTION
Fix bug introduced via #12994 where id was changed and "-tab" was appended. Due to this the selected tab was not anymore working and empty object was returned here: https://github.com/dudumanbogdan/jitsi-meet/blob/05da37b56de391e3f67d5919a751a81a4e803d73/react/features/desktop-picker/components/DesktopPicker.tsx#L270

Originally part of #13096 by @dudumanbogdan, but pulled ahead to fix application
window sharing via Electron desktop app.

Fixes: jitsi/jitsi-meet-electron#857

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
