### PR TITLE
fix(ios) disable CallKit when running in a simulator

### DIFF
--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -39,11 +39,6 @@
         [builder setFeatureFlag:@"ios.screensharing.enabled" withBoolean:YES];
         [builder setFeatureFlag:@"ios.recording.enabled" withBoolean:YES];
         builder.serverURL = [NSURL URLWithString:@"https://meet.jit.si"];
-#if TARGET_IPHONE_SIMULATOR
-        // CallKit has started to create problems starting with the iOS 16 simulator.
-        // Disable it since it never worked in the simulator anyway.
-        [builder setFeatureFlag:@"call-integration.enabled" withBoolean:NO];
-#endif
     }];
 
   [jitsiMeet application:application didFinishLaunchingWithOptions:launchOptions];

--- a/ios/sdk/src/AppInfo.m
+++ b/ios/sdk/src/AppInfo.m
@@ -70,10 +70,7 @@ RCT_EXPORT_MODULE();
         = [[NSBundle bundleForClass:self.class] infoDictionary];
     NSString *sdkVersion = sdkInfoDictionary[@"CFBundleShortVersionString"];
     if (sdkVersion == nil) {
-        sdkVersion = sdkInfoDictionary[@"CFBundleVersion"];
-        if (sdkVersion == nil) {
-            sdkVersion = @"";
-        }
+        sdkVersion = @"";
     }
 
     // build number

--- a/react/features/app/components/App.native.tsx
+++ b/react/features/app/components/App.native.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentType } from 'react';
 import { NativeModules, Platform, StyleSheet, View } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import SplashScreen from 'react-native-splash-screen';
 
@@ -36,7 +37,7 @@ interface IProps extends AbstractAppProps {
     /**
      * An object with the feature flags.
      */
-    flags: Object;
+    flags: any;
 
     /**
      * An object with user information (display name, email, avatar URL).
@@ -95,7 +96,13 @@ export class App extends AbstractApp<IProps> {
      */
     async _extraInit() {
         const { dispatch, getState } = this.state.store ?? {};
-        const { flags } = this.props;
+        const { flags = {} } = this.props;
+
+        // CallKit does not work on the simulator, make sure we disable it.
+        if (Platform.OS === 'ios' && DeviceInfo.isEmulatorSync()) {
+            flags['call-integration.enabled'] = false;
+            logger.info('Disabling CallKit because this is a simulator');
+        }
 
         // We set these early enough so then we avoid any unnecessary re-renders.
         dispatch?.(updateFlags(flags));


### PR DESCRIPTION
It doesn't work and causes weird failures. We used to disable it in the iOS app, but it's better to move it to JS since any SDK will benefit from it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
