### PR TITLE
fix(dev) fix dev server watcher limit on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
         "eslint-plugin-react": "7.26.1",
         "eslint-plugin-react-native": "3.11.0",
         "eslint-plugin-typescript-sort-keys": "2.1.0",
+        "fsevents": "2.3.2",
         "jetifier": "1.6.4",
         "metro-react-native-babel-preset": "0.67.0",
         "patch-package": "6.4.7",
@@ -11251,8 +11252,8 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "devOptional": true,
       "hasInstallScript": true,
-      "optional": true,
       "os": [
         "darwin"
       ],
@@ -28853,7 +28854,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
+      "devOptional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "eslint-plugin-react": "7.26.1",
     "eslint-plugin-react-native": "3.11.0",
     "eslint-plugin-typescript-sort-keys": "2.1.0",
+    "fsevents": "2.3.2",
     "jetifier": "1.6.4",
     "metro-react-native-babel-preset": "0.67.0",
     "patch-package": "6.4.7",


### PR DESCRIPTION
On 7fb7c3de9cbd4322c925e64b3fe6c2651c83542f I disabled installing optional dependencies, which removed fsevents, an optional dependency from chokidar, which provides high-performance file watching for macOS.

So we depend on it directly now.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
