### PR TITLE
fix(debian): No svg available in root folder.

### DIFF
--- a/debian/jitsi-meet-web.install
+++ b/debian/jitsi-meet-web.install
@@ -1,6 +1,5 @@
 interface_config.js		/usr/share/jitsi-meet/
 *.html					/usr/share/jitsi-meet/
-*.svg					/usr/share/jitsi-meet/
 libs					/usr/share/jitsi-meet/
 static                  /usr/share/jitsi-meet/
 css/all.css 			/usr/share/jitsi-meet/css/


### PR DESCRIPTION
We reference the favicon from index as svg directly from the images folder.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
