### PR TITLE
fix(visitors): Fixes replacing visitor domain.

### DIFF
--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -95,11 +95,15 @@ local function request_promotion_received(room, from_jid, from_vnode, nick, time
             local iq_id = new_id();
             sent_iq_cache:set(iq_id, socket.gettime());
 
+            local node, host = jid.split(room.jid);
+            local visitorHost = string.gsub(host, muc_domain_base, req_from);
+            local visitorRoom = jid.join(node, visitorHost);
+
             module:send(st.iq({
                     type='set', to = req_from, from = module.host, id = iq_id })
                 :tag('visitors', {
                     xmlns='jitsi:visitors',
-                    room = string.gsub(room.jid, muc_domain_base, req_from),
+                    room = visitorRoom,
                     focusjid = focus_jid })
                  :tag('promotion-response', {
                     xmlns='jitsi:visitors',
@@ -282,11 +286,15 @@ local function process_promotion_response(room, id, approved)
     local iq_id = new_id();
     sent_iq_cache:set(iq_id, socket.gettime());
 
+    local node, host = jid.split(room.jid);
+    local visitorHost = string.gsub(host, muc_domain_base, req_from);
+    local visitorRoom = jid.join(node, visitorHost);
+
     module:send(st.iq({
             type='set', to = req_from, from = module.host, id = iq_id })
         :tag('visitors', {
             xmlns='jitsi:visitors',
-            room = string.gsub(room.jid, muc_domain_base, req_from),
+            room = visitorRoom,
             focusjid = focus_jid })
          :tag('promotion-response', {
             xmlns='jitsi:visitors',

--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -95,15 +95,13 @@ local function request_promotion_received(room, from_jid, from_vnode, nick, time
             local iq_id = new_id();
             sent_iq_cache:set(iq_id, socket.gettime());
 
-            local node, host = jid.split(room.jid);
-            local visitorHost = string.gsub(host, muc_domain_base, req_from);
-            local visitorRoom = jid.join(node, visitorHost);
+            local node = jid.node(room.jid);
 
             module:send(st.iq({
                     type='set', to = req_from, from = module.host, id = iq_id })
                 :tag('visitors', {
                     xmlns='jitsi:visitors',
-                    room = visitorRoom,
+                    room = jid.join(node, muc_domain_prefix..'.'..req_from),
                     focusjid = focus_jid })
                  :tag('promotion-response', {
                     xmlns='jitsi:visitors',
@@ -286,15 +284,13 @@ local function process_promotion_response(room, id, approved)
     local iq_id = new_id();
     sent_iq_cache:set(iq_id, socket.gettime());
 
-    local node, host = jid.split(room.jid);
-    local visitorHost = string.gsub(host, muc_domain_base, req_from);
-    local visitorRoom = jid.join(node, visitorHost);
+    local node = jid.node(room.jid);
 
     module:send(st.iq({
             type='set', to = req_from, from = module.host, id = iq_id })
         :tag('visitors', {
             xmlns='jitsi:visitors',
-            room = visitorRoom,
+            room = jid.join(node, muc_domain_prefix..'.'..req_from),
             focusjid = focus_jid })
          :tag('promotion-response', {
             xmlns='jitsi:visitors',


### PR DESCRIPTION
Replacement only on the host part of the jid.

The problem is having a room like:
[meet-jit-si-shard]someroomname@conference.meet.jit.si and replacing with 'meet.jit.si', the dots match the -.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
