### PR TITLE
feat: add i18next compatible IDE-extension for i18n handling

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,23 @@
+/**
+ * @type { import("@inlang/core/config").DefineConfig }
+ */
+export async function defineConfig(env) {
+    const { default: i18nextPlugin } = await env.$import(
+        'https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@2/dist/index.js'
+    );
+
+    const { default: standardLintRules } = await env.$import(
+        'https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js'
+    );
+
+    return {
+        referenceLanguage: 'main',
+        plugins: [
+            i18nextPlugin({
+                pathPattern: 'lang/{language}.json',
+                ignore: [ 'languages.json', 'translation-languages.json' ]
+            }),
+            standardLintRules()
+        ]
+    };
+}


### PR DESCRIPTION
> let me know if there is something to be changed in order to merge

I added the `inlang` [IDE extension](https://inlang.com/documentation/apps/ide-extension) to Jitsi Meet. That should make the life of devs easier while developing (extracting and inline annotations).

#### Extract Messages (translations)

Extract Messages (translations) via the `Inlang: Extract Message` code action.

![Extract Messages](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/extract.gif)

#### Inline Annotations

See translations directly in your code. No more back-and-forth looking into the translation files themselves.

![Inline Annotations](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/inline.gif)