### PR TITLE
fix(i18next): use i18next-http-backend and fix ts-ignore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "i18n-iso-countries": "6.8.0",
         "i18next": "17.0.6",
         "i18next-browser-languagedetector": "3.0.1",
-        "i18next-xhr-backend": "3.0.0",
+        "i18next-http-backend": "^2.2.1",
         "image-capture": "0.4.0",
         "jquery": "3.6.1",
         "jquery-i18next": "1.2.1",
@@ -8342,6 +8342,14 @@
         "@emotion/utils": "0.11.3"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "dependencies": {
+        "node-fetch": "^2.6.11"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11197,13 +11205,12 @@
       "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-3.0.1.tgz",
       "integrity": "sha512-WFjPLNPWl62uu07AHY2g+KsC9qz0tyMq+OZEB/H7N58YKL/JLiCz9U709gaR20Mule/Ppn+uyfVx5REJJjn1HA=="
     },
-    "node_modules/i18next-xhr-backend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.0.0.tgz",
-      "integrity": "sha512-Pi/X91Zk2nEqdEHTV+FG6VeMHRcMcPKRsYW/A0wlaCfKsoJc3TI7A75Tqse/d5LVGN2Ymzx0FT+R+gLag9Eb2g==",
-      "deprecated": "replaced by i18next-http-backend",
+    "node_modules/i18next-http-backend": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.2.1.tgz",
+      "integrity": "sha512-ZXIdn/8NJIBJ0X4hzXfc3STYxKrCKh1fYjji9HPyIpEJfvTvy8/ZlTl8RuTizzCPj2ZcWrfaecyOMKs6bQ7u5A==",
       "dependencies": {
-        "@babel/runtime": "^7.4.5"
+        "cross-fetch": "3.1.6"
       }
     },
     "node_modules/iconv-lite": {
@@ -14091,9 +14098,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -25945,6 +25952,14 @@
         "@emotion/utils": "0.11.3"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "requires": {
+        "node-fetch": "^2.6.11"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -28125,12 +28140,12 @@
       "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-3.0.1.tgz",
       "integrity": "sha512-WFjPLNPWl62uu07AHY2g+KsC9qz0tyMq+OZEB/H7N58YKL/JLiCz9U709gaR20Mule/Ppn+uyfVx5REJJjn1HA=="
     },
-    "i18next-xhr-backend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.0.0.tgz",
-      "integrity": "sha512-Pi/X91Zk2nEqdEHTV+FG6VeMHRcMcPKRsYW/A0wlaCfKsoJc3TI7A75Tqse/d5LVGN2Ymzx0FT+R+gLag9Eb2g==",
+    "i18next-http-backend": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.2.1.tgz",
+      "integrity": "sha512-ZXIdn/8NJIBJ0X4hzXfc3STYxKrCKh1fYjji9HPyIpEJfvTvy8/ZlTl8RuTizzCPj2ZcWrfaecyOMKs6bQ7u5A==",
       "requires": {
-        "@babel/runtime": "^7.4.5"
+        "cross-fetch": "3.1.6"
       }
     },
     "iconv-lite": {
@@ -30325,9 +30340,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "i18n-iso-countries": "6.8.0",
     "i18next": "17.0.6",
     "i18next-browser-languagedetector": "3.0.1",
-    "i18next-xhr-backend": "3.0.0",
+    "i18next-http-backend": "^2.2.1",
     "image-capture": "0.4.0",
     "jquery": "3.6.1",
     "jquery-i18next": "1.2.1",

--- a/react/features/base/i18n/i18next.ts
+++ b/react/features/base/i18n/i18next.ts
@@ -1,6 +1,6 @@
 import COUNTRIES_RESOURCES from 'i18n-iso-countries/langs/en.json';
 import i18next from 'i18next';
-import I18nextXHRBackend from 'i18next-xhr-backend';
+import I18nextXHRBackend, { HttpBackendOptions } from 'i18next-http-backend';
 import _ from 'lodash';
 
 import LANGUAGES_RESOURCES from '../../../../lang/languages.json';
@@ -61,10 +61,10 @@ export const DEFAULT_LANGUAGE = 'en';
 /**
  * The options to initialize i18next with.
  *
- * @type {Object}
+ * @type {i18next.InitOptions}
  */
-const options = {
-    backend: {
+const options: i18next.InitOptions = {
+    backend: <HttpBackendOptions>{
         loadPath: 'lang/{{ns}}-{{lng}}.json'
     },
     defaultNS: 'main',
@@ -76,6 +76,7 @@ const options = {
     ns: [ 'main', 'languages', 'countries', 'translation-languages' ],
     react: {
         // re-render when a new resource bundle is added
+        // @ts-expect-error. Fixed in i18next 19.6.1.
         bindI18nStore: 'added',
         useSuspense: false
     },
@@ -89,7 +90,7 @@ const options = {
 
 i18next
     .use(navigator.product === 'ReactNative' ? {} : I18nextXHRBackend)
-    .use(languageDetector) // @ts-ignore
+    .use(languageDetector)
     .init(options);
 
 // Add default language which is preloaded from the source code.


### PR DESCRIPTION
i18next-xhr-backend is not maintained any more and [superseded](https://github.com/i18next/i18next-xhr-backend/issues/348#issuecomment-663060275) by i18next-http-backend.