### PR TITLE
feat: allow client JWT in Authorization header

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -33,23 +33,23 @@ function init_session(event)
 
     local token = nil;
 
-    -- preferentially extract token from Authorization header
+    -- extract token from Authorization header
     if request.headers["authorization"] then
         -- assumes the header value starts with "Bearer "
         token = request.headers["authorization"]:sub(8,#request.headers["authorization"])
     end
 
-    -- fallback to token from query parameter
-    if token == nil then
-        if query ~= nil then
-            local params = formdecode(query);
+    -- allow override of token via query parameter
+    if query ~= nil then
+        local params = formdecode(query);
 
-            -- The following fields are filled in the session, by extracting them
-            -- from the query and no validation is being done.
-            -- After validating auth_token will be cleaned in case of error and few
-            -- other fields will be extracted from the token and set in the session
+        -- The following fields are filled in the session, by extracting them
+        -- from the query and no validation is being done.
+        -- After validating auth_token will be cleaned in case of error and few
+        -- other fields will be extracted from the token and set in the session
 
-            token = query and params.token or nil;
+        if query and params.token then
+            token = params.token;
         end
     end
 

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -34,7 +34,7 @@ function init_session(event)
     local token = nil;
 
     -- preferentially extract token from Authorization header
-    if request.headers["authorization"] and starts_with(request.headers["authorization"],'Bearer ') then
+    if request.headers["authorization"] then
         token = request.headers["authorization"]:sub(8,#request.headers["authorization"])
     end
 

--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -35,6 +35,7 @@ function init_session(event)
 
     -- preferentially extract token from Authorization header
     if request.headers["authorization"] then
+        -- assumes the header value starts with "Bearer "
         token = request.headers["authorization"]:sub(8,#request.headers["authorization"])
     end
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
This change allows the prosody auth token systems to accept a client JWT via the Authorization header preferentially.