### PR TITLE
fix(language/config) deprecate defaultLanguage

### DIFF
--- a/config.js
+++ b/config.js
@@ -632,6 +632,7 @@ var config = {
     // hideDominantSpeakerBadge: false,
 
     // Default language for the user interface. Cannot be overwritten.
+    // DEPRECATED! Use the `lang` iframe option directly instead.
     // defaultLanguage: 'en',
 
     // Disables profile and the edit of all fields from the profile settings (display name and email)


### PR DESCRIPTION
Following the discussion from https://github.com/jitsi/jitsi-meet-react-sdk/issues/36, `defaultLanguage` does work when passed from the configOverwrite object, although it's whitelisted, but it would be best to use `lang` instead.