### PR TITLE
fix(jitsi-local-storage):Is empty after reload

### DIFF
--- a/react/features/base/jitsi-local-storage/setup.web.ts
+++ b/react/features/base/jitsi-local-storage/setup.web.ts
@@ -17,6 +17,8 @@ import logger from './logger';
  * @returns {void}
  */
 function onFakeLocalStorageChanged() {
+    console.error(jitsiLocalStorage.serialize([ 'jitsiLocalStorage' ]));
+
     APP.API.notifyLocalStorageChanged(jitsiLocalStorage.serialize([ 'jitsiLocalStorage' ]));
 }
 
@@ -63,6 +65,13 @@ function setupJitsiLocalStorage() {
         try {
             const localStorageContent = safeJsonParse(urlParams['appData.localStorageContent']);
 
+            // We need to disable the local storage before setting the data in case the browser local storage doesn't
+            // throw exception (in some cases when this happens the local storage may be cleared for every session.
+            // Example: when loading meet from cross-domain with the IFrame API with Brave with the default
+            // configuration). Otherwise we will set the data in the browser local storage and then switch to the dummy
+            // local storage from jitsiLocalStorage and we will loose the data.
+            jitsiLocalStorage.setLocalStorageDisabled(true);
+
             if (typeof localStorageContent === 'object') {
                 Object.keys(localStorageContent).forEach(key => {
                     jitsiLocalStorage.setItem(key, localStorageContent[key]);
@@ -72,7 +81,6 @@ function setupJitsiLocalStorage() {
             logger.error('Can\'t parse localStorageContent.', error);
         }
 
-        jitsiLocalStorage.setLocalStorageDisabled(true);
         jitsiLocalStorage.on('changed', onFakeLocalStorageChanged);
     }
 }


### PR DESCRIPTION
When using useHostPageLocalStorage on the iframe api and local storage
is not throwing error we were writting the passed data to the original
local storage and then switching to the dummy local storage from
jitsiLocalStorage.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
