### PR TITLE
feat(chat/native): fixed keyboard overlapping chat input bar

### DIFF
--- a/react/features/chat/components/native/Chat.tsx
+++ b/react/features/chat/components/native/Chat.tsx
@@ -61,9 +61,9 @@ class Chat extends Component<IProps> {
                 disableForcedKeyboardDismiss = { true }
 
                 /* eslint-disable react/jsx-no-bind */
-                footerComponent = { () => (
+                footerComponent = { () =>
                     <ChatInputBar onSend = { this._onSendMessage } />
-                )}
+                }
                 hasBottomTextInput = { true }
                 hasTabNavigator = { true }
                 style = { styles.chatContainer }>

--- a/react/features/chat/components/native/Chat.tsx
+++ b/react/features/chat/components/native/Chat.tsx
@@ -59,13 +59,17 @@ class Chat extends Component<IProps> {
         return (
             <JitsiScreen
                 disableForcedKeyboardDismiss = { true }
+
+                /* eslint-disable react/jsx-no-bind */
+                footerComponent = { () => (
+                    <ChatInputBar onSend = { this._onSendMessage } />
+                )}
                 hasBottomTextInput = { true }
                 hasTabNavigator = { true }
                 style = { styles.chatContainer }>
                 {/* @ts-ignore */}
                 <MessageContainer messages = { _messages } />
                 <MessageRecipient privateMessageRecipient = { privateMessageRecipient } />
-                <ChatInputBar onSend = { this._onSendMessage } />
             </JitsiScreen>
         );
     }

--- a/react/features/chat/components/native/ChatInputBar.tsx
+++ b/react/features/chat/components/native/ChatInputBar.tsx
@@ -1,17 +1,25 @@
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
-import { Platform, ViewStyle } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Platform, View, ViewStyle } from 'react-native';
+import { connect } from 'react-redux';
 
+import { IReduxState } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
 import { IconSend } from '../../../base/icons/svg';
+import { ASPECT_RATIO_WIDE } from '../../../base/responsive-ui/constants';
 import IconButton from '../../../base/ui/components/native/IconButton';
 import Input from '../../../base/ui/components/native/Input';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';
 
 import styles from './styles';
 
+
 interface IProps extends WithTranslation {
+
+    /**
+     * Application's aspect ratio.
+     */
+    aspectRatio: Symbol;
 
     /**
      * Callback to invoke on message send.
@@ -66,11 +74,18 @@ class ChatInputBar extends Component<IProps, IState> {
      * @inheritdoc
      */
     render() {
+        let inputBarStyles;
+
+        if (this.props.aspectRatio === ASPECT_RATIO_WIDE) {
+            inputBarStyles = styles.inputBarWide;
+        } else {
+            inputBarStyles = styles.inputBarNarrow;
+        }
+
         return (
-            <SafeAreaView
-                edges = { [ 'bottom' ] }
+            <View
                 style = { [
-                    styles.inputBar,
+                    inputBarStyles,
                     this.state.addPadding ? styles.extraBarPadding : null
                 ] as ViewStyle[] }>
                 <Input
@@ -88,9 +103,8 @@ class ChatInputBar extends Component<IProps, IState> {
                     disabled = { !this.state.message }
                     onPress = { this._onSubmit }
                     src = { IconSend }
-                    style = { styles.sendButton }
                     type = { BUTTON_TYPES.PRIMARY } />
-            </SafeAreaView>
+            </View>
         );
     }
 
@@ -137,4 +151,20 @@ class ChatInputBar extends Component<IProps, IState> {
     }
 }
 
-export default translate(ChatInputBar);
+/**
+ * Maps part of the Redux state to the props of this component.
+ *
+ * @param {Object} state - The redux state.
+ * @private
+ * @returns {IProps}
+ */
+function _mapStateToProps(state: IReduxState) {
+    const { aspectRatio } = state['features/base/responsive-ui'];
+
+    return {
+        aspectRatio
+    }
+}
+
+
+export default translate(connect(_mapStateToProps)(ChatInputBar));

--- a/react/features/chat/components/native/ChatInputBar.tsx
+++ b/react/features/chat/components/native/ChatInputBar.tsx
@@ -163,7 +163,7 @@ function _mapStateToProps(state: IReduxState) {
 
     return {
         aspectRatio
-    }
+    };
 }
 
 export default translate(connect(_mapStateToProps)(ChatInputBar));

--- a/react/features/chat/components/native/ChatInputBar.tsx
+++ b/react/features/chat/components/native/ChatInputBar.tsx
@@ -166,5 +166,4 @@ function _mapStateToProps(state: IReduxState) {
     }
 }
 
-
 export default translate(connect(_mapStateToProps)(ChatInputBar));

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -15,9 +15,9 @@ const recipientContainer = {
 };
 
 const inputBar = {
-        alignItems: 'center',
-        flexDirection: 'row',
-        justifyContent: 'space-between'
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between'
 };
 
 /**

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -14,6 +14,12 @@ const recipientContainer = {
     padding: BaseTheme.spacing[2]
 };
 
+const inputBar = {
+        alignItems: 'center',
+        flexDirection: 'row',
+        justifyContent: 'space-between'
+};
+
 /**
  * The styles of the feature chat.
  *
@@ -116,12 +122,16 @@ export default {
         paddingBottom: 30
     },
 
-    inputBar: {
-        alignItems: 'center',
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        marginLeft: BaseTheme.spacing[3],
-        width: '100%'
+    inputBarNarrow: {
+        ...inputBar,
+        height: 112,
+        marginHorizontal: BaseTheme.spacing[3]
+    },
+
+    inputBarWide: {
+        ...inputBar,
+        height: 88,
+        marginHorizontal: BaseTheme.spacing[9]
     },
 
     customInputContainer: {
@@ -155,10 +165,6 @@ export default {
     replyWrapper: {
         alignItems: 'center',
         flexDirection: 'row'
-    },
-
-    sendButton: {
-        marginRight: BaseTheme.spacing[5]
     },
 
     /**


### PR DESCRIPTION
Fixes #13748.

1. Iphone 14 
![Simulator Screenshot - iPhone 14 - 2023-10-25 at 13 36 31](https://github.com/jitsi/jitsi-meet/assets/26413496/71006dc7-ea5f-462d-bd2a-eebb25005e87) 
2. Iphone 14 PRO Max 
![Simulator Screenshot - iPhone 14 Pro Max - 2023-10-25 at 13 36 20](https://github.com/jitsi/jitsi-meet/assets/26413496/b7edcb84-534a-4c5e-8c42-f8f0b19bee4b)
3. Iphone SE 
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-25 at 13 36 16](https://github.com/jitsi/jitsi-meet/assets/26413496/b887c3e5-d016-4ebd-b305-b87d2eee1e72)
