### PR TITLE
 Accessibility: give the menu button in the toolbar attribute (aria-expended)

### DIFF
--- a/react/features/base/toolbox/components/AbstractButton.tsx
+++ b/react/features/base/toolbox/components/AbstractButton.tsx
@@ -54,6 +54,11 @@ export interface IProps extends WithTranslation {
     handleClick?: Function;
 
     /**
+     * Whether the button open a menu or not.
+     */
+    isMenuButton?: boolean;
+
+    /**
      * Notify mode for `toolbarButtonClicked` event -
      * whether to only notify or to also prevent button click routine.
      */
@@ -102,7 +107,7 @@ export const defaultDisabledButtonStyles = {
 /**
  * An abstract implementation of a button.
  */
-export default class AbstractButton<P extends IProps, S=any> extends Component<P, S> {
+export default class AbstractButton<P extends IProps, S = any> extends Component<P, S> {
     static defaultProps = {
         afterClick: undefined,
         disabledStyles: defaultDisabledButtonStyles,
@@ -354,7 +359,7 @@ export default class AbstractButton<P extends IProps, S=any> extends Component<P
 
         if (typeof APP !== 'undefined' && notifyMode) {
             APP.API.notifyToolbarButtonClicked(
-                    buttonKey, notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
+                buttonKey, notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY
             );
         }
 

--- a/react/features/base/toolbox/components/ToolboxItem.web.tsx
+++ b/react/features/base/toolbox/components/ToolboxItem.web.tsx
@@ -20,6 +20,11 @@ interface IProps extends AbstractToolboxItemProps {
     contextMenu?: boolean;
 
     /**
+     * Whether the button open a menu or not.
+     */
+    isMenuButton?: boolean;
+
+    /**
     * On key down handler.
     */
     onKeyDown: (e?: React.KeyboardEvent) => void;
@@ -67,6 +72,7 @@ export default class ToolboxItem extends AbstractToolboxItem<IProps> {
         const {
             backgroundColor,
             contextMenu,
+            isMenuButton,
             disabled,
             elementAfter,
             icon,
@@ -77,8 +83,9 @@ export default class ToolboxItem extends AbstractToolboxItem<IProps> {
             toggled
         } = this.props;
         const className = showLabel ? 'overflow-menu-item' : 'toolbox-button';
+        const buttonAttribute = isMenuButton ? 'aria-expanded' : 'aria-pressed';
         const props = {
-            'aria-pressed': toggled,
+            [buttonAttribute]: toggled,
             'aria-disabled': disabled,
             'aria-label': this.accessibilityLabel,
             className: className + (disabled ? ' disabled' : ''),

--- a/react/features/toolbox/components/web/OverflowMenuButton.tsx
+++ b/react/features/toolbox/components/web/OverflowMenuButton.tsx
@@ -238,6 +238,7 @@ const OverflowMenuButton = ({
                 trigger = 'click'
                 visible = { isOpen }>
                 <OverflowToggleButton
+                    isMenuButton = { true }
                     isOpen = { isOpen }
                     onKeyDown = { onEscClick } />
             </Popover>


### PR DESCRIPTION
All button in the toolbar has an aria-pressed (true, false) but to make it properly accessible and readable from the screen reader the button that open menu should have aria-expanded (true, false).

![Screenshot 2023-11-06 124455](https://github.com/jitsi/jitsi-meet/assets/52747422/74239324-e25e-485d-9bdd-3326e93812c1)
