### PR TITLE
fix(breakout-rooms): Closes menu after clicking on it.

### DIFF
--- a/react/features/base/ui/hooks/useContextMenu.web.ts
+++ b/react/features/base/ui/hooks/useContextMenu.web.ts
@@ -39,7 +39,7 @@ const useContextMenu = <T>(): [(force?: boolean | Object) => void,
                 return;
             }
 
-            if (raiseContext !== initialState) {
+            if (raiseContext !== initialState || force) {
                 setRaiseContext(initialState);
             }
         });


### PR DESCRIPTION
The menu with Rename and Close for the breakout rooms.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
