### PR TITLE
fix(KbShortcuts): remove listeners on leave.

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -140,7 +140,6 @@ import { openLeaveReasonDialog } from './react/features/conference/actions.web';
 import { showDesktopPicker } from './react/features/desktop-picker/actions';
 import { appendSuffix } from './react/features/display-name/functions';
 import { maybeOpenFeedbackDialog, submitFeedback } from './react/features/feedback/actions';
-import { initKeyboardShortcuts } from './react/features/keyboard-shortcuts/actions';
 import { maybeSetLobbyChatMessageListener } from './react/features/lobby/actions.any';
 import { setNoiseSuppressionEnabled } from './react/features/noise-suppression/actions';
 import {
@@ -2005,7 +2004,6 @@ export default {
 
         APP.UI.initConference();
 
-        dispatch(initKeyboardShortcuts());
         dispatch(conferenceJoined(room));
 
         const jwt = APP.store.getState()['features/base/jwt'];

--- a/react/features/keyboard-shortcuts/actions.native.ts
+++ b/react/features/keyboard-shortcuts/actions.native.ts
@@ -1,1 +1,0 @@
-export * from './actions.any';

--- a/react/features/keyboard-shortcuts/middleware.ts
+++ b/react/features/keyboard-shortcuts/middleware.ts
@@ -1,11 +1,17 @@
 import { AnyAction } from 'redux';
 
 import { IStore } from '../app/types';
+import { CONFERENCE_JOINED, CONFERENCE_LEFT } from '../base/conference/actionTypes';
 import { SET_CONFIG } from '../base/config/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { CAPTURE_EVENTS } from '../remote-control/actionTypes';
 
-import { disableKeyboardShortcuts, enableKeyboardShortcuts } from './actions';
+import {
+    disableKeyboardShortcuts,
+    disposeKeyboardShortcuts,
+    enableKeyboardShortcuts,
+    initKeyboardShortcuts
+} from './actions';
 
 MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyAction) => {
     const { dispatch } = store;
@@ -35,6 +41,11 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
 
         return result;
     }
+    case CONFERENCE_JOINED:
+        dispatch(initKeyboardShortcuts());
+        break;
+    case CONFERENCE_LEFT:
+        dispatch(disposeKeyboardShortcuts());
     }
 
     return next(action);

--- a/tsconfig.native.json
+++ b/tsconfig.native.json
@@ -25,6 +25,7 @@
         "react/features/e2ee",
         "react/features/embed-meeting",
         "react/features/face-landmarks",
+        "react/features/keyboard-shortcuts",
         "react/features/no-audio-signal",
         "react/features/noise-suppression",
         "react/features/old-client-notification",


### PR DESCRIPTION
Currently we add keyboard listeners on conference join but never remove them. In the cases where we have multiple join events during a call (visitors promotion, breakout rooms), there are multiple keyboard handlers added and the shortcuts are executed multiple times on a single press.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
