### PR TITLE
fix(visitors): Fixes s2s multiple connections.

### DIFF
--- a/resources/prosody-plugins/mod_muc_domain_mapper.lua
+++ b/resources/prosody-plugins/mod_muc_domain_mapper.lua
@@ -17,6 +17,10 @@ local internal_room_jid_match_rewrite = util.internal_room_jid_match_rewrite;
 
 -- We must filter stanzas in order to hook in to all incoming and outgoing messaging which skips the stanza routers
 function filter_stanza(stanza)
+    if stanza.skipMapping then
+        return stanza;
+    end
+
     if stanza.name == "message" or stanza.name == "iq" or stanza.name == "presence" then
         -- module:log("debug", "Filtering stanza type %s  to %s from %s",stanza.name,stanza.attr.to,stanza.attr.from);
         if stanza.name == "iq" then

--- a/resources/prosody-plugins/mod_muc_meeting_id.lua
+++ b/resources/prosody-plugins/mod_muc_meeting_id.lua
@@ -115,8 +115,6 @@ function handle_jicofo_unlock(event)
 
     -- and now let's handle all pre_join_queue events
     for _, ev in room.pre_join_queue:items() do
-        -- we see wrong from on some stanzas when using tenants with visitor nodes
-        ev.stanza.attr.from = internal_room_jid_match_rewrite(ev.stanza.attr.from, ev.stanza)
         module:log('info', 'Occupant processed from queue %s', ev.occupant.nick);
         room:handle_normal_presence(ev.origin, ev.stanza);
     end

--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -129,7 +129,8 @@ local function stanza_handler(event)
         return;
     end
 
-    if stanza.attr.type == 'result' and sent_iq_cache:get(stanza.attr.id) then
+    -- we receive error from vnode for our disconnect message as the room was already destroyed (all visitors left)
+    if (stanza.attr.type == 'result' or stanza.attr.type == 'error') and sent_iq_cache:get(stanza.attr.id) then
         sent_iq_cache:set(stanza.attr.id, nil);
         return true;
     end


### PR DESCRIPTION
We cannot use filters with s2s as not sending a stanza will result skipping existing connection and creating a new one. This also clears some of the "No hosts[from_host] (please report)" errors, but there is still one (easy to repro is we disable the jicofo locking) on join we see a presence trying to be routed using the wrong from (virtual  tenant jid).

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
