### PR TITLE
fix(toolbox-visible) Fix hiding toolbox

### DIFF
--- a/react/features/toolbox/actions.web.ts
+++ b/react/features/toolbox/actions.web.ts
@@ -84,7 +84,7 @@ export function hideToolbox(force = false) {
 
         dispatch(clearToolboxTimeout());
 
-        const focusSelector = '.toolbox-content-items:focus-within,.filmstrip:focus-within,.remotevideomenu:hover';
+        const focusSelector = '.filmstrip:hover,.remotevideomenu:hover';
 
         if (!force
                 && (hovered

--- a/react/features/toolbox/actions.web.ts
+++ b/react/features/toolbox/actions.web.ts
@@ -84,13 +84,13 @@ export function hideToolbox(force = false) {
 
         dispatch(clearToolboxTimeout());
 
-        const focusSelector = '.filmstrip:hover,.remotevideomenu:hover';
+        const hoverSelector = '.filmstrip:hover,.remotevideomenu:hover';
 
         if (!force
                 && (hovered
                     || state['features/invite'].calleeInfoVisible
                     || (state['features/chat'].isOpen && !autoHideWhileChatIsOpen)
-                    || document.querySelector(focusSelector))) {
+                    || document.querySelector(hoverSelector))) {
             dispatch(
                 setToolboxTimeout(
                     () => dispatch(hideToolbox()),


### PR DESCRIPTION
- clicking toolbox button was keeping focus on toolbox even after mouse move(as focus would only be changed when clicking on some other element), so .toolbox-content-items:focus-within selector was returning a value even when mouse was moved from toolbox
- .filmstrip:focus-within did not seem to ever activate, I replaced with :hover since the intent was probably to keep the toolbox open while filmstrip is hovered

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
