### PR TITLE
Accessibility: keyboard navigation on the toolbar (Context menu)

### DIFF
--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -381,3 +381,21 @@ export function getLegalUrls(state: IReduxState) {
         terms: configLegalUrls?.terms || DEFAULT_TERMS_URL
     };
 }
+
+/**
+ * Utility function to debounce the execution of a callback function.
+ *
+ * @param {Function} callback - The callback to debounce.
+ * @param {number} delay - The debounce delay in milliseconds.
+ * @returns {Function} - A debounced function that delays the execution of the callback.
+ */
+export function debounce(callback: (...args: any[]) => void, delay: number) {
+    let timerId: any;
+
+    return (...args: any[]) => {
+        if (timerId) {
+            clearTimeout(timerId);
+        }
+        timerId = setTimeout(() => callback(...args), delay);
+    };
+}

--- a/react/features/settings/components/web/audio/AudioSettingsContent.tsx
+++ b/react/features/settings/components/web/audio/AudioSettingsContent.tsx
@@ -281,6 +281,7 @@ const AudioSettingsContent = ({
 
     return (
         <ContextMenu
+            activateFocusTrap = { true }
             aria-labelledby = 'audio-settings-button'
             className = { classes.contextMenu }
             hidden = { false }

--- a/react/features/settings/components/web/video/VideoSettingsContent.tsx
+++ b/react/features/settings/components/web/video/VideoSettingsContent.tsx
@@ -295,6 +295,7 @@ const VideoSettingsContent = ({
 
     return (
         <ContextMenu
+            activateFocusTrap = { true }
             aria-labelledby = 'video-settings-button'
             className = { classes.container }
             hidden = { false }

--- a/react/features/toolbox/components/web/DialogPortal.ts
+++ b/react/features/toolbox/components/web/DialogPortal.ts
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { useSelector } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
+import { debounce } from '../../../base/config/functions.any';
 import { ZINDEX_DIALOG_PORTAL } from '../../constants';
 
 interface IProps {
@@ -43,24 +44,6 @@ interface IProps {
      */
     targetSelector?: string;
 }
-
-/**
- * Utility function to debounce the execution of a callback function.
- *
- * @param {Function} callback - The callback to debounce.
- * @param {number} delay - The debounce delay in milliseconds.
- * @returns {Function} - A debounced function that delays the execution of the callback.
- */
-const debounce = (callback: (...args: any[]) => void, delay: number) => {
-    let timerId: any;
-
-    return (...args: any[]) => {
-        if (timerId) {
-            clearTimeout(timerId);
-        }
-        timerId = setTimeout(() => callback(...args), delay);
-    };
-};
 
 /**
  * Component meant to render a drawer at the bottom of the screen,

--- a/react/features/toolbox/components/web/DialogPortal.ts
+++ b/react/features/toolbox/components/web/DialogPortal.ts
@@ -8,8 +8,8 @@ import { ZINDEX_DIALOG_PORTAL } from '../../constants';
 interface IProps {
 
     /**
-     * The component(s) to be displayed within the drawer portal.
-     */
+    * The component(s) to be displayed within the drawer portal.
+    */
     children: ReactNode;
 
     /**
@@ -43,6 +43,24 @@ interface IProps {
      */
     targetSelector?: string;
 }
+
+/**
+ * Utility function to debounce the execution of a callback function.
+ *
+ * @param {Function} callback - The callback to debounce.
+ * @param {number} delay - The debounce delay in milliseconds.
+ * @returns {Function} - A debounced function that delays the execution of the callback.
+ */
+const debounce = (callback: (...args: any[]) => void, delay: number) => {
+    let timerId: any;
+
+    return (...args: any[]) => {
+        if (timerId) {
+            clearTimeout(timerId);
+        }
+        timerId = setTimeout(() => callback(...args), delay);
+    };
+};
 
 /**
  * Component meant to render a drawer at the bottom of the screen,
@@ -86,7 +104,7 @@ function DialogPortal({ children, className, style, getRef, setSize, targetSelec
             width: 1,
             height: 1
         };
-        const observer = new ResizeObserver(entries => {
+        const debouncedResizeCallback = debounce((entries: ResizeObserverEntry[]) => {
             const { contentRect } = entries[0];
 
             if (contentRect.width !== size.width || contentRect.height !== size.height) {
@@ -97,8 +115,10 @@ function DialogPortal({ children, className, style, getRef, setSize, targetSelec
                     onVisible?.();
                 }, 100);
             }
-        });
+        }, 20); // 20ms delay
 
+        // Create and observe ResizeObserver
+        const observer = new ResizeObserver(debouncedResizeCallback);
         const target = targetSelector ? portalTarget.querySelector(targetSelector) : portalTarget;
 
         if (document.body) {


### PR DESCRIPTION
**Description:** When user use the keyboard navigation and open video or audio settings under menu the focus should move and stay in the under menu till the under menu closed.

**Actual Behavior:** 
1- After opening the menu using keyboard navigation, user have navigate with tap on all toolbar buttons to reach it.
2- The keyboard focus with tap move to other elements (buttons) even if the menu is open.
3- If the menu is open and the focus on other element press ESC doesn't close it. 

**Expected Behavior:** 
1- After opening the menu using keyboard navigation, the focus should move directly to the menu.
2- The focus should stay in inside the menu.
3- By clicking ESC closed the menu and move the focus back to the button.


Before:

https://github.com/user-attachments/assets/f26bd5c8-47b9-44e3-a705-fb383c8f2c49


After:

https://github.com/user-attachments/assets/0ebe1e9e-39e6-423d-9112-2474e5078ce5


issue jitsi community: https://community.jitsi.org/t/accessibility-keyboard-navigation/133334

**NOTE:** This PR included the fix of "ResizeObserver loop completed with undelivered notifications". This error typically occurs when the ResizeObserver detects changes in element sizes and tries to update the layout, but the changes trigger more layout recalculations than the browser can handle in a single event loop cycle. Browsers like Chrome trigger this error as a warning and not necessarily because something is broken.





