### PR TITLE
chore(rn-orientation-locker, version): bump to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -373,7 +373,7 @@ PODS:
     - React
   - react-native-netinfo (11.1.0):
     - React-Core
-  - react-native-orientation-locker (1.5.0):
+  - react-native-orientation-locker (1.6.0):
     - React-Core
   - react-native-pager-view (6.2.0):
     - React-Core
@@ -752,7 +752,7 @@ SPEC CHECKSUMS:
   react-native-get-random-values: dee677497c6a740b71e5612e8dbd83e7539ed5bb
   react-native-keep-awake: afad8a51dfef9fe9655a6344771be32c8596d774
   react-native-netinfo: 3aa5637c18834966e0c932de8ae1ae56fea20a97
-  react-native-orientation-locker: 851f6510d8046ea2f14aa169b1e01fcd309a94ba
+  react-native-orientation-locker: 4409c5b12b65f942e75449872b4f078b6f27af81
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-performance: 47ac22ebf2aa24f324a96a5825581f6ce18c09e8
   react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "react-native-get-random-values": "1.9.0",
         "react-native-immersive-mode": "2.0.1",
         "react-native-keep-awake": "4.0.0",
-        "react-native-orientation-locker": "https://github.com/jitsi/react-native-orientation-locker/releases/download/v1.5.0-jitsi1/react-native-orientation-locker-1.5.0.tgz",
+        "react-native-orientation-locker": "1.6.0",
         "react-native-pager-view": "6.2.0",
         "react-native-paper": "5.10.3",
         "react-native-performance": "5.0.0",
@@ -15701,10 +15701,9 @@
       "integrity": "sha512-0Fotox+eLXQooeibVs3P60yASYUWjtRw9MZNmbuHt5UZQrgUrAKsE4jm7gTr4tPU1m1RkwGzcgUFpcOkh/ec7g=="
     },
     "node_modules/react-native-orientation-locker": {
-      "version": "1.5.0",
-      "resolved": "https://github.com/jitsi/react-native-orientation-locker/releases/download/v1.5.0-jitsi1/react-native-orientation-locker-1.5.0.tgz",
-      "integrity": "sha512-fR/lyo2Pqlf7ubWAhUmOKku7Ciaf83q6f7sNgYvPGUhDEjWUy/lyOJu2WZBnM4XdAmftBVSXl/JhBQAqXcckVw==",
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-orientation-locker/-/react-native-orientation-locker-1.6.0.tgz",
+      "integrity": "sha512-D3IOtAcaAi6S2w0Y1EUnr16I47isosQbE7F67fAu9A+gE67NkyKaJ9HL5EsZ+Uc7+7m+NsuBjx3dxuANNy8rVA==",
       "peerDependencies": {
         "react": ">=16.13.1",
         "react-native": ">=0.63.2",
@@ -31728,8 +31727,9 @@
       "integrity": "sha512-0Fotox+eLXQooeibVs3P60yASYUWjtRw9MZNmbuHt5UZQrgUrAKsE4jm7gTr4tPU1m1RkwGzcgUFpcOkh/ec7g=="
     },
     "react-native-orientation-locker": {
-      "version": "https://github.com/jitsi/react-native-orientation-locker/releases/download/v1.5.0-jitsi1/react-native-orientation-locker-1.5.0.tgz",
-      "integrity": "sha512-fR/lyo2Pqlf7ubWAhUmOKku7Ciaf83q6f7sNgYvPGUhDEjWUy/lyOJu2WZBnM4XdAmftBVSXl/JhBQAqXcckVw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-orientation-locker/-/react-native-orientation-locker-1.6.0.tgz",
+      "integrity": "sha512-D3IOtAcaAi6S2w0Y1EUnr16I47isosQbE7F67fAu9A+gE67NkyKaJ9HL5EsZ+Uc7+7m+NsuBjx3dxuANNy8rVA=="
     },
     "react-native-pager-view": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-native-get-random-values": "1.9.0",
     "react-native-immersive-mode": "2.0.1",
     "react-native-keep-awake": "4.0.0",
-    "react-native-orientation-locker": "https://github.com/jitsi/react-native-orientation-locker/releases/download/v1.5.0-jitsi1/react-native-orientation-locker-1.5.0.tgz",
+    "react-native-orientation-locker": "1.6.0",
     "react-native-pager-view": "6.2.0",
     "react-native-paper": "5.10.3",
     "react-native-performance": "5.0.0",


### PR DESCRIPTION
Latest version contains the fix for Android 14.

1. Add: Add vs2022 support. Remove unnecessary reference
2. Fix: Change WindowsTargetPlatformVersion to 10.0
3. Fix: added check for broadcast receiver being registered and unregistered to avoid IllegalArgumentException
4. Fix: RN-0.73 change Android configs for RN 0.73 compatibility
5. Fix: Add RECEIVER_EXPORTED/RECEIVER_NOT_EXPORTED to support Android 14

