### PR TITLE
fix(visitors): Fixes clearing promotion requests.

### DIFF
--- a/react/features/visitors/reducer.ts
+++ b/react/features/visitors/reducer.ts
@@ -53,11 +53,9 @@ ReducerRegistry.register<IVisitorsState>('features/visitors', (state = DEFAULT_S
     case VISITOR_PROMOTION_REQUEST: {
         const currentRequests = state.promotionRequests || [];
 
-        currentRequests.push(action.request);
-
         return {
             ...state,
-            promotionRequests: [ ...currentRequests ]
+            promotionRequests: [ ...currentRequests, action.request ]
         };
     }
     case CLEAR_VISITOR_PROMOTION_REQUEST: {


### PR DESCRIPTION
We were modifying DEFAULT_STATE and later the request magically appears after the state is cleared, like joining and leaving breakout rooms.
