### PR TITLE
fix(api) fix parsing API ID

### DIFF
--- a/modules/API/constants.js
+++ b/modules/API/constants.js
@@ -8,8 +8,15 @@ import { parseURLParams } from '../../react/features/base/util/parseURLParams';
 
 /**
  * JitsiMeetExternalAPI id - unique for a webpage.
+ * TODO: This shouldn't be computed here.
  */
-export const API_ID = parseURLParams(window.location).jitsi_meet_external_api_id;
+let _apiID;
+
+try {
+    _apiID = parseURLParams(window.location).jitsi_meet_external_api_id;
+} catch (_) { /* Ignore. */ }
+
+export const API_ID = _apiID;
 
 /**
  * The payload name for the datachannel/endpoint text message event.


### PR DESCRIPTION
Parsing the API ID happens at import time, which is not great because it also runs when loading the external API file.

In sites with weird URL patterns, such as Angular this will throw an exception.

Ignore parsing errors so it's left undefined. When modules/ is refactored we should look into making this a getter of some sort.

Fixes: https://github.com/jitsi/jitsi-meet/issues/11565

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
