### PR TITLE
fix: Fixes leaving the visitor's meeting on promotion.

### DIFF
--- a/react/features/base/conference/actions.ts
+++ b/react/features/base/conference/actions.ts
@@ -1000,8 +1000,6 @@ export function setAssumedBandwidthBps(assumedBandwidthBps: number) {
  */
 export function redirect(vnode: string, focusJid: string, username: string) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
-        const { conference, joining } = getState()['features/base/conference'];
-        const currentConference = conference || joining;
         const newConfig = getVisitorOptions(getState, vnode, focusJid, username);
 
         if (!newConfig) {
@@ -1011,8 +1009,7 @@ export function redirect(vnode: string, focusJid: string, username: string) {
         }
 
         dispatch(overwriteConfig(newConfig)) // @ts-ignore
-            .then(() => currentConference && dispatch(conferenceWillLeave(currentConference, true)))
-            .then(() => dispatch(disconnect()))
+            .then(() => dispatch(disconnect(true)))
             .then(() => dispatch(setIAmVisitor(Boolean(vnode))))
 
             // we do not clear local tracks on error, so we need to manually clear them

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -328,6 +328,7 @@ function _connectionWillConnect(connection: Object) {
 
 /**
  * Closes connection.
+ *
  * @param {boolean} isRedirect - Indicates if the action has been dispatched as part of visitor promotion.
  *
  * @returns {Function}

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -328,10 +328,11 @@ function _connectionWillConnect(connection: Object) {
 
 /**
  * Closes connection.
+ * @param {boolean} isRedirect - Indicates if the action has been dispatched as part of visitor promotion.
  *
  * @returns {Function}
  */
-export function disconnect() {
+export function disconnect(isRedirect?: boolean) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']): Promise<void> => {
         const state = getState();
 
@@ -348,7 +349,7 @@ export function disconnect() {
             // (and the respective Redux action) which is fired after the
             // conference has been left, notify the application about the
             // intention to leave the conference.
-            dispatch(conferenceWillLeave(conference_));
+            dispatch(conferenceWillLeave(conference_, isRedirect));
 
             promise
                 = conference_.leave()


### PR DESCRIPTION
This was resulting some colibri websockets reconnects as the state of the previous JitsiConference was not cleaned up.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
