### PR TITLE
fix(devices): return user selected device id if there is no device id

### DIFF
--- a/react/features/base/settings/middleware.web.ts
+++ b/react/features/base/settings/middleware.web.ts
@@ -91,13 +91,11 @@ function _maybeUpdateDeviceId({ dispatch, getState }: IStore, track: ITrack) {
         const deviceId = track.jitsiTrack.getDeviceId();
 
         if (track.mediaType === MEDIA_TYPE.VIDEO && track.videoType === 'camera' && cameraDeviceId !== deviceId) {
-            console.log('NEW CAM', deviceId);
             dispatch(updateSettings({
                 cameraDeviceId: track.jitsiTrack.getDeviceId()
             }));
             logger.info(`switched local video device to: ${deviceId}`);
         } else if (track.mediaType === MEDIA_TYPE.AUDIO && micDeviceId !== deviceId) {
-            console.log('NEW MIC', deviceId);
             dispatch(updateSettings({
                 micDeviceId: track.jitsiTrack.getDeviceId()
             }));

--- a/react/features/device-selection/functions.web.ts
+++ b/react/features/device-selection/functions.web.ts
@@ -109,7 +109,7 @@ export function getVideoDeviceSelectionDialogProps(stateful: IStateful, isDispla
     const framerate = state['features/screen-share'].captureFrameRate ?? SS_DEFAULT_FRAME_RATE;
 
     let disableVideoInputSelect = !inputDeviceChangeSupported;
-    let selectedVideoInputId = settings.cameraDeviceId;
+    let selectedVideoInputId = settings.cameraDeviceId || userSelectedCamera;
 
     // audio input change will be a problem only when we are in a
     // conference and this is not supported, when we open device selection on
@@ -180,8 +180,8 @@ export function processExternalDeviceRequest( // eslint-disable-line max-params
                 };
                 const currentlyUsedDeviceIds = new Set([
                     getAudioOutputDeviceId(),
-                    settings.micDeviceId,
-                    settings.cameraDeviceId
+                    settings.micDeviceId ?? getUserSelectedMicDeviceId(state),
+                    settings.cameraDeviceId ?? getUserSelectedCameraDeviceId(state)
                 ]);
 
                 devices.forEach(device => {


### PR DESCRIPTION
Avoid returning undefined for device if there is a user selected device id and not a device id when calling `getCurrentDevices` on the api and when selecting video device in settings. 
