### PR TITLE
fix: Adds a nil check in visitors module.

### DIFF
--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -305,7 +305,9 @@ process_host_module(main_muc_component_config, function(host_module, host)
         local from = stanza.attr.from;
         local from_vnode = jid.host(from);
 
-        if occupant or not (visitors_nodes[to] or visitors_nodes[to].nodes[from_vnode]) then
+        if occupant or not (visitors_nodes[to]
+                            and visitors_nodes[to].nodes
+                            and visitors_nodes[to].nodes[from_vnode]) then
             return;
         end
 


### PR DESCRIPTION
Sep 22 22:06:01 mod_bosh        error   Traceback[bosh]: /usr/share/jitsi-meet/prosody-plugins/mod_visitors.lua:305: attempt to index field '?' (a nil value)
        stack traceback:
        /usr/share/jitsi-meet/prosody-plugins/mod_visitors.lua:305: in function '?'
        /usr/share/lua/5.2/prosody/util/events.lua:81: in function </usr/share/lua/5.2/prosody/util/events.lua:77>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
