### PR TITLE
fix(mobile) Do not disableAudioLevels on RN since it uses feature detection now

### DIFF
--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -1,5 +1,6 @@
 import { IReduxState } from '../../app/types';
 import JitsiMeetJS from '../../base/lib-jitsi-meet';
+
 import { IConfig, IDeeplinkingConfig, IDeeplinkingMobileConfig, IDeeplinkingPlatformConfig } from './configType';
 import { TOOLBAR_BUTTONS } from './constants';
 

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -1,5 +1,5 @@
 import { IReduxState } from '../../app/types';
-
+import JitsiMeetJS from '../../base/lib-jitsi-meet';
 import { IConfig, IDeeplinkingConfig, IDeeplinkingMobileConfig, IDeeplinkingPlatformConfig } from './configType';
 import { TOOLBAR_BUTTONS } from './constants';
 
@@ -75,8 +75,7 @@ export function isToolbarButtonEnabled(buttonName: string, state: IReduxState | 
  * @returns {boolean}
  */
 export function areAudioLevelsEnabled(state: IReduxState): boolean {
-    // Default to false for React Native as audio levels are of no interest to the mobile app.
-    return navigator.product !== 'ReactNative' && !state['features/base/config'].disableAudioLevels;
+    return !state['features/base/config'].disableAudioLevels && JitsiMeetJS.isCollectingLocalStats();
 }
 
 /**

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -45,17 +45,8 @@ const INITIAL_NON_RN_STATE: IConfig = {
 const INITIAL_RN_STATE: IConfig = {
     analytics: {},
 
-    // FIXME The support for audio levels in lib-jitsi-meet polls the statistics
-    // of WebRTC at a short interval multiple times a second. Unfortunately,
-    // React Native is slow to fetch these statistics from the native WebRTC
-    // API, through the React Native bridge and eventually to JavaScript.
-    // Because the audio levels are of no interest to the mobile app, it is
-    // fastest to merely disable them.
-    disableAudioLevels: true,
-
     // FIXME: Mobile codecs should probably be configurable separately, rather
     // than requiring this override here...
-
     p2p: {
         disabledCodec: 'vp9',
         preferredCodec: 'vp8'


### PR DESCRIPTION
Local and remote audio levels will automatically be disabled on RN since receiver stats and local audio stats are not supported there.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
