### PR TITLE
docs: fix typo in jsdoc comment

### DIFF
--- a/react/features/base/tracks/loadEffects.native.ts
+++ b/react/features/base/tracks/loadEffects.native.ts
@@ -2,7 +2,7 @@
  * Loads the enabled stream effects.
  *
  * @param {Object} _store - The Redux store.
- * @returns {Promsie} - A Promise which resolves with an array of the loaded effects.
+ * @returns {Promise} - A Promise which resolves with an array of the loaded effects.
  */
 export default function loadEffects(_store: Object): Promise<Array<any>> {
     return Promise.resolve([]);

--- a/react/features/base/tracks/loadEffects.web.ts
+++ b/react/features/base/tracks/loadEffects.web.ts
@@ -8,7 +8,7 @@ import logger from './logger';
  * Loads the enabled stream effects.
  *
  * @param {Object} store - The Redux store.
- * @returns {Promsie} - A Promise which resolves when all effects are created.
+ * @returns {Promise} - A Promise which resolves when all effects are created.
  */
 export default function loadEffects(store: IStore): Promise<any> {
     const state = store.getState();


### PR DESCRIPTION
This PR fixes a typos in JSDOC comments.