### PR TITLE
fix(jicofo): conference request nginx config add expose headers for content type

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -154,6 +154,7 @@ server {
         proxy_pass http://127.0.0.1:8888/conference-request/v1$1;
         add_header "Cache-Control" "no-cache, no-store";
         add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Expose-Headers' 'Content-Type';
     }
     location ~ ^/([^/?&:'"]+)/conference-request/v1(\/.*)?$ {
         rewrite ^/([^/?&:'"]+)/conference-request/v1(\/.*)?$ /conference-request/v1$2;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Fixes the lack of Access-Control-Expose-Headers adding Content-Type for jicofo conference request proxying