### PR TITLE
feat(rn,screen-sharing) allow sharing the screen and camera on mobile

### DIFF
--- a/react/features/base/media/constants.ts
+++ b/react/features/base/media/constants.ts
@@ -56,8 +56,7 @@ export const VIDEO_MUTISM_AUTHORITY = {
     AUDIO_ONLY: 1 << 0,
     BACKGROUND: 1 << 1,
     USER: 1 << 2,
-    CAR_MODE: 1 << 3,
-    SCREEN_SHARE: 1 << 4
+    CAR_MODE: 1 << 3
 };
 
 /* eslint-enable no-bitwise */

--- a/react/features/base/tracks/actions.native.ts
+++ b/react/features/base/tracks/actions.native.ts
@@ -5,11 +5,7 @@ import { NOTIFICATION_TIMEOUT_TYPE } from '../../notifications/constants';
 import { PIP_WHILE_SCREEN_SHARING_ENABLED } from '../flags/constants';
 import { getFeatureFlag } from '../flags/functions';
 import JitsiMeetJS from '../lib-jitsi-meet';
-import {
-    setScreenshareMuted,
-    setVideoMuted
-} from '../media/actions';
-import { VIDEO_MUTISM_AUTHORITY } from '../media/constants';
+import { setScreenshareMuted } from '../media/actions';
 
 import { addLocalTrack, replaceLocalTrack } from './actions.any';
 import { getLocalDesktopTrack, getTrackState, isLocalVideoTrackDesktop } from './functions.native';
@@ -37,7 +33,6 @@ export function toggleScreensharing(enabled: boolean, _ignore1?: boolean, _ignor
             }
         } else {
             dispatch(setScreenshareMuted(true));
-            dispatch(setVideoMuted(false, VIDEO_MUTISM_AUTHORITY.SCREEN_SHARE));
             setPictureInPictureEnabled(true);
         }
     };
@@ -71,8 +66,6 @@ async function _startScreenSharing(dispatch: IStore['dispatch'], state: IReduxSt
         } else {
             dispatch(addLocalTrack(track));
         }
-
-        dispatch(setVideoMuted(true, VIDEO_MUTISM_AUTHORITY.SCREEN_SHARE));
 
         const { enabled: audioOnly } = state['features/base/audio-only'];
 

--- a/react/features/toolbox/functions.native.ts
+++ b/react/features/toolbox/functions.native.ts
@@ -1,11 +1,11 @@
 import { IReduxState } from '../app/types';
 import { IStateful } from '../base/app/types';
-import { hasAvailableDevices } from '../base/devices/functions';
+import { hasAvailableDevices } from '../base/devices/functions.native';
 import { TOOLBOX_ALWAYS_VISIBLE, TOOLBOX_ENABLED } from '../base/flags/constants';
 import { getFeatureFlag } from '../base/flags/functions';
 import { getParticipantCountWithFake } from '../base/participants/functions';
 import { toState } from '../base/redux/functions';
-import { isLocalVideoTrackDesktop } from '../base/tracks/functions';
+import { isLocalVideoTrackDesktop } from '../base/tracks/functions.native';
 
 export * from './functions.any';
 

--- a/react/features/toolbox/functions.native.ts
+++ b/react/features/toolbox/functions.native.ts
@@ -97,6 +97,5 @@ export function isVideoMuteButtonDisabled(state: IReduxState) {
     const { muted, unmuteBlocked } = state['features/base/media'].video;
 
     return !hasAvailableDevices(state, 'videoInput')
-        || (unmuteBlocked && Boolean(muted))
-        || isLocalVideoTrackDesktop(state);
+        || (unmuteBlocked && Boolean(muted));
 }


### PR DESCRIPTION
With the advancements in layer suspension it should now be ok to do. Users can still mute the camera themselves if they so desire.

Having the camera enabled while in the background is a separate effort.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
