### PR TITLE
fix(style) Add icon to unchecked ContextMenu

### DIFF
--- a/react/features/participants-pane/components/web/FooterContextMenu.tsx
+++ b/react/features/participants-pane/components/web/FooterContextMenu.tsx
@@ -17,6 +17,7 @@ import {
 import { openDialog } from '../../../base/dialog/actions';
 import {
     IconCheck,
+    IconCloseLarge,
     IconDotsHorizontal,
     IconVideoOff
 } from '../../../base/icons/svg';
@@ -116,7 +117,7 @@ export const FooterContextMenu = ({ isOpen, onDrawerClose, onMouseLeave }: IProp
             id: isAudioModerationEnabled
                 ? 'participants-pane-context-menu-stop-audio-moderation'
                 : 'participants-pane-context-menu-start-audio-moderation',
-            icon: !isAudioModerationEnabled && IconCheck,
+            icon: !isAudioModerationEnabled && IconCheck || IconCloseLarge,
             onClick: isAudioModerationEnabled ? disableAudioModeration : enableAudioModeration,
             text: t('participantsPane.actions.audioModeration')
         }, {
@@ -125,7 +126,7 @@ export const FooterContextMenu = ({ isOpen, onDrawerClose, onMouseLeave }: IProp
             id: isVideoModerationEnabled
                 ? 'participants-pane-context-menu-stop-video-moderation'
                 : 'participants-pane-context-menu-start-video-moderation',
-            icon: !isVideoModerationEnabled && IconCheck,
+            icon: !isVideoModerationEnabled && IconCheck || IconCloseLarge,
             onClick: isVideoModerationEnabled ? disableVideoModeration : enableVideoModeration,
             text: t('participantsPane.actions.videoModeration')
         }


### PR DESCRIPTION
When unchecked, the menu item is displaced. Replacing iconCheck with iconCloseLarge will keep the item aligned.