### PR TITLE
chore(deps) react-native-webrtc@111.0.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -390,7 +390,7 @@ PODS:
   - react-native-video/Video (6.0.0-alpha.1):
     - PromisesSwift
     - React-Core
-  - react-native-webrtc (111.0.0):
+  - react-native-webrtc (111.0.1):
     - JitsiWebRTC (~> 111.0.0)
     - React-Core
   - react-native-webview (11.15.1):
@@ -755,7 +755,7 @@ SPEC CHECKSUMS:
   react-native-slider: 6e9b86e76cce4b9e35b3403193a6432ed07e0c81
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-video: bb6f12a7198db53b261fefb5d609dc77417acc8b
-  react-native-webrtc: a9d4d8ef61adb634e006ffd956c494ad8318d95c
+  react-native-webrtc: 2702afae1e59882b423e6077768ca0d1e6fc42ed
   react-native-webview: ea4899a1056c782afa96dd082179a66cbebf5504
   React-perflogger: bc57c4a953c1ec913b0d984cf4f2b9842a12bde0
   React-RCTActionSheet: 3efa3546119a1050f6c34a461b386dd9e36eaf0b

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "react-native-url-polyfill": "1.3.0",
         "react-native-video": "https://git@github.com/react-native-video/react-native-video#7c48ae7c8544b2b537fb60194e9620b9fcceae52",
         "react-native-watch-connectivity": "1.0.11",
-        "react-native-webrtc": "111.0.0",
+        "react-native-webrtc": "111.0.1",
         "react-native-webview": "11.15.1",
         "react-native-youtube-iframe": "2.2.1",
         "react-redux": "7.1.0",
@@ -15975,9 +15975,9 @@
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-111.0.0.tgz",
-      "integrity": "sha512-eCvjPiU28cT85K8TBV7geAA92+uCldhmJ6F+3CMtAAG7U4AOQzxYOI5HC3h9Lt2zfTwsUzg3tyamqWf00PWndA==",
+      "version": "111.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-111.0.1.tgz",
+      "integrity": "sha512-yMRmLFtKRDXaK5b/s92+ArsMElEEjZnGW2cE+GqTHxLka0Kj0qq/sgNS2sMTuJuZRhW4oT6ryMLwTYzIrGM1lQ==",
       "dependencies": {
         "adm-zip": "0.5.9",
         "base64-js": "1.5.1",
@@ -31573,9 +31573,9 @@
       }
     },
     "react-native-webrtc": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-111.0.0.tgz",
-      "integrity": "sha512-eCvjPiU28cT85K8TBV7geAA92+uCldhmJ6F+3CMtAAG7U4AOQzxYOI5HC3h9Lt2zfTwsUzg3tyamqWf00PWndA==",
+      "version": "111.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-111.0.1.tgz",
+      "integrity": "sha512-yMRmLFtKRDXaK5b/s92+ArsMElEEjZnGW2cE+GqTHxLka0Kj0qq/sgNS2sMTuJuZRhW4oT6ryMLwTYzIrGM1lQ==",
       "requires": {
         "adm-zip": "0.5.9",
         "base64-js": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-url-polyfill": "1.3.0",
     "react-native-video": "https://git@github.com/react-native-video/react-native-video#7c48ae7c8544b2b537fb60194e9620b9fcceae52",
     "react-native-watch-connectivity": "1.0.11",
-    "react-native-webrtc": "111.0.0",
+    "react-native-webrtc": "111.0.1",
     "react-native-webview": "11.15.1",
     "react-native-youtube-iframe": "2.2.1",
     "react-redux": "7.1.0",


### PR DESCRIPTION
GCM ciphers are now enabled by default.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
