### PR TITLE
fix(ios) disable CallKit when running in the simulator

### DIFF
--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -39,6 +39,11 @@
         [builder setFeatureFlag:@"ios.screensharing.enabled" withBoolean:YES];
         [builder setFeatureFlag:@"ios.recording.enabled" withBoolean:YES];
         builder.serverURL = [NSURL URLWithString:@"https://meet.jit.si"];
+#if TARGET_IPHONE_SIMULATOR
+        // CallKit has started to create problems starting with the iOS 16 simulator.
+        // Disable it since it never worked in the simulator anyway.
+        [builder setFeatureFlag:@"call-integration.enabled" withBoolean:NO];
+#endif
     }];
 
   [jitsiMeet application:application didFinishLaunchingWithOptions:launchOptions];


### PR DESCRIPTION
It doesn't actually work on the simulator but it never caused trouble... until iOS 16.4 (or maybe earlier). Disable it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
