### PR TITLE
Change Whiteboard room id generation

### DIFF
--- a/react/features/whiteboard/functions.ts
+++ b/react/features/whiteboard/functions.ts
@@ -75,7 +75,7 @@ export const getCollabServerUrl = (state: IReduxState): string | undefined => {
     const { locationURL } = state['features/base/connection'];
     const inBreakoutRoom = isInBreakoutRoom(state);
     const roomId = getCurrentRoomId(state);
-    const room = md5.hex(`${locationURL?.href}${inBreakoutRoom ? `|${roomId}` : ''}`);
+    const room = md5.hex(`${locationURL?.origin}${locationURL?.pathname}${inBreakoutRoom ? `|${roomId}` : ''}`);
 
     return appendURLParam(collabServerBaseUrl, 'room', room);
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

A simple modification in the Whiteboard Room id computation to avoid using the jwt parameter value.
It's a fix for this issue : https://github.com/jitsi/jitsi-meet/issues/13921

