### PR TITLE
fix(sdk): custom server url is overwritten by sdk default url option value

### DIFF
--- a/android/app/src/main/res/xml/app_restrictions.xml
+++ b/android/app/src/main/res/xml/app_restrictions.xml
@@ -3,7 +3,6 @@
 
     <!-- Server URL configuration -->
     <restriction
-        android:defaultValue="https://meet.jit.si"
         android:description="@string/restriction_server_url_description"
         android:key="SERVER_URL"
         android:restrictionType="string"

--- a/ios/app/src/AppDelegate.m
+++ b/ios/app/src/AppDelegate.m
@@ -38,7 +38,6 @@
         [builder setFeatureFlag:@"resolution" withValue:@(360)];
         [builder setFeatureFlag:@"ios.screensharing.enabled" withBoolean:YES];
         [builder setFeatureFlag:@"ios.recording.enabled" withBoolean:YES];
-        builder.serverURL = [NSURL URLWithString:@"https://meet.jit.si"];
     }];
 
   [jitsiMeet application:application didFinishLaunchingWithOptions:launchOptions];
@@ -126,7 +125,7 @@
 
 - (UIInterfaceOrientationMask)application:(UIApplication *)application
   supportedInterfaceOrientationsForWindow:(UIWindow *)window {
-    return [[JitsiMeet sharedInstance] application:application 
+    return [[JitsiMeet sharedInstance] application:application
            supportedInterfaceOrientationsForWindow:window];
 }
 

--- a/react/features/app/components/App.native.tsx
+++ b/react/features/app/components/App.native.tsx
@@ -21,6 +21,7 @@ import { AbstractApp, IProps as AbstractAppProps } from './AbstractApp';
 import '../middlewares.native';
 import '../reducers.native';
 
+
 declare let __DEV__: any;
 
 const { AppInfo } = NativeModules;
@@ -110,7 +111,7 @@ export class App extends AbstractApp<IProps> {
      */
     async _extraInit() {
         const { dispatch, getState } = this.state.store ?? {};
-        const { flags = {} } = this.props;
+        const { flags = {}, url, userInfo } = this.props;
         let callIntegrationEnabled = flags[CALL_INTEGRATION_ENABLED as keyof typeof flags];
 
         // CallKit does not work on the simulator, make sure we disable it.
@@ -153,16 +154,18 @@ export class App extends AbstractApp<IProps> {
         await rootNavigationReady;
 
         // Update specified server URL.
-        if (typeof this.props.url !== 'undefined') {
+        if (typeof url !== 'undefined') {
+
             // @ts-ignore
-            const { serverURL } = this.props.url;
+            const { serverURL } = url;
 
             if (typeof serverURL !== 'undefined') {
                 dispatch?.(updateSettings({ serverURL }));
             }
         }
 
-        dispatch?.(updateSettings(this.props.userInfo || {}));
+        // @ts-ignore
+        dispatch?.(updateSettings(userInfo || {}));
 
         // Update settings with feature-flag.
         if (typeof callIntegrationEnabled !== 'undefined') {

--- a/react/features/settings/components/native/ConferenceSection.tsx
+++ b/react/features/settings/components/native/ConferenceSection.tsx
@@ -78,6 +78,7 @@ const ConferenceSection = () => {
                 editable = { serverURLChangeEnabled }
                 keyboardType = { 'url' }
                 label = { t('settingsView.serverURL') }
+                onBlur = { processServerURL }
                 onChange = { onChangeServerURL }
                 placeholder = { defaultServerURL }
                 textContentType = { 'URL' } // iOS only

--- a/react/features/settings/components/native/ConferenceSection.tsx
+++ b/react/features/settings/components/native/ConferenceSection.tsx
@@ -56,7 +56,7 @@ const ConferenceSection = () => {
     }, [ dispatch, newServerURL ]);
 
     const processServerURL = useCallback(() => {
-        const normalizedURL = normalizeUserInputURL(newServerURL ?? '');
+        const normalizedURL = normalizeUserInputURL(newServerURL);
 
         onChangeServerURL(normalizedURL);
     }, [ newServerURL ]);

--- a/react/features/settings/components/native/ConferenceSection.tsx
+++ b/react/features/settings/components/native/ConferenceSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -7,7 +7,7 @@ import { IReduxState } from '../../../app/types';
 import { updateSettings } from '../../../base/settings/actions';
 import Input from '../../../base/ui/components/native/Input';
 import Switch from '../../../base/ui/components/native/Switch';
-import { isServerURLChangeEnabled, normalizeUserInputURL } from '../../functions.any';
+import { isServerURLChangeEnabled, normalizeUserInputURL } from '../../functions.native';
 
 import FormRow from './FormRow';
 import FormSection from './FormSection';
@@ -17,7 +17,6 @@ import styles from './styles';
 const ConferenceSection = () => {
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    const defaultServerURL = useSelector((state: IReduxState) => getDefaultURL(state));
     const {
         serverURL,
         startCarMode,
@@ -25,7 +24,10 @@ const ConferenceSection = () => {
         startWithVideoMuted
     } = useSelector((state: IReduxState) => state['features/base/settings']);
 
-    const { serverURLChangeEnabled } = useSelector((state: IReduxState) => isServerURLChangeEnabled(state));
+    const defaultServerURL = useSelector((state: IReduxState) => getDefaultURL(state));
+    const [ newServerURL, setNewServerURL ] = useState(serverURL ?? '');
+
+    const serverURLChangeEnabled = useSelector((state: IReduxState) => isServerURLChangeEnabled(state));
 
     const switches = useMemo(() => [
         {
@@ -45,21 +47,27 @@ const ConferenceSection = () => {
         }
     ], [ startCarMode, startWithAudioMuted, startWithVideoMuted ]);
 
-    const onChangeServerURL = useCallback(newServerURL => {
-        dispatch(updateSettings({ serverURL: newServerURL }));
-    }, [ updateSettings ]);
+    const onChangeServerURL = useCallback(value => {
+
+        setNewServerURL(value);
+        dispatch(updateSettings({
+            serverURL: value
+        }));
+    }, [ dispatch, newServerURL ]);
 
     const processServerURL = useCallback(() => {
-        const normalizedURL = normalizeUserInputURL(serverURL ?? '');
+        const normalizedURL = normalizeUserInputURL(newServerURL ?? '');
 
         onChangeServerURL(normalizedURL);
-    }, [ serverURL ]);
+    }, [ newServerURL ]);
 
     useEffect(() => () => processServerURL(), []);
 
     const onSwitchToggled = useCallback((name: string) => (enabled?: boolean) => {
+
+        // @ts-ignore
         dispatch(updateSettings({ [name]: enabled }));
-    }, [ dispatch, updateSettings ]);
+    }, [ dispatch ]);
 
     return (
         <FormSection
@@ -70,11 +78,10 @@ const ConferenceSection = () => {
                 editable = { serverURLChangeEnabled }
                 keyboardType = { 'url' }
                 label = { t('settingsView.serverURL') }
-                onBlur = { processServerURL }
                 onChange = { onChangeServerURL }
                 placeholder = { defaultServerURL }
                 textContentType = { 'URL' } // iOS only
-                value = { serverURL ?? '' } />
+                value = { newServerURL } />
             {
                 switches.map(({ label, state, name }) => (
                     <FormRow


### PR DESCRIPTION
Fixes #14079 

We already get a DEFAULT_SERVER_URL if a custom address is not set.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
