### PR TITLE
improve logic for showing transcripts for different length of language code strings

### DIFF
--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -116,7 +116,8 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
                 newTranscriptMessage));
 
         } else if (json.type === JSON_TYPE_TRANSCRIPTION_RESULT
-                && json.language.slice(0, 2) === translationLanguage) {
+                && json.language.slice(0, Math.min(json.language.length, 
+                   translationLanguage.length)) === translationLanguage) {
             // Displays interim and final results without any translation if
             // translations are disabled.
 

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -120,7 +120,7 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
                 newTranscriptMessage));
 
         } else if (json.type === JSON_TYPE_TRANSCRIPTION_RESULT
-                && json.language.replace(countryCodeRegex, "") === translationLanguage) {
+                && json.language.replace(countryCodeRegex, '') === translationLanguage) {
             // Displays interim and final results without any translation if
             // translations are disabled.
 

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -116,7 +116,7 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
                 newTranscriptMessage));
 
         } else if (json.type === JSON_TYPE_TRANSCRIPTION_RESULT
-                && json.language.slice(0, Math.min(json.language.length, 
+                && json.language.slice(0, Math.min(json.language.length,
                    translationLanguage.length)) === translationLanguage) {
             // Displays interim and final results without any translation if
             // translations are disabled.

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -95,6 +95,10 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
         = state['features/base/conference'].conference
             ?.getLocalParticipantProperty(P_NAME_TRANSLATION_LANGUAGE);
 
+    // regex to filter out all possible country codes after language code
+    // this should catch 'en-GB' 'en_GB' and 'enGB'
+    const countryCodeRegex = /[-_A-Z].*/;
+
     try {
         const transcriptMessageID = json.message_id;
         const participantName = json.participant.name;
@@ -116,8 +120,7 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
                 newTranscriptMessage));
 
         } else if (json.type === JSON_TYPE_TRANSCRIPTION_RESULT
-                && json.language.slice(0, Math.min(json.language.length,
-                   translationLanguage.length)) === translationLanguage) {
+                && json.language.replace(countryCodeRegex, "") === translationLanguage) {
             // Displays interim and final results without any translation if
             // translations are disabled.
 


### PR DESCRIPTION
The current logic to show or drop a transcript works for language codes of 2 letters only, see https://github.com/jitsi/jitsi-meet/pull/12325#issuecomment-1330679722.

This patch improves the logic and works for different lengths of language codes. I have tested with "en", "de" and "hsb" and it works for me.

Please include it, even if there is no language yet with 3 letter code that supports transcripts. That would be my next pull request then ;-)