### PR TITLE
refactor(rnsdk): remove redundant audio and video actions

### DIFF
--- a/react/features/base/conference/actionTypes.ts
+++ b/react/features/base/conference/actionTypes.ts
@@ -73,24 +73,6 @@ export const CONFERENCE_BLURRED = 'CONFERENCE_BLURRED';
 export const CONFERENCE_FOCUSED = 'CONFERENCE_FOCUSED';
 
 /**
- * The type of (redux) action which signals that the audio mute state is changed.
- * 
- * {
- *      type: AUDIO_MUTED_CHANGED,
- * }
- */
-export const AUDIO_MUTED_CHANGED = 'AUDIO_MUTED_CHANGED';
-
-/**
- * The type of (redux) action which signals that the video mute state is changed.
- * 
- * {
- *      type: VIDEO_MUTED_CHANGED,
- * }
- */
-export const VIDEO_MUTED_CHANGED = 'VIDEO_MUTED_CHANGED';
-
-/**
  * The type of (redux) action, which indicates conference local subject changes.
  *
  * {

--- a/react/features/mobile/external-api/middleware.ts
+++ b/react/features/mobile/external-api/middleware.ts
@@ -10,15 +10,13 @@ import { appNavigate } from '../../app/actions.native';
 import { IStore } from '../../app/types';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../../base/app/actionTypes';
 import {
-    AUDIO_MUTED_CHANGED,
     CONFERENCE_BLURRED,
     CONFERENCE_FAILED,
     CONFERENCE_FOCUSED,
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
     CONFERENCE_WILL_JOIN,
-    SET_ROOM,
-    VIDEO_MUTED_CHANGED
+    SET_ROOM
 } from '../../base/conference/actionTypes';
 import { JITSI_CONFERENCE_URL_KEY } from '../../base/conference/constants';
 import {
@@ -158,16 +156,6 @@ externalAPIEnabled && MiddlewareRegistry.register(store => next => action => {
 
     case CONFERENCE_BLURRED:
         sendEvent(store, CONFERENCE_BLURRED, {});
-        break;
-
-    case AUDIO_MUTED_CHANGED:
-        sendEvent(store, AUDIO_MUTED_CHANGED,
-        /* data */ { muted: action.muted });
-        break;
-
-    case VIDEO_MUTED_CHANGED:
-        sendEvent(store, VIDEO_MUTED_CHANGED,
-        /* data */ { muted: action.muted });
         break;
 
     case CONFERENCE_FOCUSED:

--- a/react/features/mobile/react-native-sdk/middleware.js
+++ b/react/features/mobile/react-native-sdk/middleware.js
@@ -2,14 +2,13 @@ import { NativeModules } from 'react-native';
 
 import { getAppProp } from '../../base/app/functions';
 import {
-    AUDIO_MUTED_CHANGED,
     CONFERENCE_BLURRED,
     CONFERENCE_FOCUSED,
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
-    CONFERENCE_WILL_JOIN,
-    VIDEO_MUTED_CHANGED
+    CONFERENCE_WILL_JOIN
 } from '../../base/conference/actionTypes';
+import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../../base/media/actionTypes';
 import { PARTICIPANT_JOINED } from '../../base/participants/actionTypes';
 import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../../base/redux/StateListenerRegistry';
@@ -33,10 +32,10 @@ const { JMOngoingConference } = NativeModules;
     const rnSdkHandlers = getAppProp(store, 'rnSdkHandlers');
 
     switch (type) {
-    case AUDIO_MUTED_CHANGED:
+    case SET_AUDIO_MUTED:
         rnSdkHandlers?.onAudioMutedChanged && rnSdkHandlers?.onAudioMutedChanged(action.muted);
         break;
-    case VIDEO_MUTED_CHANGED:
+    case SET_VIDEO_MUTED:
         rnSdkHandlers?.onVideoMutedChanged && rnSdkHandlers?.onVideoMutedChanged(action.muted);
         break;
     case CONFERENCE_BLURRED:

--- a/react/features/mobile/react-native-sdk/middleware.js
+++ b/react/features/mobile/react-native-sdk/middleware.js
@@ -36,7 +36,7 @@ const { JMOngoingConference } = NativeModules;
         rnSdkHandlers?.onAudioMutedChanged && rnSdkHandlers?.onAudioMutedChanged(action.muted);
         break;
     case SET_VIDEO_MUTED:
-        rnSdkHandlers?.onVideoMutedChanged && rnSdkHandlers?.onVideoMutedChanged(action.muted);
+        rnSdkHandlers?.onVideoMutedChanged && rnSdkHandlers?.onVideoMutedChanged(Boolean(action.muted));
         break;
     case CONFERENCE_BLURRED:
         rnSdkHandlers?.onConferenceBlurred && rnSdkHandlers?.onConferenceBlurred();

--- a/react/features/toolbox/components/native/AudioMuteButton.tsx
+++ b/react/features/toolbox/components/native/AudioMuteButton.tsx
@@ -1,30 +1,6 @@
 import { connect } from 'react-redux';
 
-import { AUDIO_MUTED_CHANGED } from '../../../base/conference/actionTypes';
 import { translate } from '../../../base/i18n/functions';
 import AbstractAudioMuteButton, { IProps, mapStateToProps } from '../AbstractAudioMuteButton';
 
-/**
- * Component that renders native toolbar button for toggling audio mute.
- *
- * @augments AbstractAudioMuteButton
- */
-class AudioMuteButton extends AbstractAudioMuteButton<IProps> {
-    /**
-     * Changes audio muted state and dispatches the state to redux.
-     *
-     * @param {boolean} audioMuted - Whether audio should be muted or not.
-     * @protected
-     * @returns {void}
-     */
-    _setAudioMuted(audioMuted: boolean) {
-        this.props.dispatch?.({
-            type: AUDIO_MUTED_CHANGED,
-            muted: audioMuted
-        });
-
-        super._setAudioMuted(audioMuted);
-    }
-}
-
-export default translate(connect(mapStateToProps)(AudioMuteButton));
+export default translate(connect(mapStateToProps)(AbstractAudioMuteButton<IProps>));

--- a/react/features/toolbox/components/native/VideoMuteButton.tsx
+++ b/react/features/toolbox/components/native/VideoMuteButton.tsx
@@ -1,31 +1,7 @@
 import { connect } from 'react-redux';
 
-import { VIDEO_MUTED_CHANGED } from '../../../base/conference/actionTypes';
 import { translate } from '../../../base/i18n/functions';
 import AbstractVideoMuteButton, { IProps, mapStateToProps } from '../AbstractVideoMuteButton';
 
-/**
- * Component that renders native toolbar button for toggling video mute.
- *
- * @augments AbstractVideoMuteButton
- */
-class VideoMuteButton extends AbstractVideoMuteButton<IProps> {
-    /**
-     * Changes video muted state and dispatches the state to redux.
-     *
-     * @override
-     * @param {boolean} videoMuted - Whether video should be muted or not.
-     * @protected
-     * @returns {void}
-     */
-    _setVideoMuted(videoMuted: boolean) {
-        this.props.dispatch?.({
-            type: VIDEO_MUTED_CHANGED,
-            muted: videoMuted
-        });
 
-        super._setVideoMuted(videoMuted);
-    }
-}
-
-export default translate(connect(mapStateToProps)(VideoMuteButton));
+export default translate(connect(mapStateToProps)(AbstractVideoMuteButton<IProps>));


### PR DESCRIPTION
Removing redundant `AUDIO_MUTED_CHANGED` and `VIDEO_MUTED_CHANGED` actions.