### PR TITLE
Accessibility: keyboard navigation on the toolbar

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -12,7 +12,7 @@ import {
     setHangupMenuVisible,
     setOverflowMenuVisible,
     setToolbarHovered,
-    showToolbox
+    setToolboxVisible
 } from '../../actions.web';
 import {
     getJwtDisabledButtons,
@@ -193,15 +193,22 @@ export default function Toolbox({
     }, [ dispatch ]);
 
     /**
-     * Toggle the toolbar visibility when tabbing into it.
+     * Handle focus on the toolbar.
      *
      * @returns {void}
      */
-    const onTabIn = useCallback(() => {
-        if (!toolbarVisible) {
-            dispatch(showToolbox());
-        }
-    }, [ toolbarVisible, dispatch ]);
+    const handleFocus = useCallback(() => {
+        dispatch(setToolboxVisible(true));
+    }, [ dispatch ]);
+
+    /**
+     * Handle blur the toolbar..
+     *
+     * @returns {void}
+     */
+    const handleBlur = useCallback(() => {
+        dispatch(setToolboxVisible(false));
+    }, [ dispatch ]);
 
     if (iAmRecorder || iAmSipGateway) {
         return null;
@@ -238,7 +245,8 @@ export default function Toolbox({
             <div className = { containerClassName }>
                 <div
                     className = 'toolbox-content-wrapper'
-                    onFocus = { onTabIn }
+                    onBlur = { handleBlur }
+                    onFocus = { handleFocus }
                     { ...(isMobile ? {} : {
                         onMouseOut,
                         onMouseOver


### PR DESCRIPTION
**Description:** when user use the keyboard navigation and have the focus on the toolbar. this focus should stay till the user tab out of the toolbar.

**Actual Behavior:** Toolbar menu disappear after a certain time even with the focus on it.

**Expected Behavior:**  Toolbar should stay visible on focus (and closed on blur) and on mouse hover (and closed on mouse out).

before: 

https://github.com/user-attachments/assets/3590ca27-efe5-41d6-b120-c8a9c5ef3979


after:

https://github.com/user-attachments/assets/fd8ac3d2-0d41-4b1a-9dcf-e33db4c70518



issue jitsi community:  https://community.jitsi.org/t/accessibility-keyboard-navigation/133334

