### PR TITLE
fix(auth_token): check params before getting its property

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -48,7 +48,7 @@ function init_session(event)
         -- After validating auth_token will be cleaned in case of error and few
         -- other fields will be extracted from the token and set in the session
 
-        if query and params.token then
+        if params and params.token then
             token = params.token;
         end
     end


### PR DESCRIPTION
PR fixes the typo. `params` should be checked before getting `params.token`,
not `query` which is already checked before this `if` clause.