### PR TITLE
fix(breakout-rooms, persistent-lobby): support running both modules together

### DIFF
--- a/resources/prosody-plugins/mod_room_destroy.lua
+++ b/resources/prosody-plugins/mod_room_destroy.lua
@@ -1,0 +1,15 @@
+-- Handle room destroy requests it such a way that it can be suppressed by other
+-- modules that handle room lifecycle and wish to keep the room alive.
+
+function handle_room_destroy(event)
+    local room = event.room;
+    local reason = event.reason;
+    local caller = event.caller;
+
+    module:log('info', 'Destroying room %s (requested by %s)', room.jid, caller);
+    room:set_persistent(false);
+    room:destroy(nil, reason);
+end
+
+module:hook_global("maybe-destroy-room", handle_room_destroy, -1);
+module:log('info', 'loaded');


### PR DESCRIPTION
ref: https://github.com/jitsi/jitsi-meet/pull/13939#issuecomment-1807140392

Created a common module to handle room destroy, because the alternative would be for both modules to send their own events and have handlers to deal with event sent by other module. Using different events per module has some disadvantages:
1. each module needs to have knowledge of the other module
2. it gets extremely really messy to add yet another module that needs to keep main room alive since every module needs to know of all other module that does that.