### PR TITLE
Merge query string parameters in `etherpad_base` with app values

### DIFF
--- a/react/features/etherpad/middleware.ts
+++ b/react/features/etherpad/middleware.ts
@@ -29,7 +29,18 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                 const etherpadBaseUrl = sanitizeUrl(etherpadBase);
 
                 if (etherpadBaseUrl) {
-                    url = new URL(value, etherpadBaseUrl.toString()).toString();
+                    const urlObj = new URL(value, etherpadBaseUrl.toString());
+
+                    // Merge query string parameters on top of internal ones
+                    if (etherpadBaseUrl.search) {
+                        const searchParams = new URLSearchParams(urlObj.search);
+
+                        for (const [ key, val ] of new URLSearchParams(etherpadBaseUrl.search)) {
+                            searchParams.set(key, val);
+                        }
+                        urlObj.search = searchParams.toString();
+                    }
+                    url = urlObj.toString();
                 }
 
                 dispatch(setDocumentUrl(url));


### PR DESCRIPTION
Allows overriding or augmenting the default values set by the Jitsi Meet web app using the config parameter.

Use case when using EtherPad may be (in config): 
`etherpad_base = "https://hostname/etherpad/extraordinaryparameterstiekindly?useMonospaceFont=true",`