### PR TITLE
Feature/rn sdk add onparticipantleft and getroomsinfo

### DIFF
--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -16,6 +16,8 @@ import { View, ViewStyle } from 'react-native';
 import { appNavigate } from './react/features/app/actions.native';
 import { App } from './react/features/app/components/App.native';
 import { setAudioMuted, setVideoMuted } from './react/features/base/media/actions';
+import { getRoomsInfo } from './react/features/breakout-rooms/functions';
+import type { IRoomsInfo } from '../react/features/breakout-rooms/types';
 
 
 interface IEventListeners {
@@ -49,10 +51,17 @@ interface IAppProps {
     userInfo?: IUserInfo;
 }
 
+export interface JitsiRefProps {
+    close: Function;
+    setAudioMuted?: (muted: boolean) => void;
+    setVideoMuted?: (muted: boolean) => void;
+    getRoomsInfo?: () => IRoomsInfo;
+}
+
 /**
  * Main React Native SDK component that displays a Jitsi Meet conference and gets all required params as props
  */
-export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
+export const JitsiMeeting = forwardRef<JitsiRefProps, IAppProps>((props, ref) => {
     const [ appProps, setAppProps ] = useState({});
     const app = useRef(null);
     const {
@@ -82,6 +91,11 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
             const dispatch = app.current.state.store.dispatch;
 
             dispatch(setVideoMuted(muted));
+        },
+        getRoomsInfo: () => {
+            const state = app.current.state.store.getState();
+
+            return getRoomsInfo(state);
         }
     }));
 

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -28,6 +28,7 @@ interface IEventListeners {
     onConferenceWillJoin?: Function;
     onEnterPictureInPicture?: Function;
     onParticipantJoined?: Function;
+    onParticipantLeft?: ({ id }: { id: string }) => void;
     onReadyToClose?: Function;
 }
 
@@ -118,6 +119,7 @@ export const JitsiMeeting = forwardRef((props: IAppProps, ref) => {
                     onConferenceLeft: eventListeners?.onConferenceLeft,
                     onEnterPictureInPicture: eventListeners?.onEnterPictureInPicture,
                     onParticipantJoined: eventListeners?.onParticipantJoined,
+                    onParticipantLeft: eventListeners?.onParticipantLeft,
                     onReadyToClose: eventListeners?.onReadyToClose
                 },
                 'url': urlProps,

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -13,11 +13,12 @@ import React, {
 } from 'react';
 import { View, ViewStyle } from 'react-native';
 
+import type { IRoomsInfo } from '../react/features/breakout-rooms/types';
+
 import { appNavigate } from './react/features/app/actions.native';
 import { App } from './react/features/app/components/App.native';
 import { setAudioMuted, setVideoMuted } from './react/features/base/media/actions';
 import { getRoomsInfo } from './react/features/breakout-rooms/functions';
-import type { IRoomsInfo } from '../react/features/breakout-rooms/types';
 
 
 interface IEventListeners {

--- a/react/features/mobile/react-native-sdk/middleware.js
+++ b/react/features/mobile/react-native-sdk/middleware.js
@@ -9,7 +9,7 @@ import {
     CONFERENCE_WILL_JOIN
 } from '../../base/conference/actionTypes';
 import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../../base/media/actionTypes';
-import { PARTICIPANT_JOINED } from '../../base/participants/actionTypes';
+import { PARTICIPANT_JOINED, PARTICIPANT_LEFT } from '../../base/participants/actionTypes';
 import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../../base/redux/StateListenerRegistry';
 import { READY_TO_CLOSE } from '../external-api/actionTypes';
@@ -61,6 +61,14 @@ const { JMOngoingConference } = NativeModules;
         const participantInfo = participantToParticipantInfo(participant);
 
         rnSdkHandlers?.onParticipantJoined && rnSdkHandlers?.onParticipantJoined(participantInfo);
+        break;
+    }
+    case PARTICIPANT_LEFT: {
+        const { participant } = action;
+
+        const { id } = participant ?? {};
+
+        rnSdkHandlers?.onParticipantLeft && rnSdkHandlers?.onParticipantLeft({ id });
         break;
     }
     case READY_TO_CLOSE:


### PR DESCRIPTION
Adding `onParticipantLeft` event listener and `getRoomsInfo` ref callback.

I tested both by:

```
const onParticipantLeft = ({ id }) => {
  console.log('onParticipantLeft participantId', id);

  const { rooms } = jitsiUiRef.current?.getRoomsInfo();

  console.log('onParticipantLeft rooms', rooms);
  console.log('onParticipantLeft participants', rooms[0].participants);
};

return (
  <JitsiMeeting
  ...
  ref={jitsiUiRef}
  eventListeners={{ onParticipantLeft }}
```