### PR TITLE
fix(visitors): Adds a nil check for metadata.

### DIFF
--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -491,14 +491,19 @@ process_host_module(muc_domain_prefix..'.'..muc_domain_base, function(host_modul
     if visitors_queue_service then
         host_module:hook('muc-room-created', function (event)
             local room = event.room;
-            if room.jitsiMetadata.visitors and room.jitsiMetadata.visitors.live then
+
+            if is_healthcheck_room(room.jid) then
+                return;
+            end
+
+            if room.jitsiMetadata and room.jitsiMetadata.visitors and room.jitsiMetadata.visitors.live then
                 go_live(room);
             end
         end, -2); -- metadata hook on -1
         host_module:hook('jitsi-metadata-updated', function (event)
             if event.key == 'visitors' then
                 local room = event.room;
-                if room.jitsiMetadata.visitors and room.jitsiMetadata.visitors.live then
+                if room.jitsiMetadata and room.jitsiMetadata.visitors and room.jitsiMetadata.visitors.live then
                     go_live(room);
                 end
             end


### PR DESCRIPTION
The metadata initialization is skipped for healthcheck rooms.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
