### PR TITLE
fix(e2ee) don't display E2EE verified field until final

### DIFF
--- a/react/features/connection-indicator/components/web/ConnectionIndicatorContent.tsx
+++ b/react/features/connection-indicator/components/web/ConnectionIndicatorContent.tsx
@@ -96,7 +96,7 @@ interface IProps extends AbstractProps, WithTranslation {
 
     _isConnectionStatusInterrupted: boolean;
 
-    _isE2EEVerified: boolean;
+    _isE2EEVerified?: boolean;
 
     /**
      * Whether or not the displays stats are for local video.
@@ -364,7 +364,7 @@ export function _mapStateToProps(state: IReduxState, ownProps: any) {
         _enableSaveLogs: Boolean(state['features/base/config'].enableSaveLogs),
         _isConnectionStatusInactive,
         _isConnectionStatusInterrupted,
-        _isE2EEVerified: Boolean(participant?.e2eeVerified),
+        _isE2EEVerified: participant?.e2eeVerified,
         _isNarrowLayout: isNarrowLayout,
         _isVirtualScreenshareParticipant: isScreenShareParticipant(participant),
         _isLocalVideo: Boolean(participant?.local),

--- a/react/features/connection-stats/components/ConnectionStatsTable.tsx
+++ b/react/features/connection-stats/components/ConnectionStatsTable.tsx
@@ -71,7 +71,7 @@ interface IProps {
     /**
      * Whether or not the participant was verified.
      */
-    e2eeVerified: boolean;
+    e2eeVerified?: boolean;
 
     /**
      * Whether to enable assumed bandwidth.


### PR DESCRIPTION
It shows all the time otherwise, confusing users who haven't even enabled it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
