### PR TITLE
fix: Make room_metadata Prosody module depend on the required jitsi_session module

### DIFF
--- a/resources/prosody-plugins/mod_room_metadata.lua
+++ b/resources/prosody-plugins/mod_room_metadata.lua
@@ -4,5 +4,7 @@
 local COMPONENT_IDENTITY_TYPE = 'room_metadata';
 local room_metadata_component_host = module:get_option_string('room_metadata_component', 'metadata.'..module.host);
 
+module:depends("jitsi_session");
+
 -- Advertise the component so clients can pick up the address and use it
 module:add_identity('component', COMPONENT_IDENTITY_TYPE, room_metadata_component_host);


### PR DESCRIPTION
Without this room_metadata will silently discard all room metadata client requests assuming that they didn’t come from Jitsi meet clients.

Fixes #14001

Detailed description in that issue.