### PR TITLE
watchRTC as a feature for Jitsi meet.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@svgr/webpack": "6.3.1",
         "@tensorflow/tfjs-backend-wasm": "3.13.0",
         "@tensorflow/tfjs-core": "3.13.0",
+        "@testrtc/watchrtc-sdk": "^1.36.3",
         "@vladmandic/human": "2.6.5",
         "@vladmandic/human-models": "2.5.9",
         "@xmldom/xmldom": "0.8.7",
@@ -5525,6 +5526,11 @@
       "engines": {
         "yarn": ">= 1.3.2"
       }
+    },
+    "node_modules/@testrtc/watchrtc-sdk": {
+      "version": "1.36.3",
+      "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
+      "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg=="
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -23712,6 +23718,11 @@
         "node-fetch": "~2.6.1",
         "seedrandom": "2.4.3"
       }
+    },
+    "@testrtc/watchrtc-sdk": {
+      "version": "1.36.3",
+      "resolved": "https://registry.npmjs.org/@testrtc/watchrtc-sdk/-/watchrtc-sdk-1.36.3.tgz",
+      "integrity": "sha512-JtcTvvh20t553n8q5ZHpWQeSUTENkQrZbGNvQ05jD8SA2V5PHBok/7my1ZDuA44sgT0y1OfUA8VT7dhcs0VxWg=="
     },
     "@trysound/sax": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@svgr/webpack": "6.3.1",
     "@tensorflow/tfjs-backend-wasm": "3.13.0",
     "@tensorflow/tfjs-core": "3.13.0",
+    "@testrtc/watchrtc-sdk": "^1.36.3",
     "@vladmandic/human": "2.6.5",
     "@vladmandic/human-models": "2.5.9",
     "@xmldom/xmldom": "0.8.7",

--- a/react/features/app/middlewares.any.ts
+++ b/react/features/app/middlewares.any.ts
@@ -49,5 +49,6 @@ import '../video-layout/middleware';
 import '../video-quality/middleware';
 import '../videosipgw/middleware';
 import '../visitors/middleware';
+import '../watchrtc/middleware';
 
 import './middleware';

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -126,6 +126,37 @@ export interface INoiseSuppressionConfig {
     };
 }
 
+export interface IWatchRTCConfiguration {
+    /** Watchrtc api key */
+    rtcApiKey: string;
+    /** Identifier for the session */
+    rtcRoomId?: string;
+    /** Identifier for the current peer */
+    rtcPeerId?: string;
+    /**
+     * ["tag1", "tag2", "tag3"]
+     * @deprecated use 'keys' instead
+     */
+    rtcTags?: string[];
+    /** { "key1": "value1", "key2": "value2"} */
+    keys?: any;
+    /** Enables additional logging */
+    debug?: boolean;
+    rtcToken?: string;
+    /**
+     * @deprecated No longer needed. Use "proxyUrl" instead.
+     */
+    wsUrl?: string;
+    proxyUrl?: string;
+    console?: {
+        level: string;
+        override: boolean;
+    };
+    allowBrowserLogCollection?: boolean;
+    collectionInterval?: number;
+    logGetStats?: boolean;
+}
+
 export interface IConfig {
     _desktopSharingSourceDevice?: string;
     _immediateReloadThreshold?: string;
@@ -146,6 +177,7 @@ export interface IConfig {
         rtcstatsUseLegacy?: boolean;
         scriptURLs?: Array<string>;
         whiteListedEvents?: string[];
+        watchRTCEnabled?: boolean;
     };
     apiLogLevels?: Array<'warn' | 'log' | 'error' | 'info' | 'debug'>;
     appId?: string;
@@ -573,4 +605,5 @@ export interface IConfig {
         collabServerBaseUrl?: string;
         enabled?: boolean;
     };
+    watchRTCConfigParams?: IWatchRTCConfiguration;
 }

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -23,6 +23,7 @@ export default [
     'backgroundAlpha',
     'breakoutRooms',
     'buttonsWithNotifyClick',
+    'analytics.watchRTCEnabled',
 
     /**
      * The display name of the CallKit call representing the conference/meeting
@@ -230,5 +231,6 @@ export default [
     'videoQuality',
     'webrtcIceTcpDisable',
     'webrtcIceUdpDisable',
-    'whiteboard.enabled'
+    'whiteboard.enabled',
+    'watchRTCConfigParams'
 ].concat(extraConfigWhitelist);

--- a/react/features/base/config/functions.native.ts
+++ b/react/features/base/config/functions.native.ts
@@ -29,6 +29,8 @@ export function _cleanupConfig(config: IConfig) {
         delete config.analytics?.obfuscateRoomName;
         delete config.callStatsID;
         delete config.callStatsSecret;
+        delete config.analytics?.watchRTCEnabled;
+        delete config.watchRTCConfigParams;
         config.giphy = { enabled: false };
     }
 }

--- a/react/features/watchrtc/functions.ts
+++ b/react/features/watchrtc/functions.ts
@@ -1,0 +1,15 @@
+import { IStateful } from '../base/app/types';
+import { toState } from '../base/redux/functions';
+
+/**
+ * Checks whether watchrtc is enabled or not.
+ *
+ * @param {IStateful} stateful - The redux store or {@code getState} function.
+ * @returns {boolean}
+ */
+export function isWatchRTCEnabled(stateful: IStateful) {
+    const state = toState(stateful);
+    const { analytics } = state['features/base/config'];
+
+    return analytics?.watchRTCEnabled ?? false;
+}

--- a/react/features/watchrtc/logger.ts
+++ b/react/features/watchrtc/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('features/watchrtc');

--- a/react/features/watchrtc/middleware.ts
+++ b/react/features/watchrtc/middleware.ts
@@ -1,0 +1,46 @@
+import { AnyAction } from 'redux';
+
+import { IStore } from '../app/types';
+import { LIB_WILL_INIT } from '../base/lib-jitsi-meet/actionTypes';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+
+import watchRTCHandler from './watchRTCHandler';
+import { isWatchRTCEnabled } from './functions';
+import logger from './logger';
+
+/**
+ * Middleware which intercepts lib-jitsi-meet initialization and conference join in order init the
+ * watchRTC.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyAction) => {
+    const { getState } = store;
+    const state = getState();
+    const config = state['features/base/config'];
+    const { watchRTCConfigParams } = config;
+
+    switch (action.type) {
+    case LIB_WILL_INIT: {
+        if (isWatchRTCEnabled(state)) {
+            // watchRTC "proxies" WebRTC functions such as GUM and RTCPeerConnection by rewriting the global
+            // window functions. Because lib-jitsi-meet uses references to those functions that are taken on
+            // init, we need to add these proxies before it initializes, otherwise lib-jitsi-meet will use the
+            // original non proxy versions of these functions.
+            try {
+                if (watchRTCConfigParams) {
+                    watchRTCHandler.init(watchRTCConfigParams);
+                } else {
+                    logger.error("WatchRTC enabled but no configuration");
+                }
+            } catch (error) {
+                logger.error("Failed to initialize WatchRTC: ", error);
+            }
+        }
+        break;
+    }
+    }
+
+    return next(action);
+});

--- a/react/features/watchrtc/watchRTCHandler.ts
+++ b/react/features/watchrtc/watchRTCHandler.ts
@@ -1,0 +1,47 @@
+
+/* eslint-disable lines-around-comment */
+// @ts-expect-error
+import watchRTC from '@testrtc/watchrtc-sdk';
+/* eslint-enable lines-around-comment */
+
+import logger from './logger';
+import { IWatchRTCConfiguration } from '../base/config/configType';
+
+/**
+ * Class that controls the watchRTC flow, because it overwrites and proxies global function it should only be
+ * initialized once.
+ */
+class watchRTCHandler {
+    options?: IWatchRTCConfiguration;
+    isPeerConnectionWrapped = false;
+
+    /**
+     * Initialize watchRTC, it overwrites GUM and PeerConnection global functions and adds a proxy over them used to capture stats.
+     * Note, lib-jitsi-meet takes references to these methods before initializing so the init method needs to be
+     * loaded before it does.
+     *
+     * @param {Object} options - watchRTC configuration options
+     * @returns {void}
+     */
+    init(options: IWatchRTCConfiguration) {
+        if (!this.isPeerConnectionWrapped) {
+            watchRTC.init(options);
+            logger.info("WatchRTC initialized");
+            this.isPeerConnectionWrapped = true;
+        } else {
+            logger.warn("WatchRTC peerconnection was already wrapped");
+        }
+        this.options = options;
+    }
+
+    /**
+     * Check whether or not the watchRTC is initialized.
+     *
+     * @returns {boolean}
+     */
+    isInitialized() {
+        return this.options !== undefined;
+    }
+}
+
+export default new watchRTCHandler();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Following PR contains changes required to add watchRTC as a feature for jitsi meet. 

This involves adding configuration to enable watchRTC which includes a watchRTCEnabled flag and watchRTCConfigParams for the options.
The flow is similar to what is done for @jitsi/rtcstats.
