### PR TITLE
fix(build) don't run clean after compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ else
 	WEBPACK_DEV_SERVER = ./node_modules/.bin/webpack serve --mode development
 endif
 
-all: compile deploy clean
+all: compile deploy
 
-compile:
+compile: clean
 	NODE_OPTIONS=--max-old-space-size=8192 \
 	$(WEBPACK)
 


### PR DESCRIPTION
It prevents the bundle analyzer from working because the stats files are placed in the build dir.

Clean *before* building instead.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
