### PR TITLE
fix: census lua init to 0 to avoid openmetrics errors

### DIFF
--- a/resources/prosody-plugins/mod_muc_census.lua
+++ b/resources/prosody-plugins/mod_muc_census.lua
@@ -37,7 +37,7 @@ local tostring = tostring;
 -- required parameter for custom muc component prefix, defaults to "conference"
 local muc_domain_prefix = module:get_option_string("muc_mapper_domain_prefix", "conference");
 
-local leaked_rooms;
+local leaked_rooms = 0;
 
 --- handles request to get number of participants in all rooms
 -- @return GET response


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Fixes the census module reporting nil values to the metrics handler, causing failures in openmetrics rendering