### PR TITLE
fix: Mobile browser fixes (Chrome for Android), changing "vh" to "dvh" for all layout

### DIFF
--- a/css/_reactions-menu.scss
+++ b/css/_reactions-menu.scss
@@ -154,17 +154,17 @@ $reactionCount: 20;
 	}
 
 	70% {
-		transform: translate(40px, -70vh) scale(1.5);
+		transform: translate(40px, -70dvh) scale(1.5);
 		opacity: 1;
 	}
 
 	75% {
-		transform: translate(40px, -70vh) scale(1.5);
+		transform: translate(40px, -70dvh) scale(1.5);
 		opacity: 1;
 	}
 
 	100% {
-		transform: translate(140px, -50vh) scale(1);
+		transform: translate(140px, -50dvh) scale(1);
 		opacity: 0;
 	}
 }
@@ -187,17 +187,17 @@ $reactionCount: 20;
 			}
 
 			70% {
-				transform: translate(#{$topX}px, -#{$topY}vh) scale(1.5);
+				transform: translate(#{$topX}px, -#{$topY}dvh) scale(1.5);
 				opacity: 1;
 			}
 
 			75% {
-				transform: translate(#{$topX}px, -#{$topY}vh) scale(1.5);
+				transform: translate(#{$topX}px, -#{$topY}dvh) scale(1.5);
 				opacity: 1;
 			}
 
 			100% {
-				transform: translate(#{$bottomX}px, -#{$bottomY}vh) scale(1);
+				transform: translate(#{$bottomX}px, -#{$bottomY}dvh) scale(1);
 				opacity: 0;
 			}
 		}

--- a/css/_videolayout_default.scss
+++ b/css/_videolayout_default.scss
@@ -266,10 +266,10 @@
     #avatarContainer {
         border-radius: 50%;
         display: inline-block;
-        height: 50vh;
-        margin-top: 25vh;
+        height: 50dvh;
+        margin-top: 25dvh;
         overflow: hidden;
-        width: 50vh;
+        width: 50dvh;
 
         #avatar {
             height: 100%;

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -10,7 +10,7 @@ body.welcome-page {
     flex-direction: column;
     font-family: $welcomePageFontFamily;
     justify-content: space-between;
-    min-height: 100vh;
+    min-height: 100dvh;
     position: relative;
 
     .header {

--- a/css/deep-linking/_mobile.scss
+++ b/css/deep-linking/_mobile.scss
@@ -1,6 +1,6 @@
 .deep-linking-mobile {
     background-color: #fff;
-    height: 100vh;
+    height: 100dvh;
     overflow: auto;
     position: relative;
     width: 100vw;

--- a/react/features/base/ui/constants.web.ts
+++ b/react/features/base/ui/constants.web.ts
@@ -139,7 +139,7 @@ export const commonStyles = (theme: Theme) => {
                 alignItems: 'center',
                 background: 'rgba(0,0,0,0.6)',
                 display: 'flex',
-                height: '100vh',
+                height: '100dvh',
                 justifyContent: 'center',
                 left: 0,
                 position: 'absolute' as const,

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -90,7 +90,7 @@ const useStyles = makeStyles()(theme => {
             zIndex: 300,
 
             '@media (max-width: 580px)': {
-                height: '100vh',
+                height: '100dvh',
                 position: 'fixed',
                 left: 0,
                 right: 0,

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
@@ -30,7 +30,7 @@ const useStyles = makeStyles()((theme: Theme) => {
         container: {
             background: '#1E1E1E',
             width: '100vw',
-            height: '100vh',
+            height: '100dvh',
             overflowX: 'hidden',
             overflowY: 'auto',
             justifyContent: 'center',

--- a/react/features/invite/components/dial-in-summary/web/DialInSummary.tsx
+++ b/react/features/invite/components/dial-in-summary/web/DialInSummary.tsx
@@ -93,7 +93,7 @@ const styles = (theme: Theme) => {
             color: theme.palette.text01
         },
         scrollable: {
-            height: '100vh',
+            height: '100dvh',
             overflowY: 'scroll' as const
         },
         roomName: {

--- a/react/features/participants-pane/components/web/ParticipantsPane.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsPane.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles()(theme => {
             },
 
             '@media (max-width: 580px)': {
-                height: '100vh',
+                height: '100dvh',
                 position: 'fixed',
                 left: 0,
                 right: 0,

--- a/react/features/settings/components/web/audio/AudioSettingsContent.tsx
+++ b/react/features/settings/components/web/audio/AudioSettingsContent.tsx
@@ -98,7 +98,7 @@ const useStyles = makeStyles()(theme => {
             right: 'auto',
             margin: 0,
             marginBottom: theme.spacing(1),
-            maxHeight: 'calc(100vh - 100px)',
+            maxHeight: 'calc(100dvh - 100px)',
             overflow: 'auto',
             width: '300px'
         },

--- a/react/features/settings/components/web/video/VideoSettingsContent.tsx
+++ b/react/features/settings/components/web/video/VideoSettingsContent.tsx
@@ -62,7 +62,7 @@ export interface IProps {
 const useStyles = makeStyles()(theme => {
     return {
         container: {
-            maxHeight: 'calc(100vh - 100px)',
+            maxHeight: 'calc(100dvh - 100px)',
             overflow: 'auto',
             margin: 0,
             marginBottom: theme.spacing(1),

--- a/react/features/toolbox/components/web/Drawer.tsx
+++ b/react/features/toolbox/components/web/Drawer.tsx
@@ -37,7 +37,7 @@ interface IProps {
 const useStyles = makeStyles()(theme => {
     return {
         drawerMenuContainer: {
-            height: '100vh',
+            height: '100dvh',
             display: 'flex',
             alignItems: 'flex-end'
         },

--- a/react/features/toolbox/components/web/OverflowMenuButton.tsx
+++ b/react/features/toolbox/components/web/OverflowMenuButton.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles<{ overflowDrawer: boolean; reactionsMenuHeight: num
             right: 'auto',
             margin: 0,
             marginBottom: '8px',
-            maxHeight: overflowDrawer ? undefined : 'calc(100vh - 100px)',
+            maxHeight: overflowDrawer ? undefined : 'calc(100dvh - 100px)',
             paddingBottom: overflowDrawer ? undefined : 0,
             minWidth: '240px',
             overflow: 'hidden'
@@ -88,7 +88,7 @@ const useStyles = makeStyles<{ overflowDrawer: boolean; reactionsMenuHeight: num
         content: {
             position: 'relative',
             maxHeight: overflowDrawer
-                ? `calc(100% - ${reactionsMenuHeight}px - 16px)` : `calc(100vh - 100px - ${reactionsMenuHeight}px)`,
+                ? `calc(100% - ${reactionsMenuHeight}px - 16px)` : `calc(100dvh - 100px - ${reactionsMenuHeight}px)`,
             overflowY: 'auto'
         },
         footer: {

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -153,7 +153,7 @@ const useStyles = makeStyles()(() => {
             right: 'auto',
             margin: 0,
             marginBottom: '8px',
-            maxHeight: 'calc(100vh - 100px)',
+            maxHeight: 'calc(100dvh - 100px)',
             minWidth: '240px'
         },
 

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -36,7 +36,7 @@ export const NOT_APPLICABLE = 'N/A';
 
 export const TOOLBAR_TIMEOUT = 4000;
 
-export const DRAWER_MAX_HEIGHT = '80vh - 64px';
+export const DRAWER_MAX_HEIGHT = '80dvh - 64px';
 
 export const NOTIFY_CLICK_MODE = {
     ONLY_NOTIFY: 'ONLY_NOTIFY',


### PR DESCRIPTION
This PR fixes a number of layout issues with the "Chrome for Android" browser. The issue comes from a lot of the UI using `vh` unit to determine window height. This works for all desktop browsers, but on "Chrome for Android" there's an address bar too. As you can see in the screenshots below, this doesn't calculate well and causes issues such as this https://github.com/jitsi/jitsi-meet/issues/13808 .

The fix (since this is now properly supported in browsers) is to use `dvh` instead, which takes the address bar into account.

This seems to work well from what I can see, but as this is my first PR (hurray!), perhaps a quick test would be in order (by someone other than me). 

<details>

<summary>Screenshots of the (now fixed) problem here:</summary>

![imgonline-com-ua-dexifm482wpetZxya](https://github.com/jitsi/jitsi-meet/assets/5020508/1f26686f-e90c-4148-bf93-2ef9988ad9fc)
![imgonline-com-ua-dexif0AAyznoJMaEM](https://github.com/jitsi/jitsi-meet/assets/5020508/c48ca893-f217-4c3e-a32e-457799c72fb9)

</details>

<details>

<summary>Screenshot of fixed chat UI:</summary>

![fixed-imgonline-com-ua-dexifB8CBR1T6qLFT](https://github.com/jitsi/jitsi-meet/assets/5020508/f0ebae61-0892-45cf-8131-2763dd55bc8b)

</details>

Thank you! 🙌

