### PR TITLE
fix: Restore old config for promoted visitors.

### DIFF
--- a/react/features/base/conference/functions.ts
+++ b/react/features/base/conference/functions.ts
@@ -300,7 +300,8 @@ export function getVisitorOptions(stateful: IStateful, params: Array<string>) {
 
     if (!vnode) {
         // this is redirecting back to main, lets restore config
-        // no point of updating disableFocus, we can skip the initial iq to jicofo
+        // not updating disableFocus, as if the room capacity is full the promotion to the main room will fail
+        // and the visitor will be redirected back to a vnode from jicofo
         if (config.oldConfig && username) {
             return {
                 hosts: {

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -289,6 +289,12 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
         dispatch(conferenceWillLeave(conference));
     };
 
+    if (!iAmVisitor(getState())) {
+        // if a visitor is promoted back to main room and want to join an empty breakout room
+        // we need to send iq to jicofo, so it can join/create the breakout room
+        dispatch(overwriteConfig({ disableFocus: false }));
+    }
+
     // @ts-ignore
     window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', beforeUnloadHandler);
 


### PR DESCRIPTION
In case a visitor is promoted to main room and want to join an empty breakout room we want to send conference iq to jicofo.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
