### PR TITLE
fix(remote-control) Fix caps lock key name

### DIFF
--- a/react/features/remote-control/keycodes.ts
+++ b/react/features/remote-control/keycodes.ts
@@ -40,7 +40,7 @@ export const KEYS = {
     ALT: 'alt',
     CONTROL: 'control',
     SHIFT: 'shift',
-    CAPS_LOCK: 'caps_lock', // not supported by robotjs
+    CAPS_LOCK: 'capslock',
     SPACE: 'space',
     PRINTSCREEN: 'printscreen',
     INSERT: 'insert',


### PR DESCRIPTION
- this was causing a crash on the controlled meeting instance

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
