### PR TITLE
fix(toolbarButtons): Store all buttons in redux.

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -1,40 +1,4 @@
-export type ToolbarButton = 'camera' |
-    'chat' |
-    'closedcaptions' |
-    'desktop' |
-    'download' |
-    'embedmeeting' |
-    'etherpad' |
-    'feedback' |
-    'filmstrip' |
-    'fullscreen' |
-    'hangup' |
-    'help' |
-    'highlight' |
-    'invite' |
-    'linktosalesforce' |
-    'livestreaming' |
-    'microphone' |
-    'mute-everyone' |
-    'mute-video-everyone' |
-    'noisesuppression' |
-    'participants-pane' |
-    'profile' |
-    'raisehand' |
-    'reactions' |
-    'recording' |
-    'security' |
-    'select-background' |
-    'settings' |
-    'shareaudio' |
-    'sharedvideo' |
-    'shortcuts' |
-    'stats' |
-    'tileview' |
-    'toggle-camera' |
-    'videoquality' |
-    'whiteboard' |
-    '__end';
+import { ToolbarButton } from '../../toolbox/types';
 
 type ButtonsWithNotifyClick = 'camera' |
     'chat' |

--- a/react/features/base/config/constants.ts
+++ b/react/features/base/config/constants.ts
@@ -1,5 +1,3 @@
-import { ToolbarButton } from './configType';
-
 /**
  * The prefix of the {@code localStorage} key into which {@link storeConfig}
  * stores and from which {@link restoreConfig} restores.
@@ -8,50 +6,6 @@ import { ToolbarButton } from './configType';
  * @type string
  */
 export const _CONFIG_STORE_PREFIX = 'config.js';
-
-/**
- * The list of all possible UI buttons.
- *
- * @protected
- * @type Array<string>
- */
-export const TOOLBAR_BUTTONS: ToolbarButton[] = [
-    'camera',
-    'chat',
-    'closedcaptions',
-    'desktop',
-    'download',
-    'embedmeeting',
-    'etherpad',
-    'feedback',
-    'filmstrip',
-    'fullscreen',
-    'hangup',
-    'help',
-    'highlight',
-    'invite',
-    'linktosalesforce',
-    'livestreaming',
-    'microphone',
-    'mute-everyone',
-    'mute-video-everyone',
-    'participants-pane',
-    'profile',
-    'raisehand',
-    'recording',
-    'security',
-    'select-background',
-    'settings',
-    'shareaudio',
-    'noisesuppression',
-    'sharedvideo',
-    'shortcuts',
-    'stats',
-    'tileview',
-    'toggle-camera',
-    'videoquality',
-    'whiteboard'
-];
 
 /**
  * The toolbar buttons to show on premeeting screens.

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -7,10 +7,8 @@ import {
     IDeeplinkingConfig,
     IDeeplinkingDesktopConfig,
     IDeeplinkingMobileConfig,
-    NotifyClickButton,
-    ToolbarButton
+    NotifyClickButton
 } from './configType';
-import { TOOLBAR_BUTTONS } from './constants';
 
 export * from './functions.any';
 
@@ -35,25 +33,6 @@ export function getReplaceParticipant(state: IReduxState): string | undefined {
 }
 
 /**
- * Returns the list of enabled toolbar buttons.
- *
- * @param {Object} state - The redux state.
- * @returns {Array<string>} - The list of enabled toolbar buttons.
- */
-export function getToolbarButtons(state: IReduxState): Array<string> {
-    const { toolbarButtons, customToolbarButtons } = state['features/base/config'];
-    const customButtons = customToolbarButtons?.map(({ id }) => id);
-
-    const buttons = Array.isArray(toolbarButtons) ? toolbarButtons : TOOLBAR_BUTTONS;
-
-    if (customButtons) {
-        buttons.push(...customButtons as ToolbarButton[]);
-    }
-
-    return buttons;
-}
-
-/**
  * Returns the configuration value of web-hid feature.
  *
  * @param {Object} state - The state of the app.
@@ -71,7 +50,7 @@ export function getWebHIDFeatureConfig(state: IReduxState): boolean {
  * @returns {boolean} - True if the button is enabled and false otherwise.
  */
 export function isToolbarButtonEnabled(buttonName: string, state: IReduxState | Array<string>) {
-    const buttons = Array.isArray(state) ? state : getToolbarButtons(state);
+    const buttons = Array.isArray(state) ? state : state['features/toolbox'].toolbarButtons || [];
 
     return buttons.includes(buttonName);
 }

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 
 import { CONFERENCE_INFO } from '../../conference/components/constants';
+import { TOOLBAR_BUTTONS } from '../../toolbox/constants';
+import { ToolbarButton } from '../../toolbox/types';
 import ReducerRegistry from '../redux/ReducerRegistry';
 import { equals } from '../redux/functions';
 
@@ -16,10 +18,8 @@ import {
     IDeeplinkingConfig,
     IDeeplinkingDesktopConfig,
     IDeeplinkingMobileConfig,
-    IMobileDynamicLink,
-    ToolbarButton
+    IMobileDynamicLink
 } from './configType';
-import { TOOLBAR_BUTTONS } from './constants';
 import { _cleanupConfig, _setDeeplinkingDefaults } from './functions';
 
 /**

--- a/react/features/base/premeeting/components/web/PreMeetingScreen.tsx
+++ b/react/features/base/premeeting/components/web/PreMeetingScreen.tsx
@@ -9,7 +9,7 @@ import { isRoomNameEnabled } from '../../../../prejoin/functions';
 import Toolbox from '../../../../toolbox/components/web/Toolbox';
 import { getConferenceName } from '../../../conference/functions';
 import { PREMEETING_BUTTONS, THIRD_PARTY_PREJOIN_BUTTONS } from '../../../config/constants';
-import { getToolbarButtons, isToolbarButtonEnabled } from '../../../config/functions.web';
+import { isToolbarButtonEnabled } from '../../../config/functions.web';
 import { withPixelLineHeight } from '../../../styles/functions.web';
 
 import ConnectionStatus from './ConnectionStatus';
@@ -229,7 +229,7 @@ const PreMeetingScreen = ({
  */
 function mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
     const { hiddenPremeetingButtons } = state['features/base/config'];
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
     const premeetingButtons = (ownProps.thirdParty
         ? THIRD_PARTY_PREJOIN_BUTTONS
         : PREMEETING_BUTTONS).filter((b: any) => !(hiddenPremeetingButtons || []).includes(b));

--- a/react/features/filmstrip/components/web/Filmstrip.tsx
+++ b/react/features/filmstrip/components/web/Filmstrip.tsx
@@ -9,7 +9,6 @@ import { withStyles } from 'tss-react/mui';
 import { ACTION_SHORTCUT_TRIGGERED, createShortcutEvent, createToolbarEvent } from '../../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../../analytics/functions';
 import { IReduxState, IStore } from '../../../app/types';
-import { getToolbarButtons } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
 import Icon from '../../../base/icons/components/Icon';
@@ -884,11 +883,11 @@ class Filmstrip extends PureComponent <IProps, IState> {
  */
 function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { _hasScroll = false, filmstripType, _topPanelFilmstrip, _remoteParticipants } = ownProps;
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
     const { iAmRecorder } = state['features/base/config'];
     const { topPanelHeight, topPanelVisible, visible, width: verticalFilmstripWidth } = state['features/filmstrip'];
     const { localScreenShare } = state['features/base/participants'];
-    const reduceHeight = state['features/toolbox'].visible && toolbarButtons.length;
+    const reduceHeight = state['features/toolbox'].visible && toolbarButtons?.length;
     const remoteVideosVisible = shouldRemoteVideosBeVisible(state);
     const { isOpen: shiftRight } = state['features/chat'];
     const disableSelfView = getHideSelfView(state);

--- a/react/features/filmstrip/components/web/MainFilmstrip.tsx
+++ b/react/features/filmstrip/components/web/MainFilmstrip.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { getToolbarButtons } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { LAYOUTS } from '../../../video-layout/constants';
 import { getCurrentLayout } from '../../../video-layout/functions.web';
@@ -107,9 +106,9 @@ const MainFilmstrip = (props: IProps) => (
  * @returns {IProps}
  */
 function _mapStateToProps(state: IReduxState, _ownProps: any) {
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
     const { remoteParticipants, width: verticalFilmstripWidth } = state['features/filmstrip'];
-    const reduceHeight = state['features/toolbox'].visible && toolbarButtons.length;
+    const reduceHeight = state['features/toolbox'].visible && toolbarButtons?.length;
     const {
         gridDimensions: dimensions = { columns: undefined,
             rows: undefined },

--- a/react/features/filmstrip/components/web/StageFilmstrip.tsx
+++ b/react/features/filmstrip/components/web/StageFilmstrip.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { getToolbarButtons } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { LAYOUTS, LAYOUT_CLASSNAMES } from '../../../video-layout/constants';
 import { getCurrentLayout } from '../../../video-layout/functions.web';
@@ -108,9 +107,9 @@ const StageFilmstrip = (props: IProps) =>
  * @returns {IProps}
  */
 function _mapStateToProps(state: IReduxState, _ownProps: any) {
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
     const activeParticipants = getActiveParticipantsIds(state);
-    const reduceHeight = state['features/toolbox'].visible && toolbarButtons.length;
+    const reduceHeight = state['features/toolbox'].visible && toolbarButtons?.length;
     const {
         gridDimensions: dimensions = { columns: undefined,
             rows: undefined },

--- a/react/features/reactions/functions.web.ts
+++ b/react/features/reactions/functions.web.ts
@@ -1,5 +1,4 @@
 import { IReduxState } from '../app/types';
-import { getToolbarButtons } from '../base/config/functions.web';
 
 import { shouldDisplayReactionsButtons } from './functions.any';
 
@@ -22,5 +21,7 @@ export function getReactionsMenuVisibility(state: IReduxState): boolean {
  * @returns {boolean}
  */
 export function isReactionsButtonEnabled(state: IReduxState) {
-    return Boolean(getToolbarButtons(state).includes('reactions')) && shouldDisplayReactionsButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
+
+    return Boolean(toolbarButtons?.includes('reactions')) && shouldDisplayReactionsButtons(state);
 }

--- a/react/features/recording/components/LiveStream/web/LiveStreamButton.ts
+++ b/react/features/recording/components/LiveStream/web/LiveStreamButton.ts
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
-import { getToolbarButtons } from '../../../../base/config/functions.web';
 import { openDialog } from '../../../../base/dialog/actions';
 import { translate } from '../../../../base/i18n/functions';
 import AbstractLiveStreamButton, {
@@ -50,11 +49,11 @@ class LiveStreamButton extends AbstractLiveStreamButton<IProps> {
  */
 function _mapStateToProps(state: IReduxState, ownProps: any) {
     const abstractProps = _abstractMapStateToProps(state, ownProps);
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
     let { visible } = ownProps;
 
     if (typeof visible === 'undefined') {
-        visible = toolbarButtons.includes('livestreaming') && abstractProps.visible;
+        visible = Boolean(toolbarButtons?.includes('livestreaming') && abstractProps.visible);
     }
 
     return {

--- a/react/features/recording/components/Recording/web/RecordButton.ts
+++ b/react/features/recording/components/Recording/web/RecordButton.ts
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
-import { getToolbarButtons } from '../../../../base/config/functions.web';
 import { openDialog } from '../../../../base/dialog/actions';
 import { translate } from '../../../../base/i18n/functions';
 import AbstractRecordButton, {
@@ -49,8 +48,8 @@ class RecordingButton extends AbstractRecordButton<IProps> {
  */
 export function _mapStateToProps(state: IReduxState) {
     const abstractProps = _abstractMapStateToProps(state);
-    const toolbarButtons = getToolbarButtons(state);
-    const visible = toolbarButtons.includes('recording') && abstractProps.visible;
+    const { toolbarButtons } = state['features/toolbox'];
+    const visible = Boolean(toolbarButtons?.includes('recording') && abstractProps.visible);
 
     return {
         ...abstractProps,

--- a/react/features/toolbox/actionTypes.ts
+++ b/react/features/toolbox/actionTypes.ts
@@ -54,6 +54,17 @@ export const SET_OVERFLOW_DRAWER = 'SET_OVERFLOW_DRAWER';
  */
 export const SET_OVERFLOW_MENU_VISIBLE = 'SET_OVERFLOW_MENU_VISIBLE';
 
+
+/**
+ * The type of the action which sets enabled toolbar buttons.
+ *
+ * {
+ *     type: SET_TOOLBAR_BUTTONS,
+ *     toolbarButtons: Array<string>
+ * }
+ */
+export const SET_TOOLBAR_BUTTONS = 'SET_TOOLBAR_BUTTONS';
+
 /**
  * The type of the action which sets the indicator which determines whether a
  * fToolbar in the Toolbox is hovered.

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -9,7 +9,6 @@ import { VISITORS_MODE_BUTTONS } from '../../../base/config/constants';
 import {
     getButtonNotifyMode,
     getButtonsWithNotifyClick,
-    getToolbarButtons,
     isToolbarButtonEnabled
 } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
@@ -502,7 +501,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
         overflowDrawer
     } = state['features/toolbox'];
     const { clientWidth } = state['features/base/responsive-ui'];
-    let toolbarButtons = ownProps.toolbarButtons || getToolbarButtons(state);
+    let toolbarButtons = ownProps.toolbarButtons || state['features/toolbox'].toolbarButtons;
 
     if (iAmVisitor(state)) {
         toolbarButtons = VISITORS_MODE_BUTTONS.filter(e => toolbarButtons.indexOf(e) > -1);

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -1,3 +1,5 @@
+import { ToolbarButton } from './types';
+
 /**
  * Thresholds for displaying toolbox buttons.
  */
@@ -50,3 +52,49 @@ export const ZINDEX_DIALOG_PORTAL = 302;
  * Color for spinner displayed in the toolbar.
  */
 export const SPINNER_COLOR = '#929292';
+
+
+/**
+ * The list of all possible UI buttons.
+ *
+ * @protected
+ * @type Array<string>
+ */
+export const TOOLBAR_BUTTONS: ToolbarButton[] = [
+    'camera',
+    'chat',
+    'closedcaptions',
+    'desktop',
+    'download',
+    'embedmeeting',
+    'etherpad',
+    'feedback',
+    'filmstrip',
+    'fullscreen',
+    'hangup',
+    'help',
+    'highlight',
+    'invite',
+    'linktosalesforce',
+    'livestreaming',
+    'microphone',
+    'mute-everyone',
+    'mute-video-everyone',
+    'participants-pane',
+    'profile',
+    'raisehand',
+    'recording',
+    'security',
+    'select-background',
+    'settings',
+    'shareaudio',
+    'noisesuppression',
+    'sharedvideo',
+    'shortcuts',
+    'stats',
+    'tileview',
+    'toggle-camera',
+    'videoquality',
+    'whiteboard'
+];
+

--- a/react/features/toolbox/functions.web.ts
+++ b/react/features/toolbox/functions.web.ts
@@ -1,5 +1,4 @@
 import { IReduxState } from '../app/types';
-import { getToolbarButtons } from '../base/config/functions.web';
 import { hasAvailableDevices } from '../base/devices/functions';
 import { MEET_FEATURES } from '../base/jwt/constants';
 import { isJwtFeatureEnabled } from '../base/jwt/functions';
@@ -65,9 +64,9 @@ export function getToolboxHeight() {
  * is enabled, false - otherwise.
  */
 export function isButtonEnabled(name: string, state: IReduxState) {
-    const toolbarButtons = getToolbarButtons(state);
+    const { toolbarButtons } = state['features/toolbox'];
 
-    return toolbarButtons.indexOf(name) !== -1;
+    return toolbarButtons?.indexOf(name) !== -1;
 }
 
 /**

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -4,7 +4,7 @@ import { batch, useDispatch, useSelector } from 'react-redux';
 import { ACTION_SHORTCUT_TRIGGERED, createShortcutEvent } from '../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../analytics/functions';
 import { IReduxState } from '../app/types';
-import { getToolbarButtons, isToolbarButtonEnabled } from '../base/config/functions.web';
+import { isToolbarButtonEnabled } from '../base/config/functions.web';
 import { toggleDialog } from '../base/dialog/actions';
 import JitsiMeetJS from '../base/lib-jitsi-meet';
 import { raiseHand } from '../base/participants/actions';
@@ -41,7 +41,8 @@ export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
     const _isSpeakerStatsDisabled = useSelector(isSpeakerStatsDisabled);
     const _isParticipantsPaneEnabled = useSelector(isParticipantsPaneEnabled);
     const _shouldDisplayReactionsButtons = useSelector(shouldDisplayReactionsButtons);
-    const _toolbarButtons = useSelector((state: IReduxState) => toolbarButtons || getToolbarButtons(state));
+    const _toolbarButtons = useSelector(
+        (state: IReduxState) => toolbarButtons || state['features/toolbox'].toolbarButtons);
     const chatOpen = useSelector((state: IReduxState) => state['features/chat'].isOpen);
     const desktopSharingButtonDisabled = useSelector(isDesktopShareButtonDisabled);
     const desktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled();

--- a/react/features/toolbox/middleware.web.ts
+++ b/react/features/toolbox/middleware.web.ts
@@ -1,12 +1,16 @@
 import { AnyAction } from 'redux';
 
+import { IReduxState } from '../app/types';
+import { OVERWRITE_CONFIG, SET_CONFIG, UPDATE_CONFIG } from '../base/config/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 
 import {
     CLEAR_TOOLBOX_TIMEOUT,
     SET_FULL_SCREEN,
+    SET_TOOLBAR_BUTTONS,
     SET_TOOLBOX_TIMEOUT
 } from './actionTypes';
+import { TOOLBAR_BUTTONS } from './constants';
 
 import './subscriber.web';
 
@@ -24,6 +28,19 @@ MiddlewareRegistry.register(store => next => action => {
 
         clearTimeout(timeoutID ?? undefined);
         break;
+    }
+    case UPDATE_CONFIG:
+    case OVERWRITE_CONFIG:
+    case SET_CONFIG: {
+        const result = next(action);
+        const toolbarButtons = _getToolbarButtons(store.getState());
+
+        store.dispatch({
+            type: SET_TOOLBAR_BUTTONS,
+            toolbarButtons
+        });
+
+        return result;
     }
 
     case SET_FULL_SCREEN:
@@ -84,4 +101,23 @@ function _setFullScreen(next: Function, action: AnyAction) {
     }
 
     return result;
+}
+
+/**
+ * Returns the list of enabled toolbar buttons.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {Array<string>} - The list of enabled toolbar buttons.
+ */
+function _getToolbarButtons(state: IReduxState): Array<string> {
+    const { toolbarButtons, customToolbarButtons } = state['features/base/config'];
+    const customButtons = customToolbarButtons?.map(({ id }) => id);
+
+    const buttons = Array.isArray(toolbarButtons) ? toolbarButtons : TOOLBAR_BUTTONS;
+
+    if (customButtons) {
+        return [ ...buttons, ...customButtons ];
+    }
+
+    return buttons;
 }

--- a/react/features/toolbox/reducer.ts
+++ b/react/features/toolbox/reducer.ts
@@ -7,6 +7,7 @@ import {
     SET_HANGUP_MENU_VISIBLE,
     SET_OVERFLOW_DRAWER,
     SET_OVERFLOW_MENU_VISIBLE,
+    SET_TOOLBAR_BUTTONS,
     SET_TOOLBAR_HOVERED,
     SET_TOOLBOX_ENABLED,
     SET_TOOLBOX_SHIFT_UP,
@@ -69,6 +70,13 @@ const INITIAL_STATE = {
      */
     timeoutID: null,
 
+    /**
+     * The list of enabled toolbar buttons.
+     *
+     * @type {Array<string>}
+     */
+    toolbarButtons: [],
+
 
     /**
      * The indicator that determines whether the Toolbox is visible.
@@ -87,6 +95,7 @@ export interface IToolboxState {
     overflowMenuVisible: boolean;
     shiftUp: boolean;
     timeoutID?: number | null;
+    toolbarButtons: Array<string>;
     visible: boolean;
 }
 
@@ -122,6 +131,12 @@ ReducerRegistry.register<IToolboxState>(
             return {
                 ...state,
                 overflowMenuVisible: action.visible
+            };
+
+        case SET_TOOLBAR_BUTTONS:
+            return {
+                ...state,
+                toolbarButtons: action.toolbarButtons
             };
 
         case SET_TOOLBAR_HOVERED:

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -6,3 +6,41 @@ export interface IToolboxButton {
     group: number;
     key: string;
 }
+
+export type ToolbarButton = 'camera' |
+    'chat' |
+    'closedcaptions' |
+    'desktop' |
+    'download' |
+    'embedmeeting' |
+    'etherpad' |
+    'feedback' |
+    'filmstrip' |
+    'fullscreen' |
+    'hangup' |
+    'help' |
+    'highlight' |
+    'invite' |
+    'linktosalesforce' |
+    'livestreaming' |
+    'microphone' |
+    'mute-everyone' |
+    'mute-video-everyone' |
+    'noisesuppression' |
+    'participants-pane' |
+    'profile' |
+    'raisehand' |
+    'reactions' |
+    'recording' |
+    'security' |
+    'select-background' |
+    'settings' |
+    'shareaudio' |
+    'sharedvideo' |
+    'shortcuts' |
+    'stats' |
+    'tileview' |
+    'toggle-camera' |
+    'videoquality' |
+    'whiteboard' |
+    '__end';


### PR DESCRIPTION
The previous version of getToolbarButtons function was actually adding the custom buttons on every call to the config toolbarButtons array, effectively creating dublicates of every custom button. The PR fixes this issue.

Also now we will be running the getToolbarButtons calculation only when needed.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
