### PR TITLE
fix(rn) allow default server URL to be set from native

### DIFF
--- a/react/features/app/components/App.native.tsx
+++ b/react/features/app/components/App.native.tsx
@@ -7,8 +7,7 @@ import SplashScreen from 'react-native-splash-screen';
 import BottomSheetContainer from '../../base/dialog/components/native/BottomSheetContainer';
 import DialogContainer from '../../base/dialog/components/native/DialogContainer';
 import { updateFlags } from '../../base/flags/actions';
-import { CALL_INTEGRATION_ENABLED, SERVER_URL_CHANGE_ENABLED } from '../../base/flags/constants';
-import { getFeatureFlag } from '../../base/flags/functions';
+import { CALL_INTEGRATION_ENABLED } from '../../base/flags/constants';
 import { clientResized, setSafeAreaInsets } from '../../base/responsive-ui/actions';
 import DimensionsDetector from '../../base/responsive-ui/components/DimensionsDetector.native';
 import { updateSettings } from '../../base/settings/actions';
@@ -153,18 +152,13 @@ export class App extends AbstractApp<IProps> {
 
         await rootNavigationReady;
 
-        // Check if serverURL is configured externally and not allowed to change.
-        const serverURLChangeEnabled = getState && getFeatureFlag(getState(), SERVER_URL_CHANGE_ENABLED, true);
+        // Update specified server URL.
+        if (typeof this.props.url !== 'undefined') {
+            // @ts-ignore
+            const { serverURL } = this.props.url;
 
-        if (!serverURLChangeEnabled) {
-            // As serverURL is provided externally, so we push it to settings.
-            if (typeof this.props.url !== 'undefined') {
-                // @ts-ignore
-                const { serverURL } = this.props.url;
-
-                if (typeof serverURL !== 'undefined') {
-                    dispatch?.(updateSettings({ serverURL }));
-                }
+            if (typeof serverURL !== 'undefined') {
+                dispatch?.(updateSettings({ serverURL }));
             }
         }
 


### PR DESCRIPTION
On Android we support RestrictionManager, but that already sets it, so make sure we always save it on the settings.

Editing will be restricted in the Settings dialog if changing it is restricted anyway.

Fixes: https://github.com/jitsi/jitsi-meet/issues/13994

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
