### PR TITLE
fix(react-native-sdk): Declare JitsiMeeting `flags` prop as an object instead of an array

### DIFF
--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -18,7 +18,7 @@ import JitsiThemePaperProvider from './react/features/base/ui/components/JitsiTh
 
 
 interface IAppProps {
-    flags: [];
+    flags: object;
     meetingOptions: {
         domain: string;
         roomName: string;


### PR DESCRIPTION
The following code is producing TS compilation errors because `flags` is expecting an array.

```
<JitsiMeeting flags={{'recording.enabled': false}} meetingOptions={...} />
```