### PR TITLE
(react-native-sdk) Makes `flags` and `eventListeners` props optional

### DIFF
--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -35,8 +35,8 @@ interface IUserInfo {
 
 interface IAppProps {
     config: object;
-    flags: object;
-    eventListeners: IEventListeners;
+    eventListeners?: IEventListeners;
+    flags?: object;
     room: string;
     serverURL?: string;
     style?: Object;
@@ -105,12 +105,12 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
             setAppProps({
                 'flags': flags,
                 'rnSdkHandlers': {
-                    onConferenceJoined: eventListeners.onConferenceJoined,
-                    onConferenceWillJoin: eventListeners.onConferenceWillJoin,
-                    onConferenceLeft: eventListeners.onConferenceLeft,
-                    onEnterPictureInPicture: eventListeners.onEnterPictureInPicture,
-                    onParticipantJoined: eventListeners.onParticipantJoined,
-                    onReadyToClose: eventListeners.onReadyToClose
+                    onConferenceJoined: eventListeners?.onConferenceJoined,
+                    onConferenceWillJoin: eventListeners?.onConferenceWillJoin,
+                    onConferenceLeft: eventListeners?.onConferenceLeft,
+                    onEnterPictureInPicture: eventListeners?.onEnterPictureInPicture,
+                    onParticipantJoined: eventListeners?.onParticipantJoined,
+                    onReadyToClose: eventListeners?.onReadyToClose
                 },
                 'url': urlProps,
                 'userInfo': userInfo


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
