### PR TITLE
fix(native app): Display poll creator name

### DIFF
--- a/react/features/polls/components/native/PollResults.tsx
+++ b/react/features/polls/components/native/PollResults.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback } from 'react';
 import { FlatList, Text, TextStyle, View, ViewStyle } from 'react-native';
-import { useSelector } from 'react-redux';
 
-import { getLocalParticipant } from '../../../base/participants/functions';
 import Button from '../../../base/ui/components/native/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';
 import AbstractPollResults from '../AbstractPollResults';
@@ -20,6 +18,7 @@ const PollResults = (props: AbstractProps) => {
     const {
         answers,
         changeVote,
+        creatorName,
         haveVoted,
         question,
         showDetails,
@@ -88,7 +87,6 @@ const PollResults = (props: AbstractProps) => {
         );
 
     }, [ showDetails ]);
-    const localParticipant = useSelector(getLocalParticipant);
 
 
     /* eslint-disable react/jsx-no-bind */
@@ -96,7 +94,7 @@ const PollResults = (props: AbstractProps) => {
         <View>
             <Text style = { dialogStyles.questionText as TextStyle } >{ question }</Text>
             <Text style = { dialogStyles.questionOwnerText as TextStyle } >
-                { t('polls.by', { name: localParticipant?.name }) }
+                { t('polls.by', { name: creatorName }) }
             </Text>
             <FlatList
                 data = { answers }


### PR DESCRIPTION
In the jitsi web app, the poll creator is displayed for all published votes whereas in the native app the current username of the participant has been displayed for all polls regardless of the creator

In order to fix this issue I simply copied the creatorName parameter as show in the [web app implementation](https://github.com/jitsi/jitsi-meet/blob/6fda5924a3bf5bec1000b2cc6f7412bcc3c0c8b7/react/features/polls/components/web/PollResults.tsx#L115) 
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
