### PR TITLE
fix: Fixes installing let's encrypt on clean system.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Description: WebRTC JavaScript video conferences
 
 Package: jitsi-meet-web-config
 Architecture: all
-Depends: openssl, nginx | nginx-full | nginx-extras | openresty | apache2, curl
+Pre-Depends: nginx | nginx-full | nginx-extras | openresty | apache2
+Depends: openssl, curl
 Description: Configuration for web serving of Jitsi Meet
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
  Videobridge to provide high quality, scalable video conferences.


### PR DESCRIPTION
When testing on 24.04 fails to create let's encrypt successfully because the webserver(nginx) is not installed completely.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
