### PR TITLE
Fix(desktopSharingFrameRate): default desktop sharing Framerate not applied when shared without changing desktop FPS from video settings

### DIFF
--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -19,6 +19,7 @@ import {
     IMobileDynamicLink
 } from './configType';
 import { _cleanupConfig, _setDeeplinkingDefaults } from './functions';
+import { SS_DEFAULT_FRAME_RATE } from '../../settings/constants';
 
 /**
  * The initial state of the feature base/config when executing in a
@@ -394,6 +395,9 @@ function _translateLegacyConfig(oldValue: IConfig) {
     ) {
         newValue.prejoinConfig.enabled = oldValue.prejoinPageEnabled;
     }
+
+    newValue.desktopSharingFrameRate = 
+        oldValue.desktopSharingFrameRate || { min: SS_DEFAULT_FRAME_RATE, max: SS_DEFAULT_FRAME_RATE };
 
     newValue.disabledSounds = newValue.disabledSounds || [];
 


### PR DESCRIPTION
By default, jitsi shares desktop sharing at 5 Frames Per Second. If you share the desktop it will not be applied, until you change the desktop FPS from settings in video section and restart desktop sharing. This fix will pass the default values set for desktop sharing FPS
