### PR TITLE
chore(tileview) Add config for disabling tileview

### DIFF
--- a/config.js
+++ b/config.js
@@ -1594,6 +1594,8 @@ var config = {
 
     // Tile view related config options.
     // tileView: {
+    //     // Tileview is disabled only if enabled flag is specifically set to false. If not specified, it is enabled.
+    //     enabled: true,
     //     // The optimal number of tiles that are going to be shown in tile view. Depending on the screen size it may
     //     // not be possible to show the exact number of participants specified here.
     //     numberOfVisibleTiles: 25,

--- a/config.js
+++ b/config.js
@@ -1594,8 +1594,8 @@ var config = {
 
     // Tile view related config options.
     // tileView: {
-    //     // Tileview is disabled only if enabled flag is specifically set to false. If not specified, it is enabled.
-    //     enabled: true,
+    //     // Whether tileview should be disabled.
+    //     disabled: false,
     //     // The optimal number of tiles that are going to be shown in tile view. Depending on the screen size it may
     //     // not be possible to show the exact number of participants specified here.
     //     numberOfVisibleTiles: 25,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -573,7 +573,7 @@ export interface IConfig {
         testMode?: boolean;
     };
     tileView?: {
-        enabled?: boolean;
+        disabled?: boolean;
         numberOfVisibleTiles?: number;
     };
     tokenAuthUrl?: string;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -573,6 +573,7 @@ export interface IConfig {
         testMode?: boolean;
     };
     tileView?: {
+        enabled?: boolean;
         numberOfVisibleTiles?: number;
     };
     tokenAuthUrl?: string;

--- a/react/features/base/ui/constants.web.ts
+++ b/react/features/base/ui/constants.web.ts
@@ -260,6 +260,7 @@ export const commonStyles = (theme: Theme) => {
             padding: 6,
             textAlign: 'center' as const,
             pointerEvents: 'all' as const,
+            display: 'flex',
             boxShadow: '0px 2px 8px 4px rgba(0, 0, 0, 0.25), 0px 0px 0px 1px rgba(0, 0, 0, 0.15)',
 
             '& > div': {

--- a/react/features/filmstrip/functions.any.ts
+++ b/react/features/filmstrip/functions.any.ts
@@ -1,4 +1,4 @@
-import { IStore } from '../app/types';
+import { IReduxState, IStore } from '../app/types';
 import {
     getActiveSpeakersToBeDisplayed,
     getVirtualScreenshareParticipantOwnerId
@@ -94,4 +94,16 @@ export function updateRemoteParticipantsOnLeave(store: IStore, participantId: st
 
     reorderedParticipants.delete(participantId)
         && store.dispatch(setRemoteParticipants(Array.from(reorderedParticipants)));
+}
+
+/**
+ * Returns whether tileview is completely disabled.
+ *
+ * @param {IReduxState} state - Redux state.
+ * @returns {boolean} - Whether tileview is completely disabled.
+ */
+export function isTileViewModeDisabled(state: IReduxState) {
+    const { tileView = {} } = state['features/base/config'];
+
+    return tileView.enabled === false;
 }

--- a/react/features/filmstrip/functions.any.ts
+++ b/react/features/filmstrip/functions.any.ts
@@ -105,5 +105,5 @@ export function updateRemoteParticipantsOnLeave(store: IStore, participantId: st
 export function isTileViewModeDisabled(state: IReduxState) {
     const { tileView = {} } = state['features/base/config'];
 
-    return tileView.enabled === false;
+    return tileView.disabled;
 }

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -290,7 +290,7 @@ const Toolbox = ({
 
         setButtonsNotifyClickMode(buttons);
         const isHangupVisible = isToolbarButtonEnabled('hangup', _toolbarButtons);
-        let { order } = THRESHOLDS.find(({ width }) => _clientWidth > width)
+        const { order } = THRESHOLDS.find(({ width }) => _clientWidth > width)
             || THRESHOLDS[THRESHOLDS.length - 1];
 
         const keys = Object.keys(buttons);
@@ -302,11 +302,8 @@ const Toolbox = ({
             !_jwtDisabledButtons.includes(key)
             && (isToolbarButtonEnabled(key, _toolbarButtons) || isToolbarButtonEnabled(alias, _toolbarButtons))
         );
-        const filteredKeys = filtered.map(button => button.key);
 
-        order = order.filter(key => filteredKeys.includes(buttons[key as keyof typeof buttons].key));
-
-        let sliceIndex = order.length + 2;
+        let sliceIndex = _overflowDrawer ? order.length + 2 : order.length + 1;
 
         if (isHangupVisible) {
             sliceIndex -= 1;

--- a/react/features/video-layout/actions.any.ts
+++ b/react/features/video-layout/actions.any.ts
@@ -36,9 +36,9 @@ export function virtualScreenshareParticipantsUpdated(participantIds: Array<stri
  */
 export function setTileView(enabled?: boolean) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
-        const tileviewDisabled = isTileViewModeDisabled(getState());
+        const tileViewDisabled = isTileViewModeDisabled(getState());
 
-        !tileviewDisabled && dispatch({
+        !tileViewDisabled && dispatch({
             type: SET_TILE_VIEW,
             enabled
         });

--- a/react/features/video-layout/actions.any.ts
+++ b/react/features/video-layout/actions.any.ts
@@ -1,4 +1,5 @@
 import { IStore } from '../app/types';
+import { isTileViewModeDisabled } from '../filmstrip/functions.any';
 
 import {
     SET_TILE_VIEW,
@@ -34,9 +35,13 @@ export function virtualScreenshareParticipantsUpdated(participantIds: Array<stri
  * }}
  */
 export function setTileView(enabled?: boolean) {
-    return {
-        type: SET_TILE_VIEW,
-        enabled
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const tileviewDisabled = isTileViewModeDisabled(getState());
+
+        !tileviewDisabled && dispatch({
+            type: SET_TILE_VIEW,
+            enabled
+        });
     };
 }
 

--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -60,9 +60,9 @@ export function getCurrentLayout(state: IReduxState) {
  * @returns {boolean} True if tile view should be displayed.
  */
 export function shouldDisplayTileView(state: IReduxState) {
-    const tileviewDisabled = isTileViewModeDisabled(state);
+    const tileViewDisabled = isTileViewModeDisabled(state);
 
-    if (tileviewDisabled) {
+    if (tileViewDisabled) {
         return false;
     }
 

--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -4,7 +4,7 @@ import { getFeatureFlag } from '../base/flags/functions';
 import { pinParticipant } from '../base/participants/actions';
 import { getParticipantCount, getPinnedParticipant } from '../base/participants/functions';
 import { FakeParticipant } from '../base/participants/types';
-import { isStageFilmstripAvailable } from '../filmstrip/functions';
+import { isStageFilmstripAvailable, isTileViewModeDisabled } from '../filmstrip/functions';
 import { isVideoPlaying } from '../shared-video/functions';
 import { VIDEO_QUALITY_LEVELS } from '../video-quality/constants';
 import { getReceiverVideoQualityLevel } from '../video-quality/functions';
@@ -60,6 +60,12 @@ export function getCurrentLayout(state: IReduxState) {
  * @returns {boolean} True if tile view should be displayed.
  */
 export function shouldDisplayTileView(state: IReduxState) {
+    const tileviewDisabled = isTileViewModeDisabled(state);
+
+    if (tileviewDisabled) {
+        return false;
+    }
+
     const { tileViewEnabled } = state['features/video-layout'] ?? {};
 
     if (tileViewEnabled !== undefined) {


### PR DESCRIPTION
- show fixed number of toolbar buttons in toolbar (including custom buttons) instead of sending to overflow menu


before:
![image](https://github.com/jitsi/jitsi-meet/assets/39557534/d6099d3a-a9d1-469e-badc-d8db30e91cb7)

after:
![image](https://github.com/jitsi/jitsi-meet/assets/39557534/feda2cec-7088-426f-8d5b-3e46e4ed5c2e)


<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
