### PR TITLE
fix(lastN) simplify lastN calculation when in background

### DIFF
--- a/react/features/base/lastn/middleware.ts
+++ b/react/features/base/lastn/middleware.ts
@@ -11,7 +11,6 @@ import { SET_AUDIO_ONLY } from '../audio-only/actionTypes';
 import { CONFERENCE_JOINED } from '../conference/actionTypes';
 import { getParticipantById } from '../participants/functions';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
-import { isLocalVideoTrackDesktop } from '../tracks/functions';
 
 import { setLastN } from './actions';
 import logger from './logger';
@@ -45,9 +44,7 @@ const _updateLastN = debounce(({ dispatch, getState }: IStore) => {
     // 3. -1 as the default value.
     let lastNSelected = config.startLastN ?? (config.channelLastN ?? -1);
 
-    if (typeof appState !== 'undefined' && appState !== 'active') {
-        lastNSelected = isLocalVideoTrackDesktop(state) ? 1 : 0;
-    } else if (carMode) {
+    if (appState === 'background' || carMode) {
         lastNSelected = 0;
     } else if (audioOnly) {
         const { remoteScreenShares, tileViewEnabled } = state['features/video-layout'];


### PR DESCRIPTION
There is no point in ever setting lastN to anything other than 0 when in the background because we are not rendering anything.

When in PiP mode, the app state is not background, which might have deceived us into adding that check there way back when.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
