### PR TITLE
fix(moderation) Show Screensharing blocked notification

### DIFF
--- a/react/features/av-moderation/middleware.ts
+++ b/react/features/av-moderation/middleware.ts
@@ -48,6 +48,7 @@ import {
     ASKED_TO_UNMUTE_NOTIFICATION_ID,
     ASKED_TO_UNMUTE_SOUND_ID,
     AUDIO_MODERATION_NOTIFICATION_ID,
+    CS_MODERATION_NOTIFICATION_ID,
     VIDEO_MODERATION_NOTIFICATION_ID
 } from './constants';
 import {
@@ -86,6 +87,11 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         case MEDIA_TYPE.VIDEO: {
             titleKey = 'notify.moderationInEffectVideoTitle';
             uid = VIDEO_MODERATION_NOTIFICATION_ID;
+            break;
+        }
+        case MEDIA_TYPE.SCREENSHARE: {
+            titleKey = 'notify.moderationInEffectCSTitle';
+            uid = CS_MODERATION_NOTIFICATION_ID;
             break;
         }
         }

--- a/react/features/base/tracks/actions.web.ts
+++ b/react/features/base/tracks/actions.web.ts
@@ -1,10 +1,12 @@
 // @ts-expect-error
 import { AUDIO_ONLY_SCREEN_SHARE_NO_TRACK } from '../../../../modules/UI/UIErrors';
 import { IReduxState, IStore } from '../../app/types';
+import { showModeratedNotification } from '../../av-moderation/actions';
 import { shouldShowModeratedNotification } from '../../av-moderation/functions';
 import { setNoiseSuppressionEnabled } from '../../noise-suppression/actions';
 import { showNotification } from '../../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../../notifications/constants';
+import { isModerationNotificationDisplayed } from '../../notifications/functions';
 import { stopReceiver } from '../../remote-control/actions';
 import { setScreenAudioShareState, setScreenshareAudioTrack } from '../../screen-share/actions';
 import { isAudioOnlySharing, isScreenVideoShared } from '../../screen-share/functions';
@@ -44,6 +46,9 @@ export function toggleScreensharing(
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         // check for A/V Moderation when trying to start screen sharing
         if ((enabled || enabled === undefined) && shouldShowModeratedNotification(MEDIA_TYPE.VIDEO, getState())) {
+            if (!isModerationNotificationDisplayed(MEDIA_TYPE.SCREENSHARE, getState)) {
+                dispatch(showModeratedNotification(MEDIA_TYPE.SCREENSHARE));
+            }
 
             return Promise.reject();
         }

--- a/react/features/base/tracks/actions.web.ts
+++ b/react/features/base/tracks/actions.web.ts
@@ -6,7 +6,6 @@ import { shouldShowModeratedNotification } from '../../av-moderation/functions';
 import { setNoiseSuppressionEnabled } from '../../noise-suppression/actions';
 import { showNotification } from '../../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../../notifications/constants';
-import { isModerationNotificationDisplayed } from '../../notifications/functions';
 import { stopReceiver } from '../../remote-control/actions';
 import { setScreenAudioShareState, setScreenshareAudioTrack } from '../../screen-share/actions';
 import { isAudioOnlySharing, isScreenVideoShared } from '../../screen-share/functions';
@@ -46,9 +45,7 @@ export function toggleScreensharing(
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         // check for A/V Moderation when trying to start screen sharing
         if ((enabled || enabled === undefined) && shouldShowModeratedNotification(MEDIA_TYPE.VIDEO, getState())) {
-            if (!isModerationNotificationDisplayed(MEDIA_TYPE.SCREENSHARE, getState)) {
-                dispatch(showModeratedNotification(MEDIA_TYPE.SCREENSHARE));
-            }
+            dispatch(showModeratedNotification(MEDIA_TYPE.SCREENSHARE));
 
             return Promise.reject();
         }


### PR DESCRIPTION
When video moderation is on and the participant tries to share their screen show a notification saying the screen sharing is blocked

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
