### PR TITLE
fix(config): missing colon in example for lobby config

### DIFF
--- a/config.js
+++ b/config.js
@@ -588,7 +588,7 @@ var config = {
     // },
 
     // Configs for the lobby screen.
-    // lobby {
+    // lobby: {
     //     // If Lobby is enabled, it starts knocking automatically. Replaces `autoKnockLobby`.
     //     autoKnock: false,
     //     // Enables the lobby chat. Replaces `enableLobbyChat`.


### PR DESCRIPTION
Example config is invalid JS due to typo and could confuse new users. E.g https://community.jitsi.org/t/problem-with-lobby/126890?u=shawn