### PR TITLE
fix(android) Keep microphone enabled when app is in background

### DIFF
--- a/android/sdk/src/main/AndroidManifest.xml
+++ b/android/sdk/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -50,7 +51,7 @@
 
         <service
             android:name="org.jitsi.meet.sdk.JitsiMeetOngoingConferenceService"
-            android:foregroundServiceType="mediaPlayback" />
+            android:foregroundServiceType="mediaPlayback|microphone" />
 
         <provider
             android:name="com.reactnativecommunity.webview.RNCWebViewFileProvider"

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
@@ -133,7 +133,7 @@ public class JitsiMeetOngoingConferenceService extends Service
             JitsiMeetLogger.w(TAG + " Couldn't start service, notification is null");
         } else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
+                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK | ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE);
             } else {
                 startForeground(NOTIFICATION_ID, notification);
             }


### PR DESCRIPTION
### Description
Android app currently mutes when it's in the background or loses focus, which wasn't an issue in previous versions.
This PR fixes the issue and restoring the ability to use the microphone in the background.
(Maybe) Fixes https://github.com/jitsi/jitsi-meet/issues/14615

### Cause
Since Android 14, it appears to require more explicit permissions for foreground services.  ( Reference : https://medium.com/@domen.lanisnik/guide-to-foreground-services-on-android-9d0127dc8f9a )
Currently, the app lacks the required permission, causing app to lose access to microphone in the background. This behavior maybe relates `targetSdkVersion`.

### How to fix
Added the `FOREGROUND_SERVICE_MICROPHONE` permission to the app's manifest and configured it to be used by the `JitsiMeetOngoingConferenceService`.

### Tested devices
- SONY Xperia 5 V SO-53D (Android 14)
-  Motorola moto g52j 5G (Android 12)

Thank you.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
