### PR TITLE
feat(base/ui): remove force capitalize from button labels

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -843,7 +843,7 @@
             "blockEveryoneMicCamera": "Block everyone's mic and camera",
             "breakoutRooms": "Breakout rooms",
             "goLive": "Go live",
-            "invite": "Invite Someone",
+            "invite": "Invite someone",
             "lowerAllHands": "Lower all hands",
             "lowerHand": "Lower the hand",
             "moreModerationActions": "More moderation options",

--- a/react/features/base/ui/components/native/buttonStyles.ts
+++ b/react/features/base/ui/components/native/buttonStyles.ts
@@ -10,8 +10,7 @@ const button = {
 };
 
 const buttonLabel = {
-    ...BaseTheme.typography.bodyShortBold,
-    textTransform: 'capitalize'
+    ...BaseTheme.typography.bodyShortBold
 };
 
 export default {

--- a/react/features/polls/components/native/styles.ts
+++ b/react/features/polls/components/native/styles.ts
@@ -164,13 +164,11 @@ export const pollsStyles = createStyleSheet({
     },
 
     pollSendLabel: {
-        color: BaseTheme.palette.text01,
-        textTransform: 'capitalize'
+        color: BaseTheme.palette.text01
     },
 
     pollSendDisabledLabel: {
-        color: BaseTheme.palette.text03,
-        textTransform: 'capitalize'
+        color: BaseTheme.palette.text03
     },
 
     buttonRow: {


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/cd9278c7-b31e-4776-b175-f1f91d9804cc)


![image](https://github.com/user-attachments/assets/0d2741df-0ec4-4670-8a21-eecbab1d66ee)

It seems that react-native-paper Button no longer needs force capitalisation on its label.
Right now only the first word gets capitalised.
Fixes #15224.