### PR TITLE
fix(visitors): Fixes rate limit module.

### DIFF
--- a/resources/prosody-plugins/mod_rate_limit.lua
+++ b/resources/prosody-plugins/mod_rate_limit.lua
@@ -171,6 +171,11 @@ local function on_login(session, ip)
 end
 
 local function filter_hook(session)
+    -- ignore outgoing sessions (s2s)
+    if session.outgoing then
+        return;
+    end
+
 	local request = get_request_from_conn(session.conn);
 	local ip = request and request.ip or session.ip;
 	module:log("debug", "New session from %s", ip);


### PR DESCRIPTION
Rate limit to ignore outgoing sessions, otherwise it fails to discover ip and fails with an error.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
