### PR TITLE
Update config.js, missing comma

### DIFF
--- a/config.js
+++ b/config.js
@@ -513,7 +513,7 @@ var config = {
     //      scalabilityModeEnabled: true,
     //      useSimulcast: false,
     //      useKSVC: true
-    //    }
+    //    },
     //
     //    DEPRECATED! Use `codec specific settings` instead.
     //    // Provides a way to configure the maximum bitrates that will be enforced on the simulcast streams for


### PR DESCRIPTION
When uncommenting full video quality block it breaks cause of this comma

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
