### PR TITLE
fix(google-api): native sign out button label on smaller devices

### DIFF
--- a/react/features/google-api/components/styles.js
+++ b/react/features/google-api/components/styles.js
@@ -35,7 +35,7 @@ export default createStyleSheet({
      */
     signOutButton: {
         alignSelf: 'center',
-        maxWidth: 104,
+        maxWidth: 120,
         width: 'auto'
     }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
