### PR TITLE
add toggleWhiteboard to Jitsi API

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -113,8 +113,8 @@ import { isAudioMuteButtonDisabled } from '../../react/features/toolbox/function
 import { setTileView, toggleTileView } from '../../react/features/video-layout/actions.any';
 import { muteAllParticipants } from '../../react/features/video-menu/actions';
 import { setVideoQuality } from '../../react/features/video-quality/actions';
+import { toggleWhiteboard } from '../../react/features/whiteboard/actions.any';
 import { getJitsiMeetTransport } from '../transport';
-import {  toggleWhiteboard } from '../../react/features/whiteboard/actions.any';
 
 import {
     API_ID,
@@ -837,7 +837,7 @@ function initCommands() {
         },
         'toggle-whiteboard': () => {
             APP.store.dispatch(toggleWhiteboard(APP.store.getState()));
-        },
+        }
     };
     transport.on('event', ({ data, name }) => {
         if (name && commands[name]) {
@@ -2019,18 +2019,18 @@ class API {
     }
 
     /**
-     * Notify external application (if API is enabled) if whiteboard state is 
+     * Notify external application (if API is enabled) if whiteboard state is
      * changed.
      *
-     * @param {boolean} muted - The new whiteboard status
+     * @param {string} status - The new whiteboard status.
      * @returns {void}
      */
-        notifyWhiteboardStatusChanged(status: string) {
-            this._sendEvent({
-                name: 'whiteboard-status-changed',
-                status
-            });
-        }
+    notifyWhiteboardStatusChanged(status: string) {
+        this._sendEvent({
+            name: 'whiteboard-status-changed',
+            status
+        });
+    }
 
     /**
      * Disposes the allocated resources.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -114,6 +114,7 @@ import { setTileView, toggleTileView } from '../../react/features/video-layout/a
 import { muteAllParticipants } from '../../react/features/video-menu/actions';
 import { setVideoQuality } from '../../react/features/video-quality/actions';
 import { getJitsiMeetTransport } from '../transport';
+import {  toggleWhiteboard } from '../../react/features/whiteboard/actions.any';
 
 import {
     API_ID,
@@ -833,7 +834,10 @@ function initCommands() {
             } else {
                 logger.error(' End Conference not supported');
             }
-        }
+        },
+        'toggle-whiteboard': () => {
+            APP.store.dispatch(toggleWhiteboard(APP.store.getState()));
+        },
     };
     transport.on('event', ({ data, name }) => {
         if (name && commands[name]) {
@@ -2013,6 +2017,20 @@ class API {
             participantId
         });
     }
+
+    /**
+     * Notify external application (if API is enabled) if whiteboard state is 
+     * changed.
+     *
+     * @param {boolean} muted - The new whiteboard status
+     * @returns {void}
+     */
+        notifyWhiteboardStatusChanged(status: string) {
+            this._sendEvent({
+                name: 'whiteboard-status-changed',
+                status
+            });
+        }
 
     /**
      * Disposes the allocated resources.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -114,6 +114,7 @@ import { setTileView, toggleTileView } from '../../react/features/video-layout/a
 import { muteAllParticipants } from '../../react/features/video-menu/actions';
 import { setVideoQuality } from '../../react/features/video-quality/actions';
 import { toggleWhiteboard } from '../../react/features/whiteboard/actions.any';
+import { WhiteboardStatus } from '../../react/features/whiteboard/types';
 import { getJitsiMeetTransport } from '../transport';
 
 import {
@@ -836,7 +837,7 @@ function initCommands() {
             }
         },
         'toggle-whiteboard': () => {
-            APP.store.dispatch(toggleWhiteboard(APP.store.getState()));
+            APP.store.dispatch(toggleWhiteboard());
         }
     };
     transport.on('event', ({ data, name }) => {
@@ -2022,10 +2023,10 @@ class API {
      * Notify external application (if API is enabled) if whiteboard state is
      * changed.
      *
-     * @param {string} status - The new whiteboard status.
+     * @param {WhiteboardStatus} status - The new whiteboard status.
      * @returns {void}
      */
-    notifyWhiteboardStatusChanged(status: string) {
+    notifyWhiteboardStatusChanged(status: WhiteboardStatus) {
         this._sendEvent({
             name: 'whiteboard-status-changed',
             status

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -90,7 +90,8 @@ const commands = {
     toggleSubtitles: 'toggle-subtitles',
     toggleTileView: 'toggle-tile-view',
     toggleVirtualBackgroundDialog: 'toggle-virtual-background',
-    toggleVideo: 'toggle-video'
+    toggleVideo: 'toggle-video',
+    toggleWhiteboard: 'toggle-whiteboard'
 };
 
 /**
@@ -154,7 +155,8 @@ const events = {
     'subject-change': 'subjectChange',
     'suspend-detected': 'suspendDetected',
     'tile-view-changed': 'tileViewChanged',
-    'toolbar-button-clicked': 'toolbarButtonClicked'
+    'toolbar-button-clicked': 'toolbarButtonClicked',
+    'whiteboard-status-changed': 'whiteboardStatusChanged'
 };
 
 /**

--- a/react/features/whiteboard/actions.any.ts
+++ b/react/features/whiteboard/actions.any.ts
@@ -1,17 +1,18 @@
-import { IReduxState, IStore } from '../app/types';
+import { IStore } from '../app/types';
 
 import { setWhiteboardOpen } from './actions';
 import { isWhiteboardAllowed, isWhiteboardOpen, isWhiteboardVisible } from './functions';
+import { WhiteboardStatus } from './types';
 
 
 /**
  * API to toggle the whiteboard.
  *
- * @param {Object} state - The redux state.
  * @returns {Function}
  */
-export function toggleWhiteboard(state: IReduxState) {
-    return async (dispatch: IStore['dispatch']) => {
+export function toggleWhiteboard() {
+    return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const state = getState();
         const isAllowed = isWhiteboardAllowed(state);
         const isOpen = isWhiteboardOpen(state);
 
@@ -23,6 +24,8 @@ export function toggleWhiteboard(state: IReduxState) {
             } else if (!isOpen) {
                 dispatch(setWhiteboardOpen(true));
             }
+        } else if (typeof APP !== 'undefined') {
+            APP.API.notifyWhiteboardStatusChanged(WhiteboardStatus.FORBIDDEN);
         }
     };
 }

--- a/react/features/whiteboard/actions.any.ts
+++ b/react/features/whiteboard/actions.any.ts
@@ -1,10 +1,11 @@
-import { IStore, IReduxState } from '../app/types';
+import { IReduxState, IStore } from '../app/types';
+
 import { setWhiteboardOpen } from './actions';
-import { isWhiteboardOpen, isWhiteboardVisible, isWhiteboardAllowed } from './functions';
+import { isWhiteboardAllowed, isWhiteboardOpen, isWhiteboardVisible } from './functions';
 
 
 /**
- * API to toggle the whiteboard
+ * API to toggle the whiteboard.
  *
  * @param {Object} state - The redux state.
  * @returns {Function}
@@ -22,6 +23,6 @@ export function toggleWhiteboard(state: IReduxState) {
             } else if (!isOpen) {
                 dispatch(setWhiteboardOpen(true));
             }
-        } 
+        }
     };
 }

--- a/react/features/whiteboard/actions.any.ts
+++ b/react/features/whiteboard/actions.any.ts
@@ -1,0 +1,27 @@
+import { IStore, IReduxState } from '../app/types';
+import { setWhiteboardOpen } from './actions';
+import { isWhiteboardOpen, isWhiteboardVisible, isWhiteboardAllowed } from './functions';
+
+
+/**
+ * API to toggle the whiteboard
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Function}
+ */
+export function toggleWhiteboard(state: IReduxState) {
+    return async (dispatch: IStore['dispatch']) => {
+        const isAllowed = isWhiteboardAllowed(state);
+        const isOpen = isWhiteboardOpen(state);
+
+        if (isAllowed) {
+            if (isOpen && !isWhiteboardVisible(state)) {
+                dispatch(setWhiteboardOpen(true));
+            } else if (isOpen && isWhiteboardVisible(state)) {
+                dispatch(setWhiteboardOpen(false));
+            } else if (!isOpen) {
+                dispatch(setWhiteboardOpen(true));
+            }
+        } 
+    };
+}

--- a/react/features/whiteboard/functions.ts
+++ b/react/features/whiteboard/functions.ts
@@ -91,10 +91,10 @@ export const isWhiteboardVisible = (state: IReduxState): boolean =>
     || state['features/large-video'].participantId === WHITEBOARD_ID;
 
 /**
-* Indicates whether the whiteboard is accessible to a participant that has a moderator role
+* Indicates whether the whiteboard is accessible to a participant that has a moderator role.
 *
 * @param {IReduxState} state - The state from the Redux store.
 * @returns {boolean}
 */
 export const isWhiteboardAllowed = (state: IReduxState): boolean =>
-isWhiteboardEnabled(state) && (isLocalParticipantModerator(state));
+    isWhiteboardEnabled(state) && isLocalParticipantModerator(state);

--- a/react/features/whiteboard/functions.ts
+++ b/react/features/whiteboard/functions.ts
@@ -89,3 +89,12 @@ export const getCollabServerUrl = (state: IReduxState): string | undefined => {
 export const isWhiteboardVisible = (state: IReduxState): boolean =>
     getPinnedParticipant(state)?.id === WHITEBOARD_ID
     || state['features/large-video'].participantId === WHITEBOARD_ID;
+
+/**
+* Indicates whether the whiteboard is accessible to a participant that has a moderator role
+*
+* @param {IReduxState} state - The state from the Redux store.
+* @returns {boolean}
+*/
+export const isWhiteboardAllowed = (state: IReduxState): boolean =>
+isWhiteboardEnabled(state) && (isLocalParticipantModerator(state));

--- a/react/features/whiteboard/middleware.ts
+++ b/react/features/whiteboard/middleware.ts
@@ -50,47 +50,47 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => async (action
     const conference = getCurrentConference(state);
 
     switch (action.type) {
-        case SET_WHITEBOARD_OPEN: {
-            const existingCollabDetails = getCollabDetails(state);
+    case SET_WHITEBOARD_OPEN: {
+        const existingCollabDetails = getCollabDetails(state);
 
-            if (!existingCollabDetails) {
-                const collabLinkData = await generateCollaborationLinkData();
-                const collabServerUrl = getCollabServerUrl(state);
-                const roomId = getCurrentRoomId(state);
-                const collabDetails = {
-                    roomId,
-                    roomKey: collabLinkData.roomKey
-                };
+        if (!existingCollabDetails) {
+            const collabLinkData = await generateCollaborationLinkData();
+            const collabServerUrl = getCollabServerUrl(state);
+            const roomId = getCurrentRoomId(state);
+            const collabDetails = {
+                roomId,
+                roomKey: collabLinkData.roomKey
+            };
 
-                focusWhiteboard(store);
-                dispatch(setupWhiteboard({ collabDetails }));
-                conference?.getMetadataHandler().setMetadata(WHITEBOARD_ID, {
-                    collabServerUrl,
-                    collabDetails
-                });
-                raiseWhiteboardNotification('Instantiated');
+            focusWhiteboard(store);
+            dispatch(setupWhiteboard({ collabDetails }));
+            conference?.getMetadataHandler().setMetadata(WHITEBOARD_ID, {
+                collabServerUrl,
+                collabDetails
+            });
+            raiseWhiteboardNotification('Instantiated');
 
-                return;
-            }
-
-            if (action.isOpen) {
-                focusWhiteboard(store);
-                raiseWhiteboardNotification('Shown');
-
-                return;
-            }
-
-            dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
-            raiseWhiteboardNotification('Hidden');
-
-            break;
+            return;
         }
-        case RESET_WHITEBOARD: {
-            dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
-            raiseWhiteboardNotification('Reset');
 
-            break;
+        if (action.isOpen) {
+            focusWhiteboard(store);
+            raiseWhiteboardNotification('Shown');
+
+            return;
         }
+
+        dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
+        raiseWhiteboardNotification('Hidden');
+
+        break;
+    }
+    case RESET_WHITEBOARD: {
+        dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
+        raiseWhiteboardNotification('Reset');
+
+        break;
+    }
     }
 
     return next(action);
@@ -98,37 +98,40 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => async (action
 
 /**
  * Raises the whiteboard status notifications changes (if API is enabled).
+ *
+ * @param {string} event - The whiteboard event to be raised.
+ * @returns {Function}
  */
 function raiseWhiteboardNotification(event: string) {
     switch (event) {
-        case 'Instantiated': {
-            if (typeof APP !== 'undefined') {
-                APP.API.notifyWhiteboardStatusChanged('Instantiated');
-            }
-
-            break;
+    case 'Instantiated': {
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyWhiteboardStatusChanged('Instantiated');
         }
-        case 'Shown': {
-            if (typeof APP !== 'undefined') {
-                APP.API.notifyWhiteboardStatusChanged('Shown');
-            }
 
-            break;
+        break;
+    }
+    case 'Shown': {
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyWhiteboardStatusChanged('Shown');
         }
-        case 'Hidden': {
-            if (typeof APP !== 'undefined') {
-                APP.API.notifyWhiteboardStatusChanged('Hidden');
-            }
 
-            break;
+        break;
+    }
+    case 'Hidden': {
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyWhiteboardStatusChanged('Hidden');
         }
-        case 'Reset': {
-            if (typeof APP !== 'undefined') {
-                APP.API.notifyWhiteboardStatusChanged('Reset');
-            }
 
-            break;
+        break;
+    }
+    case 'Reset': {
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyWhiteboardStatusChanged('Reset');
         }
+
+        break;
+    }
     }
 }
 

--- a/react/features/whiteboard/middleware.ts
+++ b/react/features/whiteboard/middleware.ts
@@ -69,22 +69,26 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => async (action
                 collabDetails
             });
             APP.API.notifyWhiteboardStatusChanged('Instantiated');
+
             return;
         }
 
         if (action.isOpen) {
             focusWhiteboard(store);
             APP.API.notifyWhiteboardStatusChanged('Shown');
+
             return;
         }
 
         dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
         APP.API.notifyWhiteboardStatusChanged('Hidden');
+
         break;
     }
     case RESET_WHITEBOARD: {
         dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
         APP.API.notifyWhiteboardStatusChanged('Reset');
+
         break;
     }
     }

--- a/react/features/whiteboard/middleware.ts
+++ b/react/features/whiteboard/middleware.ts
@@ -68,21 +68,23 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => async (action
                 collabServerUrl,
                 collabDetails
             });
-
+            APP.API.notifyWhiteboardStatusChanged('Instantiated');
             return;
         }
 
         if (action.isOpen) {
             focusWhiteboard(store);
-
+            APP.API.notifyWhiteboardStatusChanged('Shown');
             return;
         }
 
         dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
+        APP.API.notifyWhiteboardStatusChanged('Hidden');
         break;
     }
     case RESET_WHITEBOARD: {
         dispatch(participantLeft(WHITEBOARD_ID, conference, { fakeParticipant: FakeParticipant.Whiteboard }));
+        APP.API.notifyWhiteboardStatusChanged('Reset');
         break;
     }
     }

--- a/react/features/whiteboard/types.ts
+++ b/react/features/whiteboard/types.ts
@@ -1,0 +1,13 @@
+
+/**
+ * Whiteboard statuses used to raise the notification when it's changed.
+ *
+ * @enum
+ */
+export enum WhiteboardStatus {
+    FORBIDDEN = 'FORBIDDEN',
+    HIDDEN = 'HIDDEN',
+    INSTANTIATED = 'INSTANTIATED',
+    RESET = 'RESET',
+    SHOWN = 'SHOWN'
+}


### PR DESCRIPTION
Hi,

The new API call is added to jitsi "toggleWhiteboard". This API is available only for moderator participants in a meeting. When this method is called, jitsi sends a notification on the whiteboard status change (listen to whiteboardStatusChanged to get these notifications). There are four notifications currently: 

Instantiated - when the whiteboard is instantiated for the first time in a meeting.
Shown - when the whiteboard is shown to a participant user
Hidden - when the whiteboard is closed by a participant user
Reset - when the participant user has left the whiteboard.