### PR TITLE
Correct accusative error in Esperanto translation

### DIFF
--- a/lang/main-eo.json
+++ b/lang/main-eo.json
@@ -925,7 +925,7 @@
         "iWantToDialIn": "Mi volas alvoki",
         "initiated": "Voko komencita",
         "joinAudioByPhone": "Aliĝu kun telefona mikrofono",
-        "joinMeeting": "Aliĝu al la kunvenon",
+        "joinMeeting": "Aliĝu al la kunveno",
         "joinMeetingInLowBandwidthMode": "Aliĝu en malaltkapacita modo",
         "joinWithoutAudio": "Aliĝu sen mikrofono",
         "keyboardShortcuts": "Ŝaltu fulmoklavojn",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
There is a small error in the Esperanto translation. In Esperanto "al" no accusative. Thus the phrase is "Aliĝu al la kunveno" with out the accusative marker "-n".