### PR TITLE
fix(chat): show focus on chat

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -1,5 +1,8 @@
+@use './variables';
+
 #chat-conversation-container {
     // extract message input height
+    box-sizing: border-box;
     height: calc(100% - 64px);
     overflow: hidden;
     position: relative;
@@ -9,7 +12,7 @@
     box-sizing: border-box;
     flex: 1;
     font-size: 10pt;
-    height: 100%;
+    height: calc(100% - 10px);
     line-height: 20px;
     overflow: auto;
     padding: 16px;
@@ -18,6 +21,13 @@
 
     display: flex;
     flex-direction: column;
+
+    &.focus-visible {
+        outline: 0;
+        margin: 4px;
+        border-radius: 0 0 variables.$borderRadius variables.$borderRadius;
+        box-shadow: 0px 0px 0px 2px #4687ed; // focus01/primary07
+    }
 
     & > :first-child {
         margin-top: auto;


### PR DESCRIPTION
Navigating via keyboard to the chat container enables scrolling via arrow keys. No focus is visible on the container.

This adds the focus according to [WCAG v2.2 Criterion 2.4.7 Focus Visible](https://www.w3.org/TR/WCAG22/#focus-visible).
