### PR TITLE
fix(settings-dialog) On mobile open on the correct tab

### DIFF
--- a/react/features/base/ui/components/web/DialogWithTabs.tsx
+++ b/react/features/base/ui/components/web/DialogWithTabs.tsx
@@ -187,7 +187,7 @@ const DialogWithTabs = ({
 
     useEffect(() => {
         if (isMobile) {
-            setSelectedTab(undefined);
+            setSelectedTab(defaultTab);
         } else {
             setSelectedTab(defaultTab ?? tabs[0].name);
         }

--- a/react/features/settings/actions.web.ts
+++ b/react/features/settings/actions.web.ts
@@ -48,7 +48,7 @@ export function openLogoutDialog(onLogout: Function) {
  * welcome page or not.
  * @returns {Function}
  */
-export function openSettingsDialog(defaultTab: string, isDisplayedOnWelcomePage?: boolean) {
+export function openSettingsDialog(defaultTab?: string, isDisplayedOnWelcomePage?: boolean) {
     return openDialog(SettingsDialog, {
         defaultTab,
         isDisplayedOnWelcomePage

--- a/react/features/settings/components/web/SettingsButton.ts
+++ b/react/features/settings/components/web/SettingsButton.ts
@@ -6,7 +6,6 @@ import { translate } from '../../../base/i18n/functions';
 import { IconGear } from '../../../base/icons/svg';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { openSettingsDialog } from '../../actions';
-import { SETTINGS_TABS } from '../../constants';
 
 /**
  * The type of the React {@code Component} props of {@link SettingsButton}.
@@ -41,10 +40,10 @@ class SettingsButton extends AbstractButton<IProps> {
      * @returns {void}
      */
     _handleClick() {
-        const { defaultTab = SETTINGS_TABS.AUDIO, dispatch, isDisplayedOnWelcomePage = false } = this.props;
+        const { dispatch, isDisplayedOnWelcomePage = false } = this.props;
 
         sendAnalytics(createToolbarEvent('settings'));
-        dispatch(openSettingsDialog(defaultTab, isDisplayedOnWelcomePage));
+        dispatch(openSettingsDialog(undefined, isDisplayedOnWelcomePage));
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
