### PR TITLE
feat(react-native-sdk): added setAudioOnly to the ref props

### DIFF
--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -17,6 +17,7 @@ import type { IRoomsInfo } from '../react/features/breakout-rooms/types';
 
 import { appNavigate } from './react/features/app/actions.native';
 import { App } from './react/features/app/components/App.native';
+import { setAudioOnly } from './react/features/base/audio-only/actions';
 import { setAudioMuted, setVideoMuted } from './react/features/base/media/actions';
 import { getRoomsInfo } from './react/features/breakout-rooms/functions';
 
@@ -54,6 +55,7 @@ interface IAppProps {
 
 export interface JitsiRefProps {
     close: Function;
+    setAudioOnly?: (value: boolean) => void;
     setAudioMuted?: (muted: boolean) => void;
     setVideoMuted?: (muted: boolean) => void;
     getRoomsInfo?: () => IRoomsInfo;
@@ -82,6 +84,11 @@ export const JitsiMeeting = forwardRef<JitsiRefProps, IAppProps>((props, ref) =>
             const dispatch = app.current.state.store.dispatch;
 
             dispatch(appNavigate(undefined));
+        },
+        setAudioOnly: value => {
+            const dispatch = app.current.state.store.dispatch;
+
+            dispatch(setAudioOnly(value));
         },
         setAudioMuted: muted => {
             const dispatch = app.current.state.store.dispatch;


### PR DESCRIPTION
Added setAudioOnly for the component ref functions. Thus we can easily control the audio only behavior by this feature.