### PR TITLE
Hebrew Typo Fix for Issue #14927

### DIFF
--- a/lang/main-he.json
+++ b/lang/main-he.json
@@ -9,7 +9,7 @@
         "loading": "מחפש אנשים ומספרי טלפון",
         "loadingNumber": "מאמת מספר טלפון",
         "loadingPeople": "מחפש אנשים להזמין",
-        "noResults": "לא נמצאו תואצות מתאימות",
+        "noResults": "לא נמצאו תוצאות מתאימות",
         "noValidNumbers": "אנא הזן מסםר טלפון",
         "searchNumbers": "הוסף מספר טלפון",
         "searchPeople": "חפש אנשים",
@@ -47,7 +47,7 @@
     },
     "chat": {
         "error": "שגיאה: ההודעה שלך \"{{originalText}}\" לא נשלחה. סיבה: {{error}}",
-        "fieldPlaceHolder": "הקלד הודעתך כאו",
+        "fieldPlaceHolder": "הקלד הודעתך כאן",
         "messageTo": "הודעה פרטית אל {{recipient}}",
         "messagebox": "הקלד הודעה",
         "nickname": {
@@ -442,7 +442,7 @@
     "me": "אני",
     "notify": {
         "OldElectronAPPTitle": "פגיעות אבטחה!",
-        "connectedOneMember": "{{name}} הצטרף למפדש",
+        "connectedOneMember": "{{name}} הצטרף למפגש",
         "connectedThreePlusMembers": "{{name}} ו-{{count}} אחרים הצטרפו למפגש",
         "connectedTwoMembers": "{{first}} ו-{{second}} הצטרפו למפגש",
         "disconnected": "מנותק",


### PR DESCRIPTION
## Fix typos in `lang/main-he.json`

This PR addresses the following typos in the Hebrew language file:

1. **`notify.connectedOneMember`**:
   - **Before**: `{{name}} הצטרף למפדש`
   - **After**: `{{name}} הצטרף למפגש`

2. **`addPeople.noResults`**:
   - **Before**: `לא נמצאו תואצות מתאימות`
   - **After**: `לא נמצאו תוצאות מתאימות`

3. **`chat.fieldPlaceHolder`**:
   - **Before**: `הקלד הודעתך כאו`
   - **After**: `הקלד הודעתך כאן`

These corrections improve the clarity and accuracy of the text in the application.

**Fixes Issue:** #14927 
