### PR TITLE
fix(android) fix JitsiMeetActivity.onDestroy not leaving the room

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -177,8 +177,11 @@ public class JitsiMeetActivity extends AppCompatActivity
     }
 
     protected void leave() {
-        Intent hangupBroadcastIntent = BroadcastIntentHelper.buildHangUpIntent();
-        LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(hangupBroadcastIntent);
+        if (this.jitsiView != null) {
+            this.jitsiView.abort();
+        } else {
+            JitsiMeetLogger.w("Cannot leave, view is null");
+        }
     }
 
     private @Nullable

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -158,6 +158,14 @@ public class JitsiMeetView extends FrameLayout {
     }
 
     /**
+     * Internal method which aborts running RN by passing empty props.
+     * This is only meant to be used from the enclosing Activity's onDestroy.
+     */
+    public void abort() {
+        setProps(new Bundle());
+    }
+
+    /**
      * Creates the {@code ReactRootView} for the given app name with the given
      * props. Once created it's set as the view of this {@code FrameLayout}.
      *


### PR DESCRIPTION
When we refactored the external API to use broadcast actions leave() was changes to use the hangup broadcast action.

This mechanism does not seem to work while onDestroy is getting executed, however.

There is another way to accomplish the same, for the particular case of hangup: to pass empty props to the running RN application. This was the previous behavior too.

This PR introduces a new abort() method on JitsiMeetView, which does exactly that, passes empty props to RN. This allows cleanup to happen and the meeting properly ends when the activity is swipped from the recents list.

Fixes: https://github.com/jitsi/jitsi-meet/issues/13175

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
