### PR TITLE
fix(video-quality): Correctly pin camera tile.

### DIFF
--- a/react/features/video-quality/subscriber.ts
+++ b/react/features/video-quality/subscriber.ts
@@ -428,9 +428,7 @@ function _updateReceiverVideoConstraints({ getState }: IStore) {
         if (remoteScreenShares.includes(largeVideoParticipantId)) {
             largeVideoSourceName = largeVideoParticipantId;
         } else {
-            largeVideoSourceName = getSsrcRewritingFeatureFlag(state)
-                ? getSourceNamesByMediaType(state, largeVideoParticipantId, MEDIA_TYPE.VIDEO)?.[0]
-                : getTrackSourceNameByMediaTypeAndParticipant(
+            largeVideoSourceName = getTrackSourceNameByMediaTypeAndParticipant(
                     tracks, MEDIA_TYPE.VIDEO, largeVideoParticipantId);
         }
     }


### PR DESCRIPTION
When screensharing source is the first source to be added with ssrc-rewriting enabled, constraints for the camera tile don't get updated when its pinned. Fixes https://github.com/jitsi/jitsi-meet/issues/14501

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
