### PR TITLE
Rn jitsi sdk component unmount close

### DIFF
--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -122,15 +122,17 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
         }, []
     );
 
-    /**
-     * When you close the component you need to reset it.
-     * In some cases it needs to be added as the parent component may have been destroyed.
-     * Without this change the call remains active without having the jitsi screen.
-     */
-    useLayoutEffect(() => {
-        const dispatch = app.current?.state?.store?.dispatch;
 
-        dispatch && dispatch(appNavigate(undefined));
+    useLayoutEffect(() => {
+        /**
+         * When you close the component you need to reset it.
+         * In some cases it needs to be added as the parent component may have been destroyed.
+         * Without this change the call remains active without having the jitsi screen.
+        */
+        return () => {
+            const dispatch = app.current?.state?.store?.dispatch;
+            dispatch && dispatch(appNavigate(undefined));
+        }
     }, []);
 
 

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -6,7 +6,14 @@ import 'react-native-gesture-handler';
 import 'react-native-get-random-values';
 import './react/features/mobile/polyfills';
 
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, {
+    forwardRef,
+    useEffect,
+    useLayoutEffect,
+    useImperativeHandle,
+    useRef,
+    useState
+} from 'react';
 import { View, ViewStyle } from 'react-native';
 
 import { appNavigate } from './react/features/app/actions.native';
@@ -114,6 +121,18 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
             });
         }, []
     );
+
+    /**
+     * When you close the component you need to reset it.
+     * In some cases it needs to be added as the parent component may have been destroyed.
+     * Without this change the call remains active without having the jitsi screen.
+     */
+    useLayoutEffect(() => {
+        return () => {
+            const dispatch = app.current?.state?.store?.dispatch;
+            dispatch && dispatch(appNavigate(undefined));
+        };
+    }, []);
 
     return (
         <View style = { style as ViewStyle }>

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -123,6 +123,7 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
     );
 
 
+    // eslint-disable-next-line arrow-body-style
     useLayoutEffect(() => {
         /**
          * When you close the component you need to reset it.
@@ -131,7 +132,7 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
         */
         return () => {
             const dispatch = app.current?.state?.store?.dispatch;
-            
+
             dispatch && dispatch(appNavigate(undefined));
         };
     }, []);

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -128,11 +128,10 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
      * Without this change the call remains active without having the jitsi screen.
      */
     useLayoutEffect(() => {
-        return () => {
             const dispatch = app.current?.state?.store?.dispatch;
             dispatch && dispatch(appNavigate(undefined));
-        };
     }, []);
+
 
     return (
         <View style = { style as ViewStyle }>

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -9,8 +9,8 @@ import './react/features/mobile/polyfills';
 import React, {
     forwardRef,
     useEffect,
-    useLayoutEffect,
     useImperativeHandle,
+    useLayoutEffect,
     useRef,
     useState
 } from 'react';

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -131,8 +131,9 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
         */
         return () => {
             const dispatch = app.current?.state?.store?.dispatch;
+            
             dispatch && dispatch(appNavigate(undefined));
-        }
+        };
     }, []);
 
 

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -128,8 +128,9 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
      * Without this change the call remains active without having the jitsi screen.
      */
     useLayoutEffect(() => {
-            const dispatch = app.current?.state?.store?.dispatch;
-            dispatch && dispatch(appNavigate(undefined));
+        const dispatch = app.current?.state?.store?.dispatch;
+
+        dispatch && dispatch(appNavigate(undefined));
     }, []);
 
 


### PR DESCRIPTION
Hello

the problem is that the call remains active if the parent component is destroyed... in my case I need jitsi to manage autonomously the resources no longer needed when the component is closed and then close everything.

Sincerely