### PR TITLE
fix(virtual-background) Use correct video device

### DIFF
--- a/react/features/base/ui/components/web/DialogWithTabs.tsx
+++ b/react/features/base/ui/components/web/DialogWithTabs.tsx
@@ -153,7 +153,7 @@ export interface IDialogTab<P> {
     labelKey: string;
     name: string;
     props?: IObject;
-    propsUpdateFunction?: (tabState: IObject, newProps: P) => P;
+    propsUpdateFunction?: (tabState: IObject, newProps: P, tabStates?: (IObject | undefined)[]) => P;
     submit?: Function;
 }
 
@@ -257,7 +257,8 @@ const DialogWithTabs = ({
         if (tabConfiguration.propsUpdateFunction) {
             return tabConfiguration.propsUpdateFunction(
                 currentTabState ?? {},
-                tabConfiguration.props ?? {});
+                tabConfiguration.props ?? {},
+                tabStates);
         }
 
         return { ...currentTabState };

--- a/react/features/settings/actions.web.ts
+++ b/react/features/settings/actions.web.ts
@@ -9,6 +9,7 @@ import {
 import { openDialog } from '../base/dialog/actions';
 import i18next from '../base/i18n/i18next';
 import { updateSettings } from '../base/settings/actions';
+import { getLocalVideoTrack } from '../base/tracks/functions.any';
 import { disableKeyboardShortcuts, enableKeyboardShortcuts } from '../keyboard-shortcuts/actions';
 import { toggleBackgroundEffect } from '../virtual-background/actions';
 import virtualBackgroundLogger from '../virtual-background/logger';
@@ -24,8 +25,7 @@ import {
     getMoreTabProps,
     getNotificationsTabProps,
     getProfileTabProps,
-    getShortcutsTabProps,
-    getVirtualBackgroundTabProps
+    getShortcutsTabProps
 } from './functions.web';
 
 /**
@@ -264,10 +264,11 @@ export function submitShortcutsTab(newState: any) {
  */
 export function submitVirtualBackgroundTab(newState: any, isCancel = false) {
     return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
-        const currentState = getVirtualBackgroundTabProps(getState());
+        const state = getState();
+        const track = getLocalVideoTrack(state['features/base/tracks'])?.jitsiTrack;
 
         if (newState.options?.selectedThumbnail) {
-            await dispatch(toggleBackgroundEffect(newState.options, currentState._jitsiTrack));
+            await dispatch(toggleBackgroundEffect(newState.options, track));
 
             if (!isCancel) {
                 // Set x scale to default value.

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -196,18 +196,28 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
             name: SETTINGS_TABS.VIRTUAL_BACKGROUND,
             component: VirtualBackgroundTab,
             labelKey: 'virtualBackground.title',
-            props: getVirtualBackgroundTabProps(state),
+            props: getVirtualBackgroundTabProps(state, isDisplayedOnWelcomePage),
+            propsUpdateFunction: (tabState: any, newProps: ReturnType<typeof getVirtualBackgroundTabProps>,
+                    tabStates: any) => {
+                const videoTabState = tabStates[tabs.findIndex(tab => tab.name === SETTINGS_TABS.VIDEO)];
+
+                return {
+                    ...newProps,
+                    selectedVideoInputId: videoTabState.selectedVideoInputId || newProps.selectedVideoInputId,
+                    options: tabState.options
+                };
+            },
             submit: (newState: any) => submitVirtualBackgroundTab(newState),
             cancel: () => {
-                const { _virtualBackground } = getVirtualBackgroundTabProps(state);
+                const { options } = getVirtualBackgroundTabProps(state, isDisplayedOnWelcomePage);
 
                 return submitVirtualBackgroundTab({
                     options: {
-                        backgroundType: _virtualBackground.backgroundType,
-                        enabled: _virtualBackground.backgroundEffectEnabled,
-                        url: _virtualBackground.virtualSource,
-                        selectedThumbnail: _virtualBackground.selectedThumbnail,
-                        blurValue: _virtualBackground.blurValue
+                        backgroundType: options.backgroundType,
+                        enabled: options.backgroundEffectEnabled,
+                        url: options.virtualSource,
+                        selectedThumbnail: options.selectedThumbnail,
+                        blurValue: options.blurValue
                     }
                 }, true);
             },

--- a/react/features/settings/components/web/VirtualBackgroundTab.tsx
+++ b/react/features/settings/components/web/VirtualBackgroundTab.tsx
@@ -7,16 +7,12 @@ import AbstractDialogTab, {
 } from '../../../base/dialog/components/web/AbstractDialogTab';
 import { translate } from '../../../base/i18n/functions';
 import VirtualBackgrounds from '../../../virtual-background/components/VirtualBackgrounds';
+import { IVirtualBackground } from '../../../virtual-background/reducer';
 
 /**
  * The type of the React {@code Component} props of {@link VirtualBackgroundTab}.
  */
 export interface IProps extends AbstractDialogTabProps, WithTranslation {
-
-    /**
-     * Returns the jitsi track that will have background effect applied.
-     */
-    _jitsiTrack: Object;
 
     /**
      * CSS classes object.
@@ -26,12 +22,12 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     /**
      * Virtual background options.
      */
-    options: any;
+    options: IVirtualBackground;
 
     /**
-     * The selected thumbnail identifier.
+     * The id of the selected video device.
      */
-    selectedThumbnail: string;
+    selectedVideoInputId: string;
 }
 
 const styles = () => {
@@ -85,8 +81,7 @@ class VirtualBackgroundTab extends AbstractDialogTab<IProps, any> {
         const {
             classes,
             options,
-            selectedThumbnail,
-            _jitsiTrack
+            selectedVideoInputId
         } = this.props;
 
         return (
@@ -95,10 +90,10 @@ class VirtualBackgroundTab extends AbstractDialogTab<IProps, any> {
                 id = 'virtual-background-dialog'
                 key = 'virtual-background'>
                 <VirtualBackgrounds
-                    _jitsiTrack = { _jitsiTrack }
                     onOptionsChange = { this._onOptionsChanged }
                     options = { options }
-                    selectedThumbnail = { selectedThumbnail } />
+                    selectedThumbnail = { options.selectedThumbnail ?? '' }
+                    selectedVideoInputId = { selectedVideoInputId } />
             </div>
         );
     }

--- a/react/features/settings/functions.any.ts
+++ b/react/features/settings/functions.any.ts
@@ -10,7 +10,6 @@ import {
 } from '../base/participants/functions';
 import { toState } from '../base/redux/functions';
 import { getHideSelfView } from '../base/settings/functions';
-import { getLocalVideoTrack } from '../base/tracks/functions.any';
 import { parseStandardURIString } from '../base/util/uri';
 import { isStageFilmstripEnabled } from '../filmstrip/functions';
 import { isFollowMeActive } from '../follow-me/functions';
@@ -272,23 +271,4 @@ export function getAudioSettingsVisibility(state: IReduxState) {
  */
 export function getVideoSettingsVisibility(state: IReduxState) {
     return state['features/settings'].videoSettingsVisible;
-}
-
-/**
- * Returns the properties for the "Virtual Background" tab from settings dialog from Redux
- * state.
- *
- * @param {(Function|Object)} stateful -The (whole) redux state, or redux's
- * {@code getState} function to be used to retrieve the state.
- * @returns {Object} - The properties for the "Shortcuts" tab from settings
- * dialog.
- */
-export function getVirtualBackgroundTabProps(stateful: IStateful) {
-    const state = toState(stateful);
-
-    return {
-        _virtualBackground: state['features/virtual-background'],
-        selectedThumbnail: state['features/virtual-background'].selectedThumbnail,
-        _jitsiTrack: getLocalVideoTrack(state['features/base/tracks'])?.jitsiTrack
-    };
 }

--- a/react/features/settings/functions.web.ts
+++ b/react/features/settings/functions.web.ts
@@ -1,6 +1,7 @@
 import { IStateful } from '../base/app/types';
 import { createLocalTrack } from '../base/lib-jitsi-meet/functions';
 import { toState } from '../base/redux/functions';
+import { getUserSelectedCameraDeviceId } from '../base/settings/functions.web';
 import { areKeyboardShortcutsEnabled, getKeyboardShortcutsHelpDescriptions } from '../keyboard-shortcuts/functions';
 import { isPrejoinPageVisible } from '../prejoin/functions';
 
@@ -85,5 +86,32 @@ export function getShortcutsTabProps(stateful: IStateful, isDisplayedOnWelcomePa
         displayShortcuts: !isDisplayedOnWelcomePage && !isPrejoinPageVisible(state),
         keyboardShortcutsEnabled: areKeyboardShortcutsEnabled(state),
         keyboardShortcutsHelpDescriptions: getKeyboardShortcutsHelpDescriptions(state)
+    };
+}
+
+/**
+ * Returns the properties for the "Virtual Background" tab from settings dialog from Redux
+ * state.
+ *
+ * @param {(Function|Object)} stateful -The (whole) redux state, or redux's
+ * {@code getState} function to be used to retrieve the state.
+ * @param {boolean} isDisplayedOnWelcomePage - Indicates whether the device selection dialog is displayed on the
+ * welcome page or not.
+ * @returns {Object} - The properties for the "Shortcuts" tab from settings
+ * dialog.
+ */
+export function getVirtualBackgroundTabProps(stateful: IStateful, isDisplayedOnWelcomePage?: boolean) {
+    const state = toState(stateful);
+    const settings = state['features/base/settings'];
+    const userSelectedCamera = getUserSelectedCameraDeviceId(state);
+    let selectedVideoInputId = settings.cameraDeviceId;
+
+    if (isDisplayedOnWelcomePage) {
+        selectedVideoInputId = userSelectedCamera;
+    }
+
+    return {
+        options: state['features/virtual-background'],
+        selectedVideoInputId
     };
 }

--- a/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
+++ b/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
@@ -4,12 +4,10 @@ import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
-import { IReduxState } from '../../app/types';
 import { hideDialog } from '../../base/dialog/actions';
 import { translate } from '../../base/i18n/functions';
 import { Video } from '../../base/media/components/index';
 import { equals } from '../../base/redux/functions';
-import { getCurrentCameraDeviceId } from '../../base/settings/functions.web';
 import { createLocalTracksF } from '../../base/tracks/functions';
 import Spinner from '../../base/ui/components/web/Spinner';
 import { showWarningNotification } from '../../notifications/actions';
@@ -21,11 +19,6 @@ import logger from '../logger';
  * The type of the React {@code PureComponent} props of {@link VirtualBackgroundPreview}.
  */
 export interface IProps extends WithTranslation {
-
-    /**
-     * The deviceId of the camera device currently being used.
-     */
-    _currentCameraDeviceId: string;
 
     /**
      * An object containing the CSS classes.
@@ -46,6 +39,11 @@ export interface IProps extends WithTranslation {
      * Represents the virtual background set options.
      */
     options: any;
+
+    /**
+     * The id of the selected video device.
+     */
+    selectedVideoInputId: string;
 }
 
 /**
@@ -162,7 +160,7 @@ class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
         try {
             this.setState({ loading: true });
             const [ jitsiTrack ] = await createLocalTracksF({
-                cameraDeviceId: this.props._currentCameraDeviceId,
+                cameraDeviceId: this.props.selectedVideoInputId,
                 devices: [ 'video' ]
             });
 
@@ -271,7 +269,7 @@ class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
      * @inheritdoc
      */
     async componentDidUpdate(prevProps: IProps) {
-        if (!equals(this.props._currentCameraDeviceId, prevProps._currentCameraDeviceId)) {
+        if (!equals(this.props.selectedVideoInputId, prevProps.selectedVideoInputId)) {
             this._setTracks();
         }
         if (!equals(this.props.options, prevProps.options) && this.state.localTrackLoaded) {
@@ -296,18 +294,4 @@ class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
     }
 }
 
-/**
- * Maps (parts of) the redux state to the associated props for the
- * {@code VirtualBackgroundPreview} component.
- *
- * @param {Object} state - The Redux state.
- * @private
- * @returns {{Props}}
- */
-function _mapStateToProps(state: IReduxState) {
-    return {
-        _currentCameraDeviceId: getCurrentCameraDeviceId(state)
-    };
-}
-
-export default translate(connect(_mapStateToProps)(withStyles(styles)(VirtualBackgroundPreview)));
+export default translate(connect()(withStyles(styles)(VirtualBackgroundPreview)));

--- a/react/features/virtual-background/components/VirtualBackgrounds.tsx
+++ b/react/features/virtual-background/components/VirtualBackgrounds.tsx
@@ -32,11 +32,6 @@ interface IProps extends WithTranslation {
     _images: Array<Image>;
 
     /**
-     * Returns the jitsi track that will have background effect applied.
-     */
-    _jitsiTrack: Object;
-
-    /**
      * The current local flip x status.
      */
     _localFlipX: boolean;
@@ -83,6 +78,11 @@ interface IProps extends WithTranslation {
      * Returns the selected thumbnail identifier.
      */
     selectedThumbnail: string;
+
+    /**
+     * The id of the selected video device.
+     */
+    selectedVideoInputId: string;
 }
 
 const onError = (event: any) => {
@@ -204,7 +204,6 @@ const useStyles = makeStyles()(theme => {
  */
 function VirtualBackgrounds({
     _images,
-    _jitsiTrack,
     _localFlipX,
     selectedThumbnail,
     _showUploadButton,
@@ -212,6 +211,7 @@ function VirtualBackgrounds({
     onOptionsChange,
     options,
     initialOptions,
+    selectedVideoInputId,
     t
 }: IProps) {
     const { classes, cx } = useStyles();
@@ -364,7 +364,8 @@ function VirtualBackgrounds({
         <>
             <VirtualBackgroundPreview
                 loadedPreview = { loadedPreviewState }
-                options = { options } />
+                options = { options }
+                selectedVideoInputId = { selectedVideoInputId } />
             {loading ? (
                 <div className = { classes.virtualBackgroundLoading }>
                     <Spinner />


### PR DESCRIPTION
In the case when the user selects a new video device then goes to Virtual Background without saving first, use the newly selected device for the virtual background preview instead of the saved one

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
