### PR TITLE
fix(iFrame): Add 'speaker-selection' to the allow list.

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -420,7 +420,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             'display-capture',
             'hid',
             'microphone',
-            'screen-wake-lock'
+            'screen-wake-lock',
+            'speaker-selection'
         ].join('; ');
         this._frame.name = frameName;
         this._frame.id = frameName;


### PR DESCRIPTION
This is needed for Firefox 116 and above for setSinkId to succeed.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
