### PR TITLE
fix(reactions-popup) Fix tooltip not closing correctly

### DIFF
--- a/react/features/base/tooltip/components/Tooltip.tsx
+++ b/react/features/base/tooltip/components/Tooltip.tsx
@@ -91,6 +91,10 @@ const Tooltip = ({ containerClassName, content, children, position = 'top' }: IP
     };
 
     const onPopoverOpen = useCallback(() => {
+        if (isUnmounting) {
+            return;
+        }
+
         clearTimeout(timeoutID.current.close);
         timeoutID.current.close = 0;
         if (!visible) {
@@ -102,7 +106,7 @@ const Tooltip = ({ containerClassName, content, children, position = 'top' }: IP
                 }, TOOLTIP_DELAY);
             }
         }
-    }, [ visible, isVisible ]);
+    }, [ visible, isVisible, isUnmounting ]);
 
     const onPopoverClose = useCallback(() => {
         clearTimeout(timeoutID.current.open);

--- a/react/features/reactions/components/web/ReactionsMenuButton.tsx
+++ b/react/features/reactions/components/web/ReactionsMenuButton.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useCallback } from 'react';
 import { WithTranslation } from 'react-i18next';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import { isMobileBrowser } from '../../../base/environment/utils';
@@ -98,18 +98,17 @@ function ReactionsMenuButton({
     reactionsQueue,
     t
 }: IProps) {
-    const visible = useSelector(getReactionsMenuVisibility);
     const toggleReactionsMenu = useCallback(() => {
         dispatch(toggleReactionsMenuVisibility());
     }, [ dispatch ]);
 
     const openReactionsMenu = useCallback(() => {
-        !visible && toggleReactionsMenu();
-    }, [ visible, toggleReactionsMenu ]);
+        !isOpen && toggleReactionsMenu();
+    }, [ isOpen, toggleReactionsMenu ]);
 
     const closeReactionsMenu = useCallback(() => {
-        visible && toggleReactionsMenu();
-    }, [ visible, toggleReactionsMenu ]);
+        isOpen && toggleReactionsMenu();
+    }, [ isOpen, toggleReactionsMenu ]);
 
     const reactionsMenu = (<div className = 'reactions-menu-container'>
         <ReactionsMenu parent = { IReactionsMenuParent.Button } />
@@ -124,11 +123,11 @@ function ReactionsMenuButton({
                 ariaExpanded = { isOpen }
                 ariaHasPopup = { true }
                 ariaLabel = { t('toolbar.accessibilityLabel.reactionsMenu') }
-                onPopoverClose = { _isMobile ? closeReactionsMenu : toggleReactionsMenu }
+                onPopoverClose = { closeReactionsMenu }
                 onPopoverOpen = { openReactionsMenu }
                 popoverContent = { reactionsMenu }
                 trigger = { _isMobile ? 'click' : undefined }
-                visible = { visible }>
+                visible = { isOpen }>
                 <ReactionsButton
                     buttonKey = { buttonKey }
                     notifyMode = { notifyMode } />
@@ -152,7 +151,7 @@ function ReactionsMenuButton({
                     onPopoverClose = { toggleReactionsMenu }
                     onPopoverOpen = { openReactionsMenu }
                     popoverContent = { reactionsMenu }
-                    visible = { visible }>
+                    visible = { isOpen }>
                     <RaiseHandButton
                         buttonKey = { buttonKey }
                         handleClick = { handleClick }


### PR DESCRIPTION
- tooltip was reopening in an inconsistent state(without the tooltip text visible), taking the focus from the reactions popup
- removed duplicate store prop from ReactionsMenuButton

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
