### PR TITLE
feat: auto-open invite window when room creator joins

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -112,7 +112,7 @@ import {
 import {
     getLocalParticipant,
     getNormalizedDisplayName,
-    getParticipantByIdOrUndefined,
+    getParticipantByIdOrUndefined, getParticipantCount,
     getVirtualScreenshareParticipantByOwnerId
 } from './react/features/base/participants/functions';
 import { updateSettings } from './react/features/base/settings/actions';
@@ -142,6 +142,7 @@ import { openLeaveReasonDialog } from './react/features/conference/actions.web';
 import { showDesktopPicker } from './react/features/desktop-picker/actions';
 import { appendSuffix } from './react/features/display-name/functions';
 import { maybeOpenFeedbackDialog, submitFeedback } from './react/features/feedback/actions';
+import { beginAddPeople } from './react/features/invite/actions.any';
 import { maybeSetLobbyChatMessageListener } from './react/features/lobby/actions.any';
 import { setNoiseSuppressionEnabled } from './react/features/noise-suppression/actions';
 import {
@@ -1573,6 +1574,11 @@ export default {
 
                 if (role === 'moderator') {
                     APP.store.dispatch(maybeSetLobbyChatMessageListener());
+                    const participantsCount = getParticipantCount(APP.store.getState());
+
+                    if (participantsCount === 1) {
+                        APP.store.dispatch(beginAddPeople());
+                    }
                 }
 
                 APP.store.dispatch(localParticipantRoleChanged(role));


### PR DESCRIPTION
Added logic to detect the room creator's entry and trigger the invite window automatically. This feature improves user experience by making it easier for the host to invite participants.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
