### PR TITLE
fix(auth): Preserve iceServers URL params

### DIFF
--- a/react/features/authentication/functions.any.ts
+++ b/react/features/authentication/functions.any.ts
@@ -76,7 +76,7 @@ export const _getTokenAuthState = (
 
     for (const key of Object.keys(params)) {
         // we allow only config and interfaceConfig overrides in the state
-        if (key.startsWith('config.') || key.startsWith('interfaceConfig.')) {
+        if (key.startsWith('config.') || key.startsWith('interfaceConfig.') || key.startsWith('iceServers.')) {
             // @ts-ignore
             state[key] = params[key];
         }


### PR DESCRIPTION
During authentication cycle the iceServers URL params are not passed through the various redirects. The result is that the when we finally return back to the conference page authenticated and with the JWT token the iceServers URL param is lost.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
