### PR TITLE
fix: transcript results from whisper may have json.language="zh-TW" a…

### DIFF
--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -261,10 +261,10 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
 }
 
 /**
- * Utility function to extract the primary language code like 'en-GB' 'en_GB' 
- * 'enGB' 'zh-CN' and 'zh-TW'
- * 
- * @param {string} language The language to use for translation or user requested
+ * Utility function to extract the primary language code like 'en-GB' 'en_GB'
+ * 'enGB' 'zh-CN' and 'zh-TW'.
+ *
+ * @param {string} language - The language to use for translation or user requested.
  * @returns {string}
  */
 function _getPrimaryLanguageCode(language: string) {

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -196,7 +196,7 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
         // Regex to filter out all possible country codes after language code:
         // this should catch all notations like 'en-GB' 'en_GB' and 'enGB'
         // and be independent of the country code length
-        if (json.language.replace(/[-_A-Z].*/, '') !== language) {
+        if (_getPrimaryLanguageCode(json.language) !== _getPrimaryLanguageCode(language)) {
             return next(action);
         }
 
@@ -258,6 +258,17 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
     }
 
     return next(action);
+}
+
+/**
+ * Utility function to extract the primary language code like 'en-GB' 'en_GB' 
+ * 'enGB' 'zh-CN' and 'zh-TW'
+ * 
+ * @param {string} language The language to use for translation or user requested
+ * @returns {string}
+ */
+function _getPrimaryLanguageCode(language: string) {
+    return language.replace(/[-_A-Z].*/, '');
 }
 
 /**


### PR DESCRIPTION
transcript result from Whisper like:

```
{
    "transcript": [
        {
            "confidence": 1,
            "text": "大家好"
        }
    ],
    "is_interim": false,
    "language": "zh-TW",
    "message_id": "019368ee-0910-70c8-9b69-15b5d404551d",
    "event": "SPEECH",
    "type": "transcription-result",
    "participant": {
        "avatar_url": "https://www.gravatar.com/avatar/myavatarid?d=wavatar&size=200",
        "name": "韋智Chrome",
        "id": "1721a87f",
        "email": "me@gmail.com"
    },
    "stability": 1,
    "timestamp": 1732632250201
}
```

Current code only checks one direction.