### PR TITLE
refactor(watermark): Move static styles into stylesheet, refactor a bit

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -115,17 +115,18 @@ form {
 }
 
 .leftwatermark {
+    max-width: 140px;
+    max-height:70px;
     left: 32px;
     top: 32px;
     background-position: center left;
     background-repeat: no-repeat;
     background-size: contain;
-}
 
-.leftwatermarknomargin {
-    background-position: center left;
-    background-repeat: no-repeat;
-    background-size: contain;
+    &.no-margin {
+        left:0;
+        top:0;
+    }
 }
 
 .rightwatermark {

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -231,11 +231,6 @@ body.welcome-page {
             width: $welcomePageWatermarkWidth;
             height: $welcomePageWatermarkHeight;
         }
-
-        .watermark.leftwatermarknomargin {
-            width: $welcomePageWatermarkWidth;
-            height: $welcomePageWatermarkHeight;
-        }
     }
 
     &.without-content {

--- a/react/features/base/react/components/web/Watermarks.tsx
+++ b/react/features/base/react/components/web/Watermarks.tsx
@@ -158,15 +158,13 @@ class Watermarks extends Component<IProps, State> {
             _showJitsiWatermark
         } = this.props;
         const { noMargins, t } = this.props;
-        const className = `watermark ${noMargins ? 'leftwatermarknomargin' : 'leftwatermark'}`;
+        const className = `watermark leftwatermark ${noMargins ? 'no-margin' : ''}`;
 
         let reactElement = null;
 
         if (_showJitsiWatermark) {
             const style = {
                 backgroundImage: `url(${_logoUrl})`,
-                maxWidth: 140,
-                maxHeight: 70,
                 position: _logoLink ? 'static' : 'absolute'
             } as const;
 


### PR DESCRIPTION
This PR refactors the watermark styles, moving the `maxWidth` and `maxHeight` to the .scss file instead. Some light refactoring too. 

It will also resolve https://github.com/jitsi/jitsi-meet/issues/8604.

Thank you! 🙌