### PR TITLE
fix: Fixes parsing hash params to be passed to tokenAuthUrl.

### DIFF
--- a/react/features/authentication/functions.any.ts
+++ b/react/features/authentication/functions.any.ts
@@ -1,4 +1,5 @@
 import { IConfig } from '../base/config/configType';
+import { parseURLParams } from '../base/util/parseURLParams';
 import { getBackendSafeRoomName } from '../base/util/uri';
 
 /**
@@ -72,13 +73,13 @@ export const _getTokenAuthState = (
         state['config.startWithVideoMuted'] = true;
     }
 
-    const params = new URLSearchParams(locationURL.hash);
+    const params = parseURLParams(locationURL, true);
 
-    for (const [ key, value ] of params) {
+    for (const key of Object.keys(params)) {
         // we allow only config and interfaceConfig overrides in the state
         if (key.startsWith('config.') || key.startsWith('interfaceConfig.')) {
             // @ts-ignore
-            state[key] = value;
+            state[key] = params[key];
         }
     }
 


### PR DESCRIPTION
The URL.hash returns the # sign, and so we always ignore the first parameter.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
