### PR TITLE
fix(conference) fix incorrect meeting name in CallKit

### DIFF
--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -596,7 +596,10 @@ function _setRoom(state: IConferenceState, action: AnyAction) {
      */
     return assign(state, {
         error: undefined,
-        room
+        localSubject: undefined,
+        pendingSubjectChange: undefined,
+        room,
+        subject: undefined
     });
 }
 


### PR DESCRIPTION
Reset subject when setting a new room name.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
