### PR TITLE
fix(conference): Make sure join waits for confernce.init.

### DIFF
--- a/react/features/prejoin/actions.web.ts
+++ b/react/features/prejoin/actions.web.ts
@@ -228,6 +228,8 @@ export function joinConference(options?: Object, ignoreJoiningInProgress = false
             dispatch(setJoiningInProgress(true));
         }
 
+        logger.debug('joinConference executed!');
+
         options && dispatch(updateConfig(options));
 
         dispatch(connect(jid, password)).then(async () => {


### PR DESCRIPTION
It was possible that join can be executed before conference.init have even started or we haven't reached the point ot create the initialGUMPromise. This was causing the following issues:
 - users stuck on the prejoin screen
 - participants join 2+ times in the call (we have been creating more than 1 local participants from a single page).

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
