### PR TITLE
fix(lang) (a11y) update screen reader related french translation

### DIFF
--- a/lang/main-fr.json
+++ b/lang/main-fr.json
@@ -1169,7 +1169,7 @@
     "toolbar": {
         "Settings": "Paramètres",
         "accessibilityLabel": {
-            "Settings": "Afficher / Masquer le menu des paramètres",
+            "Settings": "Ouvrir le menu des paramètres",
             "audioOnly": "Activer / Désactiver le mode voix uniquement",
             "audioRoute": "Sélectionner la source audio",
             "boo": "Hou",
@@ -1215,7 +1215,7 @@
             "moreActions": "Activer / Désactiver le menu d'actions supplémentaires",
             "moreActionsMenu": "Menu d'actions supplémentaires",
             "moreOptions": "Voir plus d'options",
-            "mute": "Activer / Désactiver l'audio",
+            "mute": "Couper votre micro",
             "muteEveryone": "Couper le micro de tout le monde",
             "muteEveryoneElse": "Couper le micro de tous les autres",
             "muteEveryoneElsesVideoStream": "Couper la caméra de tous les autres",
@@ -1251,11 +1251,11 @@
             "tileView": "Activer / Désactiver la vue mosaïque",
             "toggleCamera": "Changer de caméra",
             "toggleFilmstrip": "Afficher ou masquer les vignettes vidéo",
-            "unmute": "Rétablir le son",
+            "unmute": "Activer votre micro",
             "videoblur": "Activer / désactiver le floutage",
-            "videomute": "Activer / Couper la vidéo",
+            "videomute": "Couper votre vidéo",
             "videomuteGUMPending": "Connexion de votre caméra",
-            "videounmute": "Démarrer la vidéo"
+            "videounmute": "Activer votre vidéo"
         },
         "addPeople": "Ajouter des personnes à votre appel",
         "audioOnlyOff": "Désactiver le mode bande passante réduite",


### PR DESCRIPTION
:wave: Here a couple changes on french translations. The unmute/mute string changes are quite important, as for now, french screen reader users don't get the info about the current state. The button is vocalized as "Mute/unmute mic", but you don't get the info about if it's muted on press, or on unpressed. **So this tiny translation change has a huge impact for french screen reader users.**

The changes explained in details:

- settings string contained a string saying "show / hide settings", but we should match the english string saying only "show settings" as the button is only used to show the settings (its a dialog you can't go out of, so there is no way to go back to the settings button to close, the "hide" case doesn't exist)

- use "Activer" instead of "Rétablir" and "Démarrer" for toggle on states, as this wording is used accross lots of other buttons, it makes more sense to use the same wording

- change the unmute/mute audio/video strings to tell the user its *their* device they toggle. There are a few spots in this app where we label stuff as "mute microphone", sometimes its for you, sometimes its for other people. The idea here is to say "Mute your microphone" instead of "Mute microphone" so that screen reader users fully understand what they do.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
