### PR TITLE
Toolbox-custom-order

### DIFF
--- a/config.js
+++ b/config.js
@@ -848,6 +848,22 @@ var config = {
     //     autoHideWhileChatIsOpen: false,
     // },
 
+    // Overrides the buttons displayed in the main toolbar. Depending on the screen size the number of displayed
+    // buttons varies from 2 buttons to 8 buttons. Every array in the mainToolbarButtons array will replace the
+    // corresponding default buttons configuration matched by the number of buttons specified in the array. Arrays with
+    // more than 8 buttons or less then 2 buttons will be ignored. When there there isn't an override for a cerain
+    // configuration (for example when 3 buttons are displayed) the default jitsi-meet configuration will be used.
+    // The order of the buttons in the array is preserved.
+    // mainToolbarButtons: [
+    //     [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'reactions', 'participants-pane', 'tileview' ],
+    //     [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane', 'tileview' ],
+    //     [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane' ],
+    //     [ 'microphone', 'camera', 'desktop', 'chat', 'participants-pane' ],
+    //     [ 'microphone', 'camera', 'chat', 'participants-pane' ],
+    //     [ 'microphone', 'camera', 'chat' ],
+    //     [ 'microphone', 'camera' ]
+    // ],
+
     // Toolbar buttons which have their click/tap event exposed through the API on
     // `toolbarButtonClicked`. Passing a string for the button key will
     // prevent execution of the click/tap routine; passing an object with `key` and

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -440,6 +440,7 @@ export interface IConfig {
     };
     localSubject?: string;
     locationURL?: URL;
+    mainToolbarButtons?: Array<Array<string>>;
     maxFullResolutionParticipants?: number;
     microsoftApiApplicationClientID?: string;
     moderatedRoomServiceUrl?: string;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -185,6 +185,7 @@ export default [
     'localRecording',
     'localSubject',
     'logging',
+    'mainToolbarButtons',
     'maxFullResolutionParticipants',
     'mouseMoveCallbackInterval',
     'notifications',

--- a/react/features/toolbox/actionTypes.ts
+++ b/react/features/toolbox/actionTypes.ts
@@ -60,6 +60,16 @@ export const SET_FULL_SCREEN = 'SET_FULL_SCREEN';
 export const SET_HANGUP_MENU_VISIBLE = 'SET_HANGUP_MENU_VISIBLE';
 
 /**
+ * The type of the (redux) action which sets the main toolbar thresholds.
+ *
+ * {
+ *     type: SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS,
+ *     mainToolbarButtonsThresholds: IMainToolbarButtonThresholds
+ * }
+ */
+export const SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS = 'SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS';
+
+/**
  * The type of the redux action that toggles whether the overflow menu(s) should be shown as drawers.
  */
 export const SET_OVERFLOW_DRAWER = 'SET_OVERFLOW_DRAWER';

--- a/react/features/toolbox/actions.web.ts
+++ b/react/features/toolbox/actions.web.ts
@@ -8,13 +8,16 @@ import {
     FULL_SCREEN_CHANGED,
     SET_FULL_SCREEN,
     SET_HANGUP_MENU_VISIBLE,
+    SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS,
     SET_OVERFLOW_DRAWER,
     SET_OVERFLOW_MENU_VISIBLE,
     SET_TOOLBAR_HOVERED,
     SET_TOOLBOX_TIMEOUT
 } from './actionTypes';
 import { setToolboxVisible } from './actions.web';
+import { THRESHOLDS } from './constants';
 import { getToolbarTimeout } from './functions.web';
+import { IMainToolbarButtonThresholds } from './types';
 
 export * from './actions.any';
 
@@ -118,6 +121,56 @@ export function setFullScreen(fullScreen: boolean) {
     return {
         type: SET_FULL_SCREEN,
         fullScreen
+    };
+}
+
+/**
+ * Sets the mainToolbarButtonsThresholds.
+ *
+ * @returns {Function}
+ */
+export function setMainToolbarThresholds() {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const { mainToolbarButtons } = getState()['features/base/config'];
+
+        if (!mainToolbarButtons || !Array.isArray(mainToolbarButtons) || mainToolbarButtons.length === 0) {
+            return;
+        }
+
+        const mainToolbarButtonsThresholds: IMainToolbarButtonThresholds = [];
+
+        const mainToolbarButtonsLenghtMap = new Map();
+        let orderIsChanged = false;
+
+        mainToolbarButtons.forEach(buttons => {
+            if (!Array.isArray(buttons) || buttons.length === 0) {
+                return;
+            }
+
+            mainToolbarButtonsLenghtMap.set(buttons.length, buttons);
+        });
+
+        THRESHOLDS.forEach(({ width, order }) => {
+            let finalOrder = mainToolbarButtonsLenghtMap.get(order.length);
+
+            if (finalOrder) {
+                orderIsChanged = true;
+            } else {
+                finalOrder = order;
+            }
+
+            mainToolbarButtonsThresholds.push({
+                order: finalOrder,
+                width
+            });
+        });
+
+        if (orderIsChanged) {
+            dispatch({
+                type: SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS,
+                mainToolbarButtonsThresholds
+            });
+        }
     };
 }
 

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -6,23 +6,23 @@ import { ToolbarButton } from './types';
 export const THRESHOLDS = [
     {
         width: 565,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'reactions', 'participants', 'tileview' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'reactions', 'participants-pane', 'tileview' ]
     },
     {
         width: 520,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants', 'tileview' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane', 'tileview' ]
     },
     {
         width: 470,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'raisehand', 'participants-pane' ]
     },
     {
         width: 420,
-        order: [ 'microphone', 'camera', 'desktop', 'chat', 'participants' ]
+        order: [ 'microphone', 'camera', 'desktop', 'chat', 'participants-pane' ]
     },
     {
         width: 370,
-        order: [ 'microphone', 'camera', 'chat', 'participants' ]
+        order: [ 'microphone', 'camera', 'chat', 'participants-pane' ]
     },
     {
         width: 225,
@@ -34,7 +34,43 @@ export const THRESHOLDS = [
     }
 ];
 
-export const NOT_APPLICABLE = 'N/A';
+/**
+ * Main toolbar buttons priority used to determine which button should be picked to fill empty spaces for disabled
+ * buttons.
+ */
+export const MAIN_TOOLBAR_BUTTONS_PRIORITY = [
+    'microphone',
+    'camera',
+    'desktop',
+    'chat',
+    'raisehand',
+    'reactions',
+    'participants-pane',
+    'tileview',
+    'invite',
+    'toggle-camera',
+    'videoquality',
+    'fullscreen',
+    'security',
+    'closedcaptions',
+    'recording',
+    'livestreaming',
+    'linktosalesforce',
+    'sharedvideo',
+    'shareaudio',
+    'noisesuppression',
+    'whiteboard',
+    'etherpad',
+    'select-background',
+    'stats',
+    'settings',
+    'shortcuts',
+    'profile',
+    'embedmeeting',
+    'feedback',
+    'download',
+    'help'
+];
 
 export const TOOLBAR_TIMEOUT = 4000;
 

--- a/react/features/toolbox/functions.web.ts
+++ b/react/features/toolbox/functions.web.ts
@@ -271,7 +271,7 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
         group: 2
     };
 
-    const videoQuality = {
+    const videoquality = {
         key: 'videoquality',
         Content: VideoQualityButton,
         group: 2
@@ -285,12 +285,11 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
 
     const security = {
         key: 'security',
-        alias: 'info',
         Content: SecurityDialogButton,
         group: 2
     };
 
-    const cc = {
+    const closedcaptions = {
         key: 'closedcaptions',
         Content: ClosedCaptionButton,
         group: 2
@@ -308,25 +307,25 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
         group: 2
     };
 
-    const linkToSalesforce = {
+    const linktosalesforce = {
         key: 'linktosalesforce',
         Content: LinkToSalesforceButton,
         group: 2
     };
 
-    const shareVideo = {
+    const sharedvideo = {
         key: 'sharedvideo',
         Content: SharedVideoButton,
         group: 3
     };
 
-    const shareAudio = {
+    const shareaudio = {
         key: 'shareaudio',
         Content: ShareAudioButton,
         group: 3
     };
 
-    const noiseSuppression = {
+    const noisesuppression = {
         key: 'noisesuppression',
         Content: NoiseSuppressionButton,
         group: 3
@@ -351,7 +350,7 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
         group: 3
     };
 
-    const speakerStats = {
+    const stats = {
         key: 'stats',
         Content: SpeakerStatsButton,
         group: 3
@@ -369,7 +368,7 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
         group: 4
     };
 
-    const embed = {
+    const embedmeeting = {
         key: 'embedmeeting',
         Content: EmbedMeetingButton,
         group: 4
@@ -415,27 +414,27 @@ export function getAllToolboxButtons(_customToolbarButtons?: {
         chat,
         raisehand,
         reactions,
-        participants,
+        'participants-pane': participants,
         invite,
         tileview,
-        toggleCamera,
-        videoQuality,
+        'toggle-camera': toggleCamera,
+        videoquality,
         fullscreen,
         security,
-        cc,
+        closedcaptions,
         recording,
         livestreaming,
-        linkToSalesforce,
-        shareVideo,
-        shareAudio,
-        noiseSuppression,
+        linktosalesforce,
+        sharedvideo,
+        shareaudio,
+        noisesuppression,
         whiteboard,
         etherpad,
-        virtualBackground,
-        speakerStats,
+        'select-background': virtualBackground,
+        stats,
         settings,
         shortcuts,
-        embed,
+        embedmeeting,
         feedback,
         download,
         help,

--- a/react/features/toolbox/middleware.web.ts
+++ b/react/features/toolbox/middleware.web.ts
@@ -16,6 +16,7 @@ import {
     SET_TOOLBAR_BUTTONS,
     SET_TOOLBOX_TIMEOUT
 } from './actionTypes';
+import { setMainToolbarThresholds } from './actions.web';
 import { TOOLBAR_BUTTONS, VISITORS_MODE_BUTTONS } from './constants';
 import { NOTIFY_CLICK_MODE } from './types';
 
@@ -53,6 +54,9 @@ MiddlewareRegistry.register(store => next => action => {
             } = state['features/base/config'];
 
             batch(() => {
+                if (action.type !== I_AM_VISITOR_MODE) {
+                    dispatch(setMainToolbarThresholds());
+                }
                 dispatch({
                     type: SET_BUTTONS_WITH_NOTIFY_CLICK,
                     buttonsWithNotifyClick: _buildButtonsArray(buttonsWithNotifyClick, customToolbarButtons)

--- a/react/features/toolbox/reducer.ts
+++ b/react/features/toolbox/reducer.ts
@@ -6,6 +6,7 @@ import {
     FULL_SCREEN_CHANGED,
     SET_BUTTONS_WITH_NOTIFY_CLICK,
     SET_HANGUP_MENU_VISIBLE,
+    SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS,
     SET_OVERFLOW_DRAWER,
     SET_OVERFLOW_MENU_VISIBLE,
     SET_PARTICIPANT_MENU_BUTTONS_WITH_NOTIFY_CLICK,
@@ -17,7 +18,8 @@ import {
     SET_TOOLBOX_VISIBLE,
     TOGGLE_TOOLBOX_VISIBLE
 } from './actionTypes';
-import { NOTIFY_CLICK_MODE } from './types';
+import { THRESHOLDS } from './constants';
+import { IMainToolbarButtonThresholds, NOTIFY_CLICK_MODE } from './types';
 
 /**
  * Initial state of toolbox's part of Redux store.
@@ -46,6 +48,11 @@ const INITIAL_STATE = {
      * @type {boolean}
      */
     hovered: false,
+
+    /**
+     * The thresholds for screen size and visible main toolbar buttons.
+     */
+    mainToolbarButtonsThresholds: THRESHOLDS,
 
     participantMenuButtonsWithNotifyClick: new Map(),
 
@@ -98,6 +105,7 @@ export interface IToolboxState {
     fullScreen?: boolean;
     hangupMenuVisible: boolean;
     hovered: boolean;
+    mainToolbarButtonsThresholds: IMainToolbarButtonThresholds;
     overflowDrawer: boolean;
     overflowMenuVisible: boolean;
     participantMenuButtonsWithNotifyClick: Map<string, NOTIFY_CLICK_MODE>;
@@ -150,6 +158,12 @@ ReducerRegistry.register<IToolboxState>(
             return {
                 ...state,
                 buttonsWithNotifyClick: action.buttonsWithNotifyClick
+            };
+
+        case SET_MAIN_TOOLBAR_BUTTONS_THRESHOLDS:
+            return {
+                ...state,
+                mainToolbarButtonsThresholds: action.mainToolbarButtonsThresholds
             };
         case SET_TOOLBAR_HOVERED:
             return {

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -2,7 +2,6 @@ import { ComponentType } from 'react';
 
 export interface IToolboxButton {
     Content: ComponentType<any>;
-    alias?: string;
     group: number;
     key: string;
 }
@@ -49,3 +48,8 @@ export enum NOTIFY_CLICK_MODE {
     ONLY_NOTIFY = 'ONLY_NOTIFY',
     PREVENT_AND_NOTIFY = 'PREVENT_AND_NOTIFY'
 }
+
+export type IMainToolbarButtonThresholds = Array<{
+    order: Array<ToolbarButton | string>;
+    width: number;
+}>;


### PR DESCRIPTION
As part of the PR, it also fixes:
 - Removes button aliases
 - Unifies the keys in the object returned by getAllToolboxButtons and the button keys
 - Makes sure that the number of buttons displayed are always the same as the number of buttons specified in the thresholds and removes the exception for not filling up the main toolbar with buttons from overflow menu when reactions button is disabled.
 - Introduces a priority for buttons that will be used to fill empty spaces in the main toolbar.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
