### PR TITLE
feat(invite): move JWT to Authorization header for invite and search endpoints

### DIFF
--- a/react/features/invite/functions.ts
+++ b/react/features/invite/functions.ts
@@ -427,17 +427,20 @@ export function invitePeopleAndChatRooms(
         return Promise.resolve();
     }
 
+    const headers = {
+        ...jwt ? { 'Authorization': `Bearer ${jwt}` } : {},
+        'Content-Type': 'application/json'
+    };
+
     return fetch(
-        `${inviteServiceUrl}?token=${jwt}`,
+        `${inviteServiceUrl}`,
         {
             body: JSON.stringify({
                 'invited': inviteItems,
                 'url': inviteUrl
             }),
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            }
+            headers
         }
     );
 }
@@ -544,8 +547,12 @@ export function searchDirectory( // eslint-disable-line max-params
     const query = encodeURIComponent(text);
     const queryTypesString = encodeURIComponent(JSON.stringify(queryTypes));
 
+    const headers = {
+        ...jwt ? { 'Authorization': `Bearer ${jwt}` } : {},
+    };
+
     return fetch(`${serviceUrl}?query=${query}&queryTypes=${
-        queryTypesString}&jwt=${jwt}`)
+        queryTypesString}`, { method: 'GET', headers })
             .then(response => {
                 const jsonify = response.json();
 

--- a/react/features/invite/functions.ts
+++ b/react/features/invite/functions.ts
@@ -548,11 +548,15 @@ export function searchDirectory( // eslint-disable-line max-params
     const queryTypesString = encodeURIComponent(JSON.stringify(queryTypes));
 
     const headers = {
-        ...jwt ? { 'Authorization': `Bearer ${jwt}` } : {},
+        ...jwt ? { 'Authorization': `Bearer ${jwt}` } : {}
     };
 
     return fetch(`${serviceUrl}?query=${query}&queryTypes=${
-        queryTypesString}`, { method: 'GET', headers })
+        queryTypesString}`,
+            {
+                method: 'GET',
+                headers
+            })
             .then(response => {
                 const jsonify = response.json();
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Removes the JWT from URL query parameter, moving it to the Authorization header.