### PR TITLE
feat(external-api): expose authentication

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -3,7 +3,7 @@ import Logger from '@jitsi/logger';
 
 import { createApiEvent } from '../../react/features/analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../react/features/analytics/functions';
-import { authenticateAndUpgradeRole } from "../../react/features/authentication/actions.any";
+import { authenticateAndUpgradeRole } from '../../react/features/authentication/actions.any';
 import {
     approveParticipantAudio,
     approveParticipantVideo,
@@ -98,7 +98,7 @@ import {
     open as openParticipantsPane
 } from '../../react/features/participants-pane/actions';
 import { getParticipantsPaneOpen, isForceMuted } from '../../react/features/participants-pane/functions';
-import { joinConference } from "../../react/features/prejoin/actions.web";
+import { joinConference } from '../../react/features/prejoin/actions.web';
 import { startLocalVideoRecording, stopLocalVideoRecording } from '../../react/features/recording/actions.any';
 import { RECORDING_TYPES } from '../../react/features/recording/constants';
 import { getActiveSession, supportsLocalRecording } from '../../react/features/recording/functions';
@@ -492,7 +492,7 @@ function initCommands() {
             const conference = getCurrentConference(state);
 
             if (conference) {
-                APP.store.dispatch(authenticateAndUpgradeRole(jid, password, conference))
+                APP.store.dispatch(authenticateAndUpgradeRole(jid, password, conference));
             } else {
                 // FIXME: Workaround for the web version. To be removed once we get rid of conference.js
                 APP.store.dispatch(joinConference(undefined, false, jid, password));

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -3,6 +3,7 @@ import Logger from '@jitsi/logger';
 
 import { createApiEvent } from '../../react/features/analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../react/features/analytics/functions';
+import { authenticateAndUpgradeRole } from "../../react/features/authentication/actions.any";
 import {
     approveParticipantAudio,
     approveParticipantVideo,
@@ -97,6 +98,7 @@ import {
     open as openParticipantsPane
 } from '../../react/features/participants-pane/actions';
 import { getParticipantsPaneOpen, isForceMuted } from '../../react/features/participants-pane/functions';
+import { joinConference } from "../../react/features/prejoin/actions.web";
 import { startLocalVideoRecording, stopLocalVideoRecording } from '../../react/features/recording/actions.any';
 import { RECORDING_TYPES } from '../../react/features/recording/constants';
 import { getActiveSession, supportsLocalRecording } from '../../react/features/recording/functions';
@@ -484,6 +486,17 @@ function initCommands() {
         'email': email => {
             sendAnalytics(createApiEvent('email.changed'));
             APP.conference.changeLocalEmail(email);
+        },
+        'authenticate': (jid, password) => {
+            const state = APP.store.getState();
+            const conference = getCurrentConference(state);
+
+            if (conference) {
+                APP.store.dispatch(authenticateAndUpgradeRole(jid, password, conference))
+            } else {
+                // FIXME: Workaround for the web version. To be removed once we get rid of conference.js
+                APP.store.dispatch(joinConference(undefined, false, jid, password));
+            }
         },
         'avatar-url': avatarUrl => {
             sendAnalytics(createApiEvent('avatar.url.changed'));

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -38,6 +38,7 @@ const commands = {
     displayName: 'display-name',
     endConference: 'end-conference',
     email: 'email',
+    authenticate: 'authenticate',
     grantModerator: 'grant-moderator',
     hangup: 'video-hangup',
     hideNotification: 'hide-notification',


### PR DESCRIPTION
I do have a setup, where jitsi is used inside an iframe and I have different user roles, that are joining rooms. Whereas only users with the role "support" or "lecturer" can be moderators and they have to authenticate in order to "open up the room", like in real school, others shouldn't be able to.

To achieve a comfortable, but also secure auth process, I exposed the authentication from the LoginDialog Window, to login automatically via an external api command. So I can provide login credentials from a backend api or similiar and the user doesn't have to authenticate manually.