### PR TITLE
feat(deeplinking): offer electron app for download, configurable

### DIFF
--- a/config.js
+++ b/config.js
@@ -1202,7 +1202,8 @@ var config = {
     //         appName: 'Jitsi Meet',
     //         appScheme: 'jitsi-meet,
     //         download: {
-    //             linux: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage',
+    //             linux:
+    //               'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage',
     //             macos: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg',
     //             windows: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe'
     //         },

--- a/config.js
+++ b/config.js
@@ -1201,6 +1201,11 @@ var config = {
     //     desktop: {
     //         appName: 'Jitsi Meet',
     //         appScheme: 'jitsi-meet,
+    //         download: {
+    //             linux: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage',
+    //             macos: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg',
+    //             windows: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe'
+    //         },
     //         enabled: false
     //     },
     //     // If true, any checks to handoff to another application will be prevented

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -223,7 +223,7 @@
         "termsAndConditions": "Indem Sie fortfahren, stimmen Sie underen<a href='{{termsAndConditionsLink}}' rel='noopener noreferrer' target='_blank'>Nutzungsbedingungen</a> zu.",
         "title": "Die Konferenz wird in {{app}} geöffnet …",
         "titleNew": "Konferenz starten ...",
-        "tryAgainButton": "Erneut mit der nativen Applikation versuchen",
+        "tryAgainButton": "Erneut versuchen",
         "unsupportedBrowser": "Sie verwenden einen Browser, der noch nicht unterstützt wird."
     },
     "defaultLink": "Bsp.: {{url}}",

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -219,6 +219,7 @@
         "joinInBrowser": "Im Browser",
         "launchMeetingLabel": "Wie möchten Sie an der Konferenz teilnehmen?",
         "launchWebButton": "Im Web öffnen",
+        "noDesktopApp": "Sie haben die App noch nicht installiert?",
         "noMobileApp": "Sie haben die App noch nicht installiert?",
         "termsAndConditions": "Indem Sie fortfahren, stimmen Sie underen<a href='{{termsAndConditionsLink}}' rel='noopener noreferrer' target='_blank'>Nutzungsbedingungen</a> zu.",
         "title": "Die Konferenz wird in {{app}} geöffnet …",

--- a/lang/main.json
+++ b/lang/main.json
@@ -219,6 +219,7 @@
         "joinInBrowser": "Join in browser",
         "launchMeetingLabel": "How do you want to join this meeting?",
         "launchWebButton": "Launch in web",
+        "noDesktopApp": "You don’t have the app?",
         "noMobileApp": "You don’t have the app?",
         "termsAndConditions": "By continuing you agree to our <a href='{{termsAndConditionsLink}}' rel='noopener noreferrer' target='_blank'>terms & conditions.</a>",
         "title": "Launching your meeting in {{app}}...",

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -141,7 +141,14 @@ export interface IDeeplinkingMobileConfig extends IDeeplinkingPlatformConfig {
     fDroidUrl?: string;
 }
 
+export interface IDesktopDownloadConfig {
+    linux?: string;
+    macos?: string;
+    windows?: string;
+}
+
 export interface IDeeplinkingDesktopConfig extends IDeeplinkingPlatformConfig {
+    download?: IDesktopDownloadConfig;
     enabled: boolean;
 }
 

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -102,6 +102,20 @@ export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
 
     desktop.appName = desktop.appName || 'Jitsi Meet';
     desktop.appScheme = desktop.appScheme || 'jitsi-meet';
+    if (desktop.download) {
+        desktop.download.windows = desktop.download.windows
+            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe';
+        desktop.download.macos = desktop.download.macos
+            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg';
+        desktop.download.linux = desktop.download.linux
+            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage';
+    } else {
+        desktop.download = {
+            windows: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe',
+            macos: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg',
+            linux: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage'
+        };
+    }
 
     ios.appName = ios.appName || 'Jitsi Meet';
     ios.appScheme = ios.appScheme || 'org.jitsi.meet';

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -102,20 +102,13 @@ export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
 
     desktop.appName = desktop.appName || 'Jitsi Meet';
     desktop.appScheme = desktop.appScheme || 'jitsi-meet';
-    if (desktop.download) {
-        desktop.download.windows = desktop.download.windows
-            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe';
-        desktop.download.macos = desktop.download.macos
-            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg';
-        desktop.download.linux = desktop.download.linux
-            || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage';
-    } else {
-        desktop.download = {
-            windows: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe',
-            macos: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg',
-            linux: 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage'
-        };
-    }
+    desktop.download = desktop.download || {};
+    desktop.download.windows = desktop.download.windows
+        || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.exe';
+    desktop.download.macos = desktop.download.macos
+        || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet.dmg';
+    desktop.download.linux = desktop.download.linux
+        || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage';
 
     ios.appName = ios.appName || 'Jitsi Meet';
     ios.appScheme = ios.appScheme || 'org.jitsi.meet';

--- a/react/features/base/react/Platform.web.ts
+++ b/react/features/base/react/Platform.web.ts
@@ -10,6 +10,8 @@ if (userAgent.match(/Android/i)) {
     OS = 'macos';
 } else if (userAgent.match(/Windows/i)) {
     OS = 'windows';
+} else if (userAgent.match(/Linux/i)) {
+    OS = 'linux';
 }
 
 /**

--- a/react/features/deep-linking/components/DeepLinkingDesktopPage.web.tsx
+++ b/react/features/deep-linking/components/DeepLinkingDesktopPage.web.tsx
@@ -145,10 +145,8 @@ const DeepLinkingDesktopPage: React.FC<WithTranslation> = ({ t }) => {
                 </div>
                 <div className = { styles.descriptionLabel }>
                     {
-                        t(`${_TNS}.noMobileApp`)
-                    }
-                </div>
-                <div className = { styles.descriptionLabel }>
+                        t(`${_TNS}.noDesktopApp`)
+                    } &nbsp;
                     <a href = { generateDownloadURL() }>
                         {
                             t(`${_TNS}.downloadApp`)

--- a/react/features/deep-linking/components/DeepLinkingDesktopPage.web.tsx
+++ b/react/features/deep-linking/components/DeepLinkingDesktopPage.web.tsx
@@ -11,6 +11,7 @@ import { IDeeplinkingConfig } from '../../base/config/configType';
 import { getLegalUrls } from '../../base/config/functions.any';
 import { isSupportedBrowser } from '../../base/environment/environment';
 import { translate, translateToHTML } from '../../base/i18n/functions';
+import Platform from '../../base/react/Platform.web';
 import { withPixelLineHeight } from '../../base/styles/functions.web';
 import Button from '../../base/ui/components/web/Button';
 import { BUTTON_TYPES } from '../../base/ui/constants.any';
@@ -85,6 +86,14 @@ const DeepLinkingDesktopPage: React.FC<WithTranslation> = ({ t }) => {
     const deeplinkingCfg = useSelector((state: IReduxState) =>
         state['features/base/config']?.deeplinking || {} as IDeeplinkingConfig);
 
+    const generateDownloadURL = useCallback(() => {
+        const downloadCfg = deeplinkingCfg.desktop?.download;
+
+        if (downloadCfg) {
+            return downloadCfg[Platform.OS as keyof typeof downloadCfg];
+        }
+    }, [ deeplinkingCfg ]);
+
     const legalUrls = useSelector(getLegalUrls);
 
     const { hideLogo, desktop } = deeplinkingCfg;
@@ -133,6 +142,18 @@ const DeepLinkingDesktopPage: React.FC<WithTranslation> = ({ t }) => {
                             ? translateToHTML(t, `${_TNS}.descriptionNew`, { app: desktop?.appName })
                             : t(`${_TNS}.descriptionWithoutWeb`, { app: desktop?.appName })
                     }
+                </div>
+                <div className = { styles.descriptionLabel }>
+                    {
+                        t(`${_TNS}.noMobileApp`)
+                    }
+                </div>
+                <div className = { styles.descriptionLabel }>
+                    <a href = { generateDownloadURL() }>
+                        {
+                            t(`${_TNS}.downloadApp`)
+                        }
+                    </a>
                 </div>
                 <div className = { styles.buttonsContainer }>
                     <Button


### PR DESCRIPTION
Offer the default app, but make it configurable for own branded
desktop clients

Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
