### PR TITLE
fix(recording/livestreaming):  labels

### DIFF
--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -36,7 +36,7 @@ import {
     getRecordButtonProps,
     getRecordingLink,
     getResourceId,
-    isRecordingRunning,
+    isRecordingOrTranscribingRunning,
     isRecordingSharingEnabled,
     isSavingRecordingOnDropbox,
     sendMeetingHighlight,
@@ -408,7 +408,7 @@ export function showStartRecordingNotificationWithCallback(openRecordingDialog: 
         const { recordings } = state['features/base/config'];
         const { suggestRecording } = recordings || {};
         const recordButtonProps = getRecordButtonProps(state);
-        const isAlreadyRecording = isRecordingRunning(state);
+        const isAlreadyRecording = isRecordingOrTranscribingRunning(state);
         const wasNotificationShown = state['features/recording'].wasStartRecordingSuggested;
 
         if (!suggestRecording

--- a/react/features/recording/components/AbstractRecordingLabel.ts
+++ b/react/features/recording/components/AbstractRecordingLabel.ts
@@ -14,15 +14,16 @@ interface IProps extends WithTranslation {
      */
     _iAmRecorder: boolean;
 
-    /**
-     * Whether the recording/livestreaming/transcriber is currently running.
-     */
-    _isRunning: boolean;
 
     /**
      * Whether this meeting is being transcribed.
-     */
-    _isTranscribing: boolean;
+    */
+   _isTranscribing: boolean;
+
+   /**
+    * Whether the recording/livestreaming/transcriber is currently running.
+    */
+   _isVisible: boolean;
 
     /**
      * The status of the higher priority session.
@@ -50,9 +51,9 @@ export default class AbstractRecordingLabel extends Component<IProps> {
      * @inheritdoc
      */
     render() {
-        const { _iAmRecorder, _isRunning } = this.props;
+        const { _iAmRecorder, _isVisible } = this.props;
 
-        return _isRunning && !_iAmRecorder ? this._renderLabel() : null;
+        return _isVisible && !_iAmRecorder ? this._renderLabel() : null;
     }
 
     /**
@@ -79,14 +80,17 @@ export default class AbstractRecordingLabel extends Component<IProps> {
  */
 export function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { mode } = ownProps;
-    const isLiveStreaming = mode === JitsiRecordingConstants.mode.STREAM;
-    const isRunning = isLiveStreaming
-        ? Boolean(getActiveSession(state, JitsiRecordingConstants.mode.STREAM)) : isRecordingRunning(state);
+    const isLiveStreamingLabel = mode === JitsiRecordingConstants.mode.STREAM;
+    const _isTranscribing = isTranscribing(state);
+    const isLivestreamingRunning = Boolean(getActiveSession(state, JitsiRecordingConstants.mode.STREAM));
+    const _isVisible = isLiveStreamingLabel
+        ? isLivestreamingRunning // this is the livestreaming label
+        : isRecordingRunning(state) || (_isTranscribing && !isLivestreamingRunning); // this is the recording label
 
     return {
-        _isRunning: isRunning,
+        _isVisible,
         _iAmRecorder: Boolean(state['features/base/config'].iAmRecorder),
-        _isTranscribing: isTranscribing(state),
+        _isTranscribing,
         _status: getSessionStatusToShow(state, mode)
     };
 }

--- a/react/features/recording/components/web/RecordingLabel.tsx
+++ b/react/features/recording/components/web/RecordingLabel.tsx
@@ -40,11 +40,11 @@ class RecordingLabel extends AbstractRecordingLabel {
     _renderLabel() {
         const { _isTranscribing, _status, classes, mode, t } = this.props;
         const isRecording = mode === JitsiRecordingConstants.mode.FILE;
-        const icon = isRecording || _isTranscribing ? IconRecord : IconSites;
+        const icon = isRecording ? IconRecord : IconSites;
         let content;
 
         if (_status === JitsiRecordingConstants.status.ON) {
-            content = t(isRecording || _isTranscribing ? 'videoStatus.recording' : 'videoStatus.streaming');
+            content = t(isRecording ? 'videoStatus.recording' : 'videoStatus.streaming');
 
             if (_isTranscribing) {
                 content += ` \u00B7 ${t('transcribing.labelToolTip')}`;

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -179,8 +179,17 @@ export function isRecordingRunning(state: IReduxState) {
     return (
         isCloudRecordingRunning(state)
         || LocalRecordingManager.isRecordingLocally()
-        || isTranscribing(state)
     );
+}
+
+/**
+ * Returns true if there is a recording or transcribing session running.
+ *
+ * @param {Object} state - The redux state to search in.
+ * @returns {boolean}
+ */
+export function isRecordingOrTranscribingRunning(state: IReduxState) {
+    return isRecordingRunning(state) || isTranscribing(state);
 }
 
 /**
@@ -190,7 +199,7 @@ export function isRecordingRunning(state: IReduxState) {
  * @returns {boolean}
  */
 export function canStopRecording(state: IReduxState) {
-    if (!isRecordingRunning(state)) {
+    if (!isRecordingOrTranscribingRunning(state)) {
         return false;
     }
 


### PR DESCRIPTION
Display only livestreaming label when the livestreaming and the transcribtions are on.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
