### PR TITLE
ref(conference.js): fix null is not an object

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1127,15 +1127,15 @@ export default {
      *
      * @param {string} id participant's identifier(MUC nickname).
      *
-     * @returns {JitsiParticipant|null} participant instance for given id or
+     * @returns {JitsiParticipant} participant instance for given id or
      * null if not found.
      */
     getParticipantById(id) {
-        return room ? room.getParticipantById(id) : null;
+        return room?.getParticipantById(id);
     },
 
     getMyUserId() {
-        return room && room.myUserId();
+        return room?.myUserId();
     },
 
     /**


### PR DESCRIPTION

![Simulator Screenshot - iPhone 14 Pro Max - 2023-10-31 at 12 57 20](https://github.com/jitsi/jitsi-meet/assets/26413496/31d501e6-f2a2-4cb2-89da-9fb6568152eb)

 ERROR  TypeError: null is not an object (evaluating 'this.room.myroomjid')

This happens rarely, a few seconds after leaving the conference.

