### PR TITLE
fix(deps) override xmldom dependency from strophe.js

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,3 @@
 package-lock=true
 ; FIXME Set legacy-peer-deps=false when we upgrade RN.
 legacy-peer-deps=true
-; Omit optional dependencies
-omit=optional
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -18358,15 +18358,6 @@
         "ws": "^8.5.0"
       }
     },
-    "node_modules/strophe.js/node_modules/@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/strophe.js/node_modules/ws": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
@@ -34256,18 +34247,12 @@
       "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.6.0.tgz",
       "integrity": "sha512-LE2B6nEJNUbF2Cl/p1tLIsXVJ9l86B/Z12HYYiO3n92VwYkhJ/5vJ+1ZMdwP9eN9GP8a3nbqfS5zE9umcK0FdA==",
       "requires": {
-        "@xmldom/xmldom": "0.8.3",
+        "@xmldom/xmldom": "0.8.7",
         "abab": "^2.0.3",
         "karma-rollup-preprocessor": "^7.0.8",
         "ws": "^8.5.0"
       },
       "dependencies": {
-        "@xmldom/xmldom": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-          "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
-          "optional": true
-        },
         "ws": {
           "version": "8.13.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
     "webpack-cli": "4.9.0",
     "webpack-dev-server": "4.7.3"
   },
+  "overrides": {
+    "strophe.js@1.6.0": {
+        "@xmldom/xmldom": "0.8.7"
+    }
+  },
   "engines": {
     "node": ">=14.0.0",
     "npm": ">=7.0.0"


### PR DESCRIPTION
lib-jitsi-meet does not bundle xmldom anyway, and we are providing it here. strophe seems to be stuck in a slightly old version which creates spurious security warnings.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
