### PR TITLE
fix(deb): Restart jicofo on new install.

### DIFF
--- a/debian/jitsi-meet-prosody.postinst
+++ b/debian/jitsi-meet-prosody.postinst
@@ -252,9 +252,10 @@ case "$1" in
         if [ "$PROSODY_CONFIG_PRESENT" = "false" ]; then
             invoke-rc.d prosody restart || true
 
-            # In case we had updated the certificates and restarted prosody, let's restart and the bridge if possible
+            # In case we had updated the certificates and restarted prosody, let's restart and the bridge and jicofo if possible
             if [ -d /run/systemd/system ] && [ "$CERT_ADDED_TO_TRUST" = "true" ]; then
                 systemctl restart jitsi-videobridge2.service >/dev/null || true
+                systemctl restart jicofo.service >/dev/null || true
             fi
         fi
     ;;


### PR DESCRIPTION
Testing clean install on Ubuntu 24.04 seems to end up with jicofo not connected due to the certificate not being validated.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
