### PR TITLE
fix(horizontal-filmstrip): JS error.

### DIFF
--- a/modules/UI/videolayout/Filmstrip.js
+++ b/modules/UI/videolayout/Filmstrip.js
@@ -15,7 +15,7 @@ const Filmstrip = {
         // horizontal film strip mode for calculating how tall large video
         // display should be.
         if (isFilmstripVisible(APP.store) && !interfaceConfig.VERTICAL_FILMSTRIP) {
-            return document.querySelector('.filmstrip').offsetHeight;
+            return document.querySelector('.filmstrip')?.offsetHeight ?? 0;
         }
 
         return 0;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Fixes the following JS error which prevents the whole page from
rendering:
TypeError: Cannot read properties of null (reading 'offsetHeight')
