### PR TITLE
correction of incorrect translation of the word ayarla

### DIFF
--- a/lang/main-tr.json
+++ b/lang/main-tr.json
@@ -1251,7 +1251,7 @@
         "pending": "{{displayName}} davet edildi"
     },
     "videoStatus": {
-        "adjustFor": "Ayala:",
+        "adjustFor": "Ayarla:",
         "audioOnly": "SES",
         "audioOnlyExpanded": "Yalnızca ses modundasınız. Bu mod bant genişliğinden tasarruf sağlar, ancak başkalarının videolarını göremezsiniz.",
         "bestPerformance": "En iyi performans",


### PR DESCRIPTION
The Turkish translation of the "adjust for" is "ayarla". It was misspelled as "ayala".

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
