### PR TITLE
fix(reactions-firefox) Fix drawer menu not scrollable on FF

### DIFF
--- a/react/features/toolbox/components/web/OverflowMenuButton.tsx
+++ b/react/features/toolbox/components/web/OverflowMenuButton.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles<{ overflowDrawer: boolean; reactionsMenuHeight: num
 (_theme, { reactionsMenuHeight, overflowDrawer }) => {
     return {
         overflowMenuDrawer: {
-            overflow: 'hidden',
+            overflowY: 'scroll',
             height: `calc(${DRAWER_MAX_HEIGHT})`
         },
         contextMenu: {
@@ -92,8 +92,13 @@ const useStyles = makeStyles<{ overflowDrawer: boolean; reactionsMenuHeight: num
             overflowY: 'auto'
         },
         footer: {
-            position: 'relative',
-            bottom: 0
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0
+        },
+        reactionsPadding: {
+            height: `${reactionsMenuHeight}px`
         }
     };
 });
@@ -211,6 +216,7 @@ const OverflowMenuButton = ({
                             <>
                                 <div className = { classes.overflowMenuDrawer }>
                                     { overflowMenu }
+                                    <div className = { classes.reactionsPadding } />
                                 </div>
                             </>
                         </Drawer>

--- a/react/features/toolbox/subscriber.web.ts
+++ b/react/features/toolbox/subscriber.web.ts
@@ -92,11 +92,9 @@ StateListenerRegistry.register(
             isTileView: isLayoutTileView(state)
         };
     },
-    /* listener */({ clientHeight, isTileView: previousIsTileView }, store) => {
-        const state = store.getState();
-
-        if (!isLayoutTileView(state)) {
-            if (previousIsTileView) {
+    /* listener */({ clientHeight, isTileView }, store, previousState) => {
+        if (!isTileView) {
+            if (previousState?.isTileView) {
                 store.dispatch(setShiftUp(false));
             }
 


### PR DESCRIPTION
- fix reactions menu not visibile on FF when in drawer mode
- fix subscriber for tileview

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
