### PR TITLE
fix(chat): added emoji tooltip and enter key in smiley panel

### DIFF
--- a/react/features/chat/components/web/SmileysPanel.tsx
+++ b/react/features/chat/components/web/SmileysPanel.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import Emoji from 'react-emoji-render';
 
+import Tooltip from '../../../base/tooltip/components/Tooltip';
 import { smileys } from '../../smileys';
 
 /**
@@ -60,7 +61,7 @@ class SmileysPanel extends PureComponent<IProps> {
      * @returns {void}
      */
     _onKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
-        if (e.key === ' ') {
+        if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault(); // @ts-ignore
             this.props.onSmileySelect(e.target.id && smileys[e.target.id]);
         }
@@ -95,9 +96,11 @@ class SmileysPanel extends PureComponent<IProps> {
                 onKeyPress = { this._onKeyPress }
                 role = 'option'
                 tabIndex = { 0 }>
-                <Emoji
-                    onlyEmojiClassName = 'smiley'
-                    text = { smileys[smileyKey as keyof typeof smileys] } />
+                <Tooltip content = { smileys[smileyKey as keyof typeof smileys] }>
+                    <Emoji
+                        onlyEmojiClassName = 'smiley'
+                        text = { smileys[smileyKey as keyof typeof smileys] } />
+                </Tooltip>
             </div>
         ));
 


### PR DESCRIPTION
added emoji tooltip and enter key capability in smiley panel https://github.com/jitsi/jitsi-meet/issues/14568

<img width="302" alt="Screenshot 2024-03-29 at 02 11 56" src="https://github.com/jitsi/jitsi-meet/assets/43909097/83293aef-b71d-42c5-9b59-fe7431595aef">
