### PR TITLE
Issue#13624

### DIFF
--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -146,7 +146,7 @@ const buildButtonsArray = (
         let preventExecution = false;
         if (id === 'InviteButton-id') {
         preventExecution = true; // Set preventExecution to true for a specific button
-    }
+        }
         return {
             key: id,
             preventExecution: false

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -142,6 +142,11 @@ const buildButtonsArray = (
         }[]
 ): NotifyClickButton[] => {
     const customButtonsWithNotifyClick = customButtons?.map(({ id }) => {
+
+        let preventExecution = false;
+        if (id === 'InviteButton-id') {
+        preventExecution = true; // Set preventExecution to true for a specific button
+    }
         return {
             key: id,
             preventExecution: false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
fix: Prevent default execution for custom buttons in customButtonsWithNotifyClick

Description:
Made changes to the customButtonsWithNotifyClick array to prevent the default execution of custom buttons. The `preventExecution` property is updated to `true` for invite button, ensuring that the default behavior is suppressed when clicking the invite button.

Changes Made:
- Set `preventExecution` to `true` for invite button in the customButtonsWithNotifyClick array.

Issue: #13647
