### PR TITLE
feat(android/ios/sdk): removed tagging from release scripts

### DIFF
--- a/android/scripts/release-sdk.sh
+++ b/android/scripts/release-sdk.sh
@@ -10,7 +10,6 @@ MVN_HTTP=0
 DEFAULT_SDK_VERSION=$(grep sdkVersion ${THIS_DIR}/../gradle.properties | cut -d"=" -f2)
 SDK_VERSION=${OVERRIDE_SDK_VERSION:-${DEFAULT_SDK_VERSION}}
 JSC_VERSION="r"$(jq -r '.dependencies."jsc-android"' ${THIS_DIR}/../../node_modules/react-native/package.json | cut -d . -f 1 | cut -c 2-)
-DO_GIT_TAG=${GIT_TAG:-0}
 
 if [[ $THE_MVN_REPO == http* ]]; then
     MVN_HTTP=1
@@ -67,15 +66,12 @@ pushd ${THIS_DIR}/../
 ./gradlew publish
 popd
 
-if [[ $DO_GIT_TAG == 1 ]]; then
-    # The artifacts are now on the Maven repo, commit them
+# The artifacts are now on the Maven repo, commit them
+if [[ $MVN_HTTP == 0 ]]; then
     pushd ${MVN_REPO_PATH}
     git add -A .
     git commit -m "Jitsi Meet SDK + dependencies: ${SDK_VERSION}"
     popd
-
-    # Tag the release
-    git tag android-sdk-${SDK_VERSION}
 fi
 
 # Done!

--- a/ios/scripts/release-sdk-lite.sh
+++ b/ios/scripts/release-sdk-lite.sh
@@ -7,8 +7,6 @@ PROJECT_REPO=$(realpath ${THIS_DIR}/../..)
 RELEASE_REPO=$(realpath ${THIS_DIR}/../../../jitsi-meet-ios-sdk-releases)
 DEFAULT_SDK_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" ${THIS_DIR}/../sdk/src/Lite-Info.plist)
 SDK_VERSION=${OVERRIDE_SDK_VERSION:-${DEFAULT_SDK_VERSION}}
-DO_GIT_TAG=${GIT_TAG:-0}
-
 
 echo "Releasing Jitsi Meet SDK Lite ${SDK_VERSION}"
 
@@ -50,9 +48,6 @@ xcodebuild -create-xcframework \
     -framework ios/sdk/out/ios-device.xcarchive/Products/Library/Frameworks/JitsiMeetSDK.framework \
     -framework ios/sdk/out/ios-simulator.xcarchive/Products/Library/Frameworks/JitsiMeetSDK.framework \
     -output ios/sdk/out/JitsiMeetSDK.xcframework
-if [[ $DO_GIT_TAG == 1 ]]; then
-    git tag ios-sdk-lite-${SDK_VERSION}
-fi
 popd
 
 pushd ${RELEASE_REPO}
@@ -61,11 +56,8 @@ pushd ${RELEASE_REPO}
 cp -a ${PROJECT_REPO}/ios/sdk/out/JitsiMeetSDK.xcframework lite/Frameworks/
 
 # Add all files to git
-if [[ $DO_GIT_TAG == 1 ]]; then
-    git add -A .
-    git commit -m "${SDK_VERSION} lite"
-    git tag "${SDK_VERSION}-lite"
-fi
+git add -A .
+git commit -m "${SDK_VERSION} lite"
 
 popd
 

--- a/ios/scripts/release-sdk.sh
+++ b/ios/scripts/release-sdk.sh
@@ -7,8 +7,6 @@ PROJECT_REPO=$(realpath ${THIS_DIR}/../..)
 RELEASE_REPO=$(realpath ${THIS_DIR}/../../../jitsi-meet-ios-sdk-releases)
 DEFAULT_SDK_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" ${THIS_DIR}/../sdk/src/Info.plist)
 SDK_VERSION=${OVERRIDE_SDK_VERSION:-${DEFAULT_SDK_VERSION}}
-DO_GIT_TAG=${GIT_TAG:-0}
-
 
 echo "Releasing Jitsi Meet SDK ${SDK_VERSION}"
 
@@ -50,9 +48,6 @@ xcodebuild -create-xcframework \
     -framework ios/sdk/out/ios-device.xcarchive/Products/Library/Frameworks/JitsiMeetSDK.framework \
     -framework ios/sdk/out/ios-simulator.xcarchive/Products/Library/Frameworks/JitsiMeetSDK.framework \
     -output ios/sdk/out/JitsiMeetSDK.xcframework
-if [[ $DO_GIT_TAG == 1 ]]; then
-    git tag ios-sdk-${SDK_VERSION}
-fi
 popd
 
 pushd ${RELEASE_REPO}
@@ -61,11 +56,8 @@ pushd ${RELEASE_REPO}
 cp -a ${PROJECT_REPO}/ios/sdk/out/JitsiMeetSDK.xcframework Frameworks/
 
 # Add all files to git
-if [[ $DO_GIT_TAG == 1 ]]; then
-    git add -A .
-    git commit -m "${SDK_VERSION}"
-    git tag ${SDK_VERSION}
-fi
+git add -A .
+git commit -m "${SDK_VERSION}"
 
 popd
 


### PR DESCRIPTION
Adding GIT_TAG in jenkins, so we no longer need to set one in the release scripts.
