### PR TITLE
feat(react-native-sdk): match any version between react native and metro-config

### DIFF
--- a/react-native-sdk/package.json
+++ b/react-native-sdk/package.json
@@ -55,7 +55,7 @@
         "@amplitude/react-native": "0.0.0",
         "@braintree/sanitize-url": "0.0.0",
         "@giphy/react-native-sdk": "0.0.0",
-        "@react-native/metro-config": "0.0.0",
+        "@react-native/metro-config": "*",
         "@react-native-async-storage/async-storage": "0.0.0",
         "@react-native-community/clipboard": "0.0.0",
         "@react-native-community/netinfo": "0.0.0",


### PR DESCRIPTION
Some users have a diff react native version than the one we use and metro-config needs to be in sync with that version.
