### PR TITLE
feat(rnsdk) copy sounds files

### DIFF
--- a/react-native-sdk/android/build.gradle
+++ b/react-native-sdk/android/build.gradle
@@ -138,3 +138,19 @@ if (isNewArchitectureEnabled()) {
     codegenJavaPackageName = "org.jitsi.meet.sdk"
   }
 }
+
+// Copy sounds to assets directory
+android.libraryVariants.all { def variant ->
+    def mergeAssetsTask = variant.mergeAssetsProvider.get()
+    def mergeResourcesTask = variant.mergeResourcesProvider.get()
+    mergeAssetsTask.doLast {
+        def assetsDir = mergeAssetsTask.outputDir.get()
+        def soundsDir = "${projectDir}/../sounds"
+        copy {
+            from("${soundsDir}")
+            include("*.wav")
+            include("*.mp3")
+            into("${assetsDir}/sounds")
+        }
+    }
+}

--- a/react-native-sdk/jitsi-meet-rnsdk.podspec
+++ b/react-native-sdk/jitsi-meet-rnsdk.podspec
@@ -22,4 +22,14 @@ Pod::Spec.new do |s|
   s.dependency 'react-native-webrtc'
 
   s.dependency 'ObjectiveDropboxOfficial', '6.2.3'
+
+  s.script_phase = {
+      :name => 'Copy Sound Files',
+      :script => '
+          SOURCE_PATH="${PODS_TARGET_SRCROOT}/sounds"
+          TARGET_PATH="$(dirname ${CONFIGURATION_BUILD_DIR})"
+          PROJECT_NAME=$(basename $(dirname $(dirname ${PROJECT_DIR}))).app
+          cp -R "${PODS_TARGET_SRCROOT}/sounds/" "${TARGET_PATH}/${PROJECT_NAME}"
+      ',
+  }
 end


### PR DESCRIPTION
Copy sounds file 

- Add Copy Sounds step to build.gradle
- Include copy sounds step in podspec

_May not be the best solution, but the changes allow to copy the sound files as a part of build/installation process when integrated with a react-native host app._ 