### PR TITLE
Fix: Issue #13705 - "Copy Sound Files" Phase failing on iOS Archive

### DIFF
--- a/react-native-sdk/jitsi-meet-rnsdk.podspec
+++ b/react-native-sdk/jitsi-meet-rnsdk.podspec
@@ -26,10 +26,10 @@ Pod::Spec.new do |s|
   s.script_phase = {
       :name => 'Copy Sound Files',
       :script => '
-          SOURCE_PATH="${PODS_TARGET_SRCROOT}/sounds"
-          TARGET_PATH="$(dirname ${CONFIGURATION_BUILD_DIR})"
-          PROJECT_NAME=$(basename $(dirname $(dirname ${PROJECT_DIR}))).app
-          cp -R "${PODS_TARGET_SRCROOT}/sounds/" "${TARGET_PATH}/${PROJECT_NAME}"
+          SOURCE_PATH="${PODS_TARGET_SRCROOT}/sounds/"
+          TARGET_PATH=$(dirname "${CONFIGURATION_BUILD_DIR}")
+          PROJECT_NAME=$(basename $(dirname $(dirname "${PROJECT_DIR}"))).app
+          cp -R "${SOURCE_PATH}" "${TARGET_PATH}/${PROJECT_NAME}"
       ',
   }
 end


### PR DESCRIPTION
Fix for Issue #13705 causing the "Copy Sound Files" Phase to fail with a nonzero exit code when attempting to Archive a project.