### PR TITLE
feat(subtitles): Don't show delayed final

### DIFF
--- a/react/features/subtitles/actionTypes.ts
+++ b/react/features/subtitles/actionTypes.ts
@@ -10,6 +10,17 @@
 export const REMOVE_TRANSCRIPT_MESSAGE = 'REMOVE_TRANSCRIPT_MESSAGE';
 
 /**
+ * The type of (redux) action which indicates that an cached transcript
+ * has to be removed from the state.
+ *
+ * {
+ *      type: REMOVE_CACHED_TRANSCRIPT_MESSAGE,
+ *      transciptMessageID: string,
+ * }
+ */
+export const REMOVE_CACHED_TRANSCRIPT_MESSAGE = 'REMOVE_CACHED_TRANSCRIPT_MESSAGE';
+
+/**
  * The type of (redux) action which indicates that a transcript with an
  * given message_id to be added or updated is received.
  *

--- a/react/features/subtitles/actions.any.ts
+++ b/react/features/subtitles/actions.any.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_LANGUAGE } from '../base/i18n/i18next';
 
 import {
+    REMOVE_CACHED_TRANSCRIPT_MESSAGE,
     REMOVE_TRANSCRIPT_MESSAGE,
     SET_REQUESTING_SUBTITLES,
     TOGGLE_REQUESTING_SUBTITLES,
@@ -19,6 +20,22 @@ import {
 export function removeTranscriptMessage(transcriptMessageID: string) {
     return {
         type: REMOVE_TRANSCRIPT_MESSAGE,
+        transcriptMessageID
+    };
+}
+
+/**
+ * Signals that a cached transcript has to be removed from the state.
+ *
+ * @param {string} transcriptMessageID - The message_id to be removed.
+ * @returns {{
+*      type: REMOVE_CACHED_TRANSCRIPT_MESSAGE,
+*      transcriptMessageID: string,
+* }}
+*/
+export function removeCachedTranscriptMessage(transcriptMessageID: string) {
+    return {
+        type: REMOVE_CACHED_TRANSCRIPT_MESSAGE,
         transcriptMessageID
     };
 }

--- a/react/features/subtitles/reducer.ts
+++ b/react/features/subtitles/reducer.ts
@@ -2,6 +2,7 @@ import ReducerRegistry from '../base/redux/ReducerRegistry';
 import { TRANSCRIBER_LEFT } from '../transcribing/actionTypes';
 
 import {
+    REMOVE_CACHED_TRANSCRIPT_MESSAGE,
     REMOVE_TRANSCRIPT_MESSAGE,
     SET_REQUESTING_SUBTITLES,
     TOGGLE_REQUESTING_SUBTITLES,
@@ -13,6 +14,7 @@ import { ITranscriptMessage } from './types';
  * Default State for 'features/transcription' feature.
  */
 const defaultState = {
+    _cachedTranscriptMessages: new Map(),
     _displaySubtitles: false,
     _transcriptMessages: new Map(),
     _requestingSubtitles: false,
@@ -20,6 +22,7 @@ const defaultState = {
 };
 
 export interface ISubtitlesState {
+    _cachedTranscriptMessages: Map<string, ITranscriptMessage>;
     _displaySubtitles: boolean;
     _language: string | null;
     _requestingSubtitles: boolean;
@@ -35,6 +38,8 @@ ReducerRegistry.register<ISubtitlesState>('features/subtitles', (
     switch (action.type) {
     case REMOVE_TRANSCRIPT_MESSAGE:
         return _removeTranscriptMessage(state, action);
+    case REMOVE_CACHED_TRANSCRIPT_MESSAGE:
+        return _removeCachedTranscriptMessage(state, action);
     case UPDATE_TRANSCRIPT_MESSAGE:
         return _updateTranscriptMessage(state, action);
     case SET_REQUESTING_SUBTITLES:
@@ -70,13 +75,42 @@ ReducerRegistry.register<ISubtitlesState>('features/subtitles', (
  */
 function _removeTranscriptMessage(state: ISubtitlesState, { transcriptMessageID }: { transcriptMessageID: string; }) {
     const newTranscriptMessages = new Map(state._transcriptMessages);
+    const message = newTranscriptMessages.get(transcriptMessageID);
+    let { _cachedTranscriptMessages } = state;
+
+    if (message && !message.final) {
+        _cachedTranscriptMessages = new Map(_cachedTranscriptMessages);
+        _cachedTranscriptMessages.set(transcriptMessageID, message);
+    }
 
     // Deletes the key from Map once a final message arrives.
     newTranscriptMessages.delete(transcriptMessageID);
 
     return {
         ...state,
+        _cachedTranscriptMessages,
         _transcriptMessages: newTranscriptMessages
+    };
+}
+
+
+/**
+ * Reduces a specific Redux action REMOVE_CACHED_TRANSCRIPT_MESSAGE of the feature transcription.
+ *
+ * @param {Object} state - The Redux state of the feature transcription.
+ * @param {Action} action -The Redux action REMOVE_CACHED_TRANSCRIPT_MESSAGE to reduce.
+ * @returns {Object} The new state of the feature transcription after the reduction of the specified action.
+ */
+function _removeCachedTranscriptMessage(state: ISubtitlesState,
+        { transcriptMessageID }: { transcriptMessageID: string; }) {
+    const newCachedTranscriptMessages = new Map(state._cachedTranscriptMessages);
+
+    // Deletes the key from Map once a final message arrives.
+    newCachedTranscriptMessages.delete(transcriptMessageID);
+
+    return {
+        ...state,
+        _cachedTranscriptMessages: newCachedTranscriptMessages
     };
 }
 
@@ -92,12 +126,16 @@ function _removeTranscriptMessage(state: ISubtitlesState, { transcriptMessageID 
 function _updateTranscriptMessage(state: ISubtitlesState, { transcriptMessageID, newTranscriptMessage }:
     { newTranscriptMessage: ITranscriptMessage; transcriptMessageID: string; }) {
     const newTranscriptMessages = new Map(state._transcriptMessages);
+    const _cachedTranscriptMessages = new Map(state._cachedTranscriptMessages);
+
+    _cachedTranscriptMessages.delete(transcriptMessageID);
 
     // Updates the new message for the given key in the Map.
     newTranscriptMessages.set(transcriptMessageID, newTranscriptMessage);
 
     return {
         ...state,
+        _cachedTranscriptMessages,
         _transcriptMessages: newTranscriptMessages
     };
 }


### PR DESCRIPTION
If a non final transcript was displayed and then hidden and then we receive a final transcript we remove the part that has already been shown before. If the final transcript is the same as the non final that was already displayed we don't show the final.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
