### PR TITLE
fix(lobby): Inconsistent state after deny and then approve.

### DIFF
--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -165,6 +165,7 @@ export interface IConferenceState {
     followMeRecorderEnabled?: boolean;
     joining?: IJitsiConference;
     leaving?: IJitsiConference;
+    lobbyError?: boolean;
     lobbyWaitingForHost?: boolean;
     localSubject?: string;
     locked?: string;
@@ -363,13 +364,24 @@ function _conferenceFailed(state: IConferenceState, { conference, error }: {
     let membersOnly;
     let passwordRequired;
     let lobbyWaitingForHost;
+    let lobbyError;
 
     switch (error.name) {
     case JitsiConferenceErrors.AUTHENTICATION_REQUIRED:
         authRequired = conference;
         break;
 
+    /**
+     * Access denied while waiting in the lobby.
+     * A conference error when we tried to join into a room with no display name when lobby is enabled in the room.
+     */
     case JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED:
+    case JitsiConferenceErrors.DISPLAY_NAME_REQUIRED: {
+        lobbyError = true;
+
+        break;
+    }
+
     case JitsiConferenceErrors.MEMBERS_ONLY_ERROR: {
         membersOnly = conference;
 
@@ -393,6 +405,7 @@ function _conferenceFailed(state: IConferenceState, { conference, error }: {
         error,
         joining: undefined,
         leaving: undefined,
+        lobbyError,
         lobbyWaitingForHost,
 
         /**
@@ -450,6 +463,7 @@ function _conferenceJoined(state: IConferenceState, { conference }: { conference
         membersOnly: undefined,
         leaving: undefined,
 
+        lobbyError: undefined,
         lobbyWaitingForHost: undefined,
 
         /**

--- a/react/features/lobby/actions.any.ts
+++ b/react/features/lobby/actions.any.ts
@@ -209,6 +209,8 @@ export function startKnocking() {
         logger.info(`Lobby starting knocking (membersOnly = ${membersOnly})`);
 
         if (!membersOnly) {
+            // let's hide the notification (the case with denied access and retrying)
+            dispatch(hideNotification(LOBBY_NOTIFICATION_ID));
 
             // no membersOnly, this means we got lobby screen shown as someone
             // tried to join a conference that has lobby enabled without setting display name

--- a/react/features/lobby/middleware.ts
+++ b/react/features/lobby/middleware.ts
@@ -324,6 +324,9 @@ function _conferenceFailed({ dispatch, getState }: IStore, next: Function, actio
     }
 
     // if both are available pre-join is with priority (the case when pre-join is enabled)
+    // when pre-join is disabled, and we are in lobby with error, we want to end up in lobby UI
+    // instead of hiding it and showing conference UI. Still in lobby the user can retry
+    // after we show the error notification
     if (isPrejoinPageVisible(state)) {
         dispatch(hideLobbyScreen());
     }
@@ -338,8 +341,6 @@ function _conferenceFailed({ dispatch, getState }: IStore, next: Function, actio
                 descriptionKey: 'lobby.joinRejectedMessage'
             }, NOTIFICATION_TIMEOUT_TYPE.STICKY)
         );
-    } else {
-        dispatch(hideLobbyScreen());
     }
 
     return next(action);

--- a/react/features/lobby/middleware.ts
+++ b/react/features/lobby/middleware.ts
@@ -331,6 +331,10 @@ function _conferenceFailed({ dispatch, getState }: IStore, next: Function, actio
         dispatch(hideLobbyScreen());
     }
 
+    // we want to finish this action before showing the notification
+    // as the conference will be cleared which will clear all notifications, including this one
+    const result = next(action);
+
     if (error.name === JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED) {
         dispatch(
             showNotification({
@@ -343,7 +347,7 @@ function _conferenceFailed({ dispatch, getState }: IStore, next: Function, actio
         );
     }
 
-    return next(action);
+    return result;
 }
 
 /**

--- a/react/features/lobby/reducer.ts
+++ b/react/features/lobby/reducer.ts
@@ -69,6 +69,7 @@ ReducerRegistry.register<ILobbyState>('features/lobby', (state = DEFAULT_STATE, 
     case CONFERENCE_LEFT:
         return {
             ...state,
+            isDisplayNameRequiredError: false,
             knocking: false,
             passwordJoinFailed: false
         };

--- a/react/features/notifications/middleware.ts
+++ b/react/features/notifications/middleware.ts
@@ -78,6 +78,22 @@ const getNotifications = (state: IReduxState) => {
 };
 
 /**
+ * Check whether we need to clear notifications.
+ *
+ * @param {Object} state - Global state.
+ * @returns {boolean} - True if we need to clear any notification.
+ */
+const shouldClearNotifications = (state: IReduxState): boolean => {
+    // in case of lobby error, access is denied, the conference is cleared, but we still
+    // want to show the notification
+    if (state['features/base/conference'].lobbyError) {
+        return false;
+    }
+
+    return !getCurrentConference(state);
+};
+
+/**
  * Middleware that captures actions to display notifications.
  *
  * @param {Store} store - The redux store.
@@ -201,9 +217,9 @@ MiddlewareRegistry.register(store => next => action => {
  * conference, where we need to clean up the notifications.
  */
 StateListenerRegistry.register(
-    /* selector */ state => getCurrentConference(state),
-    /* listener */ (conference, { dispatch }) => {
-        if (!conference) {
+    /* selector */ state => shouldClearNotifications(state),
+    /* listener */ (clear, { dispatch }) => {
+        if (clear) {
             dispatch(clearNotifications());
         }
     }

--- a/react/features/notifications/middleware.ts
+++ b/react/features/notifications/middleware.ts
@@ -78,22 +78,6 @@ const getNotifications = (state: IReduxState) => {
 };
 
 /**
- * Check whether we need to clear notifications.
- *
- * @param {Object} state - Global state.
- * @returns {boolean} - True if we need to clear any notification.
- */
-const shouldClearNotifications = (state: IReduxState): boolean => {
-    // in case of lobby error, access is denied, the conference is cleared, but we still
-    // want to show the notification
-    if (state['features/base/conference'].lobbyError) {
-        return false;
-    }
-
-    return !getCurrentConference(state);
-};
-
-/**
  * Middleware that captures actions to display notifications.
  *
  * @param {Store} store - The redux store.
@@ -217,9 +201,9 @@ MiddlewareRegistry.register(store => next => action => {
  * conference, where we need to clean up the notifications.
  */
 StateListenerRegistry.register(
-    /* selector */ state => shouldClearNotifications(state),
-    /* listener */ (clear, { dispatch }) => {
-        if (clear) {
+    /* selector */ state => getCurrentConference(state),
+    /* listener */ (conference, { dispatch }) => {
+        if (!conference) {
             dispatch(clearNotifications());
         }
     }


### PR DESCRIPTION
Fixes several issues:
- The error on lobby deny is not sticky
- When preJoin is not enabled we were showing conference UI and showing the error, while the participant is denied to enter the meeting.
- There was inconsistent state (after deny we were keeping membersOnly conference state) and when being approved on re-try while being in the meeting, no remote thumbnails are shown although media is flowing.

The scenario is enabling lobby and tryintg to join, denying the first attempt and approving the second one.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
