### PR TITLE
fix(prejoin) Check for valid url for prejoin

### DIFF
--- a/react/features/base/util/parseURLParams.ts
+++ b/react/features/base/util/parseURLParams.ts
@@ -25,6 +25,10 @@ export function parseURLParams(
         url: URL | string,
         dontParse = false,
         source = 'hash') {
+    if (!url) {
+        return {};
+    }
+
     if (typeof url === 'string') {
         // eslint-disable-next-line no-param-reassign
         url = new URL(url);


### PR DESCRIPTION
- `getPropertyValue` calls `parseUrlParam` with the connection URL from store, which is not yet defined

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
