### PR TITLE
Add upper sorbian to transcription languages

### DIFF
--- a/lang/translation-languages.json
+++ b/lang/translation-languages.json
@@ -34,6 +34,7 @@
     "hi": "Hindi",
     "hmn": "Hmong",
     "hr": "Croatian",
+    "hsb": "Upper Sorbian",
     "ht": "Haitian Creole",
     "hu": "Hungarian",
     "hy": "Armenian",

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -148,8 +148,11 @@ function _endpointMessageReceived({ dispatch, getState }: IStore, next: Function
             });
         }
 
-        // If the suer is not requesting transcriptions just bail.
-        if (json.language.slice(0, 2) !== language) {
+        // If the user is not requesting transcriptions just bail.
+        // Regex to filter out all possible country codes after language code:
+        // this should catch all notations like 'en-GB' 'en_GB' and 'enGB'
+        // and be independent of the country code length
+        if (json.language.replace(/[-_A-Z].*/, '') !== language) {
             return next(action);
         }
 

--- a/react/features/transcribing/jitsi-bcp47-map.json
+++ b/react/features/transcribing/jitsi-bcp47-map.json
@@ -20,6 +20,7 @@
     "hi": "hi-IN",
     "mr": "mr-IN",
     "hr": "hr-HR",
+    "hsb": "hsb-DE",
     "hu": "hu-HU",
     "hy": "hy-AM",
     "id": "id-ID",

--- a/react/features/transcribing/transcriber-langs.json
+++ b/react/features/transcribing/transcriber-langs.json
@@ -45,6 +45,7 @@
     "is-IS": "Icelandic (Iceland)",
     "it-IT": "Italian (Italy)",
     "lt-LT": "Lithuanian (Lithuania)",
+    "hsb-DE": "Upper Sorbian (Germany)",
     "hu-HU": "Hungarian (Hungary)",
     "nl-NL": "Dutch (Netherlands)",
     "no-NO": "Norwegian Bokmål (Norway)",


### PR DESCRIPTION
This is a continuation of this PR: https://github.com/jitsi/jitsi-meet/pull/13925 

It includes a simple fix for transcription display if the language code is not 2 letters long, and adds Upper Sorbian (language code "hsb") to the list of supported languages for transcription and translation.

Patch has been tested with release 9220.
