### PR TITLE
feat(web) ✨ new config to start with tileView

### DIFF
--- a/config.js
+++ b/config.js
@@ -1782,9 +1782,6 @@ var config = {
     //         collectionInterval?: number;
     //         logGetStats?: boolean;
     // },
-
-    // Hide login button on auth dialog, you may want to enable this if you are using JWT tokens to authenticate users
-    // hideLoginButton: true,
 };
 
 // Temporary backwards compatibility with old mobile clients.

--- a/config.js
+++ b/config.js
@@ -1688,6 +1688,10 @@ var config = {
     // tileView: {
     //     // Whether tileview should be disabled.
     //     disabled: false,
+    //     // If true start the video in tile view. It is enforced in all cases,
+    //     // including jibri recording, screen sharing etc. The only exception are local
+    //     // user preference, which comes before everything else, or if tile view is disabled.
+    //     force: false,
     //     // The optimal number of tiles that are going to be shown in tile view. Depending on the screen size it may
     //     // not be possible to show the exact number of participants specified here.
     //     numberOfVisibleTiles: 25,
@@ -1778,6 +1782,9 @@ var config = {
     //         collectionInterval?: number;
     //         logGetStats?: boolean;
     // },
+
+    // Hide login button on auth dialog, you may want to enable this if you are using JWT tokens to authenticate users
+    // hideLoginButton: true,
 };
 
 // Temporary backwards compatibility with old mobile clients.

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -550,6 +550,7 @@ export interface IConfig {
     };
     tileView?: {
         disabled?: boolean;
+        force?: boolean;
         numberOfVisibleTiles?: number;
     };
     tokenAuthUrl?: string;

--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -106,7 +106,7 @@ export function shouldDisplayTileView(state: IReduxState) {
         // It's a 1-on-1 meeting
         || participantCount < 3
 
-        // There is a shared YouTube video in the meeting
+        // Screen or YouTube video is shared in the meeting
         || isVideoPlaying(state)
 
         // We want jibri to use stage view by default
@@ -139,7 +139,7 @@ export function updateAutoPinnedParticipant(
     // Unpin the screen share when the screen sharing participant leaves. Switch to tile view if no other
     // participant was pinned before screen share was auto-pinned, pin the previously pinned participant otherwise.
     if (!remoteScreenShares?.length) {
-        let participantId = null;
+        let participantId: string | null = null;
 
         if (pinned && !screenShares.find(share => share === pinned.id)) {
             participantId = pinned.id;

--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -81,6 +81,13 @@ export function shouldDisplayTileView(state: IReduxState) {
         return false;
     }
 
+    const { tileView } = state['features/base/config'];
+
+    if (tileView?.force) {
+        return true;
+    }
+
+
     const participantCount = getParticipantCount(state);
     const { iAmRecorder } = state['features/base/config'];
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Currently there is no config option to set tile view layout as default starting point. This PR introduces a new config `tileView.force` which will set tileView if enabled. It is called force as it will also be forced when a video is shared, 1:1 meeting, jibri etc.

The user can still manually toggle tileView if the button is available or if tileView is disabled in the config it will be disabled, as this check comes before the force check.

We actually need this feature, as we want jibri to capture the video in tile view. 

Other issues related to this setting:
- https://github.com/jitsi/jitsi-meet/issues/5764
- https://github.com/jitsi/jitsi-meet/issues/13493
- https://community.jitsi.org/t/default-view-as-tile-view/28138/20

Contribution Agreement was signed as company, Certible GmbH.

(Note: One commit includes a small typo and type fix as it was in the same file.)

Cheers
Hannes
