### PR TITLE
Fixed insecure-room-name-warning color to dark red.

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -92,7 +92,7 @@ body.welcome-page {
 
         .insecure-room-name-warning {
             align-items: center;
-            color: rgb(215, 121, 118);
+            color: rgb(255, 8, 0);
             font-weight: 600;
             display: flex;
             flex-direction: row;


### PR DESCRIPTION
Close https://github.com/jitsi/jitsi-meet/issues/14224

The color message changed to dark red, now the message can be easily read.