### PR TITLE
fix(toolbarButtons): filter visitor buttons in redux.

### DIFF
--- a/react/features/base/config/constants.ts
+++ b/react/features/base/config/constants.ts
@@ -18,11 +18,6 @@ export const PREMEETING_BUTTONS = [ 'microphone', 'camera', 'select-background',
 export const THIRD_PARTY_PREJOIN_BUTTONS = [ 'microphone', 'camera', 'select-background' ];
 
 /**
- * The toolbar buttons to show when in visitors mode.
- */
-export const VISITORS_MODE_BUTTONS = [ 'chat', 'hangup', 'raisehand', 'settings', 'tileview' ];
-
-/**
  * The set of feature flags.
  *
  * @enum {string}

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -43,19 +43,6 @@ export function getWebHIDFeatureConfig(state: IReduxState): boolean {
 }
 
 /**
- * Checks if the specified button is enabled.
- *
- * @param {string} buttonName - The name of the button. See {@link interfaceConfig}.
- * @param {Object|Array<string>} state - The redux state or the array with the enabled buttons.
- * @returns {boolean} - True if the button is enabled and false otherwise.
- */
-export function isToolbarButtonEnabled(buttonName: string, state: IReduxState | Array<string>) {
-    const buttons = Array.isArray(state) ? state : state['features/toolbox'].toolbarButtons || [];
-
-    return buttons.includes(buttonName);
-}
-
-/**
  * Returns whether audio level measurement is enabled or not.
  *
  * @param {Object} state - The state of the app.

--- a/react/features/base/premeeting/components/web/PreMeetingScreen.tsx
+++ b/react/features/base/premeeting/components/web/PreMeetingScreen.tsx
@@ -7,9 +7,9 @@ import { IReduxState } from '../../../../app/types';
 import DeviceStatus from '../../../../prejoin/components/web/preview/DeviceStatus';
 import { isRoomNameEnabled } from '../../../../prejoin/functions';
 import Toolbox from '../../../../toolbox/components/web/Toolbox';
+import { isButtonEnabled } from '../../../../toolbox/functions.web';
 import { getConferenceName } from '../../../conference/functions';
 import { PREMEETING_BUTTONS, THIRD_PARTY_PREJOIN_BUTTONS } from '../../../config/constants';
-import { isToolbarButtonEnabled } from '../../../config/functions.web';
 import { withPixelLineHeight } from '../../../styles/functions.web';
 
 import ConnectionStatus from './ConnectionStatus';
@@ -244,7 +244,7 @@ function mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
         // toolbarButtons config overwrite.
         _buttons: hiddenPremeetingButtons
             ? premeetingButtons
-            : premeetingButtons.filter(b => isToolbarButtonEnabled(b, toolbarButtons)),
+            : premeetingButtons.filter(b => isButtonEnabled(b, toolbarButtons)),
         _premeetingBackground: premeetingBackground,
         _roomName: isRoomNameEnabled(state) ? getConferenceName(state) : ''
     };

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -6,7 +6,6 @@ import { makeStyles } from 'tss-react/mui';
 import { IReduxState } from '../../../app/types';
 import { rejectParticipantAudio, rejectParticipantVideo } from '../../../av-moderation/actions';
 import participantsPaneTheme from '../../../base/components/themes/participantsPaneTheme.json';
-import { isToolbarButtonEnabled } from '../../../base/config/functions.web';
 import { MEDIA_TYPE } from '../../../base/media/constants';
 import { getParticipantById, isScreenShareParticipant } from '../../../base/participants/functions';
 import { withPixelLineHeight } from '../../../base/styles/functions.web';
@@ -14,7 +13,7 @@ import Input from '../../../base/ui/components/web/Input';
 import useContextMenu from '../../../base/ui/hooks/useContextMenu.web';
 import { normalizeAccents } from '../../../base/util/strings.web';
 import { getBreakoutRooms, getCurrentRoomId, isInBreakoutRoom } from '../../../breakout-rooms/functions';
-import { showOverflowDrawer } from '../../../toolbox/functions.web';
+import { isButtonEnabled, showOverflowDrawer } from '../../../toolbox/functions.web';
 import { muteRemote } from '../../../video-menu/actions.web';
 import { getSortedParticipantIds, isCurrentRoomRenamable, shouldRenderInviteButton } from '../../functions';
 import { useParticipantDrawer } from '../../hooks';
@@ -184,7 +183,7 @@ function _mapStateToProps(state: IReduxState) {
     });
 
     const participantsCount = sortedParticipantIds.length;
-    const showInviteButton = shouldRenderInviteButton(state) && isToolbarButtonEnabled('invite', state);
+    const showInviteButton = shouldRenderInviteButton(state) && isButtonEnabled('invite', state);
     const overflowDrawer = showOverflowDrawer(state);
     const currentRoomId = getCurrentRoomId(state);
     const currentRoom = getBreakoutRooms(state)[currentRoomId];

--- a/react/features/reactions/functions.web.ts
+++ b/react/features/reactions/functions.web.ts
@@ -1,6 +1,6 @@
 import { IReduxState } from '../app/types';
 
-import { shouldDisplayReactionsButtons } from './functions.any';
+import { isReactionsEnabled } from './functions.any';
 
 export * from './functions.any';
 
@@ -23,5 +23,5 @@ export function getReactionsMenuVisibility(state: IReduxState): boolean {
 export function isReactionsButtonEnabled(state: IReduxState) {
     const { toolbarButtons } = state['features/toolbox'];
 
-    return Boolean(toolbarButtons?.includes('reactions')) && shouldDisplayReactionsButtons(state);
+    return Boolean(toolbarButtons?.includes('reactions')) && isReactionsEnabled(state);
 }

--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -5,18 +5,12 @@ import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState, IStore } from '../../../app/types';
 import { NotifyClickButton } from '../../../base/config/configType';
-import { VISITORS_MODE_BUTTONS } from '../../../base/config/constants';
-import {
-    getButtonNotifyMode,
-    getButtonsWithNotifyClick,
-    isToolbarButtonEnabled
-} from '../../../base/config/functions.web';
+import { getButtonNotifyMode, getButtonsWithNotifyClick } from '../../../base/config/functions.web';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
 import { isLocalParticipantModerator } from '../../../base/participants/functions';
 import ContextMenu from '../../../base/ui/components/web/ContextMenu';
 import { isReactionsButtonEnabled, shouldDisplayReactionsButtons } from '../../../reactions/functions.web';
-import { iAmVisitor } from '../../../visitors/functions';
 import {
     setHangupMenuVisible,
     setOverflowMenuVisible,
@@ -27,6 +21,7 @@ import { NOT_APPLICABLE, THRESHOLDS } from '../../constants';
 import {
     getAllToolboxButtons,
     getJwtDisabledButtons,
+    isButtonEnabled,
     isToolboxVisible
 } from '../../functions.web';
 import { useKeyboardShortcuts } from '../../hooks.web';
@@ -288,7 +283,7 @@ const Toolbox = ({
         const buttons = getAllToolboxButtons(_customToolbarButtons);
 
         setButtonsNotifyClickMode(buttons);
-        const isHangupVisible = isToolbarButtonEnabled('hangup', _toolbarButtons);
+        const isHangupVisible = isButtonEnabled('hangup', _toolbarButtons);
         const { order } = THRESHOLDS.find(({ width }) => _clientWidth > width)
             || THRESHOLDS[THRESHOLDS.length - 1];
 
@@ -299,7 +294,7 @@ const Toolbox = ({
             ...Object.values(buttons).filter((button, index) => !order.includes(keys[index]))
         ].filter(({ key, alias = NOT_APPLICABLE }) =>
             !_jwtDisabledButtons.includes(key)
-            && (isToolbarButtonEnabled(key, _toolbarButtons) || isToolbarButtonEnabled(alias, _toolbarButtons))
+            && (isButtonEnabled(key, _toolbarButtons) || isButtonEnabled(alias, _toolbarButtons))
         );
 
         let sliceIndex = _overflowDrawer || _reactionsButtonEnabled ? order.length + 2 : order.length + 1;
@@ -422,7 +417,7 @@ const Toolbox = ({
                                 showReactionsMenu = { showReactionsInOverflowMenu } />
                         )}
 
-                        {isToolbarButtonEnabled('hangup', _toolbarButtons) && (
+                        {isButtonEnabled('hangup', _toolbarButtons) && (
                             _endConferenceSupported
                                 ? <HangupMenuButton
                                     ariaControls = 'hangup-menu'
@@ -452,7 +447,7 @@ const Toolbox = ({
                                     customClass = 'hangup-button'
                                     key = 'hangup-button'
                                     notifyMode = { getButtonNotifyMode('hangup', _buttonsWithNotifyClick) }
-                                    visible = { isToolbarButtonEnabled('hangup', _toolbarButtons) } />
+                                    visible = { isButtonEnabled('hangup', _toolbarButtons) } />
                         )}
                     </div>
                 </div>
@@ -501,11 +496,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
         overflowDrawer
     } = state['features/toolbox'];
     const { clientWidth } = state['features/base/responsive-ui'];
-    let toolbarButtons = ownProps.toolbarButtons || state['features/toolbox'].toolbarButtons;
-
-    if (iAmVisitor(state)) {
-        toolbarButtons = VISITORS_MODE_BUTTONS.filter(e => toolbarButtons.indexOf(e) > -1);
-    }
+    const toolbarButtons = ownProps.toolbarButtons || state['features/toolbox'].toolbarButtons;
 
     return {
         _buttonsWithNotifyClick: getButtonsWithNotifyClick(state),

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -98,3 +98,16 @@ export const TOOLBAR_BUTTONS: ToolbarButton[] = [
     'whiteboard'
 ];
 
+/**
+ * The toolbar buttons to show when in visitors mode.
+ */
+export const VISITORS_MODE_BUTTONS: ToolbarButton[] = [
+    'chat',
+    'hangup',
+    'raisehand',
+    'settings',
+    'tileview',
+    'fullscreen',
+    'stats',
+    'videoquality'
+];

--- a/react/features/toolbox/functions.web.ts
+++ b/react/features/toolbox/functions.web.ts
@@ -55,18 +55,16 @@ export function getToolboxHeight() {
 }
 
 /**
- * Indicates if a toolbar button is enabled.
+ * Checks if the specified button is enabled.
  *
- * @param {string} name - The name of the setting section as defined in
- * interface_config.js.
- * @param {IReduxState} state - The redux state.
- * @returns {boolean|undefined} - True to indicate that the given toolbar button
- * is enabled, false - otherwise.
+ * @param {string} buttonName - The name of the button. See {@link interfaceConfig}.
+ * @param {Object|Array<string>} state - The redux state or the array with the enabled buttons.
+ * @returns {boolean} - True if the button is enabled and false otherwise.
  */
-export function isButtonEnabled(name: string, state: IReduxState) {
-    const { toolbarButtons } = state['features/toolbox'];
+export function isButtonEnabled(buttonName: string, state: IReduxState | Array<string>) {
+    const buttons = Array.isArray(state) ? state : state['features/toolbox'].toolbarButtons || [];
 
-    return toolbarButtons?.indexOf(name) !== -1;
+    return buttons.includes(buttonName);
 }
 
 /**

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -4,7 +4,6 @@ import { batch, useDispatch, useSelector } from 'react-redux';
 import { ACTION_SHORTCUT_TRIGGERED, createShortcutEvent } from '../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../analytics/functions';
 import { IReduxState } from '../app/types';
-import { isToolbarButtonEnabled } from '../base/config/functions.web';
 import { toggleDialog } from '../base/dialog/actions';
 import JitsiMeetJS from '../base/lib-jitsi-meet';
 import { raiseHand } from '../base/participants/actions';
@@ -34,7 +33,7 @@ import { shouldDisplayTileView } from '../video-layout/functions.any';
 import VideoQualityDialog from '../video-quality/components/VideoQualityDialog.web';
 
 import { setFullScreen } from './actions.web';
-import { isDesktopShareButtonDisabled } from './functions.web';
+import { isButtonEnabled, isDesktopShareButtonDisabled } from './functions.web';
 
 export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
     const dispatch = useDispatch();
@@ -206,42 +205,42 @@ export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
 
     useEffect(() => {
         const KEYBOARD_SHORTCUTS = [
-            isToolbarButtonEnabled('videoquality', _toolbarButtons) && {
+            isButtonEnabled('videoquality', _toolbarButtons) && {
                 character: 'A',
                 exec: onToggleVideoQuality,
                 helpDescription: 'toolbar.callQuality'
             },
-            isToolbarButtonEnabled('chat', _toolbarButtons) && {
+            isButtonEnabled('chat', _toolbarButtons) && {
                 character: 'C',
                 exec: onToggleChat,
                 helpDescription: 'keyboardShortcuts.toggleChat'
             },
-            isToolbarButtonEnabled('desktop', _toolbarButtons) && {
+            isButtonEnabled('desktop', _toolbarButtons) && {
                 character: 'D',
                 exec: onToggleScreenshare,
                 helpDescription: 'keyboardShortcuts.toggleScreensharing'
             },
-            _isParticipantsPaneEnabled && isToolbarButtonEnabled('participants-pane', _toolbarButtons) && {
+            _isParticipantsPaneEnabled && isButtonEnabled('participants-pane', _toolbarButtons) && {
                 character: 'P',
                 exec: onToggleParticipantsPane,
                 helpDescription: 'keyboardShortcuts.toggleParticipantsPane'
             },
-            isToolbarButtonEnabled('raisehand', _toolbarButtons) && {
+            isButtonEnabled('raisehand', _toolbarButtons) && {
                 character: 'R',
                 exec: onToggleRaiseHand,
                 helpDescription: 'keyboardShortcuts.raiseHand'
             },
-            isToolbarButtonEnabled('fullscreen', _toolbarButtons) && {
+            isButtonEnabled('fullscreen', _toolbarButtons) && {
                 character: 'S',
                 exec: onToggleFullScreen,
                 helpDescription: 'keyboardShortcuts.fullScreen'
             },
-            isToolbarButtonEnabled('tileview', _toolbarButtons) && {
+            isButtonEnabled('tileview', _toolbarButtons) && {
                 character: 'W',
                 exec: onToggleTileView,
                 helpDescription: 'toolbar.tileViewToggle'
             },
-            !_isSpeakerStatsDisabled && isToolbarButtonEnabled('stats', _toolbarButtons) && {
+            !_isSpeakerStatsDisabled && isButtonEnabled('stats', _toolbarButtons) && {
                 character: 'T',
                 exec: onSpeakerStats,
                 helpDescription: 'keyboardShortcuts.showSpeakerStats'

--- a/react/features/toolbox/middleware.web.ts
+++ b/react/features/toolbox/middleware.web.ts
@@ -3,6 +3,8 @@ import { AnyAction } from 'redux';
 import { IReduxState } from '../app/types';
 import { OVERWRITE_CONFIG, SET_CONFIG, UPDATE_CONFIG } from '../base/config/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+import { I_AM_VISITOR_MODE } from '../visitors/actionTypes';
+import { iAmVisitor } from '../visitors/functions';
 
 import {
     CLEAR_TOOLBOX_TIMEOUT,
@@ -10,7 +12,7 @@ import {
     SET_TOOLBAR_BUTTONS,
     SET_TOOLBOX_TIMEOUT
 } from './actionTypes';
-import { TOOLBAR_BUTTONS } from './constants';
+import { TOOLBAR_BUTTONS, VISITORS_MODE_BUTTONS } from './constants';
 
 import './subscriber.web';
 
@@ -31,6 +33,7 @@ MiddlewareRegistry.register(store => next => action => {
     }
     case UPDATE_CONFIG:
     case OVERWRITE_CONFIG:
+    case I_AM_VISITOR_MODE:
     case SET_CONFIG: {
         const result = next(action);
         const toolbarButtons = _getToolbarButtons(store.getState());
@@ -112,8 +115,11 @@ function _setFullScreen(next: Function, action: AnyAction) {
 function _getToolbarButtons(state: IReduxState): Array<string> {
     const { toolbarButtons, customToolbarButtons } = state['features/base/config'];
     const customButtons = customToolbarButtons?.map(({ id }) => id);
+    let buttons = Array.isArray(toolbarButtons) ? toolbarButtons : TOOLBAR_BUTTONS;
 
-    const buttons = Array.isArray(toolbarButtons) ? toolbarButtons : TOOLBAR_BUTTONS;
+    if (iAmVisitor(state)) {
+        buttons = VISITORS_MODE_BUTTONS.filter(button => buttons.indexOf(button) > -1);
+    }
 
     if (customButtons) {
         return [ ...buttons, ...customButtons ];


### PR DESCRIPTION
Filters the toolbarButtons in redux depending on the visitor state instead of filtering them every time in mapStateToProps. This will prevent unnecessary rerenders of the toolbar.

Additionally:
 - Moves visitor buttons const from features/config in features/toolbox.
 - Removes dublicate functions isButtonEnabled and isToolbarButtonEnabled.
 - Adds more buttons to the visitor allowed buttons which functionality has been any way accessible trough shortcuts or somewhere else.
 - Enables customButtons to be visible for visitors.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
