### PR TITLE
Fix context menu double click behaviour if closed with ESC

### DIFF
--- a/react/features/base/ui/components/web/ContextMenu.tsx
+++ b/react/features/base/ui/components/web/ContextMenu.tsx
@@ -344,7 +344,6 @@ const ContextMenu = ({
 
         if (event.key === 'Escape') {
             // Close the menu
-            event.preventDefault();
             setIsHidden(true);
 
         } else if (event.key === 'ArrowUp') {


### PR DESCRIPTION
This PR fixes double click issue with context menu when it is closed with ESC key: currently user has to click twice the menu button in order to show the menu if it was closed with ESC key before.

### Before:
https://github.com/jitsi/jitsi-meet/assets/9369306/6a848421-19f4-43d3-8f4d-380f1de0e8f7

### After:
https://github.com/jitsi/jitsi-meet/assets/9369306/d82e1a68-6c78-427e-bd64-06a08de9f2a6

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
