### PR TITLE
fix(chat): fixed error message colors

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -102,7 +102,7 @@
         }
 
         .usermessage {
-            color: red;
+            color: #ffffff;
             padding: 0;
         }
     }

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles()((theme: Theme) => {
             },
 
             '&.error': {
-                backgroundColor: 'rgb(215, 121, 118)',
+                backgroundColor: theme.palette.ui04,
                 borderRadius: 0,
                 fontWeight: 100
             },


### PR DESCRIPTION
the fix is related to https://github.com/jitsi/jitsi-meet/issues/14573 


after fix the error message looks better

<img width="313" alt="Screenshot 2024-03-29 at 17 21 19" src="https://github.com/jitsi/jitsi-meet/assets/43909097/31c4fc54-dae0-44fa-8c57-7a232e685523">

