### PR TITLE
feat: Notify jicofo when room_metadata changes the config form.

### DIFF
--- a/resources/prosody-plugins/mod_room_metadata_component.lua
+++ b/resources/prosody-plugins/mod_room_metadata_component.lua
@@ -62,6 +62,11 @@ function broadcastMetadata(room)
     for _, occupant in room:each_occupant() do
         if jid_node(occupant.jid) ~= 'focus' then
             send_json_msg(occupant.jid, json_msg)
+        else
+            -- Jicofo reads room_metadata only from the MUC config form. Notify it that the form changed.
+            module:send(st.message({ type='groupchat', from=room.jid, to = occupant.jid })
+                :tag('x', { xmlns='http://jabber.org/protocol/muc#user' })
+                :tag('status', { code='104' }));
         end
     end
 end


### PR DESCRIPTION
Send a message to jicofo with a status code 104 (config update) to make it re-read the MUC configuration form when room_metadata changes