### PR TITLE
13231: currentMuted is checked against nextVolume instead of nextMute…

### DIFF
--- a/react/features/base/media/components/web/AudioTrack.tsx
+++ b/react/features/base/media/components/web/AudioTrack.tsx
@@ -152,7 +152,7 @@ class AudioTrack extends Component<IProps> {
             const currentMuted = this._ref.muted;
             const nextMuted = nextProps._muted;
 
-            if (typeof nextMuted === 'boolean' && currentMuted !== nextVolume) {
+            if (typeof nextMuted === 'boolean' && currentMuted !== nextMuted) {
                 this._ref.muted = nextMuted;
             }
         }


### PR DESCRIPTION
### Description:
In shouldComponentUpdate method of base/media/components/web/AudioTrack.tsx, currentMuted is checked against nextVolume instead of nextMuted which is wrong.

```
            if (typeof nextMuted === 'boolean' && currentMuted !== nextVolume) {
                this._ref.muted = nextMuted;
            }
```
https://github.com/jitsi/jitsi-meet/blob/master/react/features/base/media/components/web/AudioTrack.tsx#L155

### Steps to reproduce:

Found through code review 

### Expected behavior:

```
            if (typeof nextMuted === 'boolean' && currentMuted !== nextMuted) {
                this._ref.muted = nextMuted;
            }
```

### Server information:

- Jitsi Meet version: 2.0.8319 Latest
- Operating System: All

### Client information:

- Browser / app version: Chrome
- Operating System: All

