### PR TITLE
Rename breakout rooms on native

### DIFF
--- a/react/features/breakout-rooms/components/native/BreakoutRoomNamePrompt.tsx
+++ b/react/features/breakout-rooms/components/native/BreakoutRoomNamePrompt.tsx
@@ -18,7 +18,7 @@ export default function BreakoutRoomNamePrompt({ breakoutRoomJid, initialRoomNam
         const formattedRoomName = roomName?.trim();
 
         if (formattedRoomName) {
-            dispatch(renameBreakoutRoom(formattedRoomName, roomName));
+            dispatch(renameBreakoutRoom(breakoutRoomJid, formattedRoomName));
 
             return true;
         }


### PR DESCRIPTION
The option to rename breakout rooms was not working for moderators on native devices.