### PR TITLE
feat(external-api) extend event to listen to system buttons and add config to prevent execution

### DIFF
--- a/config.js
+++ b/config.js
@@ -826,6 +826,42 @@ var config = {
     //     'whiteboard',
     // ],
 
+    // Participant context menu buttons which have their click/tap event exposed through the API on
+    // `participantMenuButtonClick`. Passing a string for the button key will
+    // prevent execution of the click/tap routine; passing an object with `key` and
+    // `preventExecution` flag on false will not prevent execution of the click/tap
+    // routine. Below array with mixed mode for passing the buttons.
+    // participantMenuButtonsWithNotifyClick: [
+    //     'allow-video',
+    //     {
+    //         key: 'ask-unmute',
+    //         preventExecution: false
+    //     },
+    //     'conn-status',
+    //     'flip-local-video',
+    //     'grant-moderator',
+    //     {
+    //         key: 'kick',
+    //         preventExecution: true
+    //     },
+    //     {
+    //         key: 'hide-self-view',
+    //         preventExecution: false
+    //     },
+    //     'mute',
+    //     'mute-others',
+    //     'mute-others-video',
+    //     'mute-video',
+    //     'pinToStage',
+    //     'privateMessage',
+    //     {
+    //         key: 'remote-control',
+    //         preventExecution: false
+    //     },
+    //     'send-participant-to-room',
+    //     'verify',
+    // ],
+
     // List of pre meeting screens buttons to hide. The values must be one or more of the 5 allowed buttons:
     // 'microphone', 'camera', 'select-background', 'invite', 'settings'
     // hiddenPremeetingButtons: [],

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2002,14 +2002,16 @@ class API {
      * Notify external application ( if API is enabled) that a participant menu button was clicked.
      *
      * @param {string} key - The key of the participant menu button.
-     * @param {string} participantId - The ID of the participant for with the participant menu button was clicked.
+     * @param {string} participantId - The ID of the participant for whom the participant menu button was clicked.
+     * @param {boolean} preventExecution - Whether execution of the button click was prevented or not.
      * @returns {void}
      */
-    notifyParticipantMenuButtonClicked(key, participantId) {
+    notifyParticipantMenuButtonClicked(key, participantId, preventExecution) {
         this._sendEvent({
             name: 'participant-menu-button-clicked',
             key,
-            participantId
+            participantId,
+            preventExecution
         });
     }
 

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -32,7 +32,7 @@ type ToolbarButtons = 'camera' |
     'videoquality' |
     '__end';
 
-export type ButtonsWithNotifyClick = 'camera' |
+type ButtonsWithNotifyClick = 'camera' |
     'chat' |
     'closedcaptions' |
     'desktop' |
@@ -68,20 +68,32 @@ export type ButtonsWithNotifyClick = 'camera' |
     'add-passcode' |
     '__end';
 
-export type ParticipantMenuButtonsWithNotifyClick = 'allow-video' |
-'ask-unmute' |
-'conn-status' |
-'grant-moderator' |
-'kick' |
-'mute' |
-'mute-others' |
-'mute-others-video' |
-'mute-video' |
-'pinToStage' |
-'privateMessage' |
-'remote-control' |
-'send-participant-to-room' |
-'verify';
+type ParticipantMenuButtonsWithNotifyClick = 'allow-video' |
+    'ask-unmute' |
+    'conn-status' |
+    'flip-local-video' |
+    'grant-moderator' |
+    'hide-self-view' |
+    'kick' |
+    'mute' |
+    'mute-others' |
+    'mute-others-video' |
+    'mute-video' |
+    'pinToStage' |
+    'privateMessage' |
+    'remote-control' |
+    'send-participant-to-room' |
+    'verify';
+
+type NotifyClickButtonKey = string |
+    ButtonsWithNotifyClick |
+    ParticipantMenuButtonsWithNotifyClick;
+
+export type NotifyClickButton = NotifyClickButtonKey |
+    {
+        key: NotifyClickButtonKey;
+        preventExecution: boolean;
+    };
 
 export type Sounds = 'ASKED_TO_UNMUTE_SOUND' |
     'E2EE_OFF_SOUND' |
@@ -462,8 +474,8 @@ export interface IConfig {
         mobileCodecPreferenceOrder?: Array<string>;
         stunServers?: Array<{ urls: string; }>;
     };
-    participantMenuButtonsWithNotifyClick?: Array<ParticipantMenuButtonsWithNotifyClick | {
-        key: ParticipantMenuButtonsWithNotifyClick;
+    participantMenuButtonsWithNotifyClick?: Array<string | ParticipantMenuButtonsWithNotifyClick | {
+        key: string | ParticipantMenuButtonsWithNotifyClick;
         preventExecution: boolean;
     }>;
     participantsPane?: {

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -32,7 +32,7 @@ type ToolbarButtons = 'camera' |
     'videoquality' |
     '__end';
 
-type ButtonsWithNotifyClick = 'camera' |
+export type ButtonsWithNotifyClick = 'camera' |
     'chat' |
     'closedcaptions' |
     'desktop' |
@@ -67,6 +67,21 @@ type ButtonsWithNotifyClick = 'camera' |
     'videoquality' |
     'add-passcode' |
     '__end';
+
+export type ParticipantMenuButtonsWithNotifyClick = 'allow-video' |
+'ask-unmute' |
+'conn-status' |
+'grant-moderator' |
+'kick' |
+'mute' |
+'mute-others' |
+'mute-others-video' |
+'mute-video' |
+'pinToStage' |
+'privateMessage' |
+'remote-control' |
+'send-participant-to-room' |
+'verify';
 
 export type Sounds = 'ASKED_TO_UNMUTE_SOUND' |
     'E2EE_OFF_SOUND' |
@@ -447,6 +462,10 @@ export interface IConfig {
         mobileCodecPreferenceOrder?: Array<string>;
         stunServers?: Array<{ urls: string; }>;
     };
+    participantMenuButtonsWithNotifyClick?: Array<ParticipantMenuButtonsWithNotifyClick | {
+        key: ParticipantMenuButtonsWithNotifyClick;
+        preventExecution: boolean;
+    }>;
     participantsPane?: {
         hideModeratorSettingsTab?: boolean;
         hideMoreActionsButton?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -193,6 +193,7 @@ export default [
     'openSharedDocumentOnJoin',
     'opusMaxAverageBitrate',
     'p2p',
+    'participantMenuButtonsWithNotifyClick',
     'participantsPane',
     'pcStatsInterval',
     'prejoinConfig',

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -1,7 +1,15 @@
 import { IReduxState } from '../../app/types';
 import JitsiMeetJS from '../../base/lib-jitsi-meet';
+import { NOTIFY_CLICK_MODE } from '../../toolbox/constants';
 
-import { IConfig, IDeeplinkingConfig, IDeeplinkingMobileConfig, IDeeplinkingPlatformConfig } from './configType';
+import {
+    ButtonsWithNotifyClick,
+    IConfig,
+    IDeeplinkingConfig,
+    IDeeplinkingMobileConfig,
+    IDeeplinkingPlatformConfig,
+    ParticipantMenuButtonsWithNotifyClick
+} from './configType';
 import { TOOLBAR_BUTTONS } from './constants';
 
 export * from './functions.any';
@@ -120,14 +128,33 @@ export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
 }
 
 /**
- * Returns the list of buttons that have that notify the api when clicked.
+ * Common logic to gather buttons that have to notify the api when clicked.
  *
- * @param {Object} state - The redux state.
- * @returns {Array} - The list of buttons.
+ * @param {Array} buttonsWithNotifyClick - The array of systme buttons that need to notify the api.
+ * @param {Array} customButtons - The custom buttons.
+ * @returns {Array}
  */
-export function getButtonsWithNotifyClick(state: IReduxState): Array<{ key: string; preventExecution: boolean; }> {
-    const { buttonsWithNotifyClick, customToolbarButtons } = state['features/base/config'];
-    const customButtons = customToolbarButtons?.map(({ id }) => {
+const buildButtonsArray = (
+        buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
+            key: ButtonsWithNotifyClick;
+            preventExecution: boolean;
+        })[] | (ParticipantMenuButtonsWithNotifyClick | {
+            key: ParticipantMenuButtonsWithNotifyClick;
+            preventExecution: boolean;
+        })[],
+        customButtons?: {
+            icon: string;
+            id: string;
+            text: string;
+        }[]
+): (ButtonsWithNotifyClick | {
+    key: ButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] | (ParticipantMenuButtonsWithNotifyClick | {
+    key: ParticipantMenuButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] => {
+    const customButtonsWithNotifyClick = customButtons?.map(({ id }) => {
         return {
             key: id,
             preventExecution: false
@@ -135,13 +162,91 @@ export function getButtonsWithNotifyClick(state: IReduxState): Array<{ key: stri
     });
 
     const buttons = Array.isArray(buttonsWithNotifyClick)
-        ? buttonsWithNotifyClick as Array<{ key: string; preventExecution: boolean; }>
+        ? buttonsWithNotifyClick
         : [];
 
-    if (customButtons) {
-        buttons.push(...customButtons);
+    if (customButtonsWithNotifyClick) {
+        // @ts-ignore
+        buttons.push(...customButtonsWithNotifyClick);
     }
 
     return buttons;
+};
+
+/**
+ * Returns the list of toolbar buttons that have to notify the api when clicked.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Array} - The list of buttons.
+ */
+export function getButtonsWithNotifyClick(
+        state: IReduxState
+): (ButtonsWithNotifyClick | {
+    key: ButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] | (ParticipantMenuButtonsWithNotifyClick | {
+    key: ParticipantMenuButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] {
+    const { buttonsWithNotifyClick, customToolbarButtons } = state['features/base/config'];
+
+    return buildButtonsArray(
+        buttonsWithNotifyClick,
+        customToolbarButtons
+    );
 }
 
+/**
+ * Returns the list of participant menu buttons that have that notify the api when clicked.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Array} - The list of participant menu buttons.
+ */
+export function getParticipantMenuButtonsWithNotifyClick(
+        state: IReduxState
+): (ButtonsWithNotifyClick | {
+    key: ButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] | (ParticipantMenuButtonsWithNotifyClick | {
+    key: ParticipantMenuButtonsWithNotifyClick;
+    preventExecution: boolean;
+})[] {
+    const { participantMenuButtonsWithNotifyClick, customParticipantMenuButtons } = state['features/base/config'];
+
+    return buildButtonsArray(
+        participantMenuButtonsWithNotifyClick,
+        customParticipantMenuButtons
+    );
+}
+
+/**
+ * Returns the notify mode for the specified button.
+ *
+ * @param {string} buttonKey - The button key.
+ * @param {Array} buttonsWithNotifyClick - The buttons with notify click.
+ * @returns {string|undefined}
+ */
+export const getButtonNotifyMode = (
+        buttonKey: string,
+        buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
+            key: ButtonsWithNotifyClick;
+            preventExecution: boolean;
+        })[] | (ParticipantMenuButtonsWithNotifyClick | {
+            key: ParticipantMenuButtonsWithNotifyClick;
+            preventExecution: boolean;
+        })[]
+): string | undefined => {
+    // @ts-ignore
+    const notify = buttonsWithNotifyClick?.find((btn: ButtonsWithNotifyClick | ParticipantMenuButtonsWithNotifyClick) =>
+
+        // @ts-ignore
+        (typeof btn === 'string' && btn === buttonKey) || (typeof btn === 'object' && btn.key === buttonKey)
+    );
+
+    if (notify) {
+        // @ts-ignore
+        return typeof notify === 'string' || notify.preventExecution
+            ? NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+            : NOTIFY_CLICK_MODE.ONLY_NOTIFY;
+    }
+};

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -3,12 +3,11 @@ import JitsiMeetJS from '../../base/lib-jitsi-meet';
 import { NOTIFY_CLICK_MODE } from '../../toolbox/constants';
 
 import {
-    ButtonsWithNotifyClick,
     IConfig,
     IDeeplinkingConfig,
     IDeeplinkingMobileConfig,
     IDeeplinkingPlatformConfig,
-    ParticipantMenuButtonsWithNotifyClick
+    NotifyClickButton
 } from './configType';
 import { TOOLBAR_BUTTONS } from './constants';
 
@@ -135,25 +134,13 @@ export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
  * @returns {Array}
  */
 const buildButtonsArray = (
-        buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
-            key: ButtonsWithNotifyClick;
-            preventExecution: boolean;
-        })[] | (ParticipantMenuButtonsWithNotifyClick | {
-            key: ParticipantMenuButtonsWithNotifyClick;
-            preventExecution: boolean;
-        })[],
+        buttonsWithNotifyClick?: NotifyClickButton[],
         customButtons?: {
             icon: string;
             id: string;
             text: string;
         }[]
-): (ButtonsWithNotifyClick | {
-    key: ButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] | (ParticipantMenuButtonsWithNotifyClick | {
-    key: ParticipantMenuButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] => {
+): NotifyClickButton[] => {
     const customButtonsWithNotifyClick = customButtons?.map(({ id }) => {
         return {
             key: id,
@@ -162,11 +149,10 @@ const buildButtonsArray = (
     });
 
     const buttons = Array.isArray(buttonsWithNotifyClick)
-        ? buttonsWithNotifyClick
+        ? buttonsWithNotifyClick as NotifyClickButton[]
         : [];
 
     if (customButtonsWithNotifyClick) {
-        // @ts-ignore
         buttons.push(...customButtonsWithNotifyClick);
     }
 
@@ -181,13 +167,7 @@ const buildButtonsArray = (
  */
 export function getButtonsWithNotifyClick(
         state: IReduxState
-): (ButtonsWithNotifyClick | {
-    key: ButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] | (ParticipantMenuButtonsWithNotifyClick | {
-    key: ParticipantMenuButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] {
+): NotifyClickButton[] {
     const { buttonsWithNotifyClick, customToolbarButtons } = state['features/base/config'];
 
     return buildButtonsArray(
@@ -204,13 +184,7 @@ export function getButtonsWithNotifyClick(
  */
 export function getParticipantMenuButtonsWithNotifyClick(
         state: IReduxState
-): (ButtonsWithNotifyClick | {
-    key: ButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] | (ParticipantMenuButtonsWithNotifyClick | {
-    key: ParticipantMenuButtonsWithNotifyClick;
-    preventExecution: boolean;
-})[] {
+): NotifyClickButton[] {
     const { participantMenuButtonsWithNotifyClick, customParticipantMenuButtons } = state['features/base/config'];
 
     return buildButtonsArray(
@@ -228,23 +202,14 @@ export function getParticipantMenuButtonsWithNotifyClick(
  */
 export const getButtonNotifyMode = (
         buttonKey: string,
-        buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
-            key: ButtonsWithNotifyClick;
-            preventExecution: boolean;
-        })[] | (ParticipantMenuButtonsWithNotifyClick | {
-            key: ParticipantMenuButtonsWithNotifyClick;
-            preventExecution: boolean;
-        })[]
+        buttonsWithNotifyClick?: NotifyClickButton[]
 ): string | undefined => {
-    // @ts-ignore
-    const notify = buttonsWithNotifyClick?.find((btn: ButtonsWithNotifyClick | ParticipantMenuButtonsWithNotifyClick) =>
-
-        // @ts-ignore
-        (typeof btn === 'string' && btn === buttonKey) || (typeof btn === 'object' && btn.key === buttonKey)
+    const notify = buttonsWithNotifyClick?.find(
+        (btn: NotifyClickButton) =>
+            (typeof btn === 'string' && btn === buttonKey) || (typeof btn === 'object' && btn.key === buttonKey)
     );
 
     if (notify) {
-        // @ts-ignore
         return typeof notify === 'string' || notify.preventExecution
             ? NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
             : NOTIFY_CLICK_MODE.ONLY_NOTIFY;

--- a/react/features/base/toolbox/components/AbstractButton.tsx
+++ b/react/features/base/toolbox/components/AbstractButton.tsx
@@ -49,6 +49,11 @@ export interface IProps extends WithTranslation {
     handleClick?: Function;
 
     /**
+     * Callback to notify the api.
+     */
+    notifyClick?: Function;
+
+    /**
      * Notify mode for `toolbarButtonClicked` event -
      * whether to only notify or to also prevent button click routine.
      */
@@ -337,13 +342,17 @@ export default class AbstractButton<P extends IProps, S=any> extends Component<P
      * @private
      * @returns {void}
      */
-    _onClick(e?: React.MouseEvent<HTMLElement> | GestureResponderEvent) {
-        const { afterClick, handleClick, notifyMode, buttonKey } = this.props;
+    _onClick(e?: React.MouseEvent | GestureResponderEvent) {
+        const { afterClick, buttonKey, handleClick, notifyClick, notifyMode } = this.props;
 
         if (typeof APP !== 'undefined' && notifyMode) {
-            APP.API.notifyToolbarButtonClicked(
-                buttonKey, notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
-            );
+            if (notifyClick) {
+                notifyClick(buttonKey);
+            } else {
+                APP.API.notifyToolbarButtonClicked(
+                    buttonKey, notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+                );
+            }
         }
 
         if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {

--- a/react/features/base/toolbox/components/AbstractButton.tsx
+++ b/react/features/base/toolbox/components/AbstractButton.tsx
@@ -49,11 +49,6 @@ export interface IProps extends WithTranslation {
     handleClick?: Function;
 
     /**
-     * Callback to notify the api.
-     */
-    notifyClick?: Function;
-
-    /**
      * Notify mode for `toolbarButtonClicked` event -
      * whether to only notify or to also prevent button click routine.
      */
@@ -343,16 +338,12 @@ export default class AbstractButton<P extends IProps, S=any> extends Component<P
      * @returns {void}
      */
     _onClick(e?: React.MouseEvent | GestureResponderEvent) {
-        const { afterClick, buttonKey, handleClick, notifyClick, notifyMode } = this.props;
+        const { afterClick, buttonKey, handleClick, notifyMode } = this.props;
 
         if (typeof APP !== 'undefined' && notifyMode) {
-            if (notifyClick) {
-                notifyClick(buttonKey);
-            } else {
-                APP.API.notifyToolbarButtonClicked(
+            APP.API.notifyToolbarButtonClicked(
                     buttonKey, notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
-                );
-            }
+            );
         }
 
         if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {

--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
@@ -98,9 +98,9 @@ export const RoomParticipantContextMenu = ({
     const breakoutRoomsButtons = useMemo(() => Object.values(rooms || {}).map((room: any) => {
         if (room.id !== entity?.room?.id) {
             return (<SendToRoomButton
-                buttonKey = { BUTTONS.SEND_PARTICIPANT_TO_ROOM }
                 key = { room.id }
-                notifyClick = { notifyClick }
+                // eslint-disable-next-line react/jsx-no-bind
+                notifyClick = { () => notifyClick(BUTTONS.SEND_PARTICIPANT_TO_ROOM, entity?.jid) }
                 notifyMode = { getButtonNotifyMode(BUTTONS.SEND_PARTICIPANT_TO_ROOM, buttonsWithNotifyClick) }
                 onClick = { lowerMenu }
                 participantID = { entity?.jid ?? '' }

--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
@@ -4,12 +4,18 @@ import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import Avatar from '../../../../../base/avatar/components/Avatar';
+import {
+    getButtonNotifyMode,
+    getParticipantMenuButtonsWithNotifyClick
+} from '../../../../../base/config/functions.web';
 import { isLocalParticipantModerator } from '../../../../../base/participants/functions';
 import ContextMenu from '../../../../../base/ui/components/web/ContextMenu';
 import ContextMenuItemGroup from '../../../../../base/ui/components/web/ContextMenuItemGroup';
 import { getBreakoutRooms } from '../../../../../breakout-rooms/functions';
+import { NOTIFY_CLICK_MODE } from '../../../../../toolbox/constants';
 import { showOverflowDrawer } from '../../../../../toolbox/functions.web';
 import SendToRoomButton from '../../../../../video-menu/components/web/SendToRoomButton';
+import { PARTICIPANT_MENU_BUTTONS as BUTTONS } from '../../../../../video-menu/constants';
 import { AVATAR_SIZE } from '../../../../constants';
 
 
@@ -72,11 +78,30 @@ export const RoomParticipantContextMenu = ({
     const lowerMenu = useCallback(() => onSelect(true), [ onSelect ]);
     const rooms: Object = useSelector(getBreakoutRooms);
     const overflowDrawer = useSelector(showOverflowDrawer);
+    const buttonsWithNotifyClick = useSelector(getParticipantMenuButtonsWithNotifyClick);
+
+    const notifyClick = useCallback(
+        (buttonKey: string, participantId?: string) => {
+            const notifyMode = getButtonNotifyMode(buttonKey, buttonsWithNotifyClick);
+
+            if (!notifyMode) {
+                return;
+            }
+
+            APP.API.notifyParticipantMenuButtonClicked(
+                buttonKey,
+                participantId,
+                notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+            );
+        }, [ buttonsWithNotifyClick, getButtonNotifyMode ]);
 
     const breakoutRoomsButtons = useMemo(() => Object.values(rooms || {}).map((room: any) => {
         if (room.id !== entity?.room?.id) {
             return (<SendToRoomButton
+                buttonKey = { BUTTONS.SEND_PARTICIPANT_TO_ROOM }
                 key = { room.id }
+                notifyClick = { notifyClick }
+                notifyMode = { getButtonNotifyMode(BUTTONS.SEND_PARTICIPANT_TO_ROOM, buttonsWithNotifyClick) }
                 onClick = { lowerMenu }
                 participantID = { entity?.jid ?? '' }
                 room = { room } />);

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState, IStore } from '../../../app/types';
-import { ButtonsWithNotifyClick, ParticipantMenuButtonsWithNotifyClick } from '../../../base/config/configType';
+import { NotifyClickButton } from '../../../base/config/configType';
 import { VISITORS_MODE_BUTTONS } from '../../../base/config/constants';
 import {
     getButtonNotifyMode,
@@ -48,13 +48,7 @@ interface IProps extends WithTranslation {
     /**
      * Toolbar buttons which have their click exposed through the API.
      */
-    _buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
-        key: ButtonsWithNotifyClick;
-        preventExecution: boolean;
-    })[] | (ParticipantMenuButtonsWithNotifyClick | {
-        key: ParticipantMenuButtonsWithNotifyClick;
-        preventExecution: boolean;
-    })[];
+    _buttonsWithNotifyClick?: NotifyClickButton[];
 
     /**
      * Whether or not the chat feature is currently displayed.

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -4,8 +4,10 @@ import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState, IStore } from '../../../app/types';
+import { ButtonsWithNotifyClick, ParticipantMenuButtonsWithNotifyClick } from '../../../base/config/configType';
 import { VISITORS_MODE_BUTTONS } from '../../../base/config/constants';
 import {
+    getButtonNotifyMode,
     getButtonsWithNotifyClick,
     getToolbarButtons,
     isToolbarButtonEnabled
@@ -22,7 +24,7 @@ import {
     setToolbarHovered,
     showToolbox
 } from '../../actions.web';
-import { NOTIFY_CLICK_MODE, NOT_APPLICABLE, THRESHOLDS } from '../../constants';
+import { NOT_APPLICABLE, THRESHOLDS } from '../../constants';
 import {
     getAllToolboxButtons,
     getJwtDisabledButtons,
@@ -46,10 +48,13 @@ interface IProps extends WithTranslation {
     /**
      * Toolbar buttons which have their click exposed through the API.
      */
-    _buttonsWithNotifyClick?: Array<string | {
-        key: string;
+    _buttonsWithNotifyClick?: (ButtonsWithNotifyClick | {
+        key: ButtonsWithNotifyClick;
         preventExecution: boolean;
-    }>;
+    })[] | (ParticipantMenuButtonsWithNotifyClick | {
+        key: ParticipantMenuButtonsWithNotifyClick;
+        preventExecution: boolean;
+    })[];
 
     /**
      * Whether or not the chat feature is currently displayed.
@@ -263,26 +268,6 @@ const Toolbox = ({
     }, [ _hangupMenuVisible, _overflowMenuVisible ]);
 
     /**
-     * Returns the notify mode of the given toolbox button.
-     *
-     * @param {string} btnName - The toolbar button's name.
-     * @returns {string|undefined} - The button's notify mode.
-     */
-    function getButtonNotifyMode(btnName: string) {
-        const notify = _buttonsWithNotifyClick?.find(
-            btn =>
-                (typeof btn === 'string' && btn === btnName)
-                || (typeof btn === 'object' && btn.key === btnName)
-        );
-
-        if (notify) {
-            return typeof notify === 'string' || notify.preventExecution
-                ? NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
-                : NOTIFY_CLICK_MODE.ONLY_NOTIFY;
-        }
-    }
-
-    /**
      * Sets the notify click mode for the buttons.
      *
      * @param {Object} buttons - The list of toolbar buttons.
@@ -295,7 +280,7 @@ const Toolbox = ({
 
         Object.values(buttons).forEach((button: any) => {
             if (typeof button === 'object') {
-                button.notifyMode = getButtonNotifyMode(button.key);
+                button.notifyMode = getButtonNotifyMode(button.key, _buttonsWithNotifyClick);
             }
         });
     }
@@ -452,7 +437,7 @@ const Toolbox = ({
                                     ariaControls = 'hangup-menu'
                                     isOpen = { _hangupMenuVisible }
                                     key = 'hangup-menu'
-                                    notifyMode = { getButtonNotifyMode('hangup-menu') }
+                                    notifyMode = { getButtonNotifyMode('hangup-menu', _buttonsWithNotifyClick) }
                                     onVisibilityChange = { onSetHangupVisible }>
                                     <ContextMenu
                                         accessibilityLabel = { t(toolbarAccLabel) }
@@ -462,17 +447,20 @@ const Toolbox = ({
                                         onKeyDown = { onEscKey }>
                                         <EndConferenceButton
                                             buttonKey = 'end-meeting'
-                                            notifyMode = { getButtonNotifyMode('end-meeting') } />
+                                            notifyMode = { getButtonNotifyMode(
+                                                'end-meeting',
+                                                _buttonsWithNotifyClick
+                                            ) } />
                                         <LeaveConferenceButton
                                             buttonKey = 'hangup'
-                                            notifyMode = { getButtonNotifyMode('hangup') } />
+                                            notifyMode = { getButtonNotifyMode('hangup', _buttonsWithNotifyClick) } />
                                     </ContextMenu>
                                 </HangupMenuButton>
                                 : <HangupButton
                                     buttonKey = 'hangup'
                                     customClass = 'hangup-button'
                                     key = 'hangup-button'
-                                    notifyMode = { getButtonNotifyMode('hangup') }
+                                    notifyMode = { getButtonNotifyMode('hangup', _buttonsWithNotifyClick) }
                                     visible = { isToolbarButtonEnabled('hangup', _toolbarButtons) } />
                         )}
                     </div>

--- a/react/features/video-menu/components/web/AskToUnmuteButton.tsx
+++ b/react/features/video-menu/components/web/AskToUnmuteButton.tsx
@@ -6,10 +6,27 @@ import { approveParticipantAudio, approveParticipantVideo } from '../../../av-mo
 import { IconMic, IconVideo } from '../../../base/icons/svg';
 import { MEDIA_TYPE, MediaType } from '../../../base/media/constants';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 interface IProps {
 
-    buttonType: MediaType;
+    /**
+     * The button key used to identify the click event.
+     */
+    buttonKey?: string;
+
+    buttonType?: MediaType;
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 
     /**
      * The ID for the participant on which the button will act.
@@ -17,16 +34,30 @@ interface IProps {
     participantID: string;
 }
 
-const AskToUnmuteButton = ({ buttonType, participantID }: IProps) => {
+const AskToUnmuteButton = ({
+    buttonKey, buttonType = MEDIA_TYPE.AUDIO, notifyMode, notifyClick, participantID
+}: IProps) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const _onClick = useCallback(() => {
-        if (buttonType === MEDIA_TYPE.AUDIO) {
-            dispatch(approveParticipantAudio(participantID));
-        } else if (buttonType === MEDIA_TYPE.VIDEO) {
-            dispatch(approveParticipantVideo(participantID));
+        notifyClick?.(buttonKey);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            if (buttonType === MEDIA_TYPE.AUDIO) {
+                dispatch(approveParticipantAudio(participantID));
+            } else if (buttonType === MEDIA_TYPE.VIDEO) {
+                dispatch(approveParticipantVideo(participantID));
+            }
         }
-    }, [ participantID, buttonType ]);
+    }, [
+        approveParticipantAudio,
+        approveParticipantVideo,
+        buttonKey,
+        buttonType,
+        dispatch,
+        notifyClick,
+        notifyMode,
+        participantID
+    ]);
 
     const text = useMemo(() => {
         if (buttonType === MEDIA_TYPE.AUDIO) {

--- a/react/features/video-menu/components/web/AskToUnmuteButton.tsx
+++ b/react/features/video-menu/components/web/AskToUnmuteButton.tsx
@@ -7,57 +7,37 @@ import { IconMic, IconVideo } from '../../../base/icons/svg';
 import { MEDIA_TYPE, MediaType } from '../../../base/media/constants';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
 
-interface IProps {
-
-    /**
-     * The button key used to identify the click event.
-     */
-    buttonKey?: string;
-
-    buttonType?: MediaType;
-
-    /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
-
-    /**
-     * The ID for the participant on which the button will act.
-     */
-    participantID: string;
+interface IProps extends IButtonProps {
+    buttonType: MediaType;
 }
 
+/**
+ * Implements a React {@link Component} which displays a button that
+ * allows the moderator to request from a participant to mute themselves.
+ *
+ * @returns {JSX.Element}
+ */
 const AskToUnmuteButton = ({
-    buttonKey, buttonType = MEDIA_TYPE.AUDIO, notifyMode, notifyClick, participantID
-}: IProps) => {
+    buttonType,
+    notifyMode,
+    notifyClick,
+    participantID
+}: IProps): JSX.Element => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const _onClick = useCallback(() => {
-        notifyClick?.(buttonKey);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            if (buttonType === MEDIA_TYPE.AUDIO) {
-                dispatch(approveParticipantAudio(participantID));
-            } else if (buttonType === MEDIA_TYPE.VIDEO) {
-                dispatch(approveParticipantVideo(participantID));
-            }
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
-    }, [
-        approveParticipantAudio,
-        approveParticipantVideo,
-        buttonKey,
-        buttonType,
-        dispatch,
-        notifyClick,
-        notifyMode,
-        participantID
-    ]);
+        if (buttonType === MEDIA_TYPE.AUDIO) {
+            dispatch(approveParticipantAudio(participantID));
+        } else if (buttonType === MEDIA_TYPE.VIDEO) {
+            dispatch(approveParticipantVideo(participantID));
+        }
+    }, [ buttonType, dispatch, notifyClick, notifyMode, participantID ]);
 
     const text = useMemo(() => {
         if (buttonType === MEDIA_TYPE.AUDIO) {

--- a/react/features/video-menu/components/web/ConnectionStatusButton.tsx
+++ b/react/features/video-menu/components/web/ConnectionStatusButton.tsx
@@ -6,9 +6,15 @@ import { IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
 import { IconInfoCircle } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { renderConnectionStatus } from '../../actions.web';
 
 interface IProps extends WithTranslation {
+
+    /**
+     * The button key used to identify the click event.
+     */
+    buttonKey: string;
 
     /**
      * The Redux dispatch function.
@@ -16,20 +22,38 @@ interface IProps extends WithTranslation {
     dispatch: IStore['dispatch'];
 
     /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
+
+    /**
      * The ID of the participant for which to show connection stats.
      */
-    participantId: string;
+    participantID: string;
 }
 
 
 const ConnectionStatusButton = ({
+    buttonKey,
     dispatch,
+    notifyClick,
+    notifyMode,
+    participantID,
     t
 }: IProps) => {
     const onClick = useCallback(e => {
         e.stopPropagation();
-        dispatch(renderConnectionStatus(true));
-    }, [ dispatch ]);
+        notifyClick?.(buttonKey, participantID);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            dispatch(renderConnectionStatus(true));
+        }
+    }, [ buttonKey, dispatch, notifyClick, notifyMode, participantID, renderConnectionStatus ]);
 
     return (
         <ContextMenuItem

--- a/react/features/video-menu/components/web/ConnectionStatusButton.tsx
+++ b/react/features/video-menu/components/web/ConnectionStatusButton.tsx
@@ -1,67 +1,42 @@
 import React, { useCallback } from 'react';
-import { WithTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
-import { IStore } from '../../../app/types';
-import { translate } from '../../../base/i18n/functions';
 import { IconInfoCircle } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { renderConnectionStatus } from '../../actions.web';
+import { IButtonProps } from '../../types';
 
-interface IProps extends WithTranslation {
-
-    /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
-
-    /**
-     * The Redux dispatch function.
-     */
-    dispatch: IStore['dispatch'];
-
-    /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
-
-    /**
-     * The ID of the participant for which to show connection stats.
-     */
-    participantID: string;
-}
-
-
+/**
+ * Implements a React {@link Component} which displays a button that shows
+ * the connection status for the given participant.
+ *
+ * @returns {JSX.Element}
+ */
 const ConnectionStatusButton = ({
-    buttonKey,
-    dispatch,
     notifyClick,
-    notifyMode,
-    participantID,
-    t
-}: IProps) => {
-    const onClick = useCallback(e => {
+    notifyMode
+}: IButtonProps): JSX.Element => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+
+    const handleClick = useCallback(e => {
         e.stopPropagation();
-        notifyClick?.(buttonKey, participantID);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            dispatch(renderConnectionStatus(true));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
-    }, [ buttonKey, dispatch, notifyClick, notifyMode, participantID, renderConnectionStatus ]);
+        dispatch(renderConnectionStatus(true));
+    }, [ dispatch, notifyClick, notifyMode ]);
 
     return (
         <ContextMenuItem
             accessibilityLabel = { t('videothumbnail.connectionInfo') }
             icon = { IconInfoCircle }
-            onClick = { onClick }
+            onClick = { handleClick }
             text = { t('videothumbnail.connectionInfo') } />
     );
 };
 
-export default translate(connect()(ConnectionStatusButton));
+export default ConnectionStatusButton;

--- a/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
@@ -164,9 +164,9 @@ const FakeParticipantContextMenu = ({
                 actions = { _getActions() }>
                 {isWhiteboardParticipant(participant) && (
                     <TogglePinToStageButton
-                        buttonKey = { BUTTONS.PIN_TO_STAGE }
                         key = 'pinToStage'
-                        notifyClick = { notifyClick }
+                        // eslint-disable-next-line react/jsx-no-bind
+                        notifyClick = { () => notifyClick(BUTTONS.PIN_TO_STAGE, WHITEBOARD_ID) }
                         notifyMode = { getButtonNotifyMode(BUTTONS.PIN_TO_STAGE, buttonsWithNotifyClick) }
                         participantID = { WHITEBOARD_ID } />
                 )}

--- a/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
@@ -4,15 +4,18 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import TogglePinToStageButton from '../../../../features/video-menu/components/web/TogglePinToStageButton';
 import Avatar from '../../../base/avatar/components/Avatar';
+import { getButtonNotifyMode, getParticipantMenuButtonsWithNotifyClick } from '../../../base/config/functions.web';
 import { IconPlay } from '../../../base/icons/svg';
 import { isWhiteboardParticipant } from '../../../base/participants/functions';
 import { IParticipant } from '../../../base/participants/types';
 import ContextMenu from '../../../base/ui/components/web/ContextMenu';
 import ContextMenuItemGroup from '../../../base/ui/components/web/ContextMenuItemGroup';
 import { stopSharedVideo } from '../../../shared-video/actions.any';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { showOverflowDrawer } from '../../../toolbox/functions.web';
 import { setWhiteboardOpen } from '../../../whiteboard/actions';
 import { WHITEBOARD_ID } from '../../../whiteboard/constants';
+import { PARTICIPANT_MENU_BUTTONS as BUTTONS } from '../../constants';
 
 interface IProps {
 
@@ -86,6 +89,23 @@ const FakeParticipantContextMenu = ({
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const _overflowDrawer: boolean = useSelector(showOverflowDrawer);
+    const buttonsWithNotifyClick = useSelector(getParticipantMenuButtonsWithNotifyClick);
+
+    const notifyClick = useCallback(
+        (buttonKey: string, participantId?: string) => {
+            const notifyMode = getButtonNotifyMode(buttonKey, buttonsWithNotifyClick);
+
+            if (!notifyMode) {
+                return;
+            }
+
+            APP.API.notifyParticipantMenuButtonClicked(
+                buttonKey,
+                participantId,
+                notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+            );
+        }, [ buttonsWithNotifyClick, getButtonNotifyMode ]);
+
 
     const clickHandler = useCallback(() => onSelect(true), [ onSelect ]);
 
@@ -144,7 +164,10 @@ const FakeParticipantContextMenu = ({
                 actions = { _getActions() }>
                 {isWhiteboardParticipant(participant) && (
                     <TogglePinToStageButton
+                        buttonKey = { BUTTONS.PIN_TO_STAGE }
                         key = 'pinToStage'
+                        notifyClick = { notifyClick }
+                        notifyMode = { getButtonNotifyMode(BUTTONS.PIN_TO_STAGE, buttonsWithNotifyClick) }
                         participantID = { WHITEBOARD_ID } />
                 )}
             </ContextMenuItemGroup>

--- a/react/features/video-menu/components/web/FlipLocalVideoButton.tsx
+++ b/react/features/video-menu/components/web/FlipLocalVideoButton.tsx
@@ -6,6 +6,7 @@ import { IReduxState, IStore } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 /**
  * The type of the React {@code Component} props of {@link FlipLocalVideoButton}.
@@ -18,6 +19,11 @@ interface IProps extends WithTranslation {
     _localFlipX: boolean;
 
     /**
+     * The button key used to identify the click event.
+     */
+    buttonKey?: string;
+
+    /**
      * Button text class name.
      */
     className: string;
@@ -26,6 +32,17 @@ interface IProps extends WithTranslation {
      * The redux dispatch function.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 
     /**
      * Click handler executed aside from the main action.
@@ -82,12 +99,15 @@ class FlipLocalVideoButton extends PureComponent<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { _localFlipX, dispatch, onClick } = this.props;
+        const { _localFlipX, buttonKey, dispatch, notifyClick, notifyMode, onClick } = this.props;
 
-        onClick?.();
-        dispatch(updateSettings({
-            localFlipX: !_localFlipX
-        }));
+        notifyClick?.(buttonKey);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            onClick?.();
+            dispatch(updateSettings({
+                localFlipX: !_localFlipX
+            }));
+        }
     }
 }
 

--- a/react/features/video-menu/components/web/FlipLocalVideoButton.tsx
+++ b/react/features/video-menu/components/web/FlipLocalVideoButton.tsx
@@ -19,11 +19,6 @@ interface IProps extends WithTranslation {
     _localFlipX: boolean;
 
     /**
-     * The button key used to identify the click event.
-     */
-    buttonKey?: string;
-
-    /**
      * Button text class name.
      */
     className: string;
@@ -99,15 +94,16 @@ class FlipLocalVideoButton extends PureComponent<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { _localFlipX, buttonKey, dispatch, notifyClick, notifyMode, onClick } = this.props;
+        const { _localFlipX, dispatch, notifyClick, notifyMode, onClick } = this.props;
 
-        notifyClick?.(buttonKey);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            onClick?.();
-            dispatch(updateSettings({
-                localFlipX: !_localFlipX
-            }));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        onClick?.();
+        dispatch(updateSettings({
+            localFlipX: !_localFlipX
+        }));
     }
 }
 

--- a/react/features/video-menu/components/web/GrantModeratorButton.tsx
+++ b/react/features/video-menu/components/web/GrantModeratorButton.tsx
@@ -1,52 +1,56 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { IReduxState } from '../../../app/types';
+import { openDialog } from '../../../base/dialog/actions';
 import { IconModerator } from '../../../base/icons/svg';
+import { PARTICIPANT_ROLE } from '../../../base/participants/constants';
+import { getLocalParticipant, getParticipantById, isParticipantModerator } from '../../../base/participants/functions';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractGrantModeratorButton, { IProps, _mapStateToProps } from '../AbstractGrantModeratorButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
+
+import GrantModeratorDialog from './GrantModeratorDialog';
 
 /**
  * Implements a React {@link Component} which displays a button for granting
  * moderator to a participant.
+ *
+ * @returns {JSX.Element|null}
  */
-class GrantModeratorButton extends AbstractGrantModeratorButton {
-    /**
-     * Instantiates a new {@code GrantModeratorButton}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const GrantModeratorButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element | null => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const localParticipant = useSelector(getLocalParticipant);
+    const targetParticipant = useSelector((state: IReduxState) => getParticipantById(state, participantID));
+    const visible = useMemo(() => Boolean(localParticipant?.role === PARTICIPANT_ROLE.MODERATOR)
+        && !isParticipantModerator(targetParticipant), [ isParticipantModerator, localParticipant, targetParticipant ]);
 
-        this._onClick = this._onClick.bind(this);
-    }
-
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { visible, t } = this.props;
-
-        if (!visible) {
-            return null;
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        dispatch(openDialog(GrantModeratorDialog, { participantID }));
+    }, [ dispatch, notifyClick, notifyMode, participantID ]);
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('toolbar.accessibilityLabel.grantModerator') }
-                className = 'grantmoderatorlink'
-                icon = { IconModerator }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('videothumbnail.grantModerator') } />
-        );
+    if (!visible) {
+        return null;
     }
 
-    _onClick: () => void;
-}
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('toolbar.accessibilityLabel.grantModerator') }
+            className = 'grantmoderatorlink'
+            icon = { IconModerator }
+            onClick = { handleClick }
+            text = { t('videothumbnail.grantModerator') } />
+    );
+};
 
-export default translate(connect(_mapStateToProps)(GrantModeratorButton));
+export default GrantModeratorButton;

--- a/react/features/video-menu/components/web/GrantModeratorButton.tsx
+++ b/react/features/video-menu/components/web/GrantModeratorButton.tsx
@@ -19,7 +19,7 @@ class GrantModeratorButton extends AbstractGrantModeratorButton {
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -29,7 +29,7 @@ class GrantModeratorButton extends AbstractGrantModeratorButton {
      * @returns {ReactElement}
      */
     render() {
-        const { t, visible } = this.props;
+        const { visible, t } = this.props;
 
         if (!visible) {
             return null;
@@ -41,12 +41,12 @@ class GrantModeratorButton extends AbstractGrantModeratorButton {
                 className = 'grantmoderatorlink'
                 icon = { IconModerator }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('videothumbnail.grantModerator') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 
 export default translate(connect(_mapStateToProps)(GrantModeratorButton));

--- a/react/features/video-menu/components/web/HideSelfViewVideoButton.tsx
+++ b/react/features/video-menu/components/web/HideSelfViewVideoButton.tsx
@@ -7,11 +7,17 @@ import { translate } from '../../../base/i18n/functions';
 import { updateSettings } from '../../../base/settings/actions';
 import { getHideSelfView } from '../../../base/settings/functions';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 /**
  * The type of the React {@code Component} props of {@link HideSelfViewVideoButton}.
  */
 interface IProps extends WithTranslation {
+
+    /**
+     * The button key used to identify the click event.
+     */
+    buttonKey?: string;
 
     /**
      * Button text class name.
@@ -27,6 +33,17 @@ interface IProps extends WithTranslation {
      * The redux dispatch function.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 
     /**
      * Click handler executed aside from the main action.
@@ -83,12 +100,15 @@ class HideSelfViewVideoButton extends PureComponent<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { disableSelfView, dispatch, onClick } = this.props;
+        const { buttonKey, disableSelfView, dispatch, notifyClick, notifyMode, onClick } = this.props;
 
-        onClick?.();
-        dispatch(updateSettings({
-            disableSelfView: !disableSelfView
-        }));
+        notifyClick?.(buttonKey);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            onClick?.();
+            dispatch(updateSettings({
+                disableSelfView: !disableSelfView
+            }));
+        }
     }
 }
 

--- a/react/features/video-menu/components/web/HideSelfViewVideoButton.tsx
+++ b/react/features/video-menu/components/web/HideSelfViewVideoButton.tsx
@@ -15,11 +15,6 @@ import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 interface IProps extends WithTranslation {
 
     /**
-     * The button key used to identify the click event.
-     */
-    buttonKey?: string;
-
-    /**
      * Button text class name.
      */
     className: string;
@@ -100,15 +95,16 @@ class HideSelfViewVideoButton extends PureComponent<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { buttonKey, disableSelfView, dispatch, notifyClick, notifyMode, onClick } = this.props;
+        const { disableSelfView, dispatch, notifyClick, notifyMode, onClick } = this.props;
 
-        notifyClick?.(buttonKey);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            onClick?.();
-            dispatch(updateSettings({
-                disableSelfView: !disableSelfView
-            }));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        onClick?.();
+        dispatch(updateSettings({
+            disableSelfView: !disableSelfView
+        }));
     }
 }
 

--- a/react/features/video-menu/components/web/KickButton.tsx
+++ b/react/features/video-menu/components/web/KickButton.tsx
@@ -1,54 +1,46 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { openDialog } from '../../../base/dialog/actions';
 import { IconUserDeleted } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractKickButton, { IProps } from '../AbstractKickButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
+
+import KickRemoteParticipantDialog from './KickRemoteParticipantDialog';
 
 /**
  * Implements a React {@link Component} which displays a button for kicking out
  * a participant from the conference.
  *
- * NOTE: At the time of writing this is a button that doesn't use the
- * {@code AbstractButton} base component, but is inherited from the same
- * super class ({@code AbstractKickButton} that extends {@code AbstractButton})
- * for the sake of code sharing between web and mobile. Once web uses the
- * {@code AbstractButton} base component, this can be fully removed.
+ * @returns {JSX.Element}
  */
-class KickButton extends AbstractKickButton {
-    /**
-     * Instantiates a new {@code Component}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const KickButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
 
-        this._onClick = this._onClick.bind(this);
-    }
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
+        }
+        dispatch(openDialog(KickRemoteParticipantDialog, { participantID }));
+    }, [ dispatch, notifyClick, notifyMode, participantID ]);
 
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { participantID, t } = this.props;
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('videothumbnail.kick') }
+            className = 'kicklink'
+            icon = { IconUserDeleted }
+            id = { `ejectlink_${participantID}` }
+            onClick = { handleClick }
+            text = { t('videothumbnail.kick') } />
+    );
+};
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('videothumbnail.kick') }
-                className = 'kicklink'
-                icon = { IconUserDeleted }
-                id = { `ejectlink_${participantID}` }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('videothumbnail.kick') } />
-        );
-    }
-
-    _onClick: () => void;
-}
-export default translate(connect()(KickButton));
+export default KickButton;

--- a/react/features/video-menu/components/web/KickButton.tsx
+++ b/react/features/video-menu/components/web/KickButton.tsx
@@ -25,7 +25,7 @@ class KickButton extends AbstractKickButton {
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -44,11 +44,11 @@ class KickButton extends AbstractKickButton {
                 icon = { IconUserDeleted }
                 id = { `ejectlink_${participantID}` }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('videothumbnail.kick') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 export default translate(connect()(KickButton));

--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { batch, connect } from 'react-redux';
+import { batch, connect, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState, IStore } from '../../../app/types';
+import { getButtonNotifyMode, getParticipantMenuButtonsWithNotifyClick } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { IconDotsHorizontal } from '../../../base/icons/svg';
 import { getLocalParticipant } from '../../../base/participants/functions';
@@ -17,7 +18,9 @@ import ContextMenuItemGroup from '../../../base/ui/components/web/ContextMenuIte
 import ConnectionIndicatorContent from '../../../connection-indicator/components/web/ConnectionIndicatorContent';
 import { THUMBNAIL_TYPE } from '../../../filmstrip/constants';
 import { isStageFilmstripAvailable } from '../../../filmstrip/functions.web';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { renderConnectionStatus } from '../../actions.web';
+import { PARTICIPANT_MENU_BUTTONS as BUTTONS } from '../../constants';
 
 import ConnectionStatusButton from './ConnectionStatusButton';
 import FlipLocalVideoButton from './FlipLocalVideoButton';
@@ -139,6 +142,22 @@ const LocalVideoMenuTriggerButton = ({
 }: IProps) => {
     const { classes } = useStyles();
     const { t } = useTranslation();
+    const buttonsWithNotifyClick = useSelector(getParticipantMenuButtonsWithNotifyClick);
+
+    const notifyClick = useCallback(
+        (buttonKey: string) => {
+            const notifyMode = getButtonNotifyMode(buttonKey, buttonsWithNotifyClick);
+
+            if (!notifyMode) {
+                return;
+            }
+
+            APP.API.notifyParticipantMenuButtonClicked(
+                buttonKey,
+                _localParticipantId,
+                notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+            );
+        }, [ buttonsWithNotifyClick, getButtonNotifyMode ]);
 
     const _onPopoverOpen = useCallback(() => {
         showPopover?.();
@@ -163,23 +182,36 @@ const LocalVideoMenuTriggerButton = ({
                 <ContextMenuItemGroup>
                     {_showLocalVideoFlipButton
                         && <FlipLocalVideoButton
+                            buttonKey = { BUTTONS.FLIP_LOCAL_VIDEO }
                             className = { _overflowDrawer ? classes.flipText : '' }
+                            notifyClick = { notifyClick }
+                            notifyMode = { getButtonNotifyMode(BUTTONS.FLIP_LOCAL_VIDEO, buttonsWithNotifyClick) }
                             onClick = { hidePopover } />
                     }
                     {_showHideSelfViewButton
                         && <HideSelfViewVideoButton
+                            buttonKey = { BUTTONS.HIDE_SELF_VIEW }
                             className = { _overflowDrawer ? classes.flipText : '' }
+                            notifyClick = { notifyClick }
+                            notifyMode = { getButtonNotifyMode(BUTTONS.HIDE_SELF_VIEW, buttonsWithNotifyClick) }
                             onClick = { hidePopover } />
                     }
                     {
                         _showPinToStage && <TogglePinToStageButton
+                            buttonKey = { BUTTONS.PIN_TO_STAGE }
                             className = { _overflowDrawer ? classes.flipText : '' }
                             noIcon = { true }
+                            notifyClick = { notifyClick }
+                            notifyMode = { getButtonNotifyMode(BUTTONS.PIN_TO_STAGE, buttonsWithNotifyClick) }
                             onClick = { hidePopover }
                             participantID = { _localParticipantId } />
                     }
-                    {isMobileBrowser()
-                        && <ConnectionStatusButton participantId = { _localParticipantId } />
+                    {
+                        isMobileBrowser() && <ConnectionStatusButton
+                            buttonKey = { BUTTONS.CONN_STATUS }
+                            notifyClick = { notifyClick }
+                            notifyMode = { getButtonNotifyMode(BUTTONS.CONN_STATUS, buttonsWithNotifyClick) }
+                            participantID = { _localParticipantId } />
                     }
                 </ContextMenuItemGroup>
             </ContextMenu>

--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
@@ -182,34 +182,34 @@ const LocalVideoMenuTriggerButton = ({
                 <ContextMenuItemGroup>
                     {_showLocalVideoFlipButton
                         && <FlipLocalVideoButton
-                            buttonKey = { BUTTONS.FLIP_LOCAL_VIDEO }
                             className = { _overflowDrawer ? classes.flipText : '' }
-                            notifyClick = { notifyClick }
+                            // eslint-disable-next-line react/jsx-no-bind
+                            notifyClick = { () => notifyClick(BUTTONS.FLIP_LOCAL_VIDEO) }
                             notifyMode = { getButtonNotifyMode(BUTTONS.FLIP_LOCAL_VIDEO, buttonsWithNotifyClick) }
                             onClick = { hidePopover } />
                     }
                     {_showHideSelfViewButton
                         && <HideSelfViewVideoButton
-                            buttonKey = { BUTTONS.HIDE_SELF_VIEW }
                             className = { _overflowDrawer ? classes.flipText : '' }
-                            notifyClick = { notifyClick }
+                            // eslint-disable-next-line react/jsx-no-bind
+                            notifyClick = { () => notifyClick(BUTTONS.HIDE_SELF_VIEW) }
                             notifyMode = { getButtonNotifyMode(BUTTONS.HIDE_SELF_VIEW, buttonsWithNotifyClick) }
                             onClick = { hidePopover } />
                     }
                     {
                         _showPinToStage && <TogglePinToStageButton
-                            buttonKey = { BUTTONS.PIN_TO_STAGE }
                             className = { _overflowDrawer ? classes.flipText : '' }
                             noIcon = { true }
-                            notifyClick = { notifyClick }
+                            // eslint-disable-next-line react/jsx-no-bind
+                            notifyClick = { () => notifyClick(BUTTONS.PIN_TO_STAGE) }
                             notifyMode = { getButtonNotifyMode(BUTTONS.PIN_TO_STAGE, buttonsWithNotifyClick) }
                             onClick = { hidePopover }
                             participantID = { _localParticipantId } />
                     }
                     {
                         isMobileBrowser() && <ConnectionStatusButton
-                            buttonKey = { BUTTONS.CONN_STATUS }
-                            notifyClick = { notifyClick }
+                            // eslint-disable-next-line react/jsx-no-bind
+                            notifyClick = { () => notifyClick(BUTTONS.CONN_STATUS) }
                             notifyMode = { getButtonNotifyMode(BUTTONS.CONN_STATUS, buttonsWithNotifyClick) }
                             participantID = { _localParticipantId } />
                     }

--- a/react/features/video-menu/components/web/MuteButton.tsx
+++ b/react/features/video-menu/components/web/MuteButton.tsx
@@ -26,7 +26,7 @@ class MuteButton extends AbstractMuteButton {
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -48,12 +48,12 @@ class MuteButton extends AbstractMuteButton {
                 className = 'mutelink'
                 icon = { IconMicSlash }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('dialog.muteParticipantButton') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 
 export default translate(connect(_mapStateToProps)(MuteButton));

--- a/react/features/video-menu/components/web/MuteButton.tsx
+++ b/react/features/video-menu/components/web/MuteButton.tsx
@@ -1,59 +1,65 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { createRemoteVideoMenuButtonEvent } from '../../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../../analytics/functions';
+import { IReduxState } from '../../../app/types';
+import { rejectParticipantAudio } from '../../../av-moderation/actions';
 import { IconMicSlash } from '../../../base/icons/svg';
+import { MEDIA_TYPE } from '../../../base/media/constants';
+import { isRemoteTrackMuted } from '../../../base/tracks/functions.any';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractMuteButton, { IProps, _mapStateToProps } from '../AbstractMuteButton';
-
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { muteRemote } from '../../actions.any';
+import { IButtonProps } from '../../types';
 
 /**
  * Implements a React {@link Component} which displays a button for audio muting
  * a participant in the conference.
  *
- * NOTE: At the time of writing this is a button that doesn't use the
- * {@code AbstractButton} base component, but is inherited from the same
- * super class ({@code AbstractMuteButton} that extends {@code AbstractButton})
- * for the sake of code sharing between web and mobile. Once web uses the
- * {@code AbstractButton} base component, this can be fully removed.
+ * @returns {JSX.Element|null}
  */
-class MuteButton extends AbstractMuteButton {
-    /**
-     * Instantiates a new {@code Component}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const MuteButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element | null => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const tracks = useSelector((state: IReduxState) => state['features/base/tracks']);
+    const audioTrackMuted = useMemo(
+        () => isRemoteTrackMuted(tracks, MEDIA_TYPE.AUDIO, participantID),
+        [ isRemoteTrackMuted, participantID, tracks ]
+    );
 
-        this._onClick = this._onClick.bind(this);
-    }
-
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { _audioTrackMuted, t } = this.props;
-
-        if (_audioTrackMuted) {
-            return null;
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        sendAnalytics(createRemoteVideoMenuButtonEvent(
+            'mute',
+            {
+                'participant_id': participantID
+            }));
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('dialog.muteParticipantButton') }
-                className = 'mutelink'
-                icon = { IconMicSlash }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('dialog.muteParticipantButton') } />
-        );
+        dispatch(muteRemote(participantID, MEDIA_TYPE.AUDIO));
+        dispatch(rejectParticipantAudio(participantID));
+    }, [ dispatch, notifyClick, notifyMode, participantID, sendAnalytics ]);
+
+    if (audioTrackMuted) {
+        return null;
     }
 
-    _onClick: () => void;
-}
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('dialog.muteParticipantButton') }
+            className = 'mutelink'
+            icon = { IconMicSlash }
+            onClick = { handleClick }
+            text = { t('dialog.muteParticipantButton') } />
+    );
+};
 
-export default translate(connect(_mapStateToProps)(MuteButton));
+export default MuteButton;

--- a/react/features/video-menu/components/web/MuteEveryoneElseButton.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneElseButton.tsx
@@ -20,7 +20,7 @@ class MuteEveryoneElseButton extends AbstractMuteEveryoneElseButton {
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -37,12 +37,12 @@ class MuteEveryoneElseButton extends AbstractMuteEveryoneElseButton {
                 accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElse') }
                 icon = { IconMicSlash }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('videothumbnail.domuteOthers') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 
 export default translate(connect()(MuteEveryoneElseButton));

--- a/react/features/video-menu/components/web/MuteEveryoneElseButton.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneElseButton.tsx
@@ -1,48 +1,48 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { createToolbarEvent } from '../../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../../analytics/functions';
+import { openDialog } from '../../../base/dialog/actions';
 import { IconMicSlash } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractMuteEveryoneElseButton, { IProps } from '../AbstractMuteEveryoneElseButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
+
+import MuteEveryoneDialog from './MuteEveryoneDialog';
 
 /**
  * Implements a React {@link Component} which displays a button for audio muting
  * every participant in the conference except the one with the given
  * participantID.
+ *
+ * @returns {JSX.Element}
  */
-class MuteEveryoneElseButton extends AbstractMuteEveryoneElseButton {
-    /**
-     * Instantiates a new {@code Component}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const MuteEveryoneElseButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
 
-        this._onClick = this._onClick.bind(this);
-    }
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
+        }
+        sendAnalytics(createToolbarEvent('mute.everyoneelse.pressed'));
+        dispatch(openDialog(MuteEveryoneDialog, { exclude: [ participantID ] }));
+    }, [ dispatch, notifyMode, notifyClick, participantID, sendAnalytics ]);
 
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { t } = this.props;
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElse') }
+            icon = { IconMicSlash }
+            onClick = { handleClick }
+            text = { t('videothumbnail.domuteOthers') } />
+    );
+};
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElse') }
-                icon = { IconMicSlash }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('videothumbnail.domuteOthers') } />
-        );
-    }
-
-    _onClick: () => void;
-}
-
-export default translate(connect()(MuteEveryoneElseButton));
+export default MuteEveryoneElseButton;

--- a/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.tsx
@@ -1,48 +1,48 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { createToolbarEvent } from '../../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../../analytics/functions';
+import { openDialog } from '../../../base/dialog/actions';
 import { IconVideoOff } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractMuteEveryoneElsesVideoButton, { IProps } from '../AbstractMuteEveryoneElsesVideoButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
+
+import MuteEveryonesVideoDialog from './MuteEveryonesVideoDialog';
 
 /**
  * Implements a React {@link Component} which displays a button for audio muting
  * every participant in the conference except the one with the given
  * participantID.
+ *
+ * @returns {JSX.Element}
  */
-class MuteEveryoneElsesVideoButton extends AbstractMuteEveryoneElsesVideoButton {
-    /**
-     * Instantiates a new {@code Component}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const MuteEveryoneElsesVideoButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
 
-        this._onClick = this._onClick.bind(this);
-    }
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
+        }
+        sendAnalytics(createToolbarEvent('mute.everyoneelsesvideo.pressed'));
+        dispatch(openDialog(MuteEveryonesVideoDialog, { exclude: [ participantID ] }));
+    }, [ notifyClick, notifyMode, participantID ]);
 
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { t } = this.props;
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElsesVideoStream') }
+            icon = { IconVideoOff }
+            onClick = { handleClick }
+            text = { t('videothumbnail.domuteVideoOfOthers') } />
+    );
+};
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElsesVideoStream') }
-                icon = { IconVideoOff }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('videothumbnail.domuteVideoOfOthers') } />
-        );
-    }
-
-    _onClick: () => void;
-}
-
-export default translate(connect()(MuteEveryoneElsesVideoButton));
+export default MuteEveryoneElsesVideoButton;

--- a/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneElsesVideoButton.tsx
@@ -20,7 +20,7 @@ class MuteEveryoneElsesVideoButton extends AbstractMuteEveryoneElsesVideoButton 
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -37,12 +37,12 @@ class MuteEveryoneElsesVideoButton extends AbstractMuteEveryoneElsesVideoButton 
                 accessibilityLabel = { t('toolbar.accessibilityLabel.muteEveryoneElsesVideoStream') }
                 icon = { IconVideoOff }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('videothumbnail.domuteVideoOfOthers') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 
 export default translate(connect()(MuteEveryoneElsesVideoButton));

--- a/react/features/video-menu/components/web/MuteVideoButton.tsx
+++ b/react/features/video-menu/components/web/MuteVideoButton.tsx
@@ -25,7 +25,7 @@ class MuteVideoButton extends AbstractMuteVideoButton {
     constructor(props: IProps) {
         super(props);
 
-        this._handleClick = this._handleClick.bind(this);
+        this._onClick = this._onClick.bind(this);
     }
 
     /**
@@ -47,12 +47,12 @@ class MuteVideoButton extends AbstractMuteVideoButton {
                 className = 'mutevideolink'
                 icon = { IconVideoOff }
                 // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._handleClick }
+                onClick = { this._onClick }
                 text = { t('participantsPane.actions.stopVideo') } />
         );
     }
 
-    _handleClick: () => void;
+    _onClick: () => void;
 }
 
 export default translate(connect(_mapStateToProps)(MuteVideoButton));

--- a/react/features/video-menu/components/web/MuteVideoButton.tsx
+++ b/react/features/video-menu/components/web/MuteVideoButton.tsx
@@ -1,58 +1,66 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { translate } from '../../../base/i18n/functions';
+import { createRemoteVideoMenuButtonEvent } from '../../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../../analytics/functions';
+import { IReduxState } from '../../../app/types';
+import { openDialog } from '../../../base/dialog/actions';
 import { IconVideoOff } from '../../../base/icons/svg';
+import { MEDIA_TYPE } from '../../../base/media/constants';
+import { isRemoteTrackMuted } from '../../../base/tracks/functions.any';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
-import AbstractMuteVideoButton, { IProps, _mapStateToProps } from '../AbstractMuteVideoButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
+
+import MuteRemoteParticipantsVideoDialog from './MuteRemoteParticipantsVideoDialog';
 
 /**
  * Implements a React {@link Component} which displays a button for disabling
  * the camera of a participant in the conference.
  *
- * NOTE: At the time of writing this is a button that doesn't use the
- * {@code AbstractButton} base component, but is inherited from the same
- * super class ({@code AbstractMuteVideoButton} that extends {@code AbstractButton})
- * for the sake of code sharing between web and mobile. Once web uses the
- * {@code AbstractButton} base component, this can be fully removed.
+ * @returns {JSX.Element|null}
  */
-class MuteVideoButton extends AbstractMuteVideoButton {
-    /**
-     * Instantiates a new {@code Component}.
-     *
-     * @inheritdoc
-     */
-    constructor(props: IProps) {
-        super(props);
+const MuteVideoButton = ({
+    notifyClick,
+    notifyMode,
+    participantID
+}: IButtonProps): JSX.Element | null => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const tracks = useSelector((state: IReduxState) => state['features/base/tracks']);
 
-        this._onClick = this._onClick.bind(this);
-    }
+    const videoTrackMuted = useMemo(
+        () => isRemoteTrackMuted(tracks, MEDIA_TYPE.VIDEO, participantID),
+        [ isRemoteTrackMuted, participantID, tracks ]
+    );
 
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    render() {
-        const { _videoTrackMuted, t } = this.props;
-
-        if (_videoTrackMuted) {
-            return null;
+    const handleClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        sendAnalytics(createRemoteVideoMenuButtonEvent(
+            'video.mute.button',
+            {
+                'participant_id': participantID
+            }));
 
-        return (
-            <ContextMenuItem
-                accessibilityLabel = { t('participantsPane.actions.stopVideo') }
-                className = 'mutevideolink'
-                icon = { IconVideoOff }
-                // eslint-disable-next-line react/jsx-handler-names
-                onClick = { this._onClick }
-                text = { t('participantsPane.actions.stopVideo') } />
-        );
+        dispatch(openDialog(MuteRemoteParticipantsVideoDialog, { participantID }));
+    }, [ dispatch, notifyClick, notifyClick, participantID, sendAnalytics ]);
+
+    if (videoTrackMuted) {
+        return null;
     }
 
-    _onClick: () => void;
-}
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { t('participantsPane.actions.stopVideo') }
+            className = 'mutevideolink'
+            icon = { IconVideoOff }
+            onClick = { handleClick }
+            text = { t('participantsPane.actions.stopVideo') } />
+    );
+};
 
-export default translate(connect(_mapStateToProps)(MuteVideoButton));
+export default MuteVideoButton;

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from 'tss-react/mui';
 import { IReduxState, IStore } from '../../../app/types';
 import { isSupported as isAvModerationSupported } from '../../../av-moderation/functions';
 import Avatar from '../../../base/avatar/components/Avatar';
+import { getButtonNotifyMode, getParticipantMenuButtonsWithNotifyClick } from '../../../base/config/functions.web';
 import { isIosMobileBrowser, isMobileBrowser } from '../../../base/environment/utils';
 import { MEDIA_TYPE } from '../../../base/media/constants';
 import { PARTICIPANT_ROLE } from '../../../base/participants/constants';
@@ -15,14 +16,17 @@ import { isParticipantAudioMuted, isParticipantVideoMuted } from '../../../base/
 import ContextMenu from '../../../base/ui/components/web/ContextMenu';
 import ContextMenuItemGroup from '../../../base/ui/components/web/ContextMenuItemGroup';
 import { getBreakoutRooms, getCurrentRoomId, isInBreakoutRoom } from '../../../breakout-rooms/functions';
+import { IRoom } from '../../../breakout-rooms/types';
 import { displayVerification } from '../../../e2ee/functions';
 import { setVolume } from '../../../filmstrip/actions.web';
 import { isStageFilmstripAvailable } from '../../../filmstrip/functions.web';
 import { QUICK_ACTION_BUTTON } from '../../../participants-pane/constants';
 import { getQuickActionButtonType, isForceMuted } from '../../../participants-pane/functions';
 import { requestRemoteControl, stopController } from '../../../remote-control/actions';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { showOverflowDrawer } from '../../../toolbox/functions.web';
 import { iAmVisitor } from '../../../visitors/functions';
+import { PARTICIPANT_MENU_BUTTONS as BUTTONS } from '../../constants';
 
 import AskToUnmuteButton from './AskToUnmuteButton';
 import ConnectionStatusButton from './ConnectionStatusButton';
@@ -145,15 +149,14 @@ const ParticipantContextMenu = ({
     const isModerationSupported = useSelector((state: IReduxState) => isAvModerationSupported()(state));
     const stageFilmstrip = useSelector(isStageFilmstripAvailable);
     const shouldDisplayVerification = useSelector((state: IReduxState) => displayVerification(state, participant?.id));
+    const buttonsWithNotifyClick = useSelector(getParticipantMenuButtonsWithNotifyClick);
 
     const _currentRoomId = useSelector(getCurrentRoomId);
-    const _rooms = Object.values(useSelector(getBreakoutRooms));
+    const _rooms: IRoom[] = Object.values(useSelector(getBreakoutRooms));
 
     const _onVolumeChange = useCallback(value => {
         dispatch(setVolume(participant.id, value));
     }, [ setVolume, dispatch ]);
-
-    const clickHandler = useCallback(() => onSelect(true), [ onSelect ]);
 
     const _getCurrentParticipantId = useCallback(() => {
         const drawer = _overflowDrawer && !thumbnailMenu;
@@ -161,6 +164,25 @@ const ParticipantContextMenu = ({
         return (drawer ? drawerParticipant?.participantID : participant?.id) ?? '';
     }
     , [ thumbnailMenu, _overflowDrawer, drawerParticipant, participant ]);
+
+    const notifyClick = useCallback(
+        (buttonKey: string) => {
+            const notifyMode = getButtonNotifyMode(buttonKey, buttonsWithNotifyClick);
+
+            if (!notifyMode) {
+                return;
+            }
+
+            APP.API.notifyParticipantMenuButtonClicked(
+                buttonKey,
+                _getCurrentParticipantId(),
+                notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+            );
+        }, [ buttonsWithNotifyClick, getButtonNotifyMode, _getCurrentParticipantId ]);
+
+    const onBreakoutRoomButtonClick = useCallback(() => {
+        onSelect(true);
+    }, [ onSelect ]);
 
     const isClickedFromParticipantPane = useMemo(
         () => !_overflowDrawer && !thumbnailMenu,
@@ -177,128 +199,103 @@ const ParticipantContextMenu = ({
         && typeof _volume === 'number'
         && !isNaN(_volume);
 
+    const getButtonProps = useCallback((key: string) => {
+        const notifyMode = getButtonNotifyMode(key, buttonsWithNotifyClick);
+        const shouldNotifyClick = notifyMode !== NOTIFY_CLICK_MODE.ONLY_NOTIFY
+            || notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY;
+
+        return {
+            buttonKey: key,
+            key,
+            notifyMode,
+            notifyClick: shouldNotifyClick ? notifyClick : undefined,
+            participantID: _getCurrentParticipantId()
+        };
+    }, [ _getCurrentParticipantId, buttonsWithNotifyClick, getButtonNotifyMode, notifyClick ]);
+
     if (_isModerator) {
         if (isModerationSupported) {
             if (_isAudioMuted
                 && !(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.ASK_TO_UNMUTE)) {
-                buttons.push(<AskToUnmuteButton
-                    buttonType = { MEDIA_TYPE.AUDIO }
-                    key = 'ask-unmute'
-                    participantID = { _getCurrentParticipantId() } />
+                buttons.push(<AskToUnmuteButton { ...getButtonProps(BUTTONS.ASK_UNMUTE) } />
                 );
             }
             if (_isVideoForceMuted
                 && !(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.ALLOW_VIDEO)) {
                 buttons.push(<AskToUnmuteButton
-                    buttonType = { MEDIA_TYPE.VIDEO }
-                    key = 'allow-video'
-                    participantID = { _getCurrentParticipantId() } />
+                    { ...getButtonProps(BUTTONS.ALLOW_VIDEO) }
+                    buttonType = { MEDIA_TYPE.VIDEO } />
                 );
             }
         }
+
         if (!disableRemoteMute) {
             if (!(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.MUTE)) {
-                buttons.push(
-                    <MuteButton
-                        key = 'mute'
-                        participantID = { _getCurrentParticipantId() } />
+                buttons.push(<MuteButton
+                    { ...getButtonProps(BUTTONS.MUTE) }
+                    preventDefaultNotify = { true } />
                 );
             }
-            buttons.push(
-                <MuteEveryoneElseButton
-                    key = 'mute-others'
-                    participantID = { _getCurrentParticipantId() } />
-            );
+            buttons.push(<MuteEveryoneElseButton { ...getButtonProps(BUTTONS.MUTE_OTHERS) } />);
             if (!(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.STOP_VIDEO)) {
-                buttons.push(
-                    <MuteVideoButton
-                        key = 'mute-video'
-                        participantID = { _getCurrentParticipantId() } />
+                buttons.push(<MuteVideoButton
+                    { ...getButtonProps(BUTTONS.MUTE_VIDEO) }
+                    preventDefaultNotify = { true } />
                 );
             }
-            buttons.push(
-                <MuteEveryoneElsesVideoButton
-                    key = 'mute-others-video'
-                    participantID = { _getCurrentParticipantId() } />
-            );
+            buttons.push(<MuteEveryoneElsesVideoButton { ...getButtonProps(BUTTONS.MUTE_OTHERS_VIDEO) } />);
         }
 
         if (!disableGrantModerator && !isBreakoutRoom) {
-            buttons2.push(
-                <GrantModeratorButton
-                    key = 'grant-moderator'
-                    participantID = { _getCurrentParticipantId() } />
-            );
+            buttons2.push(<GrantModeratorButton { ...getButtonProps(BUTTONS.GRANT_MODERATOR) } />);
         }
 
         if (!disableKick) {
-            buttons2.push(
-                <KickButton
-                    key = 'kick'
-                    participantID = { _getCurrentParticipantId() } />
-            );
+            buttons2.push(<KickButton { ...getButtonProps(BUTTONS.KICK) } />);
         }
 
         if (shouldDisplayVerification) {
-            buttons2.push(
-                <VerifyParticipantButton
-                    key = 'verify'
-                    participantID = { _getCurrentParticipantId() } />
-            );
+            buttons2.push(<VerifyParticipantButton { ...getButtonProps(BUTTONS.VERIFY) } />);
         }
-
     }
 
     if (stageFilmstrip) {
-        buttons2.push(<TogglePinToStageButton
-            key = 'pinToStage'
-            participantID = { _getCurrentParticipantId() } />);
+        buttons2.push(<TogglePinToStageButton { ...getButtonProps(BUTTONS.PIN_TO_STAGE) } />);
     }
 
     if (!disablePrivateChat && !visitorsMode) {
-        buttons2.push(<PrivateMessageMenuButton
-            key = 'privateMessage'
-            participantID = { _getCurrentParticipantId() } />
-        );
+        buttons2.push(<PrivateMessageMenuButton { ...getButtonProps(BUTTONS.PRIVATE_MESSAGE) } />);
     }
 
     if (thumbnailMenu && isMobileBrowser()) {
-        buttons2.push(
-            <ConnectionStatusButton
-                key = 'conn-status'
-                participantId = { _getCurrentParticipantId() } />
-        );
+        buttons2.push(<ConnectionStatusButton { ...getButtonProps(BUTTONS.CONN_STATUS) } />);
     }
 
     if (thumbnailMenu && remoteControlState) {
-        let onRemoteControlToggle = null;
+        const onRemoteControlToggle = useCallback(() => {
+            if (remoteControlState === REMOTE_CONTROL_MENU_STATES.STARTED) {
+                dispatch(stopController(true));
+            } else if (remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED) {
+                dispatch(requestRemoteControl(_getCurrentParticipantId()));
+            }
+        }, [ dispatch, remoteControlState, stopController, requestRemoteControl ]);
 
-        if (remoteControlState === REMOTE_CONTROL_MENU_STATES.STARTED) {
-            onRemoteControlToggle = () => dispatch(stopController(true));
-        } else if (remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED) {
-            onRemoteControlToggle = () => dispatch(requestRemoteControl(_getCurrentParticipantId()));
-        }
-
-        buttons2.push(
-            <RemoteControlButton
-                key = 'remote-control'
-                onClick = { onRemoteControlToggle }
-                participantID = { _getCurrentParticipantId() }
-                remoteControlState = { remoteControlState } />
+        buttons2.push(<RemoteControlButton
+            { ...getButtonProps(BUTTONS.REMOTE_CONTROL) }
+            onClick = { onRemoteControlToggle }
+            remoteControlState = { remoteControlState } />
         );
     }
 
     if (customParticipantMenuButtons) {
         customParticipantMenuButtons.forEach(
             ({ icon, id, text }) => {
-                const onClick = useCallback(
-                    () => APP.API.notifyParticipantMenuButtonClicked(id, _getCurrentParticipantId()), []);
-
                 buttons2.push(
                     <CustomOptionButton
                         icon = { icon }
                         key = { id }
-                        onClick = { onClick }
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onClick = { () => notifyClick(id) }
                         text = { text } />
                 );
             }
@@ -312,9 +309,9 @@ const ParticipantContextMenu = ({
             if (room.id !== _currentRoomId) {
                 breakoutRoomsButtons.push(
                     <SendToRoomButton
+                        { ...getButtonProps(BUTTONS.SEND_PARTICIPANT_TO_ROOM) }
                         key = { room.id }
-                        onClick = { clickHandler }
-                        participantID = { _getCurrentParticipantId() }
+                        onClick = { onBreakoutRoomButtonClick }
                         room = { room } />
                 );
             }

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -205,10 +205,9 @@ const ParticipantContextMenu = ({
             || notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY;
 
         return {
-            buttonKey: key,
             key,
             notifyMode,
-            notifyClick: shouldNotifyClick ? notifyClick : undefined,
+            notifyClick: shouldNotifyClick ? () => notifyClick(key) : undefined,
             participantID: _getCurrentParticipantId()
         };
     }, [ _getCurrentParticipantId, buttonsWithNotifyClick, getButtonNotifyMode, notifyClick ]);
@@ -217,7 +216,9 @@ const ParticipantContextMenu = ({
         if (isModerationSupported) {
             if (_isAudioMuted
                 && !(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.ASK_TO_UNMUTE)) {
-                buttons.push(<AskToUnmuteButton { ...getButtonProps(BUTTONS.ASK_UNMUTE) } />
+                buttons.push(<AskToUnmuteButton
+                    { ...getButtonProps(BUTTONS.ASK_UNMUTE) }
+                    buttonType = { MEDIA_TYPE.AUDIO } />
                 );
             }
             if (_isVideoForceMuted
@@ -231,17 +232,11 @@ const ParticipantContextMenu = ({
 
         if (!disableRemoteMute) {
             if (!(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.MUTE)) {
-                buttons.push(<MuteButton
-                    { ...getButtonProps(BUTTONS.MUTE) }
-                    preventDefaultNotify = { true } />
-                );
+                buttons.push(<MuteButton { ...getButtonProps(BUTTONS.MUTE) } />);
             }
             buttons.push(<MuteEveryoneElseButton { ...getButtonProps(BUTTONS.MUTE_OTHERS) } />);
             if (!(isClickedFromParticipantPane && quickActionButtonType === QUICK_ACTION_BUTTON.STOP_VIDEO)) {
-                buttons.push(<MuteVideoButton
-                    { ...getButtonProps(BUTTONS.MUTE_VIDEO) }
-                    preventDefaultNotify = { true } />
-                );
+                buttons.push(<MuteVideoButton { ...getButtonProps(BUTTONS.MUTE_VIDEO) } />);
             }
             buttons.push(<MuteEveryoneElsesVideoButton { ...getButtonProps(BUTTONS.MUTE_OTHERS_VIDEO) } />);
         }

--- a/react/features/video-menu/components/web/PrivateMessageMenuButton.tsx
+++ b/react/features/video-menu/components/web/PrivateMessageMenuButton.tsx
@@ -12,6 +12,7 @@ import { IParticipant } from '../../../base/participants/types';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { openChat } from '../../../chat/actions.web';
 import { IProps as AbstractProps } from '../../../chat/components/web/PrivateMessageButton';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { isButtonEnabled } from '../../../toolbox/functions.web';
 
 interface IProps extends AbstractProps, WithTranslation {
@@ -27,9 +28,25 @@ interface IProps extends AbstractProps, WithTranslation {
     _participant?: IParticipant;
 
     /**
+     * The button key used to identify the click event.
+     */
+    buttonKey: string;
+
+    /**
      * Redux dispatch function.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 }
 
 /**
@@ -57,7 +74,7 @@ class PrivateMessageMenuButton extends Component<IProps> {
      * @returns {ReactElement}
      */
     render() {
-        const { t, _hidden } = this.props;
+        const { _hidden, t } = this.props;
 
         if (_hidden) {
             return null;
@@ -75,12 +92,16 @@ class PrivateMessageMenuButton extends Component<IProps> {
     /**
      * Callback to be invoked on pressing the button.
      *
+     * @param {React.MouseEvent|undefined} e - The click event.
      * @returns {void}
      */
     _onClick() {
-        const { dispatch, _participant } = this.props;
+        const { _participant, buttonKey, dispatch, notifyClick, notifyMode } = this.props;
 
-        dispatch(openChat(_participant));
+        notifyClick?.(buttonKey);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            dispatch(openChat(_participant));
+        }
     }
 }
 

--- a/react/features/video-menu/components/web/PrivateMessageMenuButton.tsx
+++ b/react/features/video-menu/components/web/PrivateMessageMenuButton.tsx
@@ -11,11 +11,11 @@ import { getParticipantById } from '../../../base/participants/functions';
 import { IParticipant } from '../../../base/participants/types';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { openChat } from '../../../chat/actions.web';
-import { IProps as AbstractProps } from '../../../chat/components/web/PrivateMessageButton';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 import { isButtonEnabled } from '../../../toolbox/functions.web';
+import { IButtonProps } from '../../types';
 
-interface IProps extends AbstractProps, WithTranslation {
+interface IProps extends IButtonProps, WithTranslation {
 
     /**
      * True if the private chat functionality is disabled, hence the button is not visible.
@@ -28,25 +28,9 @@ interface IProps extends AbstractProps, WithTranslation {
     _participant?: IParticipant;
 
     /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
-
-    /**
      * Redux dispatch function.
      */
     dispatch: IStore['dispatch'];
-
-    /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
 }
 
 /**
@@ -96,12 +80,13 @@ class PrivateMessageMenuButton extends Component<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { _participant, buttonKey, dispatch, notifyClick, notifyMode } = this.props;
+        const { _participant, dispatch, notifyClick, notifyMode } = this.props;
 
-        notifyClick?.(buttonKey);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            dispatch(openChat(_participant));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+        dispatch(openChat(_participant));
     }
 }
 

--- a/react/features/video-menu/components/web/RemoteControlButton.tsx
+++ b/react/features/video-menu/components/web/RemoteControlButton.tsx
@@ -23,11 +23,6 @@ export const REMOTE_CONTROL_MENU_STATES = {
 interface IProps extends WithTranslation {
 
     /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
-
-    /**
      * Callback to execute when the button is clicked.
      */
     notifyClick?: Function;
@@ -124,27 +119,28 @@ class RemoteControlButton extends Component<IProps> {
      * @returns {void}
      */
     _onClick() {
-        const { buttonKey, notifyClick, notifyMode, onClick, participantID, remoteControlState } = this.props;
+        const { notifyClick, notifyMode, onClick, participantID, remoteControlState } = this.props;
 
-        notifyClick?.(buttonKey);
-
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            // TODO: What do we do in case the state is e.g. "requesting"?
-            if (remoteControlState === REMOTE_CONTROL_MENU_STATES.STARTED
-                || remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED) {
-
-                const enable
-                    = remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED;
-
-                sendAnalytics(createRemoteVideoMenuButtonEvent(
-                    'remote.control.button',
-                    {
-                        enable,
-                        'participant_id': participantID
-                    }));
-            }
-            onClick?.();
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
+
+        // TODO: What do we do in case the state is e.g. "requesting"?
+        if (remoteControlState === REMOTE_CONTROL_MENU_STATES.STARTED
+            || remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED) {
+
+            const enable
+                = remoteControlState === REMOTE_CONTROL_MENU_STATES.NOT_STARTED;
+
+            sendAnalytics(createRemoteVideoMenuButtonEvent(
+                'remote.control.button',
+                {
+                    enable,
+                    'participant_id': participantID
+                }));
+        }
+        onClick?.();
 
     }
 }

--- a/react/features/video-menu/components/web/SendToRoomButton.tsx
+++ b/react/features/video-menu/components/web/SendToRoomButton.tsx
@@ -9,24 +9,9 @@ import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { sendParticipantToRoom } from '../../../breakout-rooms/actions';
 import { IRoom } from '../../../breakout-rooms/types';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
 
-interface IProps {
-
-    /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
-
-    /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
+interface IProps extends IButtonProps {
 
     /**
      * Click handler.
@@ -34,38 +19,29 @@ interface IProps {
     onClick?: Function;
 
     /**
-     * The ID for the participant on which the button will act.
-     */
-    participantID: string;
-
-    /**
      * The room to send the participant to.
      */
     room: IRoom;
 }
 
-const SendToRoomButton = ({ buttonKey, notifyClick, notifyMode, onClick, participantID, room }: IProps) => {
+const SendToRoomButton = ({
+    notifyClick,
+    notifyMode,
+    onClick,
+    participantID,
+    room
+}: IProps) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const _onClick = useCallback(() => {
-        notifyClick?.(buttonKey, participantID);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            onClick?.();
-            sendAnalytics(createBreakoutRoomsEvent('send.participant.to.room'));
-            dispatch(sendParticipantToRoom(participantID, room.id));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
-    }, [
-        buttonKey,
-        createBreakoutRoomsEvent,
-        dispatch,
-        notifyClick,
-        notifyMode,
-        onClick,
-        participantID,
-        room,
-        sendAnalytics,
-        sendParticipantToRoom
-    ]);
+        onClick?.();
+        sendAnalytics(createBreakoutRoomsEvent('send.participant.to.room'));
+        dispatch(sendParticipantToRoom(participantID, room.id));
+    }, [ dispatch, notifyClick, notifyMode, onClick, participantID, room, sendAnalytics ]);
 
     const roomName = room.name || t('breakoutRooms.mainRoom');
 

--- a/react/features/video-menu/components/web/SendToRoomButton.tsx
+++ b/react/features/video-menu/components/web/SendToRoomButton.tsx
@@ -8,8 +8,25 @@ import { IconRingGroup } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { sendParticipantToRoom } from '../../../breakout-rooms/actions';
 import { IRoom } from '../../../breakout-rooms/types';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 interface IProps {
+
+    /**
+     * The button key used to identify the click event.
+     */
+    buttonKey: string;
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 
     /**
      * Click handler.
@@ -27,14 +44,28 @@ interface IProps {
     room: IRoom;
 }
 
-const SendToRoomButton = ({ onClick, participantID, room }: IProps) => {
+const SendToRoomButton = ({ buttonKey, notifyClick, notifyMode, onClick, participantID, room }: IProps) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const _onClick = useCallback(() => {
-        onClick?.();
-        sendAnalytics(createBreakoutRoomsEvent('send.participant.to.room'));
-        dispatch(sendParticipantToRoom(participantID, room.id));
-    }, [ participantID, room ]);
+        notifyClick?.(buttonKey, participantID);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            onClick?.();
+            sendAnalytics(createBreakoutRoomsEvent('send.participant.to.room'));
+            dispatch(sendParticipantToRoom(participantID, room.id));
+        }
+    }, [
+        buttonKey,
+        createBreakoutRoomsEvent,
+        dispatch,
+        notifyClick,
+        notifyMode,
+        onClick,
+        participantID,
+        room,
+        sendAnalytics,
+        sendParticipantToRoom
+    ]);
 
     const roomName = room.name || t('breakoutRooms.mainRoom');
 

--- a/react/features/video-menu/components/web/TogglePinToStageButton.tsx
+++ b/react/features/video-menu/components/web/TogglePinToStageButton.tsx
@@ -7,13 +7,9 @@ import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { togglePinStageParticipant } from '../../../filmstrip/actions.web';
 import { getPinnedActiveParticipants } from '../../../filmstrip/functions.web';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
 
-interface IProps {
-
-    /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
+interface IProps extends IButtonProps {
 
     /**
      * Button text class name.
@@ -26,49 +22,31 @@ interface IProps {
     noIcon?: boolean;
 
     /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
-
-    /**
      * Click handler executed aside from the main action.
      */
     onClick?: Function;
-
-    /**
-     * The ID for the participant on which the button will act.
-     */
-    participantID: string;
 }
 
 const TogglePinToStageButton = ({
-    buttonKey, className, noIcon = false, notifyClick, notifyMode, onClick, participantID
-}: IProps) => {
+    className,
+    noIcon = false,
+    notifyClick,
+    notifyMode,
+    onClick,
+    participantID
+}: IProps): JSX.Element => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const isActive = Boolean(useSelector(getPinnedActiveParticipants)
         .find(p => p.participantId === participantID));
     const _onClick = useCallback(() => {
-        notifyClick?.(buttonKey, participantID);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            dispatch(togglePinStageParticipant(participantID));
-            onClick?.();
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
-    }, [
-        buttonKey,
-        dispatch,
-        isActive,
-        notifyClick,
-        onClick,
-        participantID,
-        togglePinStageParticipant
-    ]);
+        dispatch(togglePinStageParticipant(participantID));
+        onClick?.();
+    }, [ dispatch, isActive, notifyClick, onClick, participantID ]);
 
     const text = isActive
         ? t('videothumbnail.unpinFromStage')

--- a/react/features/video-menu/components/web/TogglePinToStageButton.tsx
+++ b/react/features/video-menu/components/web/TogglePinToStageButton.tsx
@@ -6,8 +6,14 @@ import { IconPin, IconPinned } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { togglePinStageParticipant } from '../../../filmstrip/actions.web';
 import { getPinnedActiveParticipants } from '../../../filmstrip/functions.web';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 interface IProps {
+
+    /**
+     * The button key used to identify the click event.
+     */
+    buttonKey: string;
 
     /**
      * Button text class name.
@@ -20,6 +26,17 @@ interface IProps {
     noIcon?: boolean;
 
     /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
+
+    /**
      * Click handler executed aside from the main action.
      */
     onClick?: Function;
@@ -30,15 +47,28 @@ interface IProps {
     participantID: string;
 }
 
-const TogglePinToStageButton = ({ className, noIcon = false, onClick, participantID }: IProps) => {
+const TogglePinToStageButton = ({
+    buttonKey, className, noIcon = false, notifyClick, notifyMode, onClick, participantID
+}: IProps) => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const isActive = Boolean(useSelector(getPinnedActiveParticipants)
         .find(p => p.participantId === participantID));
     const _onClick = useCallback(() => {
-        dispatch(togglePinStageParticipant(participantID));
-        onClick?.();
-    }, [ participantID, isActive ]);
+        notifyClick?.(buttonKey, participantID);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            dispatch(togglePinStageParticipant(participantID));
+            onClick?.();
+        }
+    }, [
+        buttonKey,
+        dispatch,
+        isActive,
+        notifyClick,
+        onClick,
+        participantID,
+        togglePinStageParticipant
+    ]);
 
     const text = isActive
         ? t('videothumbnail.unpinFromStage')

--- a/react/features/video-menu/components/web/VerifyParticipantButton.tsx
+++ b/react/features/video-menu/components/web/VerifyParticipantButton.tsx
@@ -1,61 +1,34 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
-import { IReduxState, IStore } from '../../../app/types';
 import { IconCheck } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { startVerification } from '../../../e2ee/actions';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
+import { IButtonProps } from '../../types';
 
 /**
- * The type of the React {@code Component} props of
- * {@link VerifyParticipantButton}.
+ * Implements a React {@link Component} which displays a button that
+ * verifies the participant.
+ *
+ * @returns {JSX.Element}
  */
-interface IProps {
-
-    /**
-     * The button key used to identify the click event.
-     */
-    buttonKey: string;
-
-    /**
-     * The redux {@code dispatch} function.
-     */
-    dispatch: IStore['dispatch'];
-
-    /**
-     * Callback to execute when the button is clicked.
-     */
-    notifyClick?: Function;
-
-    /**
-     * Notify mode for `participantMenuButtonClicked` event -
-     * whether to only notify or to also prevent button click routine.
-     */
-    notifyMode?: string;
-
-    /**
-      * The ID of the participant that this button is supposed to verified.
-      */
-    participantID: string;
-}
-
 const VerifyParticipantButton = ({
-    buttonKey,
-    dispatch,
     notifyClick,
     notifyMode,
     participantID
-}: IProps) => {
+}: IButtonProps): JSX.Element => {
     const { t } = useTranslation();
+    const dispatch = useDispatch();
 
     const _handleClick = useCallback(() => {
-        notifyClick?.(buttonKey);
-        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
-            dispatch(startVerification(participantID));
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
         }
-    }, [ dispatch, notifyClick, notifyMode, participantID, startVerification ]);
+        dispatch(startVerification(participantID));
+    }, [ dispatch, notifyClick, notifyMode, participantID ]);
 
     return (
         <ContextMenuItem
@@ -69,20 +42,4 @@ const VerifyParticipantButton = ({
     );
 };
 
-/**
- * Maps (parts of) the Redux state to the associated {@code RemoteVideoMenuTriggerButton}'s props.
- *
- * @param {Object} state - The Redux state.
- * @param {Object} ownProps - The own props of the component.
- * @private
- * @returns {IProps}
- */
-function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
-    const { participantID } = ownProps;
-
-    return {
-        _participantID: participantID
-    };
-}
-
-export default connect(_mapStateToProps)(VerifyParticipantButton);
+export default VerifyParticipantButton;

--- a/react/features/video-menu/components/web/VerifyParticipantButton.tsx
+++ b/react/features/video-menu/components/web/VerifyParticipantButton.tsx
@@ -6,6 +6,7 @@ import { IReduxState, IStore } from '../../../app/types';
 import { IconCheck } from '../../../base/icons/svg';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { startVerification } from '../../../e2ee/actions';
+import { NOTIFY_CLICK_MODE } from '../../../toolbox/constants';
 
 /**
  * The type of the React {@code Component} props of
@@ -14,9 +15,25 @@ import { startVerification } from '../../../e2ee/actions';
 interface IProps {
 
     /**
+     * The button key used to identify the click event.
+     */
+    buttonKey: string;
+
+    /**
      * The redux {@code dispatch} function.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
 
     /**
       * The ID of the participant that this button is supposed to verified.
@@ -25,14 +42,20 @@ interface IProps {
 }
 
 const VerifyParticipantButton = ({
+    buttonKey,
     dispatch,
+    notifyClick,
+    notifyMode,
     participantID
 }: IProps) => {
     const { t } = useTranslation();
 
     const _handleClick = useCallback(() => {
-        dispatch(startVerification(participantID));
-    }, [ participantID ]);
+        notifyClick?.(buttonKey);
+        if (notifyMode !== NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            dispatch(startVerification(participantID));
+        }
+    }, [ dispatch, notifyClick, notifyMode, participantID, startVerification ]);
 
     return (
         <ContextMenuItem

--- a/react/features/video-menu/constants.ts
+++ b/react/features/video-menu/constants.ts
@@ -12,3 +12,25 @@ export const NATIVE_VOLUME_SLIDER_SCALE = 19;
  * recognizes whole numbers.
  */
 export const VOLUME_SLIDER_SCALE = 100;
+
+/**
+ * Participant context menu button keys.
+ */
+export const PARTICIPANT_MENU_BUTTONS = {
+    ALLOW_VIDEO: 'allow-video',
+    ASK_UNMUTE: 'ask-unmute',
+    CONN_STATUS: 'conn-status',
+    FLIP_LOCAL_VIDEO: 'flip-local-video',
+    GRANT_MODERATOR: 'grant-moderator',
+    HIDE_SELF_VIEW: 'hide-self-view',
+    KICK: 'kick',
+    MUTE: 'mute',
+    MUTE_OTHERS: 'mute-others',
+    MUTE_OTHERS_VIDEO: 'mute-others-video',
+    MUTE_VIDEO: 'mute-video',
+    PIN_TO_STAGE: 'pinToStage',
+    PRIVATE_MESSAGE: 'privateMessage',
+    REMOTE_CONTROL: 'remote-control',
+    SEND_PARTICIPANT_TO_ROOM: 'send-participant-to-room',
+    VERIFY: 'verify'
+};

--- a/react/features/video-menu/types.ts
+++ b/react/features/video-menu/types.ts
@@ -1,0 +1,18 @@
+export interface IButtonProps {
+
+    /**
+     * Callback to execute when the button is clicked.
+     */
+    notifyClick?: Function;
+
+    /**
+     * Notify mode for the `participantMenuButtonClicked` event -
+     * whether to only notify or to also prevent button click routine.
+     */
+    notifyMode?: string;
+
+    /**
+     * The ID of the participant that's linked to the button.
+     */
+    participantID: string;
+}


### PR DESCRIPTION
https://github.com/jitsi/jitsi-meet/issues/13446

* `participantMenuButtonClick` should now listen to the buttons defined here https://github.com/jitsi/jitsi-meet/blob/6e816cafc4f1537f0e0d1f55f3f1aa97d666d71e/react/features/video-menu/constants.ts#L19 on top of the custom ones

* `participantMenuButtonsWithNotifyClick` config should work as its toolbar counterpart, enabling click prevention