### PR TITLE
fix(visitors): informs visitor nodes when a participant is kicked.

### DIFF
--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -225,7 +225,12 @@ process_host_module(main_muc_component_config, function(host_module, host)
             return;
         end
 
-        -- we want to update visitor node that a main participant left
+        --this is probably participant kick scenario, create an unavailable presence and send to vnodes.
+        if not stanza then
+            stanza = st.presence {from = occupant.nick; type = "unavailable";};
+        end
+
+        -- we want to update visitor node that a main participant left or kicked.
         if stanza then
             local vnodes = visitors_nodes[room.jid].nodes;
             local user, _, res = jid.split(occupant.nick);
@@ -235,38 +240,6 @@ process_host_module(main_muc_component_config, function(host_module, host)
                 fmuc_pr.attr.from = occupant.jid;
                 module:send(fmuc_pr);
             end
-        else
-            module:log('warn', 'No unavailable stanza found ... leak participant on visitor');
-        end
-    end);
-
-    -- when a main participant is kicked inform the visitor nodes
-    host_module:hook('muc-broadcast-presence', function(event)
-        local x, actor = event.x, event.actor;
-        if not actor or not presence_check_status(x, '307') then
-            return;
-        end
-
-        local room, stanza, occupant = event.room, event.stanza, event.occupant;
-
-        -- ignore configured domains (jibri and transcribers)
-        if is_admin(occupant.bare_jid) or visitors_nodes[room.jid] == nil or visitors_nodes[room.jid].nodes == nil
-                or ignore_list:contains(jid.host(occupant.bare_jid)) then
-            return;
-        end
-
-        -- we want to update visitor node that a main participant is kicked
-        if stanza then
-            local vnodes = visitors_nodes[room.jid].nodes;
-            local user, _, res = jid.split(occupant.nick);
-            for k in pairs(vnodes) do
-                local fmuc_pr = st.clone(stanza);
-                fmuc_pr.attr.to = jid.join(user, k, res);
-                fmuc_pr.attr.from = occupant.jid;
-                module:send(fmuc_pr);
-            end
-        else
-            module:log('warn', 'No unavailable stanza found ... leak participant on visitor');
         end
     end);
 


### PR DESCRIPTION
When a participant in the main room is kicked while visitor mode is on, visitors cannot get this info and still see the kicked participants as if they are still in the meeting.This commit hooks the kick message and forwards it to vnodes.