### PR TITLE
fix(RN/shared-video): sharedVideoAllowedURLDomains prop from branding.

### DIFF
--- a/react/features/dynamic-branding/middleware.native.ts
+++ b/react/features/dynamic-branding/middleware.native.ts
@@ -24,7 +24,8 @@ MiddlewareRegistry.register(store => next => action => {
             brandedIcons,
             didPageUrl,
             inviteDomain,
-            labels
+            labels,
+            sharedVideoAllowedURLDomains
         } = action.value;
 
         action.value = {
@@ -34,7 +35,8 @@ MiddlewareRegistry.register(store => next => action => {
             brandedIcons,
             didPageUrl,
             inviteDomain,
-            labels
+            labels,
+            sharedVideoAllowedURLDomains
         };
 
         // The backend may send an empty string, make sure we skip that.


### PR DESCRIPTION
On mobile (React-Native) the sharedVideoAllowedURLDomains property from dynamic branding was filtered and therefore the allow list from the branding was not reaching redux and was ignored.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
