### PR TITLE
Fix Keyboard Shortcuts clashing with whiteboard

### DIFF
--- a/react/features/keyboard-shortcuts/actions.web.ts
+++ b/react/features/keyboard-shortcuts/actions.web.ts
@@ -91,7 +91,7 @@ export const initKeyboardShortcuts = () =>
                 return;
             }
 
-            if (e.ctrlKey) {
+            if (e.ctrlKey || e.metaKey) {
                 // We should ignore shortcut events with active ctrl modifier.
                 return;
             }

--- a/react/features/keyboard-shortcuts/actions.web.ts
+++ b/react/features/keyboard-shortcuts/actions.web.ts
@@ -91,6 +91,11 @@ export const initKeyboardShortcuts = () =>
                 return;
             }
 
+            if (e.ctrlKey) {
+                // We should ignore shortcut events with active ctrl modifier.
+                return;
+            }
+
             const key = getKeyboardKey(e).toUpperCase();
 
             if (shortcuts.has(key)) {

--- a/react/features/keyboard-shortcuts/utils.ts
+++ b/react/features/keyboard-shortcuts/utils.ts
@@ -2,11 +2,13 @@
  * Prefer keyboard handling of these elements over global shortcuts.
  * If a button is triggered using the Spacebar it should not trigger PTT.
  * If an input element is focused and M is pressed it should not mute audio.
+ * If whiteboard (canvas) is active and focused, the keypress should be ignored. 
  */
 const _elementsBlacklist = [
     'input',
     'textarea',
     'button',
+    'canvas',
     '[role=button]',
     '[role=menuitem]',
     '[role=radio]',

--- a/react/features/keyboard-shortcuts/utils.ts
+++ b/react/features/keyboard-shortcuts/utils.ts
@@ -2,7 +2,7 @@
  * Prefer keyboard handling of these elements over global shortcuts.
  * If a button is triggered using the Spacebar it should not trigger PTT.
  * If an input element is focused and M is pressed it should not mute audio.
- * If whiteboard (canvas) is active and focused, the keypress should be ignored. 
+ * If whiteboard (canvas) is active and focused, the keypress should be ignored.
  */
 const _elementsBlacklist = [
     'input',


### PR DESCRIPTION
Add canvas to blacklisted elements
Add return if ctrl modifier is used on the keypress.
* none of jitsis shortcuts use ctrl - so we should ignore those


Currently shortcuts like CTRL+C and CTRL + V and other system shortcuts will trigger jitsis shortcut handler, even if not intended. 

The guard check in this commit will prevent interference with system shortcuts by ignoring events with ctrl completely. 
