### PR TITLE
fix(build.gradle): When newArchEnabled=true. Refers to a non-existent category

### DIFF
--- a/react-native-sdk/android/build.gradle
+++ b/react-native-sdk/android/build.gradle
@@ -133,7 +133,7 @@ dependencies {
 
 if (isNewArchitectureEnabled()) {
   react {
-    jsRootDir = file("../src/")
+    jsRootDir = file("../")
     libraryName = "JitsiMeetReactNative"
     codegenJavaPackageName = "org.jitsi.meet.sdk"
   }


### PR DESCRIPTION
When newArchEnabled=true. Refers to a non-existent category. This prevents the application from building

https://github.com/jitsi/jitsi-meet/blob/5be616a224d315df22a17efce2a59bbdb1a91f04/react-native-sdk/android/build.gradle#L136

RN: 0.72.11
jitsi: 1.0.3

```
> Task :jitsi_react-native-sdk:generateCodegenSchemaFromJavaScript FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/8.0.1/userguide/command_line_interface.html#sec:command_line_warnings
17 actionable tasks: 3 executed, 14 up-to-date

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 

/node_modules/flow-parser/flow_parser.js:818
throw a}function
^

Error: ENOENT: no such file or directory, lstat '/node_modules/@jitsi/react-native-sdk/src'
    at Object.lstatSync (node:fs:1673:3)
```
