### PR TITLE
fix(chat) dont emojify matrix ids

### DIFF
--- a/react/features/base/react/components/web/Message.tsx
+++ b/react/features/base/react/components/web/Message.tsx
@@ -56,9 +56,9 @@ class Message extends Component<IProps> {
         } else {
             for (const token of tokens) {
 
-                if (token.includes('://')) {
+                if (token.includes('://') || token.startsWith('@')) {
 
-                    // Bypass the emojification when urls are involved
+                    // Bypass the emojification when urls or matrix ids are involved
                     content.push(token);
                 } else {
                     content.push(...toArray(token, { className: 'smiley' }));


### PR DESCRIPTION
Matrix user ids all start with an @, so lets skip these for the
smiley renderer (same as we already do for any url-like strings).

I did not use "contains @ and :", as also the :@ (shorthand for :rage:)
contains that and would have broken it...

Fixes: #10936

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
