### PR TITLE
fix: moment duration format error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,7 @@
         "@types/dom-screen-wake-lock": "1.0.1",
         "@types/js-md5": "0.4.3",
         "@types/lodash": "4.14.182",
+        "@types/moment-duration-format": "^2.2.6",
         "@types/offscreencanvas": "2019.7.2",
         "@types/pixelmatch": "5.2.5",
         "@types/punycode": "2.1.0",
@@ -5701,6 +5702,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
+    },
+    "node_modules/@types/moment-duration-format": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/moment-duration-format/-/moment-duration-format-2.2.6.tgz",
+      "integrity": "sha512-Qw+6ys3sQCatqukjoIBsL1UJq6S7ep4ixrNvDkdViSgzw2ZG3neArXNu3ww7mEG8kwP32ZDoON/esWb7OUckRQ==",
+      "dev": true,
+      "dependencies": {
+        "moment": ">=2.14.0"
+      }
     },
     "node_modules/@types/node": {
       "version": "17.0.19",
@@ -22743,6 +22753,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
+    },
+    "@types/moment-duration-format": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/moment-duration-format/-/moment-duration-format-2.2.6.tgz",
+      "integrity": "sha512-Qw+6ys3sQCatqukjoIBsL1UJq6S7ep4ixrNvDkdViSgzw2ZG3neArXNu3ww7mEG8kwP32ZDoON/esWb7OUckRQ==",
+      "dev": true,
+      "requires": {
+        "moment": ">=2.14.0"
+      }
     },
     "@types/node": {
       "version": "17.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
         "@types/dom-screen-wake-lock": "1.0.1",
         "@types/js-md5": "0.4.3",
         "@types/lodash": "4.14.182",
-        "@types/moment-duration-format": "^2.2.6",
+        "@types/moment-duration-format": "2.2.6",
         "@types/offscreencanvas": "2019.7.2",
         "@types/pixelmatch": "5.2.5",
         "@types/punycode": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@types/dom-screen-wake-lock": "1.0.1",
     "@types/js-md5": "0.4.3",
     "@types/lodash": "4.14.182",
+    "@types/moment-duration-format": "^2.2.6",
     "@types/offscreencanvas": "2019.7.2",
     "@types/pixelmatch": "5.2.5",
     "@types/punycode": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@types/dom-screen-wake-lock": "1.0.1",
     "@types/js-md5": "0.4.3",
     "@types/lodash": "4.14.182",
-    "@types/moment-duration-format": "^2.2.6",
+    "@types/moment-duration-format": "2.2.6",
     "@types/offscreencanvas": "2019.7.2",
     "@types/pixelmatch": "5.2.5",
     "@types/punycode": "2.1.0",

--- a/react/features/base/i18n/dateUtil.ts
+++ b/react/features/base/i18n/dateUtil.ts
@@ -1,9 +1,9 @@
 import moment from 'moment';
+import momentDurationFormatSetup from 'moment-duration-format';
 
 import i18next from './i18next';
 
 // allows for moment durations to be formatted
-import momentDurationFormatSetup from "moment-duration-format";
 momentDurationFormatSetup(moment);
 
 // MomentJS uses static language bundle loading, so in order to support dynamic

--- a/react/features/base/i18n/dateUtil.ts
+++ b/react/features/base/i18n/dateUtil.ts
@@ -3,7 +3,8 @@ import moment from 'moment';
 import i18next from './i18next';
 
 // allows for moment durations to be formatted
-import 'moment-duration-format';
+import momentDurationFormatSetup from "moment-duration-format";
+momentDurationFormatSetup(moment);
 
 // MomentJS uses static language bundle loading, so in order to support dynamic
 // language selection in the app we need to load all bundles that we support in


### PR DESCRIPTION
Issue: When lobby mode is active, the ui showing the elapsed time gives an error when it comes to the screen. Moment just released a new update and moment-duration-format plugin is not compatible with this version. This plugin will always try to install itself on the root.moment instance, if it exists. [source](https://github.com/jsmreese/moment-duration-format?tab=readme-ov-file#usage)

Solution: Used the moment version of jitsi-meet instead of root. [No problem with version 2.29.4](https://github.com/moment/moment/blob/develop/CHANGELOG.md)

![Simulator Screenshot - iPhone 15 - 2023-12-28 at 15 34 01](https://github.com/jitsi/jitsi-meet/assets/71596269/b1b93f07-6d67-4bda-838a-05e72fa46e08)

![Simulator Screenshot - iPhone 15 - 2023-12-28 at 15 35 00](https://github.com/jitsi/jitsi-meet/assets/71596269/3380ab85-f76c-4ff7-b3a4-9369bbee12d9)


