### PR TITLE
feat(rn,config) use WebSockets for XMPP by default on mobile

### DIFF
--- a/config.js
+++ b/config.js
@@ -91,9 +91,6 @@ var config = {
         // Enables supports for AV1 codec.
         // enableAv1Support: false,
 
-        // Enables XMPP WebSocket (as opposed to BOSH) for the given amount of users.
-        // mobileXmppWsThreshold: 10, // enable XMPP WebSockets on mobile for 10% of the users
-
         // P2P test mode disables automatic switching to P2P when there are 2
         // participants in the conference.
         // p2pTestMode: false,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -544,7 +544,6 @@ export interface IConfig {
         assumeBandwidth?: boolean;
         disableE2EE?: boolean;
         dumpTranscript?: boolean;
-        mobileXmppWsThreshold?: number;
         noAutoPlayVideo?: boolean;
         p2pTestMode?: boolean;
         skipInterimTranscriptions?: boolean;

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -126,13 +126,6 @@ export function constructOptions(state: IReduxState) {
     const { bosh, preferBosh, flags } = options;
     let { websocket } = options;
 
-    // TESTING: Only enable WebSocket for some percentage of users.
-    if (websocket && navigator.product === 'ReactNative') {
-        if ((Math.random() * 100) >= (options?.testing?.mobileXmppWsThreshold ?? 0)) {
-            websocket = undefined;
-        }
-    }
-
     if (preferBosh) {
         websocket = undefined;
     }


### PR DESCRIPTION
This aligns mobile and web. WS has been the default on meet.jit.si and beta.meet.jit.si for quite a while now.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
