### PR TITLE
fix: Self view of screen sharing sized correctly initially

### DIFF
--- a/react/features/large-video/components/LargeVideo.web.tsx
+++ b/react/features/large-video/components/LargeVideo.web.tsx
@@ -228,16 +228,17 @@ class LargeVideo extends Component<IProps> {
                       * another container for the background and the
                       * largeVideoWrapper in order to hide/show them.
                       */}
+                    { _displayScreenSharingPlaceholder ? <ScreenSharePlaceholder /> : <></>}
                     <div
                         id = 'largeVideoWrapper'
                         onTouchEnd = { this._onDoubleTap }
                         ref = { this._wrapperRef }
                         role = 'figure' >
-                        { _displayScreenSharingPlaceholder ? <ScreenSharePlaceholder /> : <video
+                        <video
                             autoPlay = { !_noAutoPlayVideo }
                             id = 'largeVideo'
                             muted = { true }
-                            playsInline = { true } /* for Safari on iOS to work */ /> }
+                            playsInline = { true } /* for Safari on iOS to work */ /> 
                     </div>
                 </div>
                 { interfaceConfig.DISABLE_TRANSCRIPTION_SUBTITLES

--- a/react/features/large-video/components/LargeVideo.web.tsx
+++ b/react/features/large-video/components/LargeVideo.web.tsx
@@ -238,7 +238,7 @@ class LargeVideo extends Component<IProps> {
                             autoPlay = { !_noAutoPlayVideo }
                             id = 'largeVideo'
                             muted = { true }
-                            playsInline = { true } /* for Safari on iOS to work */ /> 
+                            playsInline = { true } /* for Safari on iOS to work */ />
                     </div>
                 </div>
                 { interfaceConfig.DISABLE_TRANSCRIPTION_SUBTITLES

--- a/react/features/large-video/components/ScreenSharePlaceholder.web.tsx
+++ b/react/features/large-video/components/ScreenSharePlaceholder.web.tsx
@@ -15,7 +15,10 @@ const useStyles = makeStyles()(theme => {
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
-            position: 'absolute'
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            zIndex: 2
         },
         content: {
             display: 'flex',


### PR DESCRIPTION
Fixes #13968 

The initial size of screen share self view was wrong because, we conditionally rendered the ScreenSharePlaceHolder and the Video inside the largeVideoWrapper, It caused to not set the correct sizing until resized. 

I moved the ScreenSharePlaceHolder outside the largeVideoWrapper and styled it correctly to show in top of the video. 

### Screenshots
![ezgif com-video-to-gif](https://github.com/jitsi/jitsi-meet/assets/55492635/c86bef07-f886-4be2-8ef1-527759e2ab7d)


