### PR TITLE
fix(media-devices) Fix configuring media devices on init

### DIFF
--- a/react/features/conference/actions.web.ts
+++ b/react/features/conference/actions.web.ts
@@ -1,5 +1,5 @@
 import { IStore } from '../app/types';
-import { configureInitialDevices, getAvailableDevices, updateDeviceList } from '../base/devices/actions.web';
+import { configureInitialDevices, getAvailableDevices } from '../base/devices/actions.web';
 import { openDialog } from '../base/dialog/actions';
 import { getBackendSafeRoomName } from '../base/util/uri';
 

--- a/react/features/conference/actions.web.ts
+++ b/react/features/conference/actions.web.ts
@@ -1,5 +1,5 @@
 import { IStore } from '../app/types';
-import { configureInitialDevices } from '../base/devices/actions.web';
+import { configureInitialDevices, getAvailableDevices, updateDeviceList } from '../base/devices/actions.web';
 import { openDialog } from '../base/dialog/actions';
 import { getBackendSafeRoomName } from '../base/util/uri';
 
@@ -35,6 +35,18 @@ export function dismissCalendarNotification() {
 }
 
 /**
+ * Setups initial devices. Makes sure we populate availableDevices list before configuring.
+ *
+ * @returns {Promise<any>}
+ */
+export function setupInitialDevices() {
+    return async (dispatch: IStore['dispatch']) => {
+        await dispatch(getAvailableDevices());
+        await dispatch(configureInitialDevices());
+    };
+}
+
+/**
  * Init.
  *
  * @returns {Promise<JitsiConnection>}
@@ -45,7 +57,7 @@ export function init() {
 
         // XXX For web based version we use conference initialization logic
         // from the old app (at the moment of writing).
-        return dispatch(configureInitialDevices()).then(
+        return dispatch(setupInitialDevices()).then(
             () => APP.conference.init({
                 roomName: room
             }).catch((error: Error) => {

--- a/react/features/prejoin/components/web/PrejoinApp.tsx
+++ b/react/features/prejoin/components/web/PrejoinApp.tsx
@@ -8,6 +8,7 @@ import { createPrejoinTracks } from '../../../base/tracks/functions.web';
 import GlobalStyles from '../../../base/ui/components/GlobalStyles.web';
 import JitsiThemeProvider from '../../../base/ui/components/JitsiThemeProvider.web';
 import DialogContainer from '../../../base/ui/components/web/DialogContainer';
+import { setupInitialDevices } from '../../../conference/actions.web';
 import { initPrejoin, makePrecallTest } from '../../actions.web';
 
 import PrejoinThirdParty from './PrejoinThirdParty';
@@ -59,6 +60,7 @@ export default class PrejoinApp extends BaseApp<Props> {
             startWithVideoMuted
         }));
 
+        await dispatch?.(setupInitialDevices());
         const { tryCreateLocalTracks, errors } = createPrejoinTracks();
 
         const tracks = await tryCreateLocalTracks;


### PR DESCRIPTION
- on 3rd party prejoin, we did not setup the initial devices, resulting in always creating tracks for default device for camera and mic regardless of settings, and for both meeting and 3rd party prejoin to not set the audio output device at all

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
