### PR TITLE
feat(external-api): Fix reporting kicker display name.

### DIFF
--- a/react/features/external-api/middleware.ts
+++ b/react/features/external-api/middleware.ts
@@ -142,7 +142,7 @@ MiddlewareRegistry.register(store => next => action => {
             break;
         }
 
-        const pId = action.participant.getId();
+        const actor = action.participant;
 
         APP.API.notifyKickedOut(
             {
@@ -151,8 +151,8 @@ MiddlewareRegistry.register(store => next => action => {
                 local: true
             },
             {
-                id: pId,
-                name: getParticipantDisplayName(state, pId)
+                id: actor.getId(),
+                name: actor.getDisplayName()
             }
         );
         break;


### PR DESCRIPTION
We cannot look up the name as the meeting is left and data has been cleaned up already. The value is coming from ljm and the reported actor: JitsiParticipant.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
