### PR TITLE
fix(ui) style prejoin drawer

### DIFF
--- a/react/features/prejoin/components/web/Prejoin.tsx
+++ b/react/features/prejoin/components/web/Prejoin.tsx
@@ -189,7 +189,17 @@ const useStyles = makeStyles()(theme => {
             color: theme.palette.text04,
             borderRadius: theme.shape.borderRadius,
             position: 'relative',
-            top: `-${theme.spacing(3)}`
+            top: `-${theme.spacing(3)}`,
+
+            '@media (max-width: 511px)': {
+                margin: '0 auto',
+                top: 0
+            },
+
+            '@media (max-width: 420px)': {
+                top: 0,
+                width: 'calc(100% - 32px)'
+            }
         }
     };
 });

--- a/react/features/toolbox/components/web/Drawer.tsx
+++ b/react/features/toolbox/components/web/Drawer.tsx
@@ -37,6 +37,7 @@ interface IProps {
 const useStyles = makeStyles()(theme => {
     return {
         drawerMenuContainer: {
+            backgroundColor: 'rgba(0,0,0,0.6)',
             height: '100dvh',
             display: 'flex',
             alignItems: 'flex-end'


### PR DESCRIPTION
previously:
<img width="262" alt="image" src="https://github.com/jitsi/jitsi-meet/assets/20574669/8eea2579-6f4f-494a-b21c-a67f29d8481d">
and with the fix:
<img width="262" alt="image" src="https://github.com/jitsi/jitsi-meet/assets/20574669/279ec4fa-f7e5-4eb9-8271-4d40578de8fe">
<img width="262" alt="image" src="https://github.com/jitsi/jitsi-meet/assets/20574669/dba0d07a-9169-4556-84ea-fc89bcd1e321">