### PR TITLE
fix(rn, appNavigate) make sure tracks are created before prejoin

### DIFF
--- a/react/features/app/actions.native.ts
+++ b/react/features/app/actions.native.ts
@@ -137,25 +137,24 @@ export function appNavigate(uri?: string, options: IReloadNowOptions = {}) {
         dispatch(setConfig(config));
         dispatch(setRoom(room));
 
-        if (room) {
+        if (!room) {
+            goBackToRoot(getState(), dispatch);
+
+            return;
+        }
+
+        dispatch(createDesiredLocalTracks());
+        dispatch(clearNotifications());
+
+        if (!options.hidePrejoin && isPrejoinPageEnabled(getState())) {
             if (isUnsafeRoomWarningEnabled(getState()) && isInsecureRoomName(room)) {
                 navigateRoot(screen.unsafeRoomWarning);
-
-                return;
-            }
-            dispatch(createDesiredLocalTracks());
-            dispatch(clearNotifications());
-
-            const { hidePrejoin } = options;
-
-            if (!hidePrejoin && isPrejoinPageEnabled(getState())) {
-                navigateRoot(screen.preJoin);
             } else {
-                dispatch(connect());
-                navigateRoot(screen.conference.root);
+                navigateRoot(screen.preJoin);
             }
         } else {
-            goBackToRoot(getState(), dispatch);
+            dispatch(connect());
+            navigateRoot(screen.conference.root);
         }
     };
 }


### PR DESCRIPTION
- Create the tracks early, or there will be on audio on iOS on the first unmute this includes the unsafe room name screen
- Skip the unsafe room screen if prejoin is disabled, like web

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
