### PR TITLE
fix(shared-video): Removes disable pointer for non moderators.

### DIFF
--- a/react/features/shared-video/components/web/SharedVideo.tsx
+++ b/react/features/shared-video/components/web/SharedVideo.tsx
@@ -130,11 +130,9 @@ class SharedVideo extends Component<IProps> {
             return null;
         }
 
-        const className = !isResizing && isOwner ? '' : 'disable-pointer';
-
         return (
             <div
-                className = { className }
+                className = { isResizing && 'disable-pointer' }
                 id = 'sharedVideo'
                 style = { this.getDimensions() }>
                 {this.getManager()}

--- a/react/features/shared-video/components/web/SharedVideo.tsx
+++ b/react/features/shared-video/components/web/SharedVideo.tsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 // @ts-expect-error
 import Filmstrip from '../../../../../modules/UI/videolayout/Filmstrip';
 import { IReduxState } from '../../../app/types';
-import { getLocalParticipant } from '../../../base/participants/functions';
 import { getVerticalViewMaxWidth } from '../../../filmstrip/functions.web';
 import { getToolboxHeight } from '../../../toolbox/functions.web';
 import { isSharedVideoEnabled } from '../../functions';
@@ -38,11 +37,6 @@ interface IProps {
      * Whether the shared video is enabled or not.
      */
     isEnabled: boolean;
-
-    /**
-     * Is the video shared by the local user.
-     */
-    isOwner: boolean;
 
     /**
      * Whether or not the user is actively resizing the filmstrip.
@@ -124,7 +118,7 @@ class SharedVideo extends Component<IProps> {
      * @returns {React$Element}
      */
     render() {
-        const { isEnabled, isOwner, isResizing } = this.props;
+        const { isEnabled, isResizing } = this.props;
 
         if (!isEnabled) {
             return null;
@@ -132,7 +126,7 @@ class SharedVideo extends Component<IProps> {
 
         return (
             <div
-                className = { isResizing && 'disable-pointer' }
+                className = { (isResizing && 'disable-pointer') || '' }
                 id = 'sharedVideo'
                 style = { this.getDimensions() }>
                 {this.getManager()}
@@ -150,11 +144,9 @@ class SharedVideo extends Component<IProps> {
  * @returns {IProps}
  */
 function _mapStateToProps(state: IReduxState) {
-    const { ownerId, videoUrl } = state['features/shared-video'];
+    const { videoUrl } = state['features/shared-video'];
     const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
     const { visible, isResizing } = state['features/filmstrip'];
-
-    const localParticipant = getLocalParticipant(state);
 
     return {
         clientHeight,
@@ -162,7 +154,6 @@ function _mapStateToProps(state: IReduxState) {
         filmstripVisible: visible,
         filmstripWidth: getVerticalViewMaxWidth(state),
         isEnabled: isSharedVideoEnabled(state),
-        isOwner: ownerId === localParticipant?.id,
         isResizing,
         videoUrl
     };


### PR DESCRIPTION
It fixes an issue where people can see ads from YouTube, allowing them to click the Skip Ad button. If you by mistake pause, the next time sync will unpuase it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
