### PR TITLE
Fix missing closing tag for identity node in presence stanza

### DIFF
--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -236,9 +236,9 @@ function update_presence_identity(
         if creator_group then
             stanza:tag("creator_group"):text(creator_group):up();
         end
-        stanza:up();
     end
 
+    stanza:up(); -- Close identity tag
 end
 
 -- Utility function to check whether feature is present and enabled. Allow


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Fix closing of identity tag opened at line 215.

It was closed only if `creator_user` was present. This caused any prosody module following `mod_presence_identity` to add children nodes to `identity` instead of the root `presence` node (in the absence of the `creator_user` property). 