### PR TITLE
fix(visitors): Fixes slowing down after meeting becomes live.

### DIFF
--- a/react/features/visitors/middleware.ts
+++ b/react/features/visitors/middleware.ts
@@ -180,7 +180,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                                     delay = msg.randomDelayMs;
                                 }
 
-                                if (WebsocketClient.getInstance().connectCount > 1) {
+                                if (WebsocketClient.getInstance().connectCount > 3) {
                                     // if we keep connecting/disconnecting, let's slow it down
                                     delay = 30 * 1000;
                                 }


### PR DESCRIPTION
Make sure there are several connects before slowing down the visitor trying to join. This slow down is handling the case where the meeting was live few minutes ago, but ended.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
