### PR TITLE
feat(android) bump minimum API level to 24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
 ext {
     buildToolsVersion = "31.0.0"
     compileSdkVersion = 32
-    minSdkVersion    = 23
+    minSdkVersion    = 24
     targetSdkVersion = 32
     supportLibVersion = "28.0.0"
 


### PR DESCRIPTION
Some of our dependencies (most notably WebRTC) have dropped it and we can no longer claim to support API level 23).

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
