### PR TITLE
Make mod_persistent_lobby play well with breakout rooms

### DIFF
--- a/resources/prosody-plugins/mod_persistent_lobby.lua
+++ b/resources/prosody-plugins/mod_persistent_lobby.lua
@@ -106,11 +106,8 @@ run_when_component_loaded(main_muc_component_host, function(host_module, host_na
             -- Check if room should be destroyed when someone leaves the main room
 
             local main_room = event.room;
+            local main_room_active = main_room and (main_room:has_occupant() or main_room._data.breakout_rooms_active);
             if is_healthcheck_room(main_room.jid) or not has_persistent_lobby(main_room) then
-                return;
-            end
-
-            if main_room and main_room._data.breakout_rooms_active then
                 return;
             end
 
@@ -121,7 +118,7 @@ run_when_component_loaded(main_muc_component_host, function(host_module, host_na
             --   b) lobby does not exist (possible for lobby to be disabled manually by moderator in meeting)
             --
             -- (main room destroy also triggers lobby room destroy in muc_lobby_rooms)
-            if not main_room:has_occupant() then
+            if not main_room_active then
                 if lobby_room_jid == nil then  -- lobby disabled
                     trigger_room_destroy(main_room);
                 else -- lobby exists
@@ -147,18 +144,15 @@ run_when_component_loaded(lobby_muc_component_host, function(host_module, host_n
 
             local lobby_room = event.room;
             local main_room = lobby_room.main_room;
+            local main_room_active = main_room and (main_room:has_occupant() or main_room._data.breakout_rooms_active);
 
             if not main_room or is_healthcheck_room(main_room.jid) or not has_persistent_lobby(main_room) then
                 return;
             end
 
-            if main_room and main_room._data.breakout_rooms_active then
-                return;
-            end
-
             -- If both lobby room and main room are empty, we destroy main room.
             -- (main room destroy also triggers lobby room destroy in muc_lobby_rooms)
-            if not lobby_room:has_occupant() and main_room and not main_room:has_occupant() then
+            if not lobby_room:has_occupant() and not main_room_active then
                 trigger_room_destroy(main_room);
             end
 

--- a/resources/prosody-plugins/mod_persistent_lobby.lua
+++ b/resources/prosody-plugins/mod_persistent_lobby.lua
@@ -110,6 +110,10 @@ run_when_component_loaded(main_muc_component_host, function(host_module, host_na
                 return;
             end
 
+            if main_room and main_room._data.breakout_rooms_active then
+                return;
+            end
+
             local lobby_room_jid = main_room._data.lobbyroom;
 
             -- If occupant leaving results in main room being empty, we trigger room destroy if
@@ -145,6 +149,10 @@ run_when_component_loaded(lobby_muc_component_host, function(host_module, host_n
             local main_room = lobby_room.main_room;
 
             if not main_room or is_healthcheck_room(main_room.jid) or not has_persistent_lobby(main_room) then
+                return;
+            end
+
+            if main_room and main_room._data.breakout_rooms_active then
                 return;
             end
 


### PR DESCRIPTION
`mod_persistent_lobby` does not currently work well with breakout rooms. If everyone leaves the main room to join breakouts, then the `trigger_room_destroy` logic is triggered from this plugin. This causes a crash in prosody with a hard-to-trace error like the below:
```
2023-10-11 21:56:44 meet.nxtlvl.io:muc_breakout_rooms                                error      No main room (b23cb1ef-7cbd-4e98-9f1a-6b642b46ce08@breakout.meet.nxtlvl.io)!
2023-10-11 21:56:44 c2s5615aea47970                                                  error      Traceback[c2s]: /prosody-plugins/mod_muc_breakout_rooms.lua:345: attempt to index a nil value (local 'main_room')
        stack traceback:
        /prosody-plugins/mod_muc_breakout_rooms.lua:345: in field '?'
        /usr/share/lua/5.4/prosody/util/events.lua:81: in function </usr/share/lua/5.4/prosody/util/events.lua:77>
        (...tail calls...)
        /usr/lib/prosody/modules/muc/muc.lib.lua:496: in function </usr/lib/prosody/modules/muc/muc.lib.lua:492>
        (...tail calls...)
        /usr/share/lua/5.4/prosody/util/events.lua:81: in function </usr/share/lua/5.4/prosody/util/events.lua:77>
        (...tail calls...)
        /usr/share/lua/5.4/prosody/core/stanza_router.lua:188: in upvalue 'core_post_stanza'
        /usr/share/lua/5.4/prosody/core/stanza_router.lua:128: in upvalue 'core_process_stanza'
        /usr/lib/prosody/modules/mod_c2s.lua:326: in upvalue 'func'
        /usr/share/lua/5.4/prosody/util/async.lua:144: in function </usr/share/lua/5.4/prosody/util/async.lua:142>
```

This PR attempts to address this by checking whether there are active breakout rooms in the session, and if not basically letting mod_muc_breakout_rooms do its thing when it comes to closing the conference (see relevant code below):

https://github.com/jitsi/jitsi-meet/blob/stable/jitsi-meet_8960/resources/prosody-plugins/mod_muc_breakout_rooms.lua#L431

If breakout rooms are not active/not used, then mod_persistent_lobby handles destroying the conference as normal when both the lobby and the main room are empty.