### PR TITLE
Update package clipboard to @react-native-clipboard/clipboard

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,7 +11,7 @@ project(':react-native-background-timer').projectDir = new File(rootProject.proj
 include ':react-native-calendar-events'
 project(':react-native-calendar-events').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-calendar-events/android')
 include ':react-native-community_clipboard'
-project(':react-native-community_clipboard').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/clipboard/android')
+project(':react-native-community_clipboard').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-clipboard/clipboard/android')
 include ':react-native-community_netinfo'
 project(':react-native-community_netinfo').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/netinfo/android')
 include ':react-native-default-preference'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -568,7 +568,7 @@ PODS:
     - React
   - RNCAsyncStorage (1.19.4):
     - React-Core
-  - RNCClipboard (1.5.1):
+  - RNCClipboard (1.14.1):
     - React-Core
   - RNDefaultPreference (1.4.4):
     - React-Core
@@ -655,7 +655,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNCalendarEvents (from `../node_modules/react-native-calendar-events`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
-  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
+  - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - RNDefaultPreference (from `../node_modules/react-native-default-preference`)
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
@@ -804,7 +804,7 @@ EXTERNAL SOURCES:
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
-    :path: "../node_modules/@react-native-community/clipboard"
+    :path: "../node_modules/@react-native-clipboard/clipboard"
   RNDefaultPreference:
     :path: "../node_modules/react-native-default-preference"
   RNDeviceInfo:
@@ -903,7 +903,7 @@ SPEC CHECKSUMS:
   ReactCommon: 07937a01c967f2023d6f2d07114315f099b4b436
   RNCalendarEvents: 7e65eb4a94f53c1744d1e275f7fafcfaa619f7a3
   RNCAsyncStorage: 3a8f7145d17cdd9f88e7b77666c94a09e4f759c8
-  RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
+  RNCClipboard: 0a720adef5ec193aa0e3de24c3977222c7e52a37
   RNDefaultPreference: 08bdb06cfa9188d5da97d4642dac745218d7fb31
   RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.12.1",
         "@react-native-async-storage/async-storage": "1.19.4",
-        "@react-native-community/clipboard": "1.5.1",
+        "@react-native-clipboard/clipboard": "1.14.1",
         "@react-native-community/netinfo": "11.1.0",
         "@react-native-community/slider": "4.4.3",
         "@react-native-google-signin/google-signin": "10.1.0",
@@ -3962,6 +3962,17 @@
         "react-native": "^0.0.0-0 || 0.60 - 0.72 || 1000.0.0"
       }
     },
+    "node_modules/@react-native-clipboard/clipboard": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz",
+      "integrity": "sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw==",
+      "peerDependencies": {
+        "react": "16.9.0 || 16.11.0 || 16.13.1 || 17.0.1 || 17.0.2 || 18.0.0 || 18.1.0 || 18.2.0",
+        "react-native": "^0.61.5 || ^0.62.3 || ^0.63.2 || ^0.64.2 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0",
+        "react-native-macos": "^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0",
+        "react-native-windows": "^0.61.0 || ^0.62.0 || ^0.63.0 || ^0.64.0 || ^0.65.0 || ^0.66.0 || ^0.67.0 || ^0.68.0 || ^0.69.0 || ^0.70.0 || ^0.71.0 || ^0.72.0 || ^0.73.0"
+      }
+    },
     "node_modules/@react-native-community/cli": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.4.1.tgz",
@@ -4980,15 +4991,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/clipboard": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/clipboard/-/clipboard-1.5.1.tgz",
-      "integrity": "sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA==",
-      "peerDependencies": {
-        "react": ">=16.0",
-        "react-native": ">=0.57.0"
       }
     },
     "node_modules/@react-native-community/netinfo": {
@@ -21857,6 +21859,11 @@
         "merge-options": "^3.0.4"
       }
     },
+    "@react-native-clipboard/clipboard": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz",
+      "integrity": "sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw=="
+    },
     "@react-native-community/cli": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.4.1.tgz",
@@ -22605,11 +22612,6 @@
       "requires": {
         "joi": "^17.2.1"
       }
-    },
-    "@react-native-community/clipboard": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@react-native-community/clipboard/-/clipboard-1.5.1.tgz",
-      "integrity": "sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA=="
     },
     "@react-native-community/netinfo": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.12.1",
     "@react-native-async-storage/async-storage": "1.19.4",
-    "@react-native-community/clipboard": "1.5.1",
+    "@react-native-clipboard/clipboard": "1.14.1",
     "@react-native-community/netinfo": "11.1.0",
     "@react-native-community/slider": "4.4.3",
     "@react-native-google-signin/google-signin": "10.1.0",

--- a/react-native-sdk/package.json
+++ b/react-native-sdk/package.json
@@ -57,7 +57,7 @@
         "@giphy/react-native-sdk": "0.0.0",
         "@react-native/metro-config": "*",
         "@react-native-async-storage/async-storage": "0.0.0",
-        "@react-native-community/clipboard": "0.0.0",
+        "@react-native-clipboard/clipboard": "0.0.0",
         "@react-native-community/netinfo": "0.0.0",
         "@react-native-community/slider": "0.0.0",
         "@react-native-google-signin/google-signin": "0.0.0",

--- a/react/features/base/util/copyText.native.ts
+++ b/react/features/base/util/copyText.native.ts
@@ -1,4 +1,4 @@
-import Clipboard from '@react-native-community/clipboard';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
  * Tries to copy a given text to the clipboard.


### PR DESCRIPTION
Fixed [PR#14560](https://github.com/jitsi/jitsi-meet/pull/14560)

Change package `@react-native-community/clipboard` to `@react-native-clipboard/clipboard` because React-Native v0.73.x no longer supports `@react-native-community/clipboard`.

Thanks @edritech93 for original changes