### PR TITLE
#13914 BreakoutRoom Raise Condition In Timer

### DIFF
--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -362,11 +362,11 @@ function on_occupant_joined(event)
         return;
     end
 
-    local main_room = get_main_room(room.jid);
+    local main_room, main_room_jid = get_main_room(room.jid);
 
     if main_room and main_room._data.breakout_rooms_active then
         if jid_node(event.occupant.jid) ~= 'focus' then
-            broadcast_breakout_rooms(room.jid);
+            broadcast_breakout_rooms(main_room_jid);
         end
 
         -- Prevent closing all rooms if a participant has joined (see on_occupant_left).
@@ -411,14 +411,14 @@ function on_occupant_left(event)
         return;
     end
 
-    local main_room = get_main_room(room_jid);
+    local main_room, main_room_jid = get_main_room(room_jid);
 
     if not main_room then
         return;
     end
 
     if main_room._data.breakout_rooms_active and jid_node(event.occupant.jid) ~= 'focus' then
-        broadcast_breakout_rooms(room_jid);
+        broadcast_breakout_rooms(main_room_jid);
     end
 
     -- Close the conference if all left for good.


### PR DESCRIPTION
When timer is set by breakout_room_jid, if breakoutroom is removed, earlier set timer can not find mainroom. And mainroom's broadcast_timer is never set to nil. Then no other message can be broadcasted, since broadcast checks whether a timer has been already set. 

If all timer functionality is set by main_room_jid, mainroom can still be found.
