### PR TITLE
fix(ci) use macOS 15 to run iOS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
+        os: [macos-15]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
We need Xcode 16 and that version is now only available on macOS 15 action runners: https://github.com/actions/runner-images/issues/10703

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
