### PR TITLE
fix hideConferenceSubject not hiding subject on prejoin page

### DIFF
--- a/react/features/prejoin/functions.ts
+++ b/react/features/prejoin/functions.ts
@@ -207,5 +207,5 @@ export function isRoomNameEnabled(state: IReduxState): boolean {
     const { hideConferenceSubject = false } = state['features/base/config'];
 
     return getFeatureFlag(state, MEETING_NAME_ENABLED, true)
-        || !hideConferenceSubject;
+        && !hideConferenceSubject;
 }


### PR DESCRIPTION
Fixes https://github.com/jitsi/jitsi-meet/issues/14735

Updated logic = room name enabled if feature flag enable **and** conference subject not hidden.