### PR TITLE
fix: Fixes skipping the lobby for two times in a row for jibri.

### DIFF
--- a/resources/prosody-plugins/mod_muc_flip.lua
+++ b/resources/prosody-plugins/mod_muc_flip.lua
@@ -58,7 +58,7 @@ module:hook("muc-occupant-pre-join", function(event)
                 -- allow participant from flip device to bypass Lobby
                 local occupant_jid = stanza.attr.from;
                 local affiliation = room:get_affiliation(occupant_jid);
-                if not affiliation or affiliation == 0 then
+                if not affiliation or affiliation == 'none' or affiliation == 'member' then
                     module:log("debug", "Bypass lobby invitee %s", occupant_jid)
                     occupant.role = "participant";
                     room:set_affiliation(true, jid_bare(occupant_jid), "member")

--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -392,7 +392,8 @@ process_host_module(main_muc_component_config, function(host_module, host)
 
         if whitelistJoin then
             local affiliation = room:get_affiliation(invitee);
-            if not affiliation or affiliation == 0 then
+            -- if it was already set to be whitelisted member
+            if not affiliation or affiliation == 'none' or affiliation == 'member' then
                 occupant.role = 'participant';
                 room:set_affiliation(true, invitee_bare_jid, 'member');
                 room:save();


### PR DESCRIPTION
An issue where a livestreaming is started for a second time in a meeting with lobby turned on.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
