### PR TITLE
feat(config) add ability to prefer BOSH over WebSocket

### DIFF
--- a/config.js
+++ b/config.js
@@ -51,6 +51,9 @@ var config = {
     // Websocket URL (XMPP)
     // websocket: 'wss://jitsi-meet.example.com/' + subdir + 'xmpp-websocket',
 
+    // Whether BOSH should be preferred over WebSocket if both are configured.
+    // preferBosh: false,
+
     // The real JID of focus participant - can be overridden here
     // Do not change username - FIXME: Make focus username configurable
     // https://github.com/jitsi/jitsi-meet/issues/7376

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -520,6 +520,7 @@ export interface IConfig {
     pcStatsInterval?: number;
     peopleSearchQueryTypes?: string[];
     peopleSearchUrl?: string;
+    preferBosh?: boolean;
     preferredTranscribeLanguage?: string;
     prejoinConfig?: {
         enabled?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -197,6 +197,7 @@ export default [
     'participantMenuButtonsWithNotifyClick',
     'participantsPane',
     'pcStatsInterval',
+    'preferBosh',
     'prejoinConfig',
     'prejoinPageEnabled',
     'recordingService',

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -120,7 +120,7 @@ export function constructOptions(state: IReduxState) {
         options.iceServersOverride = iceServersOverride;
     }
 
-    const { bosh } = options;
+    const { bosh, preferBosh } = options;
     let { websocket } = options;
 
     // TESTING: Only enable WebSocket for some percentage of users.
@@ -128,6 +128,10 @@ export function constructOptions(state: IReduxState) {
         if ((Math.random() * 100) >= (options?.testing?.mobileXmppWsThreshold ?? 0)) {
             websocket = undefined;
         }
+    }
+
+    if (preferBosh) {
+        websocket = undefined;
     }
 
     // WebSocket is preferred over BOSH.


### PR DESCRIPTION
There might be cases where we'd want to enforce it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
