### PR TITLE
fix(lang): Add newline at the end of generated lang file

### DIFF
--- a/lang/update-translation.js
+++ b/lang/update-translation.js
@@ -35,4 +35,4 @@ for (const path of paths) {
 
 const data = JSON.stringify(result, undefined, 4);
 
-fs.writeFileSync(`./${targetLangFile}`, data);
+fs.writeFileSync(`./${targetLangFile}`, data + "\n");


### PR DESCRIPTION
Add missing newline (so the linter is happy) at the end of target language file after running commands:
```
cd lang
node update-translation.js main-es.json
```

I have already signed CLA.