### PR TITLE
fix(compute-pressure) disable when in an iframe

### DIFF
--- a/react/features/app/middlewares.any.ts
+++ b/react/features/app/middlewares.any.ts
@@ -1,7 +1,6 @@
 import '../analytics/middleware';
 import '../authentication/middleware';
 import '../av-moderation/middleware';
-import '../base/app/middleware';
 import '../base/conference/middleware';
 import '../base/config/middleware';
 import '../base/jwt/middleware';

--- a/react/features/app/middlewares.web.ts
+++ b/react/features/app/middlewares.web.ts
@@ -1,3 +1,4 @@
+import '../base/app/middleware';
 import '../base/connection/middleware';
 import '../base/i18n/middleware';
 import '../base/devices/middleware';

--- a/react/features/base/app/middleware.web.ts
+++ b/react/features/base/app/middleware.web.ts
@@ -1,6 +1,7 @@
 import { AnyAction } from 'redux';
 
-import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
+import MiddlewareRegistry from '../redux/MiddlewareRegistry';
+import { inIframe } from '../util/iframeUtils';
 
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from './actionTypes';
 import logger from './logger';
@@ -21,7 +22,9 @@ MiddlewareRegistry.register(() => (next: Function) => async (action: AnyAction) 
 
     switch (action.type) {
     case APP_WILL_MOUNT: {
-        if ('PressureObserver' in globalThis) {
+        // Disable it inside an iframe until Google fixes the origin trial for 3rd party sources:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=1504167
+        if (!inIframe() && 'PressureObserver' in globalThis) {
             pressureObserver = new window.PressureObserver(
                     (records: typeof window.PressureRecord) => {
                         logger.info('Compute pressure state changed:', JSON.stringify(records));


### PR DESCRIPTION
Permission delegation doesn't work for 3rd party iframes on this origin trial, wait until Google solves it: https://bugs.chromium.org/p/chromium/issues/detail?id=1504167

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
