### PR TITLE
Fix jicofo_lock is null when restored from storage

### DIFF
--- a/resources/prosody-plugins/mod_muc_meeting_id.lua
+++ b/resources/prosody-plugins/mod_muc_meeting_id.lua
@@ -81,7 +81,7 @@ module:hook('muc-occupant-pre-join', function (event)
     local room, stanza = event.room, event.stanza;
 
     -- we skip processing only if jicofo_lock is set to false
-    if room.jicofo_lock == false or is_healthcheck_room(stanza.attr.from) then
+    if room._data.jicofo_lock == false or is_healthcheck_room(stanza.attr.from) then
         return;
     end
 
@@ -89,7 +89,7 @@ module:hook('muc-occupant-pre-join', function (event)
     if ends_with(occupant.nick, '/focus') then
         module:fire_event('jicofo-unlock-room', { room = room; });
     else
-        room.jicofo_lock = true;
+        room._data.jicofo_lock = true;
         if not room.pre_join_queue then
             room.pre_join_queue = queue.new(QUEUE_MAX_SIZE);
         end
@@ -108,7 +108,7 @@ end, 8); -- just after the rate limit
 function handle_jicofo_unlock(event)
     local room = event.room;
 
-    room.jicofo_lock = false;
+    room._data.jicofo_lock = false;
     if not room.pre_join_queue then
         return;
     end

--- a/twa/app/src/main/res/xml/shortcuts.xml
+++ b/twa/app/src/main/res/xml/shortcuts.xml
@@ -1,1 +1,16 @@
+<!--
+    Copyright 2019 Google Inc. All Rights Reserved.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
 <shortcuts xmlns:android='http://schemas.android.com/apk/res/android' />

--- a/twa/app/src/main/res/xml/shortcuts.xml
+++ b/twa/app/src/main/res/xml/shortcuts.xml
@@ -1,16 +1,1 @@
-<!--
-    Copyright 2019 Google Inc. All Rights Reserved.
-
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-         http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
--->
 <shortcuts xmlns:android='http://schemas.android.com/apk/res/android' />


### PR DESCRIPTION
https://prosody.im/doc/modules/mod_muc
> Limit on number of rooms in-memory
> Prosody keeps recently active rooms cached in memory for faster access. The size of this cache defaults to 100 rooms and can be configured like this:
> 
> muc_room_cache_size = 100 -- the default
> When a room is pushed out of this cache by other more recently active rooms, its complete state is serialized to storage and removed from memory.
> 
> Public servers may want to monitor and possibly increase this setting if rooms are moved in and out of memory very often.

When room is serialized to storage, room.jicofo_lock is not saved.
https://github.com/bjc/prosody/blob/master/plugins/muc/muc.lib.lua#L1671-L1675

When the room is activated again, jicofo_lock is null and remains locked.

I fixed to save jicofo_lock.