### PR TITLE
feat(base/ui): removed unneeded lineHeight value

### DIFF
--- a/react/features/base/ui/components/native/buttonStyles.ts
+++ b/react/features/base/ui/components/native/buttonStyles.ts
@@ -11,7 +11,6 @@ const button = {
 
 const buttonLabel = {
     ...BaseTheme.typography.bodyShortBold,
-    lineHeight: 14,
     textTransform: 'capitalize'
 };
 


### PR DESCRIPTION
Native buttons have an extra unneeded lineHeight value that when zooming or using other languages, have their labels cut.
We already take from bodyShortBold object a lineHeight of 20, no need for an extra one.

Fixes #14039 
