### PR TITLE
[feat] Add support for jiconop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ deploy-appbundle:
 	cp \
 		$(BUILD_DIR)/app.bundle.min.js \
 		$(BUILD_DIR)/app.bundle.min.js.map \
+		$(BUILD_DIR)/do_external_connect.min.js \
+		$(BUILD_DIR)/do_external_connect.min.js.map \
 		$(BUILD_DIR)/external_api.min.js \
 		$(BUILD_DIR)/external_api.min.js.map \
 		$(BUILD_DIR)/alwaysontop.min.js \
@@ -66,6 +68,7 @@ deploy-appbundle:
 deploy-lib-jitsi-meet:
 	cp \
 		$(LIBJITSIMEET_DIR)/dist/umd/lib-jitsi-meet.* \
+		$(LIBJITSIMEET_DIR)/connection_optimization/external_connect.js \
 		$(DEPLOY_DIR)
 
 deploy-olm:
@@ -125,7 +128,7 @@ dev: deploy-init deploy-css deploy-rnnoise-binary deploy-tflite deploy-meet-mode
 
 source-package:
 	mkdir -p source_package/jitsi-meet/css && \
-	cp -r *.js *.html resources/*.txt fonts images libs static sounds LICENSE lang source_package/jitsi-meet && \
+	cp -r *.js *.html resources/*.txt connection_optimization fonts images libs static sounds LICENSE lang source_package/jitsi-meet && \
 	cp css/all.css source_package/jitsi-meet/css && \
 	(cd source_package ; tar cjf ../jitsi-meet.tar.bz2 jitsi-meet) && \
 	rm -rf source_package

--- a/app.js
+++ b/app.js
@@ -32,7 +32,18 @@ window.APP = {
     API,
     conference,
     translation,
-    UI
+    UI,
+
+    // Used by do_external_connect.js if we receive the attach data after
+    // connect was already executed. status property can be 'initialized',
+    // 'ready', or 'connecting'. We are interested in 'ready' status only which
+    // means that connect was executed but we have to wait for the attach data.
+    // In status 'ready' handler property will be set to a function that will
+    // finish the connect process when the attach data or error is received.
+    connect: {
+        handler: null,
+        status: 'initialized'
+    }
 };
 
 // TODO The execution of the mobile app starts from react/index.native.js.

--- a/connection_optimization/.eslintrc.js
+++ b/connection_optimization/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+    'extends': '../react/.eslintrc.js'
+};

--- a/connection_optimization/do_external_connect.js
+++ b/connection_optimization/do_external_connect.js
@@ -1,0 +1,90 @@
+/* global config, createConnectionExternally */
+
+// import { createConnectionExternally } from 'lib-jitsi-meet';
+
+import getRoomName from '../react/features/base/config/getRoomName';
+import { parseURLParams } from '../react/features/base/util/parseURLParams';
+
+/**
+ * Implements external connect using createConnectionExternally function defined
+ * in external_connect.js for Jitsi Meet. Parses the room name and JSON Web
+ * Token (JWT) from the URL and executes createConnectionExternally.
+ *
+ * NOTE: If you are using lib-jitsi-meet without Jitsi Meet, you should use this
+ * file as reference only because the implementation is Jitsi Meet-specific.
+ *
+ * NOTE: For optimal results this file should be included right after
+ * external_connect.js.
+ */
+
+
+if (typeof createConnectionExternally === 'function') {
+    // URL params have higher priority than config params.
+    // Do not use external connect if websocket is enabled.
+    let url
+        = parseURLParams(window.location, true, 'hash')['config.externalConnectUrl']
+            || config.websocket ? undefined : config.externalConnectUrl;
+    const isRecorder
+        = parseURLParams(window.location, true, 'hash')['config.iAmRecorder'];
+
+    let roomName;
+
+    if (url && (roomName = getRoomName()) && !isRecorder) {
+        url += `?room=${roomName}`;
+
+        const token = parseURLParams(window.location, true, 'search').jwt;
+
+        if (token) {
+            url += `&token=${token}`;
+        }
+
+        console.log(`calling createConnectionExternally with url: ${url}`);
+        createConnectionExternally(
+            url,
+            connectionInfo => {
+                // Sets that global variable to be used later by connect method
+                // in connection.js.
+                window.XMPPAttachInfo = {
+                    status: 'success',
+                    data: connectionInfo
+                };
+                checkForConnectHandlerAndConnect();
+            },
+            errorCallback);
+    } else {
+        console.log('do_external_connect.js: errorCallback as url is not defined or isRecorder is true');
+        errorCallback();
+    }
+} else {
+    errorCallback();
+}
+
+/**
+ * Check if connect from connection.js was executed and executes the handler
+ * that is going to finish the connect work.
+ *
+ * @returns {void}
+ */
+function checkForConnectHandlerAndConnect() {
+    window.APP
+        && window.APP.connect.status === 'ready'
+        && window.APP.connect.handler();
+}
+
+/**
+ * Implements a callback to be invoked if anything goes wrong.
+ *
+ * @param {Error} error - The specifics of what went wrong.
+ * @returns {void}
+ */
+function errorCallback(error) {
+    // The value of error is undefined if external connect is disabled.
+    error && console.warn(error);
+
+    // Sets that global variable to be used later by connect method in
+    // connection.js.
+    window.XMPPAttachInfo = {
+        status: 'error'
+    };
+    checkForConnectHandlerAndConnect();
+}

--- a/debian/jitsi-meet-web.install
+++ b/debian/jitsi-meet-web.install
@@ -7,6 +7,7 @@ sounds					/usr/share/jitsi-meet/
 fonts					/usr/share/jitsi-meet/
 images					/usr/share/jitsi-meet/
 lang					/usr/share/jitsi-meet/
+connection_optimization /usr/share/jitsi-meet/
 resources/robots.txt	/usr/share/jitsi-meet/
 resources/*.sh			/usr/share/jitsi-meet/scripts/
 pwa-worker.js			/usr/share/jitsi-meet/

--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -102,7 +102,7 @@ server {
     }
 
     # ensure all static content can always be found first
-    location ~ ^/(libs|css|static|images|fonts|lang|sounds|.well-known)/(.*)$
+    location ~ ^/(libs|css|static|images|fonts|lang|sounds|connection_optimization|.well-known)/(.*)$
     {
         add_header 'Access-Control-Allow-Origin' '*';
         alias /usr/share/jitsi-meet/$1/$2;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -10,6 +10,7 @@ declare global {
         API: any;
         conference: any;
         debugLogs: any;
+        connect: any;
     };
     const interfaceConfig: any;
 
@@ -25,6 +26,7 @@ declare global {
         // selenium tests handler
         _sharedVideoPlayer: any;
         alwaysOnTop: { api: any };
+        XMPPAttachInfo: any;
     }
 
     interface Document {

--- a/index.html
+++ b/index.html
@@ -191,6 +191,8 @@
             'error', loadErrHandler, true /* capture phase type of listener */);
     </script>
     <script><!--#include virtual="/config.js" --></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
+    <script src="libs/external_connect.js"></script>
+    <script src="libs/do_external_connect.min.js?v=1"></script>
     <script><!--#include virtual="/interface_config.js" --></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
     <script src="libs/app.bundle.min.js?v=139"></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -308,6 +308,16 @@ module.exports = (_env, argv) => {
         }),
         Object.assign({}, config, {
             entry: {
+                'do_external_connect': './connection_optimization/do_external_connect.js'
+            },
+            plugins: [
+                ...config.plugins,
+                ...getBundleAnalyzerPlugin(analyzeBundle, 'do_external_connect')
+            ],
+            performance: getPerformanceHints(perfHintOptions, 5 * 1024)
+        }),
+        Object.assign({}, config, {
+            entry: {
                 'analytics-ga': './react/features/analytics/handlers/GoogleAnalyticsHandler.ts'
             },
             plugins: [


### PR DESCRIPTION
> This PR is not intended for merge
> While working on GSoC Project to implement [jiconop for websockets](https://github.com/jitsi/gsoc-ideas/blob/master/2024/jiconop-ws.md), I needed to enable [jiconop for BOSH](https://github.com/jitsi/jiconop) to understand the concepts behind it and experiment it. So, This PR is part of this [guide](https://community.jitsi.org/t/how-to-how-to-enable-jiconop-for-bosh/131097), in case anyone needed to do the same.

A previously dropped service [jiconop](https://github.com/jitsi/jiconop) which optimizes the initial connection of BOSH by adding a proxy between clients and the server.

This draft pull request shows the needed changes in jitsi-meet files in order to re-add the support for this abandoned service, in case someone wanted to experiment with it.



