### PR TITLE
fix(lobby-chat): prevent keyboard from hiding input

### DIFF
--- a/react/features/lobby/components/native/LobbyChatScreen.tsx
+++ b/react/features/lobby/components/native/LobbyChatScreen.tsx
@@ -29,7 +29,9 @@ class LobbyChatScreen extends
         const { _lobbyChatMessages } = this.props;
 
         return (
-            <JitsiScreen style = { styles.lobbyChatWrapper }>
+            <JitsiScreen
+                hasTabNavigator = { true }
+                style = { styles.lobbyChatWrapper }>
                 {/* @ts-ignore */}
                 <MessageContainer messages = { _lobbyChatMessages } />
                 <ChatInputBar onSend = { this._onSendMessage } />


### PR DESCRIPTION
In the Lobby chat in iOS, the keyboard covers up the input field, so the participant in the lobby can't see what they're typing. This doesn't happen in the regular Chat, apparently due to the hasTabNavigator prop on JitsiScreen. Added that prop to the LobbyChat. (Should the other props from Chat should be applied to the JitsiScreen in LobbyChat also?)