### PR TITLE
feat(deeplinking): Desktop deeplinking configurable (default off) and using jitsi-meet-electron

### DIFF
--- a/config.js
+++ b/config.js
@@ -1197,9 +1197,11 @@ var config = {
     // https://firebase.google.com/docs/dynamic-links/create-manually
     // deeplinking: {
     //
-    //     // The desktop deeplinking config.
+    //     // The desktop deeplinking config, disabled by default.
     //     desktop: {
-    //         appName: 'Jitsi Meet'
+    //         appName: 'Jitsi Meet',
+    //         appScheme: 'jitsi-meet,
+    //         enabled: false
     //     },
     //     // If true, any checks to handoff to another application will be prevented
     //     // and instead the app will continue to display in the current browser.

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -131,19 +131,23 @@ export interface IMobileDynamicLink {
 
 export interface IDeeplinkingPlatformConfig {
     appName: string;
+    appScheme: string;
 }
 
 export interface IDeeplinkingMobileConfig extends IDeeplinkingPlatformConfig {
     appPackage?: string;
-    appScheme: string;
     downloadLink: string;
     dynamicLink?: IMobileDynamicLink;
     fDroidUrl?: string;
 }
 
+export interface IDeeplinkingDesktopConfig extends IDeeplinkingPlatformConfig {
+    enabled: boolean;
+}
+
 export interface IDeeplinkingConfig {
     android?: IDeeplinkingMobileConfig;
-    desktop?: IDeeplinkingPlatformConfig;
+    desktop?: IDeeplinkingDesktopConfig;
     disabled?: boolean;
     hideLogo?: boolean;
     ios?: IDeeplinkingMobileConfig;

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -5,8 +5,8 @@ import { NOTIFY_CLICK_MODE } from '../../toolbox/constants';
 import {
     IConfig,
     IDeeplinkingConfig,
+    IDeeplinkingDesktopConfig,
     IDeeplinkingMobileConfig,
-    IDeeplinkingPlatformConfig,
     NotifyClickButton,
     ToolbarButton
 } from './configType';
@@ -95,12 +95,13 @@ export function areAudioLevelsEnabled(state: IReduxState): boolean {
  */
 export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
     const {
-        desktop = {} as IDeeplinkingPlatformConfig,
+        desktop = {} as IDeeplinkingDesktopConfig,
         android = {} as IDeeplinkingMobileConfig,
         ios = {} as IDeeplinkingMobileConfig
     } = deeplinking;
 
     desktop.appName = desktop.appName || 'Jitsi Meet';
+    desktop.appScheme = desktop.appScheme || 'jitsi-meet';
 
     ios.appName = ios.appName || 'Jitsi Meet';
     ios.appScheme = ios.appScheme || 'org.jitsi.meet';

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -14,8 +14,8 @@ import {
 import {
     IConfig,
     IDeeplinkingConfig,
+    IDeeplinkingDesktopConfig,
     IDeeplinkingMobileConfig,
-    IDeeplinkingPlatformConfig,
     IMobileDynamicLink,
     ToolbarButton
 } from './configType';
@@ -295,7 +295,7 @@ function _translateInterfaceConfig(oldValue: IConfig) {
     } else {
         const disabled = Boolean(oldValue.disableDeepLinking);
         const deeplinking: IDeeplinkingConfig = {
-            desktop: {} as IDeeplinkingPlatformConfig,
+            desktop: {} as IDeeplinkingDesktopConfig,
             hideLogo: false,
             disabled,
             android: {} as IDeeplinkingMobileConfig,

--- a/react/features/deep-linking/openDesktopApp.ts
+++ b/react/features/deep-linking/openDesktopApp.ts
@@ -1,3 +1,6 @@
+import { IReduxState } from '../app/types';
+import { URI_PROTOCOL_PATTERN } from '../base/util/uri';
+
 /**
  * Opens the desktop app.
  *
@@ -6,5 +9,17 @@
  * with false otherwise.
  */
 export function _openDesktopApp(_state: Object) {
+    const state = _state as IReduxState;
+    const deeplinkingDesktop = state['features/base/config'].deeplinking?.desktop;
+
+    if (deeplinkingDesktop?.enabled) {
+        const { appScheme } = deeplinkingDesktop;
+        const regex = new RegExp(URI_PROTOCOL_PATTERN, 'gi');
+
+        window.location.href = window.location.href.replace(regex, `${appScheme}:`);
+
+        return Promise.resolve(true);
+    }
+
     return Promise.resolve(false);
 }


### PR DESCRIPTION
As we have the jitsi-meet-electron app, lets allow deployments to use it.

Allow deployments to enable desktop deeplinking without the need to re-implement _openDesktopApp()
Disable it by default to keep the current behaviour (deeplinking on mobile on, on desktop off)

This feature is meant as purely opt-in.

Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
