### PR TITLE
feat(recorder-transcription): Handle correctly in the UI.

### DIFF
--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -19,6 +19,7 @@ import {
 import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE } from '../notifications/constants';
 import { INotificationProps } from '../notifications/types';
 import { setRequestingSubtitles } from '../subtitles/actions.any';
+import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
 
 import {
     CLEAR_RECORDING_SESSIONS,
@@ -36,7 +37,7 @@ import {
     getRecordButtonProps,
     getRecordingLink,
     getResourceId,
-    isRecordingOrTranscribingRunning,
+    isRecordingRunning,
     isRecordingSharingEnabled,
     isSavingRecordingOnDropbox,
     sendMeetingHighlight,
@@ -408,7 +409,7 @@ export function showStartRecordingNotificationWithCallback(openRecordingDialog: 
         const { recordings } = state['features/base/config'];
         const { suggestRecording } = recordings || {};
         const recordButtonProps = getRecordButtonProps(state);
-        const isAlreadyRecording = isRecordingOrTranscribingRunning(state);
+        const isAlreadyRecording = isRecordingRunning(state) || isRecorderTranscriptionsRunning(state);
         const wasNotificationShown = state['features/recording'].wasStartRecordingSuggested;
 
         if (!suggestRecording

--- a/react/features/recording/components/AbstractRecordingLabel.ts
+++ b/react/features/recording/components/AbstractRecordingLabel.ts
@@ -3,8 +3,12 @@ import { WithTranslation } from 'react-i18next';
 
 import { IReduxState } from '../../app/types';
 import { JitsiRecordingConstants } from '../../base/lib-jitsi-meet';
-import { isTranscribing } from '../../transcribing/functions';
-import { getActiveSession, getSessionStatusToShow, isRecordingRunning } from '../functions';
+import { isRecorderTranscriptionsRunning } from '../../transcribing/functions';
+import {
+    getActiveSession,
+    getSessionStatusToShow,
+    isRecordingRunning
+} from '../functions';
 
 export interface IProps extends WithTranslation {
 
@@ -75,11 +79,11 @@ export default class AbstractRecordingLabel<P extends IProps = IProps> extends C
 export function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { mode } = ownProps;
     const isLiveStreamingLabel = mode === JitsiRecordingConstants.mode.STREAM;
-    const _isTranscribing = isTranscribing(state);
+    const _isTranscribing = isRecorderTranscriptionsRunning(state);
     const isLivestreamingRunning = Boolean(getActiveSession(state, JitsiRecordingConstants.mode.STREAM));
     const _isVisible = isLiveStreamingLabel
         ? isLivestreamingRunning // this is the livestreaming label
-        : isRecordingRunning(state) || (_isTranscribing && !isLivestreamingRunning); // this is the recording label
+        : isRecordingRunning(state) || _isTranscribing; // this is the recording label
 
     return {
         _isVisible,

--- a/react/features/recording/components/AbstractRecordingLabel.ts
+++ b/react/features/recording/components/AbstractRecordingLabel.ts
@@ -7,7 +7,8 @@ import { isRecorderTranscriptionsRunning } from '../../transcribing/functions';
 import {
     getActiveSession,
     getSessionStatusToShow,
-    isRecordingRunning
+    isRecordingRunning,
+    isRemoteParticipantRecordingLocally
 } from '../functions';
 
 export interface IProps extends WithTranslation {
@@ -83,7 +84,8 @@ export function _mapStateToProps(state: IReduxState, ownProps: any) {
     const isLivestreamingRunning = Boolean(getActiveSession(state, JitsiRecordingConstants.mode.STREAM));
     const _isVisible = isLiveStreamingLabel
         ? isLivestreamingRunning // this is the livestreaming label
-        : isRecordingRunning(state) || _isTranscribing; // this is the recording label
+        : isRecordingRunning(state) || isRemoteParticipantRecordingLocally(state)
+            || _isTranscribing; // this is the recording label
 
     return {
         _isVisible,

--- a/react/features/recording/components/LiveStream/AbstractLiveStreamButton.ts
+++ b/react/features/recording/components/LiveStream/AbstractLiveStreamButton.ts
@@ -7,6 +7,7 @@ import { isLocalParticipantModerator } from '../../../base/participants/function
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { isInBreakoutRoom } from '../../../breakout-rooms/functions';
 import { maybeShowPremiumFeatureDialog } from '../../../jaas/actions';
+import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { getActiveSession, isCloudRecordingRunning } from '../../functions';
 
 import { getLiveStreaming } from './functions';
@@ -140,7 +141,7 @@ export function _mapStateToProps(state: IReduxState, ownProps: IProps) {
     }
 
     // disable the button if the recording is running.
-    if (visible && isCloudRecordingRunning(state)) {
+    if (visible && (isCloudRecordingRunning(state) || isRecorderTranscriptionsRunning(state))) {
         _disabled = true;
         _tooltip = 'dialog.liveStreamingDisabledBecauseOfActiveRecordingTooltip';
     }

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -33,6 +33,11 @@ export interface IProps extends WithTranslation {
     _conference?: IJitsiConference;
 
     /**
+     * Whether subtitles should be displayed or not.
+     */
+    _displaySubtitles?: boolean;
+
+    /**
      * Whether to show file recordings service, even if integrations
      * are enabled.
      */
@@ -68,6 +73,11 @@ export interface IProps extends WithTranslation {
      * Whether or not the screenshot capture feature is enabled.
      */
     _screenshotCaptureEnabled: boolean;
+
+    /**
+     * The selected language for subtitles.
+     */
+    _subtitlesLanguage: string | null;
 
     /**
      * The dropbox access token.
@@ -336,8 +346,10 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
         const {
             _appKey,
             _conference,
+            _displaySubtitles,
             _isDropboxEnabled,
             _rToken,
+            _subtitlesLanguage,
             _token,
             dispatch
         } = this.props;
@@ -399,7 +411,7 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
 
         if (this.state.selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE
                 && this.state.shouldRecordTranscription) {
-            dispatch(setRequestingSubtitles(true, false, null));
+            dispatch(setRequestingSubtitles(true, _displaySubtitles, _subtitlesLanguage));
         }
 
         _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
@@ -434,17 +446,7 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
  * @param {Object} state - The Redux state.
  * @param {any} _ownProps - Component's own props.
  * @private
- * @returns {{
- *     _appKey: string,
- *     _autoTranscribeOnRecord: boolean,
- *     _conference: JitsiConference,
- *     _fileRecordingsServiceEnabled: boolean,
- *     _fileRecordingsServiceSharingEnabled: boolean,
- *     _isDropboxEnabled: boolean,
- *     _rToken:string,
- *     _tokenExpireDate: number,
- *     _token: string
- * }}
+ * @returns {IProps}
  */
 export function mapStateToProps(state: IReduxState, _ownProps: any) {
     const {
@@ -452,16 +454,22 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
         dropbox = { appKey: undefined },
         localRecording
     } = state['features/base/config'];
+    const {
+        _displaySubtitles,
+        _language: _subtitlesLanguage
+    } = state['features/subtitles'];
 
     return {
         _appKey: dropbox.appKey ?? '',
         _autoTranscribeOnRecord: shouldAutoTranscribeOnRecord(state),
         _conference: state['features/base/conference'].conference,
+        _displaySubtitles,
         _fileRecordingsServiceEnabled: recordingService?.enabled ?? false,
         _fileRecordingsServiceSharingEnabled: isRecordingSharingEnabled(state),
         _isDropboxEnabled: isDropboxEnabled(state),
         _localRecordingEnabled: !localRecording?.disable,
         _rToken: state['features/dropbox'].rToken ?? '',
+        _subtitlesLanguage,
         _tokenExpireDate: state['features/dropbox'].expireDate,
         _token: state['features/dropbox'].token ?? ''
     };

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -27,6 +27,11 @@ export interface IProps extends WithTranslation {
     _conference?: IJitsiConference;
 
     /**
+     * Whether subtitles should be displayed or not.
+     */
+    _displaySubtitles?: boolean;
+
+    /**
      * The redux representation of the recording session to be stopped.
      */
     _fileRecordingSession?: ISessionData;
@@ -35,6 +40,11 @@ export interface IProps extends WithTranslation {
      * Whether the recording is a local recording or not.
      */
     _localRecording: boolean;
+
+    /**
+     * The selected language for subtitles.
+     */
+    _subtitlesLanguage: string | null;
 
     /**
      * The redux dispatch function.
@@ -77,22 +87,28 @@ export default class AbstractStopRecordingDialog<P extends IProps>
     _onSubmit() {
         sendAnalytics(createRecordingDialogEvent('stop', 'confirm.button'));
 
-        if (this.props._localRecording) {
-            this.props.dispatch(stopLocalVideoRecording());
-            if (this.props.localRecordingVideoStop) {
-                this.props.dispatch(setVideoMuted(true));
-            }
-        } else {
-            const { _fileRecordingSession } = this.props;
+        const {
+            _conference,
+            _displaySubtitles,
+            _fileRecordingSession,
+            _localRecording,
+            _subtitlesLanguage,
+            dispatch,
+            localRecordingVideoStop
+        } = this.props;
 
-            if (_fileRecordingSession) {
-                this.props._conference?.stopRecording(_fileRecordingSession.id);
-                this._toggleScreenshotCapture();
+        if (_localRecording) {
+            dispatch(stopLocalVideoRecording());
+            if (localRecordingVideoStop) {
+                dispatch(setVideoMuted(true));
             }
+        } else if (_fileRecordingSession) {
+            _conference?.stopRecording(_fileRecordingSession.id);
+            this._toggleScreenshotCapture();
         }
 
         // TODO: this should be an action in transcribing. -saghul
-        this.props.dispatch(setRequestingSubtitles(false, false, null));
+        this.props.dispatch(setRequestingSubtitles(Boolean(_displaySubtitles), _displaySubtitles, _subtitlesLanguage));
 
         this.props._conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
             isTranscribingEnabled: false
@@ -117,16 +133,20 @@ export default class AbstractStopRecordingDialog<P extends IProps>
  *
  * @param {Object} state - The Redux state.
  * @private
- * @returns {{
- *     _conference: JitsiConference,
- *     _fileRecordingSession: Object
- * }}
+ * @returns {IProps}
  */
 export function _mapStateToProps(state: IReduxState) {
+    const {
+        _displaySubtitles,
+        _language: _subtitlesLanguage
+    } = state['features/subtitles'];
+
     return {
         _conference: state['features/base/conference'].conference,
+        _displaySubtitles,
         _fileRecordingSession:
             getActiveSession(state, JitsiRecordingConstants.mode.FILE),
-        _localRecording: LocalRecordingManager.isRecordingLocally()
+        _localRecording: LocalRecordingManager.isRecordingLocally(),
+        _subtitlesLanguage
     };
 }

--- a/react/features/recording/components/native/RecordingExpandedLabel.ts
+++ b/react/features/recording/components/native/RecordingExpandedLabel.ts
@@ -4,7 +4,7 @@ import { IReduxState } from '../../../app/types';
 import { translate } from '../../../base/i18n/functions';
 import ExpandedLabel, { IProps as AbstractProps } from '../../../base/label/components/native/ExpandedLabel';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
-import { isTranscribing } from '../../../transcribing/functions';
+import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { getSessionStatusToShow } from '../../functions';
 
 interface IProps extends AbstractProps {
@@ -91,7 +91,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { mode } = ownProps;
 
     return {
-        _isTranscribing: isTranscribing(state),
+        _isTranscribing: isRecorderTranscriptionsRunning(state),
         _status: getSessionStatusToShow(state, mode)
     };
 }

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -189,10 +189,6 @@ export function isRecordingRunning(state: IReduxState) {
  * @returns {boolean}
  */
 export function canStopRecording(state: IReduxState) {
-    if (!isRecordingRunning(state) && !isRecorderTranscriptionsRunning(state)) {
-        return false;
-    }
-
     if (LocalRecordingManager.isRecordingLocally()) {
         return true;
     }

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -140,9 +140,8 @@ export function getSessionStatusToShow(state: IReduxState, mode: string): string
             }
         }
     }
-    if ((!Array.isArray(recordingSessions) || recordingSessions.length === 0)
-        && mode === JitsiRecordingConstants.mode.FILE
-        && (LocalRecordingManager.isRecordingLocally() || isRemoteParticipantRecordingLocally(state))) {
+    if (!status && mode === JitsiRecordingConstants.mode.FILE
+            && (LocalRecordingManager.isRecordingLocally() || isRemoteParticipantRecordingLocally(state))) {
         status = JitsiRecordingConstants.status.ON;
     }
 
@@ -349,7 +348,7 @@ export async function sendMeetingHighlight(state: IReduxState) {
  * @param {Object} state - Redux state.
  * @returns {boolean}
  */
-function isRemoteParticipantRecordingLocally(state: IReduxState) {
+export function isRemoteParticipantRecordingLocally(state: IReduxState) {
     const participants = getRemoteParticipants(state);
 
     // eslint-disable-next-line prefer-const

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -14,7 +14,7 @@ import { registerSound, unregisterSound } from '../base/sounds/actions';
 import { isInBreakoutRoom } from '../breakout-rooms/functions';
 import { isEnabled as isDropboxEnabled } from '../dropbox/functions';
 import { extractFqnFromPath } from '../dynamic-branding/functions.any';
-import { isTranscribing } from '../transcribing/functions';
+import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
 
 import LocalRecordingManager from './components/Recording/LocalRecordingManager';
 import {
@@ -183,23 +183,13 @@ export function isRecordingRunning(state: IReduxState) {
 }
 
 /**
- * Returns true if there is a recording or transcribing session running.
- *
- * @param {Object} state - The redux state to search in.
- * @returns {boolean}
- */
-export function isRecordingOrTranscribingRunning(state: IReduxState) {
-    return isRecordingRunning(state) || isTranscribing(state);
-}
-
-/**
  * Returns true if the participant can stop recording.
  *
  * @param {Object} state - The redux state to search in.
  * @returns {boolean}
  */
 export function canStopRecording(state: IReduxState) {
-    if (!isRecordingOrTranscribingRunning(state)) {
+    if (!isRecordingRunning(state) && !isRecorderTranscriptionsRunning(state)) {
         return false;
     }
 
@@ -207,7 +197,7 @@ export function canStopRecording(state: IReduxState) {
         return true;
     }
 
-    if (isCloudRecordingRunning(state) || isTranscribing(state)) {
+    if (isCloudRecordingRunning(state) || isRecorderTranscriptionsRunning(state)) {
         return isLocalParticipantModerator(state) && isJwtFeatureEnabled(state, 'recording', true);
     }
 

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -22,7 +22,7 @@ import {
 import { TRACK_ADDED } from '../base/tracks/actionTypes';
 import { hideNotification, showErrorNotification, showNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
-import { isTranscribing } from '../transcribing/functions';
+import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
 
 import { RECORDING_SESSION_UPDATED, START_LOCAL_RECORDING, STOP_LOCAL_RECORDING } from './actionTypes';
 import {
@@ -226,7 +226,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => async action => 
 
                     let soundID;
 
-                    if (mode === JitsiRecordingConstants.mode.FILE && !isTranscribing(state)) {
+                    if (mode === JitsiRecordingConstants.mode.FILE && !isRecorderTranscriptionsRunning(state)) {
                         soundID = RECORDING_ON_SOUND_ID;
                     } else if (mode === JitsiRecordingConstants.mode.STREAM) {
                         soundID = LIVE_STREAMING_ON_SOUND_ID;
@@ -255,7 +255,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => async action => 
                 }
                 sendAnalytics(createRecordingEvent('stop', mode, duration));
 
-                if (mode === JitsiRecordingConstants.mode.FILE && !isTranscribing(state)) {
+                if (mode === JitsiRecordingConstants.mode.FILE && !isRecorderTranscriptionsRunning(state)) {
                     soundOff = RECORDING_OFF_SOUND_ID;
                     soundOn = RECORDING_ON_SOUND_ID;
                 } else if (mode === JitsiRecordingConstants.mode.STREAM) {

--- a/react/features/subtitles/reducer.ts
+++ b/react/features/subtitles/reducer.ts
@@ -9,7 +9,7 @@ import {
  * Default State for 'features/transcription' feature.
  */
 const defaultState = {
-    _displaySubtitles: true,
+    _displaySubtitles: false,
     _transcriptMessages: new Map(),
     _requestingSubtitles: false,
     _language: null

--- a/react/features/transcribing/functions.ts
+++ b/react/features/transcribing/functions.ts
@@ -57,6 +57,19 @@ export function isTranscribing(state: IReduxState) {
 }
 
 /**
+ * Returns true if there is a recorder transcription session running.
+ * NOTE: If only the subtitles are running this function will return false.
+ *
+ * @param {Object} state - The redux state to search in.
+ * @returns {boolean}
+ */
+export function isRecorderTranscriptionsRunning(state: IReduxState) {
+    const { metadata } = state['features/base/conference'];
+
+    return isTranscribing(state) && Boolean(metadata?.recording?.isTranscribingEnabled);
+}
+
+/**
  * Checks whether the participant can start the transcription.
  *
  * @param {IReduxState} state - The redux state.

--- a/react/features/transcribing/middleware.ts
+++ b/react/features/transcribing/middleware.ts
@@ -1,30 +1,16 @@
-import { batch } from 'react-redux';
-
-import { IStore } from '../app/types';
-import { JitsiRecordingConstants } from '../base/lib-jitsi-meet';
 import {
     HIDDEN_PARTICIPANT_JOINED,
     HIDDEN_PARTICIPANT_LEFT,
     PARTICIPANT_UPDATED
 } from '../base/participants/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
-import { playSound } from '../base/sounds/actions';
-import { showNotification } from '../notifications/actions';
-import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
-import {
-    RECORDING_OFF_SOUND_ID,
-    RECORDING_ON_SOUND_ID
-} from '../recording/constants';
 
-import {
-    _TRANSCRIBER_JOINED,
-    _TRANSCRIBER_LEFT
-} from './actionTypes';
 import {
     potentialTranscriberJoined,
     transcriberJoined,
     transcriberLeft
 } from './actions';
+import './subscriber';
 
 const TRANSCRIBER_DISPLAY_NAME = 'Transcriber';
 
@@ -42,16 +28,6 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
     } = getState()['features/transcribing'];
 
     switch (action.type) {
-    case _TRANSCRIBER_JOINED:
-        notifyTranscribingStatusChanged(true);
-        maybeEmitRecordingNotification(dispatch, getState, true);
-
-        break;
-    case _TRANSCRIBER_LEFT:
-        notifyTranscribingStatusChanged(false);
-        maybeEmitRecordingNotification(dispatch, getState, false);
-
-        break;
     case HIDDEN_PARTICIPANT_JOINED:
         if (action.displayName === TRANSCRIBER_DISPLAY_NAME) {
             dispatch(transcriberJoined(action.id));
@@ -79,44 +55,3 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
     return next(action);
 });
-
-/**
- * Emit a recording started / stopped notification if the transcription started / stopped. Only
- * if there is no recording in progress.
- *
- * @param {Dispatch} dispatch - The Redux dispatch function.
- * @param {Function} getState - The Redux state.
- * @param {boolean} on - Whether the transcription is on or not.
- *
- * @returns {void}
- */
-function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: IStore['getState'], on: boolean) {
-    const state = getState();
-    const { sessionDatas } = state['features/recording'];
-    const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
-
-    if (sessionDatas.some(sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON)) {
-        // If a recording is still ongoing, don't send any notification.
-        return;
-    }
-
-    batch(() => {
-        dispatch(showNotification({
-            descriptionKey: on ? 'recording.on' : 'recording.off',
-            titleKey: 'dialog.recording'
-        }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
-        dispatch(playSound(on ? RECORDING_ON_SOUND_ID : RECORDING_OFF_SOUND_ID));
-    });
-}
-
-/**
- * Notify external application (if API is enabled) that transcribing has started or stopped.
- *
- * @param {boolean} on - True if transcribing is on, false otherwise.
- * @returns {void}
- */
-function notifyTranscribingStatusChanged(on: boolean) {
-    if (typeof APP !== 'undefined') {
-        APP.API.notifyTranscribingStatusChanged(on);
-    }
-}

--- a/react/features/transcribing/subscriber.ts
+++ b/react/features/transcribing/subscriber.ts
@@ -1,0 +1,68 @@
+import { batch } from 'react-redux';
+
+import { IStore } from '../app/types';
+import { JitsiRecordingConstants } from '../base/lib-jitsi-meet';
+import StateListenerRegistry from '../base/redux/StateListenerRegistry';
+import { playSound } from '../base/sounds/actions';
+import { showNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
+import { RECORDING_OFF_SOUND_ID, RECORDING_ON_SOUND_ID } from '../recording/constants';
+
+import { isRecorderTranscriptionsRunning } from './functions';
+
+/**
+ * Listens for large video participant ID changes.
+ */
+StateListenerRegistry.register(
+    /* selector */ isRecorderTranscriptionsRunning,
+    /* listener */ (isRecorderTranscriptionsRunningValue, { getState, dispatch }) => {
+        if (isRecorderTranscriptionsRunningValue) {
+            notifyTranscribingStatusChanged(true);
+            maybeEmitRecordingNotification(dispatch, getState, true);
+        } else {
+            notifyTranscribingStatusChanged(false);
+            maybeEmitRecordingNotification(dispatch, getState, false);
+        }
+    }
+);
+
+/**
+ * Emit a recording started / stopped notification if the transcription started / stopped. Only
+ * if there is no recording in progress.
+ *
+ * @param {Dispatch} dispatch - The Redux dispatch function.
+ * @param {Function} getState - The Redux state.
+ * @param {boolean} on - Whether the transcription is on or not.
+ *
+ * @returns {void}
+ */
+function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: IStore['getState'], on: boolean) {
+    const state = getState();
+    const { sessionDatas } = state['features/recording'];
+    const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
+
+    if (sessionDatas.some(sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON)) {
+        // If a recording is still ongoing, don't send any notification.
+        return;
+    }
+
+    batch(() => {
+        dispatch(showNotification({
+            descriptionKey: on ? 'recording.on' : 'recording.off',
+            titleKey: 'dialog.recording'
+        }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
+        dispatch(playSound(on ? RECORDING_ON_SOUND_ID : RECORDING_OFF_SOUND_ID));
+    });
+}
+
+/**
+ * Notify external application (if API is enabled) that transcribing has started or stopped.
+ *
+ * @param {boolean} on - True if transcribing is on, false otherwise.
+ * @returns {void}
+ */
+function notifyTranscribingStatusChanged(on: boolean) {
+    if (typeof APP !== 'undefined') {
+        APP.API.notifyTranscribingStatusChanged(on);
+    }
+}


### PR DESCRIPTION
Until this commit we didn't make difference between transcriptions from the recording dialog and subtitles. Now subtitles are not considered recording anymore and only the transcriptions started from recording dialog are considered recording.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
