### PR TITLE
added option to use rtctstats from lib-jitsi-meet

### DIFF
--- a/config.js
+++ b/config.js
@@ -992,6 +992,10 @@ var config = {
         // all SDPs with an empty string instead.
         // rtcstatsSendSdp: false,
 
+        // This determines if rtcstats from lib-jitsi-meet will be used instead of the one
+        // here in jitsi-meet directly
+        // rtcstatsUseLibJitsi: false,
+
         // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
         // scriptURLs: [
         //      "libs/analytics-ga.min.js", // google-analytics

--- a/config.js
+++ b/config.js
@@ -99,6 +99,11 @@ var config = {
         // This takes a value between 0 and 100 which determines the probability for
         // the callstats to be enabled.
         // callStatsThreshold: 5, // enable callstats for 5% of the users.
+
+        // This determines if rtcstats from lib-jitsi-meet will be used instead of the one
+        // here in jitsi-meet directly
+        // rtcstatsUseLibJitsi: false,
+
     },
 
     // Disables moderator indicators.
@@ -991,10 +996,6 @@ var config = {
         // This determines if rtcstats sends the SDP to the rtcstats server or replaces
         // all SDPs with an empty string instead.
         // rtcstatsSendSdp: false,
-
-        // This determines if rtcstats from lib-jitsi-meet will be used instead of the one
-        // here in jitsi-meet directly
-        // rtcstatsUseLibJitsi: false,
 
         // Array of script URLs to load as lib-jitsi-meet "analytics handlers".
         // scriptURLs: [

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -520,6 +520,7 @@ export interface IConfig {
         noAutoPlayVideo?: boolean;
         p2pTestMode?: boolean;
         testMode?: boolean;
+        rtcstatsUseLibJitsi?: boolean;
     };
     tileView?: {
         numberOfVisibleTiles?: number;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -144,6 +144,7 @@ export interface IConfig {
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
         rtcstatsUseLegacy?: boolean;
+        rtcstatsUseLibJitsi?: boolean;
         scriptURLs?: Array<string>;
         whiteListedEvents?: string[];
     };

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -144,7 +144,6 @@ export interface IConfig {
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
         rtcstatsUseLegacy?: boolean;
-        rtcstatsUseLibJitsi?: boolean;
         scriptURLs?: Array<string>;
         whiteListedEvents?: string[];
     };
@@ -519,8 +518,8 @@ export interface IConfig {
         mobileXmppWsThreshold?: number;
         noAutoPlayVideo?: boolean;
         p2pTestMode?: boolean;
-        testMode?: boolean;
         rtcstatsUseLibJitsi?: boolean;
+        testMode?: boolean;
     };
     tileView?: {
         numberOfVisibleTiles?: number;

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -110,16 +110,17 @@ class RTCStats {
         if (useLibRtcStats) {
             logger.info('setting up libRtcStats');
 
-            const rtcOptions = {
-                meetingName: meetingFqn,
-                eventCallback: this.handleRtcstatsEvent.bind(this),
-                onCloseCallback: this.handleTraceWSClose.bind(this)
-            };
+            JitsiMeetJS.rtcstats.events.on(
+                'rtcstats_ws_disconnected',
+                (closeEvent: any) => this.handleTraceWSClose(closeEvent));
+            JitsiMeetJS.rtcstats.events.on(
+                'rtstats_pc_event',
+                (pcEvent: any) => this.handleRtcstatsEvent(pcEvent));
 
-            JitsiMeetJS.setRtcStatsMeetingFqn(rtcOptions);
-
-            JitsiMeetJS.getRtcStatsTrace().then((traceF: any) => {
+            JitsiMeetJS.rtcstats.setMeetingFqn(meetingFqn);
+            JitsiMeetJS.rtcstats.getTrace().then((traceF: any) => {
                 this.setTrace(traceF);
+
             });
 
         } else {
@@ -169,8 +170,6 @@ class RTCStats {
      * @returns {void}
      */
     setTrace(traceF: any) {
-        logger.error(`Setting RTCStats trace function to ${traceF}`);
-
         this.trace = traceF;
     }
 

--- a/react/features/rtcstats/middleware.ts
+++ b/react/features/rtcstats/middleware.ts
@@ -37,7 +37,7 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
     const { getState } = store;
     const state = getState();
     const config = state['features/base/config'];
-    const { analytics } = config;
+    const { analytics, testing } = config;
 
     switch (action.type) {
     case LIB_WILL_INIT: {
@@ -51,7 +51,7 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
                 const pollInterval = analytics?.rtcstatsPollInterval || 10000;
                 const useLegacy = analytics?.rtcstatsUseLegacy || false;
                 const sendSdp = analytics?.rtcstatsSendSdp || false;
-                const useLibRtcStats = analytics?.rtcstatsUseLibJitsi || false;
+                const useLibRtcStats = testing?.rtcstatsUseLibJitsi || false;
 
                 // Initialize but don't connect to the rtcstats server wss, as it will start sending data for all
                 // media calls made even before the conference started.

--- a/react/features/rtcstats/middleware.ts
+++ b/react/features/rtcstats/middleware.ts
@@ -51,6 +51,7 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
                 const pollInterval = analytics?.rtcstatsPollInterval || 10000;
                 const useLegacy = analytics?.rtcstatsUseLegacy || false;
                 const sendSdp = analytics?.rtcstatsSendSdp || false;
+                const useLibRtcStats = analytics?.rtcstatsUseLibJitsi || false;
 
                 // Initialize but don't connect to the rtcstats server wss, as it will start sending data for all
                 // media calls made even before the conference started.
@@ -60,7 +61,8 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
                     meetingFqn: extractFqnFromPath(state),
                     useLegacy,
                     pollInterval,
-                    sendSdp
+                    sendSdp,
+                    useLibRtcStats
                 });
             } catch (error) {
                 logger.error('Failed to initialize RTCStats: ', error);

--- a/react/features/rtcstats/types.ts
+++ b/react/features/rtcstats/types.ts
@@ -4,6 +4,7 @@ export type InitOptions = {
     pollInterval: number;
     sendSdp: boolean;
     useLegacy: boolean;
+    useLibRtcStats: boolean;
 };
 
 export type VideoTypeData = {


### PR DESCRIPTION
This PR adds a new option to use rtcstats from lib-jitsi-meet instead of the build in version in jitsi-meet.