### PR TITLE
Fixed Overflow Menu button of popover 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+
+
 # http://editorconfig.org
 root = true
 

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,3 +1,4 @@
+
 declare module '*.svg' {
     const content: any;
     export default content;

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,7 +153,7 @@
         "circular-dependency-plugin": "5.2.0",
         "clean-css-cli": "4.3.0",
         "css-loader": "6.8.1",
-        "eslint": "8.40.0",
+        "eslint": "^8.40.0",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-jsdoc": "37.0.3",
         "eslint-plugin-react": "7.32.2",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "circular-dependency-plugin": "5.2.0",
     "clean-css-cli": "4.3.0",
     "css-loader": "6.8.1",
-    "eslint": "8.40.0",
+    "eslint": "^8.40.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jsdoc": "37.0.3",
     "eslint-plugin-react": "7.32.2",

--- a/react/features/toolbox/components/web/OverflowMenuButton.tsx
+++ b/react/features/toolbox/components/web/OverflowMenuButton.tsx
@@ -76,14 +76,16 @@ const useStyles = makeStyles<{ overflowDrawer: boolean; reactionsMenuHeight: num
             height: `calc(${DRAWER_MAX_HEIGHT})`
         },
         contextMenu: {
+
+
             position: 'relative' as const,
             right: 'auto',
             margin: 0,
             marginBottom: '8px',
-            maxHeight: overflowDrawer ? undefined : 'calc(100dvh - 100px)',
+            maxHeight: "60vh",
             paddingBottom: overflowDrawer ? undefined : 0,
             minWidth: '240px',
-            overflow: 'hidden'
+            overflow: "scroll",
         },
         content: {
             position: 'relative',


### PR DESCRIPTION
closes  https://github.com/jitsi/jitsi-meet/issues/12739

This is fine with smaller machines ,the fix/ added Modified is to limit the popover's overall height and adding some overflow: scroll 