### PR TITLE
fix(participants-pane): multi words search

### DIFF
--- a/react/features/participants-pane/functions.ts
+++ b/react/features/participants-pane/functions.ts
@@ -242,19 +242,11 @@ searchString: string) {
     if (searchString === '') {
         return true;
     }
+    const participantName = normalizeAccents(participant?.name || participant?.displayName || '')
+        .toLowerCase();
+    const lowerCaseSearchString = searchString.trim().toLowerCase();
 
-    const names = normalizeAccents(participant?.name || participant?.displayName || '')
-        .toLowerCase()
-        .split(' ');
-    const lowerCaseSearchString = searchString.toLowerCase();
-
-    for (const name of names) {
-        if (name.startsWith(lowerCaseSearchString)) {
-            return true;
-        }
-    }
-
-    return false;
+    return participantName.includes(lowerCaseSearchString);
 }
 
 /**


### PR DESCRIPTION
Fixed multi words search on participants pane #14529 

The issue has been fixed according to expected behavior:

<img width="305" alt="image" src="https://github.com/jitsi/jitsi-meet/assets/43909097/e0a1a840-48db-4b1a-b2c1-b8f6cae71dd4">
