### PR TITLE
fix: Parse/decode the URL params before constructing the url.

### DIFF
--- a/react/features/authentication/functions.any.ts
+++ b/react/features/authentication/functions.any.ts
@@ -72,8 +72,7 @@ export const _getTokenAuthState = (
         // @ts-ignore
         state['config.startWithVideoMuted'] = true;
     }
-
-    const params = parseURLParams(locationURL, true);
+    const params = parseURLParams(locationURL);
 
     for (const key of Object.keys(params)) {
         // we allow only config and interfaceConfig overrides in the state


### PR DESCRIPTION
Fixes #14672.

When passing url param config.subject="Example%20Title" we will send config.subject%22%3A%22%2522Example%2520Title%2522%22 which is double quotes.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
