### PR TITLE
disable: automatical send funtion by clicking 'enter' in feedback 

### DIFF
--- a/react/features/feedback/components/FeedbackDialog.web.tsx
+++ b/react/features/feedback/components/FeedbackDialog.web.tsx
@@ -285,6 +285,7 @@ const FeedbackDialog = ({ conference, onClose, title }: IProps) => {
 
     return (
         <Dialog
+            disableEnter = { true }
             ok = {{
                 translationKey: 'dialog.Submit'
             }}


### PR DESCRIPTION
Ich sage:If the user enters a longer text and then moves to the right to the end of the input area, then the user uses the <Return> key for the next input. However, this always leads to the feedback being sentfeedback (and therefore to an incomplete description)
I fixed the code. It will not define a default button that is triggered by Return. The user should always explicitly click on the <OK> button to submit their rating. 