### PR TITLE
feat(conference): hide lonely meeting exp in tile view

### DIFF
--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -443,7 +443,7 @@ class Conference extends AbstractConference<IProps, State> {
                         )
                     }
 
-                    <LonelyMeetingExperience />
+                    { !_shouldDisplayTileView && <LonelyMeetingExperience /> }
 
                     {
                         _shouldDisplayTileView


### PR DESCRIPTION
Before
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-25 at 14 06 04](https://github.com/jitsi/jitsi-meet/assets/26413496/1d55a111-fed0-4b6e-abef-9f3d899817d9)

After
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-25 at 14 06 19](https://github.com/jitsi/jitsi-meet/assets/26413496/b8fa9903-7892-448e-a32b-e90d606e7c75)

