### PR TITLE
fix: Do not log unknown commands.

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -835,8 +835,6 @@ function initCommands() {
             return true;
         }
 
-        logger.warn(`Unknown API command received: ${name}`);
-
         return false;
     });
     transport.on('request', (request, callback) => {


### PR DESCRIPTION
Events such as "mouse-move", "mouse-leave" and "face-landmark-detected"
reach this code and pollute the logs. It's probably worth investigating
why this is the case and fixing it if necessary, but for now just remove
the log message.