### PR TITLE
change german language (main-de.json) videoSettings from Kameraeinstellungen to Kamera-Einstellungen

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -1388,7 +1388,7 @@
         "tileViewToggle": "Kachelansicht ein-/ausschalten",
         "toggleCamera": "Kamera wechseln",
         "unmute": "Stummschaltung aufheben",
-        "videoSettings": "Kameraeinstellungen",
+        "videoSettings": "Kamera-Einstellungen",
         "videomute": "Kamera stoppen",
         "videomuteGUMPending": "Verbinde Ihre Kamera",
         "videounmute": "Kamera einschalten"


### PR DESCRIPTION
A small change to the German language file so that “Kamera-Einstellungen” is the same spelling as “Ton-Einstellungen”