### PR TITLE
fix(android) remove no longer needed view clipping hack

### DIFF
--- a/react/features/base/styles/functions.any.ts
+++ b/react/features/base/styles/functions.any.ts
@@ -1,7 +1,3 @@
-import Platform from '../react/Platform';
-
-import { ColorPalette } from './components/styles/ColorPalette';
-
 declare type StyleSheet = {
     [key: string]: string | number | { [key: string]: string | number; };
 };
@@ -119,28 +115,6 @@ export function createStyleSheet(
     }
 
     return combinedStyles;
-}
-
-/**
- * Works around a bug in react-native or react-native-webrtc on Android which
- * causes Views overlaying RTCView to be clipped. Even though we (may) display
- * multiple RTCViews, it is enough to apply the fix only to a View with a
- * bounding rectangle containing all RTCviews and their overlaying Views.
- *
- * @param {StyleSheet} styles - An object which represents a stylesheet.
- * @public
- * @returns {StyleSheet}
- */
-export function fixAndroidViewClipping<T extends StyleSheet>(styles: T): T {
-    if (Platform.OS === 'android') {
-        // @ts-ignore
-        styles.borderColor = ColorPalette.appBackground;
-
-        // @ts-ignore
-        styles.borderWidth = 1;
-    }
-
-    return styles;
 }
 
 /**

--- a/react/features/conference/components/native/styles.ts
+++ b/react/features/conference/components/native/styles.ts
@@ -1,4 +1,3 @@
-import { fixAndroidViewClipping } from '../../../base/styles/functions.native';
 import BaseTheme from '../../../base/ui/components/BaseTheme.native';
 
 export const INSECURE_ROOM_NAME_LABEL_COLOR = BaseTheme.palette.actionDanger;
@@ -38,11 +37,11 @@ export default {
     /**
      * {@code Conference} Style.
      */
-    conference: fixAndroidViewClipping({
+    conference: {
         alignSelf: 'stretch',
         backgroundColor: BaseTheme.palette.uiBackground,
         flex: 1
-    }),
+    },
 
     displayNameContainer: {
         margin: 10


### PR DESCRIPTION
This should no longer be necessary since we added it for Android 6 devices a long time ago but we no longer support those.

Fixes: https://github.com/jitsi/jitsi-meet/issues/13514

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
