### PR TITLE
fix(watermarks): bring watermarks to the top

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -111,7 +111,7 @@ form {
     height: $watermarkHeight;
     background-size: contain;
     background-repeat: no-repeat;
-    z-index: $zindex2;
+    z-index: $watermarkZ;
 }
 
 .leftwatermark {
@@ -142,7 +142,7 @@ form {
     font-size: 11pt;
     color: rgba(255,255,255,.50);
     text-decoration: none;
-    z-index: 100;
+    z-index: $watermarkZ;
 }
 
 /**

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -38,6 +38,8 @@ $zindex1: 1;
 $zindex2: 2;
 $zindex3: 3;
 $toolbarZ: 250;
+$watermarkZ: 253;
+
 // Place filmstrip videos over toolbar in order
 // to make connection info visible.
 $filmstripVideosZ: $toolbarZ + 1;


### PR DESCRIPTION
The `z-index` of the `PremeetingScreen` is `252` while the watermarks  only have the `z-index` of `2` or `100` for the "powered by". This hides the watermarks behind the content panel.

If the watermarks are hidden by design here, they should be conditionally excluded from the DOM, as they can be navigated to via keyboard. This breaks the sequential navigation required for accessibility.

I opted to bring the Watermarks to the top, as determining which view is currently active (prejoin, lobby or active conference) and bringing this information down to `Watermarks` (`Conference -> LargeVideo -> Watermarks`) seems a lot more hassle, but can be implemented that way, too.