### PR TITLE
fix(iOS-responsive-ui) Attempt fix iOS responsive ui issue

### DIFF
--- a/react/features/base/responsive-ui/actions.ts
+++ b/react/features/base/responsive-ui/actions.ts
@@ -35,6 +35,10 @@ const REDUCED_UI_THRESHOLD = 300;
  */
 export function clientResized(clientWidth: number, clientHeight: number) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        if (!clientWidth && !clientHeight) {
+            return;
+        }
+
         let availableWidth = clientWidth;
 
         if (navigator.product !== 'ReactNative') {

--- a/react/features/base/responsive-ui/middleware.web.ts
+++ b/react/features/base/responsive-ui/middleware.web.ts
@@ -29,12 +29,16 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case CONFERENCE_JOINED: {
-        const {
-            innerHeight,
-            innerWidth
-        } = window;
+        const { clientHeight = 0, clientWidth = 0 } = store.getState()['features/base/responsive-ui'];
 
-        store.dispatch(clientResized(innerWidth, innerHeight));
+        if (!clientHeight && !clientWidth) {
+            const {
+                innerHeight,
+                innerWidth
+            } = window;
+
+            store.dispatch(clientResized(innerWidth, innerHeight));
+        }
         break;
     }
     }

--- a/react/features/base/responsive-ui/middleware.web.ts
+++ b/react/features/base/responsive-ui/middleware.web.ts
@@ -1,5 +1,6 @@
 import { IStore } from '../../app/types';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../app/actionTypes';
+import { CONFERENCE_JOINED } from '../conference/actionTypes';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 
 import { clientResized } from './actions';
@@ -27,6 +28,15 @@ MiddlewareRegistry.register(store => next => action => {
         _appWillMount(store);
         break;
 
+    case CONFERENCE_JOINED: {
+        const {
+            innerHeight,
+            innerWidth
+        } = window;
+
+        store.dispatch(clientResized(innerWidth, innerHeight));
+        break;
+    }
     }
 
     return result;


### PR DESCRIPTION
- on iOS safari and chrome, in case we show eg a spinner until we get the videoConferenceJoined event, all `clientResize` are done with size 0 for width/height
- on iOS we never get a `clientResize` call with correct values, except if we force a call by eg opening/closing the chat window

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
