### PR TITLE
feat(external-api) Forward non participant message to iframe

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -2029,7 +2029,10 @@ export default {
 
         room.on(
             JitsiConferenceEvents.NON_PARTICIPANT_MESSAGE_RECEIVED,
-            (...args) => APP.store.dispatch(nonParticipantMessageReceived(...args)));
+            (...args) => {
+                APP.store.dispatch(nonParticipantMessageReceived(...args));
+                APP.API.notifyNonParticipantMessageReceived(...args);
+            });
 
         room.on(
             JitsiConferenceEvents.LOCK_STATE_CHANGED,

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2035,10 +2035,10 @@ class API {
      * @param {Object} json - The json carried by the message.
      * @returns {void}
      */
-    notifyNonParticipantMessageReceived(id,json) {
+    notifyNonParticipantMessageReceived(id, json) {
         this._sendEvent({
             name: 'non-participant-message-received',
-            id: id,
+            id,
             message: json
         });
     }

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2028,6 +2028,23 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) if non participant message
+     * is received.
+     *
+     * @param {string} id - The resource id of the sender.
+     * @param {Object} json - The json carried by the endpoint message.
+     * @returns {void}
+     */
+    notifyNonParticipantMessageReceived(id,json) {
+        this._sendEvent({
+            name: 'non-participant-message-received',
+            id: id,
+            message: json
+        });
+    }
+
+
+    /**
      * Notify the external application (if API is enabled) if the connection type changed.
      *
      * @param {boolean} isP2p - Whether the new connection is P2P.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2032,7 +2032,7 @@ class API {
      * is received.
      *
      * @param {string} id - The resource id of the sender.
-     * @param {Object} json - The json carried by the endpoint message.
+     * @param {Object} json - The json carried by the message.
      * @returns {void}
      */
     notifyNonParticipantMessageReceived(id,json) {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -128,6 +128,7 @@ const events = {
     'mouse-enter': 'mouseEnter',
     'mouse-leave': 'mouseLeave',
     'mouse-move': 'mouseMove',
+    'non-participant-message-received': 'nonParticipantMessageReceived',
     'notification-triggered': 'notificationTriggered',
     'outgoing-message': 'outgoingMessage',
     'p2p-status-changed': 'p2pStatusChanged',


### PR DESCRIPTION
Added new nonParticipantMessageReceived event for the iFrame API.

This enables custom messages from prosody to meeting participants using iFrame.


