### PR TITLE
ref(conference) Simplify track creation.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -534,7 +534,7 @@ export default {
      * @returns {Promise<JitsiLocalTrack[]>, Object}
      */
     createInitialLocalTracks(options = {}) {
-        let errors = {};
+        const errors = {};
 
         // Always get a handle on the audio input device so that we have statistics (such as "No audio input" or
         // "Are you trying to speak?" ) even if the user joins the conference muted.
@@ -607,7 +607,7 @@ export default {
                 firePermissionPromptIsShownEvent: true
             })
             .catch(async error => {
-                if (error.name === JitsiTrackErrors.TIMEOUT) {
+                if (error.name === JitsiTrackErrors.TIMEOUT && !browser.isElectron()) {
                     errors.audioAndVideoError = error;
 
                     return [];
@@ -649,9 +649,7 @@ export default {
                 });
 
                 if (errors.audioOnlyError && errors.videoOnlyError) {
-                    errors = {
-                        audioAndVideoError: errorMsg
-                    };
+                    errors.audioAndVideoError = errorMsg;
                 }
 
                 return tracks;

--- a/react/features/prejoin/reducer.ts
+++ b/react/features/prejoin/reducer.ts
@@ -165,31 +165,31 @@ ReducerRegistry.register<IPrejoinState>(
 function getStatusFromErrors(errors: {
     audioAndVideoError?: { message: string; };
     audioOnlyError?: { message: string; };
-    videoOnlyError?: Object; }
+    videoOnlyError?: { message: string; }; }
 ) {
     const { audioOnlyError, videoOnlyError, audioAndVideoError } = errors;
 
     if (audioAndVideoError) {
-        if (audioOnlyError) {
-            if (videoOnlyError) {
-                return {
-                    deviceStatusType: 'warning',
-                    deviceStatusText: 'prejoin.audioAndVideoError',
-                    rawError: audioAndVideoError.message
-                };
-            }
+        return {
+            deviceStatusType: 'warning',
+            deviceStatusText: 'prejoin.audioAndVideoError',
+            rawError: audioAndVideoError.message
+        };
+    }
 
-            return {
-                deviceStatusType: 'warning',
-                deviceStatusText: 'prejoin.audioOnlyError',
-                rawError: audioOnlyError.message
-            };
-        }
+    if (audioOnlyError) {
+        return {
+            deviceStatusType: 'warning',
+            deviceStatusText: 'prejoin.audioOnlyError',
+            rawError: audioOnlyError.message
+        };
+    }
 
+    if (videoOnlyError) {
         return {
             deviceStatusType: 'warning',
             deviceStatusText: 'prejoin.videoOnlyError',
-            rawError: audioAndVideoError.message
+            rawError: videoOnlyError.message
         };
     }
 


### PR DESCRIPTION
If initial gUM fails, retry with 2 separate gUM calls if needed and display the appropriate message in the prejoin page.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
