### PR TITLE
fix(android) fix server URL parsing

### DIFF
--- a/android/app/src/main/java/org/jitsi/meet/MainActivity.java
+++ b/android/app/src/main/java/org/jitsi/meet/MainActivity.java
@@ -35,7 +35,6 @@ import org.jitsi.meet.sdk.JitsiMeetActivity;
 import org.jitsi.meet.sdk.JitsiMeetConferenceOptions;
 
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
@@ -227,7 +226,7 @@ public class MainActivity extends JitsiMeetActivity {
     private @Nullable URL buildURL(String urlStr) {
         try {
             return new URL(urlStr);
-        } catch (MalformedURLException e) {
+        } catch (Exception e) {
             return null;
         }
     }


### PR DESCRIPTION
Some devices throw NullPointerException instead of MalformedURLException.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
