### PR TITLE
fix(android) fix crash when pending intent is created without flags

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -81,7 +81,8 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.7'
 
     if (!rootProject.ext.libreBuild) {
-        implementation 'com.google.android.gms:play-services-auth:16.0.1'
+        // Sync with react-native-google-signin
+        implementation 'com.google.android.gms:play-services-auth:19.0.2'
 
         // Firebase
         //  - Crashlytics


### PR DESCRIPTION
Fix for this crash:

~~~
Fatal Exception: java.lang.IllegalArgumentException: org.jitsi.meet: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
       at android.app.PendingIntent.checkFlags(PendingIntent.java:377)
       at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:460)
       at android.app.PendingIntent.getActivity(PendingIntent.java:446)
       at android.app.PendingIntent.getActivity(PendingIntent.java:410)
       at com.google.android.gms.common.GoogleApiAvailabilityLight.getErrorResolutionPendingIntent(GoogleApiAvailabilityLight.java:25)
       at com.google.android.gms.common.GoogleApiAvailabilityLight.getErrorResolutionPendingIntent(GoogleApiAvailabilityLight.java:21)
       at com.google.android.gms.common.GoogleApiAvailability.getErrorResolutionPendingIntent(GoogleApiAvailability.java:97)
       at com.google.android.gms.common.GoogleApiAvailability.getErrorResolutionPendingIntent(GoogleApiAvailability.java:100)
       at com.google.android.gms.common.GoogleApiAvailability.zaa(GoogleApiAvailability.java:41)
       at com.google.android.gms.common.api.internal.GoogleApiManager.zac(GoogleApiManager.java:214)
       at com.google.android.gms.common.api.internal.GoogleApiManager$zaa.onConnectionFailed(GoogleApiManager.java:86)
       at com.google.android.gms.common.api.internal.GoogleApiManager$zaa.connect(GoogleApiManager.java:219)
       at com.google.android.gms.common.api.internal.GoogleApiManager$zaa.zaa(GoogleApiManager.java:112)
       at com.google.android.gms.common.api.internal.GoogleApiManager.handleMessage(GoogleApiManager.java:145)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at com.google.android.gms.internal.base.zap.dispatchMessage(zap.java:8)
       at android.os.Looper.loopOnce(Looper.java:238)
       at android.os.Looper.loop(Looper.java:357)
       at android.os.HandlerThread.run(HandlerThread.java:67)
~~~

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
