### PR TITLE
fix(face-landmarks) Ignore muted tracks while starting detection.

### DIFF
--- a/react/features/face-landmarks/FaceLandmarksDetector.ts
+++ b/react/features/face-landmarks/FaceLandmarksDetector.ts
@@ -193,8 +193,8 @@ class FaceLandmarksDetector {
         const state = getState();
         const localVideoTrack = track || getLocalVideoTrack(state['features/base/tracks']);
 
-        if (localVideoTrack === undefined) {
-            logger.warn('Face landmarks detection is disabled due to missing local track.');
+        if (!localVideoTrack || localVideoTrack.jitsiTrack?.isMuted()) {
+            logger.debug('Face landmarks detection is disabled due to missing local track.');
 
             return;
         }


### PR DESCRIPTION
This fixes an issue where a user gets stuck on lobby page when they have a muted video track after the user is accepted.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
