### PR TITLE
store only "clean" URLs in recent-list

### DIFF
--- a/react/features/recent-list/reducer.ts
+++ b/react/features/recent-list/reducer.ts
@@ -82,7 +82,7 @@ function _deleteRecentListEntry(
  * @returns {Object}
  */
 function _storeCurrentConference(state: IRecentListState, { locationURL }: { locationURL: { href: string; }; }) {
-    const conference = locationURL.href;
+    const conference = getURLWithoutParamsNormalized( new URL(locationURL.href) );
 
     // If the current conference is already in the list, we remove it to re-add
     // it to the top.

--- a/react/features/recent-list/reducer.ts
+++ b/react/features/recent-list/reducer.ts
@@ -82,7 +82,7 @@ function _deleteRecentListEntry(
  * @returns {Object}
  */
 function _storeCurrentConference(state: IRecentListState, { locationURL }: { locationURL: { href: string; }; }) {
-    const conference = getURLWithoutParamsNormalized( new URL(locationURL.href) );
+    const conference = getURLWithoutParamsNormalized(new URL(locationURL.href));
 
     // If the current conference is already in the list, we remove it to re-add
     // it to the top.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
In oder to not store the token with the conference in the recent conferences list, store only the "clean" conference URL.
Fixes jitsi/jitsi-meet#13313
