### PR TITLE
Fixing: Acme script breaking during install on Ubuntu with Apache and with configured server FQDN

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -1,7 +1,7 @@
 
 <VirtualHost *:80>
     ServerName jitsi-meet.example.com
-    # Redirect permanent / https://jitsi-meet.example.com/
+    Redirect permanent / https://jitsi-meet.example.com/
     DocumentRoot "/usr/share/jitsi-meet"
 </VirtualHost>
 

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -1,7 +1,8 @@
 
 <VirtualHost *:80>
     ServerName jitsi-meet.example.com
-    Redirect permanent / https://jitsi-meet.example.com/
+    # Redirect permanent / https://jitsi-meet.example.com/
+    DocumentRoot "/usr/share/jitsi-meet"
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -1,7 +1,7 @@
 
 <VirtualHost *:80>
     ServerName jitsi-meet.example.com
-    Redirect permanent / https://jitsi-meet.example.com/
+    # Redirect permanent / https://jitsi-meet.example.com/
     DocumentRoot "/usr/share/jitsi-meet"
 </VirtualHost>
 

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -1,8 +1,7 @@
 
 <VirtualHost *:80>
     ServerName jitsi-meet.example.com
-    # Redirect permanent / https://jitsi-meet.example.com/
-    DocumentRoot "/usr/share/jitsi-meet"
+    Redirect permanent / https://jitsi-meet.example.com/
 </VirtualHost>
 
 <VirtualHost *:443>

--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -83,11 +83,12 @@ if [ ${ISSUE_FAILED_CODE} -ne 0 ] ; then
     fi
 else
     eval "$INSTALL_CERT_CMD"
-
-        if [[ -n "$ENABLEDEFAULT_CMD" ]]; then  
-           echo "Cleanup: Enabling default Apache site back"
-           eval "$ENABLEDEFAULT_CMD"
-           echo "Cleanup succeeded"
-        fi
-
 fi
+
+if [[ -n "$ENABLEDEFAULT_CMD" ]]; then  
+    echo "Cleanup: Enabling default Apache site back"
+    eval "$ENABLEDEFAULT_CMD"
+    ENABLEDEFAULT_CMD=
+    echo "Cleanup succeeded"
+fi
+

--- a/resources/install-letsencrypt-cert.sh
+++ b/resources/install-letsencrypt-cert.sh
@@ -49,17 +49,16 @@ elif [ "$OPENRESTY_INSTALL_CHECK" = "installed" ] || [ "$OPENRESTY_INSTALL_CHECK
     RELOAD_CMD="systemctl force-reload openresty.service"
 elif [ "$APACHE_INSTALL_CHECK" = "installed" ] || [ "$APACHE_INSTALL_CHECK" = "unpacked" ] ; then
     RELOAD_CMD="systemctl force-reload apache2.service"
-	
-    FQDN=$(hostname) # Get the server FQDN
-       if [[ "$FQDN" == "$DOMAIN" ]]; then
-          DEFAULT_SITE_CONF="/etc/apache2/sites-enabled/000-default.conf"
-          if [[ -f "$DEFAULT_SITE_CONF" ]]; then # Checks if the default site is enabled
-             echo "Default Apache site may conflict with Let's Encrypt process"
-             a2dissite 000-default.conf && ${RELOAD_CMD}
-             ENABLEDEFAULT_CMD="a2ensite 000-default.conf && ${RELOAD_CMD}"
-             echo "Disabled default Apache site"
-          fi
-      fi
+
+    if [[ "$(hostname)" == "$DOMAIN" ]]; then
+        DEFAULT_SITE_CONF="/etc/apache2/sites-enabled/000-default.conf"
+        if [[ -f "$DEFAULT_SITE_CONF" ]]; then # Checks if the default site is enabled
+            echo "Default Apache site may conflict with Let's Encrypt process"
+            a2dissite 000-default.conf && ${RELOAD_CMD}
+            ENABLEDEFAULT_CMD="a2ensite 000-default.conf && ${RELOAD_CMD}"
+            echo "Disabled default Apache site"
+        fi
+    fi
 
 else
     RELOAD_CMD="echo 'No webserver found'"


### PR DESCRIPTION
During install, when:
* ubuntu hostname = desired FQDN of the new Jitsi server, and 
* Jitsi VurtualHost is not up yet on `:443`:

Apache's default host responds to the "FQDN call" and default settings supersede the Jitsi VirtualHost. 

As a result, Let's Encrypt challenge is served with Apache default webpage from `/var/www/html`, which does not have the `/var/www/html/.well-known/...` response.

Proposed solution modifies `install-letsencrypt-cert.sh` to detect this condition and disable default Apache site while Let's Encrypt process is working for the first time.

Merging this will address issue #14510.