### PR TITLE
feat: move jwt to URL hash from search parameters

### DIFF
--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -22,7 +22,8 @@ export function parseJWTFromURLParams(url: URL | typeof window.location = window
     const jwt = parseURLParams(url, true, 'hash').jwt;
 
     // TODO: eventually remove the search param and only pull from the hash
-    return jwt ? jwt : parseURLParams(<URL>url, true, 'search').jwt;
+    // @ts-ignore
+    return jwt ? jwt : parseURLParams(url, true, 'search').jwt;
 }
 
 /**

--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -21,7 +21,7 @@ export function parseJWTFromURLParams(url: URL | typeof window.location = window
     // @ts-ignore
     const jwt = parseURLParams(url, true, 'hash').jwt;
 
-    //@TODO: eventually remove the search param and only pull from the hash
+    // TODO: eventually remove the search param and only pull from the hash
     return jwt ? jwt : parseURLParams(<URL>url, true, 'search').jwt;
 }
 

--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -21,6 +21,7 @@ export function parseJWTFromURLParams(url: URL | typeof window.location = window
     // @ts-ignore
     const jwt = parseURLParams(url, true, 'hash').jwt;
 
+    //@TODO: eventually remove the search param and only pull from the hash
     return jwt ? jwt : parseURLParams(<URL>url, true, 'search').jwt;
 }
 

--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -20,7 +20,8 @@ import logger from './logger';
 export function parseJWTFromURLParams(url: URL | typeof window.location = window.location) {
     // @ts-ignore
     const jwt = parseURLParams(url, true, 'hash').jwt;
-    return jwt ? jwt : parseURLParams(url, true, 'search').jwt;
+
+    return jwt ? jwt : parseURLParams(<URL>url, true, 'search').jwt;
 }
 
 /**

--- a/react/features/base/jwt/functions.ts
+++ b/react/features/base/jwt/functions.ts
@@ -19,7 +19,8 @@ import logger from './logger';
  */
 export function parseJWTFromURLParams(url: URL | typeof window.location = window.location) {
     // @ts-ignore
-    return parseURLParams(url, true, 'search').jwt;
+    const jwt = parseURLParams(url, true, 'hash').jwt;
+    return jwt ? jwt : parseURLParams(url, true, 'search').jwt;
 }
 
 /**

--- a/react/features/base/util/uri.ts
+++ b/react/features/base/util/uri.ts
@@ -537,6 +537,7 @@ export function urlObjectToString(o: { [key: string]: any; }): string | undefine
 
     const search = new URLSearchParams(url.search);
 
+    //@TODO: once all available versions are updated to support the jwt in the hash, remove this
     if (jwt) {
         search.set('jwt', jwt);
     }

--- a/react/features/base/util/uri.ts
+++ b/react/features/base/util/uri.ts
@@ -561,6 +561,14 @@ export function urlObjectToString(o: { [key: string]: any; }): string | undefine
 
     let { hash } = url;
 
+    if (jwt) {
+        if (hash.length) {
+            hash = `${hash}&jwt=${jwt}`;
+        } else {
+            hash = `#jwt=${jwt}`;
+        }
+    }
+
     for (const urlPrefix of [ 'config', 'iceServers', 'interfaceConfig', 'devices', 'userInfo', 'appData' ]) {
         const urlParamsArray
             = _objectToURLParamsArray(

--- a/react/features/base/util/uri.ts
+++ b/react/features/base/util/uri.ts
@@ -537,7 +537,7 @@ export function urlObjectToString(o: { [key: string]: any; }): string | undefine
 
     const search = new URLSearchParams(url.search);
 
-    //@TODO: once all available versions are updated to support the jwt in the hash, remove this
+    // TODO: once all available versions are updated to support the jwt in the hash, remove this
     if (jwt) {
         search.set('jwt', jwt);
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
This updates the external API to send the JWT both as a URL hash parameter as well as a query string for backwards compatibility.  The JWT parsing function now prefers the hash value over the query string value.