### PR TITLE
chore(typos) fix various typos

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
@@ -42,7 +42,7 @@ public class JitsiMeetActivityDelegate {
     /**
      * Tells whether or not the permissions request is currently in progress.
      *
-     * @return {@code true} if the permssions are being requested or {@code false} otherwise.
+     * @return {@code true} if the permissions are being requested or {@code false} otherwise.
      */
     static boolean arePermissionsBeingRequested() {
         return permissionListener != null;

--- a/config.js
+++ b/config.js
@@ -907,7 +907,7 @@ var config = {
     // Overrides the buttons displayed in the main toolbar. Depending on the screen size the number of displayed
     // buttons varies from 2 buttons to 8 buttons. Every array in the mainToolbarButtons array will replace the
     // corresponding default buttons configuration matched by the number of buttons specified in the array. Arrays with
-    // more than 8 buttons or less then 2 buttons will be ignored. When there there isn't an override for a cerain
+    // more than 8 buttons or less then 2 buttons will be ignored. When there there isn't an override for a certain
     // configuration (for example when 3 buttons are displayed) the default jitsi-meet configuration will be used.
     // The order of the buttons in the array is preserved.
     // mainToolbarButtons: [
@@ -1735,7 +1735,7 @@ var config = {
     //     'notify.participantsWantToJoin', // shown when lobby is enabled and participants request to join meeting
     //     'notify.passwordRemovedRemotely', // shown when a password has been removed remotely
     //     'notify.passwordSetRemotely', // shown when a password has been set remotely
-    //     'notify.raisedHand', // shown when a partcipant used raise hand,
+    //     'notify.raisedHand', // shown when a participant used raise hand,
     //     'notify.screenShareNoAudio', // shown when the audio could not be shared for the selected screen
     //     'notify.screenSharingAudioOnlyTitle', // shown when the best performance has been affected by screen sharing
     //     'notify.selfViewTitle', // show "You can always un-hide the self-view from settings"
@@ -1766,7 +1766,7 @@ var config = {
     // disableFilmstripAutohiding: false,
 
     // filmstrip: {
-    //     // Disable the vertical/horizonal filmstrip.
+    //     // Disable the vertical/horizontal filmstrip.
     //     disabled: false,
     //     // Disables user resizable filmstrip. Also, allows configuration of the filmstrip
     //     // (width, tiles aspect ratios) through the interfaceConfig options.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -69,7 +69,7 @@ platform :ios do
       end
     )
 
-    # Inrement the build number by 1
+    # Increment the build number by 1
     increment_build_number(
       build_number: Time.now.to_i,
       xcodeproj: "app/app.xcodeproj"

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1571,8 +1571,8 @@ class API {
                 formattedArgument += `${arg.toString()}: ${arg.stack}`;
             } else if (typeof arg === 'object') {
                 // NOTE: The non-enumerable properties of the objects wouldn't be included in the string after
-                // JSON.strigify. For example Map instance will be translated to '{}'. So I think we have to eventually
-                // do something better for parsing the arguments. But since this option for strigify is part of the
+                // JSON.stringify. For example Map instance will be translated to '{}'. So I think we have to eventually
+                // do something better for parsing the arguments. But since this option for stringify is part of the
                 // public interface and I think it could be useful in some cases I will it for now.
                 try {
                     formattedArgument += JSON.stringify(arg);

--- a/react/features/authentication/middleware.ts
+++ b/react/features/authentication/middleware.ts
@@ -121,7 +121,7 @@ MiddlewareRegistry.register(store => next => action => {
         if (isTokenAuthEnabled(config)
             && config.tokenAuthUrlAutoRedirect
             && state['features/base/jwt'].jwt) {
-            // auto redirect is turned on and we have succesfully logged in
+            // auto redirect is turned on and we have successfully logged in
             // let's mark that
             dispatch(setTokenAuthUrlSuccess(true));
         }

--- a/react/features/base/media/reducer.ts
+++ b/react/features/base/media/reducer.ts
@@ -96,7 +96,7 @@ function _audio(state: IAudioState = _AUDIO_INITIAL_MEDIA_STATE, action: AnyActi
 const DEFAULT_INITIAL_PROMISE_STATE = createDeferred<IInitialGUMPromiseResult>();
 
 /**
- * Reducer fot the common properties in media state.
+ * Reducer for the common properties in media state.
  *
  * @param {ICommonState} state - Common media state.
  * @param {Object} action - Action object.

--- a/react/features/base/participants/actions.ts
+++ b/react/features/base/participants/actions.ts
@@ -240,7 +240,7 @@ export function participantJoined(participant: IParticipant) {
         // conference. The following check is really necessary because a
         // JitsiConference may have moved into leaving but may still manage to
         // sneak a PARTICIPANT_JOINED in if its leave is delayed for any purpose
-        // (which is not outragous given that leaving involves network
+        // (which is not outrageous given that leaving involves network
         // requests.)
         const stateFeaturesBaseConference
             = getState()['features/base/conference'];

--- a/react/features/base/participants/subscriber.ts
+++ b/react/features/base/participants/subscriber.ts
@@ -52,7 +52,7 @@ StateListenerRegistry.register(
 
 /**
  * Compares the old and new screenshare lists provided and creates/removes the virtual screenshare participant
- * tiles accodingly.
+ * tiles accordingly.
  *
  * @param {Array<string>} oldScreenshareSourceNames - List of old screenshare source names.
  * @param {Array<string>} newScreenshareSourceNames - Current list of screenshare source names.

--- a/react/features/base/react/functions.ts
+++ b/react/features/base/react/functions.ts
@@ -41,8 +41,8 @@ export function formatURLText(text = '') {
     }
 
     if (!result) {
-        // This will be the case for invalid URLs or URLs without a host (emails for example). In this case beacuse
-        // of the issue with PunycodeJS that truncates parts of the text when there is '@' we split the text by '@'
+        // This will be the case for invalid URLs or URLs without a host (emails for example). In this case due to
+        // the issue with PunycodeJS that truncates parts of the text when there is '@' we split the text by '@'
         // and use punycode for every separate part to prevent homograph attacks.
         result = text.split('@').map(punycode.toASCII)
             .join('@');
@@ -59,7 +59,7 @@ export function formatURLText(text = '') {
  */
 export function getSupportUrl(stateful: IStateful) {
 
-    // TODO: Once overwriting trough interface config is completelly gone we should think of a way to be able to set
+    // TODO: Once overwriting through interface config is completely gone we should think of a way to be able to set
     // the value in the branding and not return the default value from interface config.
     return toState(stateful)['features/dynamic-branding'].supportUrl || interfaceConfig?.SUPPORT_URL;
 }

--- a/react/features/base/redux/PersistenceRegistry.ts
+++ b/react/features/base/redux/PersistenceRegistry.ts
@@ -12,7 +12,7 @@ declare let __DEV__: any;
 /**
  * Mixed type of the element (subtree) config. If it's a {@code boolean} (and is
  * {@code true}), we persist the entire subtree. If it's an {@code Object}, we
- * perist a filtered subtree based on the properties of the config object.
+ * persist a filtered subtree based on the properties of the config object.
  */
 declare type ElementConfig = boolean | Object;
 

--- a/react/features/base/responsive-ui/middleware.native.ts
+++ b/react/features/base/responsive-ui/middleware.native.ts
@@ -5,7 +5,7 @@ import { setAspectRatio, setReducedUI } from './actions';
 
 
 /**
- * Middleware that handles widnow dimension changes and updates the aspect ratio and
+ * Middleware that handles window dimension changes and updates the aspect ratio and
  * reduced UI modes accordingly.
  *
  * @param {Store} store - The redux store.

--- a/react/features/base/tracks/functions.native.ts
+++ b/react/features/base/tracks/functions.native.ts
@@ -17,7 +17,7 @@ export * from './functions.any';
  * and/or 'video'.
  * @param {string|null} [options.micDeviceId] - Microphone device id or
  * {@code undefined} to use app's settings.
- * @param {number|undefined} [oprions.timeout] - A timeout for JitsiMeetJS.createLocalTracks used to create the tracks.
+ * @param {number|undefined} [options.timeout] - A timeout for JitsiMeetJS.createLocalTracks used to create the tracks.
  * @param {IStore} store - The redux store in the context of which the function
  * is to execute and from which state such as {@code config} is to be retrieved.
  * @returns {Promise<JitsiLocalTrack[]>}

--- a/react/features/base/tracks/functions.web.ts
+++ b/react/features/base/tracks/functions.web.ts
@@ -31,7 +31,7 @@ export * from './functions.any';
  * and/or 'video'.
  * @param {string|null} [options.micDeviceId] - Microphone device id or
  * {@code undefined} to use app's settings.
- * @param {number|undefined} [oprions.timeout] - A timeout for JitsiMeetJS.createLocalTracks used to create the tracks.
+ * @param {number|undefined} [options.timeout] - A timeout for JitsiMeetJS.createLocalTracks used to create the tracks.
  * @param {IStore} store - The redux store in the context of which the function
  * is to execute and from which state such as {@code config} is to be retrieved.
  * @param {boolean} recordTimeMetrics - If true time metrics will be recorded.

--- a/react/features/base/ui/components/web/Select.tsx
+++ b/react/features/base/ui/components/web/Select.tsx
@@ -19,12 +19,12 @@ interface ISelectProps {
     className?: string;
 
     /**
-     * Wether or not the select is disabled.
+     * Whether or not the select is disabled.
      */
     disabled?: boolean;
 
     /**
-     * Wether or not the select is in the error state.
+     * Whether or not the select is in the error state.
      */
     error?: boolean;
 

--- a/react/features/base/util/getUnsafeRoomText.native.ts
+++ b/react/features/base/util/getUnsafeRoomText.native.ts
@@ -13,7 +13,7 @@ import { SECURITY_URL } from './contants';
  *
  * @param {IReduxState} state - The redux state.
  * @param {Function} t - The translation function.
- * @param {'meeting'|'prejoin'|'welcome'} context - The given context of the warining.
+ * @param {'meeting'|'prejoin'|'welcome'} context - The given context of the warning.
  * @returns {Text}
  */
 export default function getUnsafeRoomText(state: IReduxState, t: Function, context: 'meeting' | 'prejoin' | 'welcome') {

--- a/react/features/base/util/getUnsafeRoomText.web.ts
+++ b/react/features/base/util/getUnsafeRoomText.web.ts
@@ -6,7 +6,7 @@ import { SECURITY_URL } from './contants';
  * Gets the unsafe room text for the given context.
  *
  * @param {Function} t - The translation function.
- * @param {'meeting'|'prejoin'|'welcome'} context - The given context of the warining.
+ * @param {'meeting'|'prejoin'|'welcome'} context - The given context of the warning.
  * @returns {string}
  */
 export default function getUnsafeRoomText(t: Function, context: 'meeting' | 'prejoin' | 'welcome') {

--- a/react/features/calendar-sync/components/CalendarList.native.tsx
+++ b/react/features/calendar-sync/components/CalendarList.native.tsx
@@ -18,7 +18,7 @@ import CalendarListContent from './CalendarListContent.native';
 import styles from './styles';
 
 /**
- * The tyoe of the React {@code Component} props of {@link CalendarList}.
+ * The type of the React {@code Component} props of {@link CalendarList}.
  */
 interface IProps extends WithTranslation {
 

--- a/react/features/calendar-sync/components/styles.ts
+++ b/react/features/calendar-sync/components/styles.ts
@@ -152,7 +152,7 @@ export default createStyleSheet({
     },
 
     /**
-     * The container for all the lines if the norification.
+     * The container for all the lines if the notification.
      */
     notificationTextContainer: {
         flexDirection: 'column',

--- a/react/features/conference/actions.native.ts
+++ b/react/features/conference/actions.native.ts
@@ -11,7 +11,7 @@ import { DISMISS_CALENDAR_NOTIFICATION } from './actionTypes';
  *
  * @param {JitsiParticipant} participant - The {@link JitsiParticipant}
  * instance which initiated the kick event.
- * @param {?Function} submit - The function to execute after submiting the dialog.
+ * @param {?Function} submit - The function to execute after submitting the dialog.
  * @returns {Function}
  */
 export function notifyKickedOut(participant: any, submit?: Function) {
@@ -38,7 +38,7 @@ export function notifyKickedOut(participant: any, submit?: Function) {
  * Notify that we've been kicked out of the conference.
  *
  * @param {string} reasonKey - The translation key for the reason why the conference failed.
- * @param {?Function} submit - The function to execute after submiting the dialog.
+ * @param {?Function} submit - The function to execute after submitting the dialog.
  * @returns {Function}
  */
 export function notifyConferenceFailed(reasonKey: string, submit?: Function) {

--- a/react/features/device-selection/components/AudioDevicesSelection.web.tsx
+++ b/react/features/device-selection/components/AudioDevicesSelection.web.tsx
@@ -99,7 +99,7 @@ interface IProps extends AbstractDialogTabProps, WithTranslation {
     iAmVisitor: boolean;
 
     /**
-     * Wether noise suppression is on or not.
+     * Whether noise suppression is on or not.
      */
     noiseSuppressionEnabled: boolean;
 

--- a/react/features/e2ee/actions.ts
+++ b/react/features/e2ee/actions.ts
@@ -50,7 +50,7 @@ export function setMediaEncryptionKey(keyInfo: Object) {
 }
 
 /**
- * Dispatches an action to start participant e2ee verficiation process.
+ * Dispatches an action to start participant e2ee verification process.
  *
  * @param {string} pId - The participant id.
  * @returns {{
@@ -69,7 +69,7 @@ export function startVerification(pId: string) {
  * Dispatches an action to set participant e2ee verification status.
  *
  * @param {string} pId - The participant id.
- * @param {boolean} isVerified - The verifcation status.
+ * @param {boolean} isVerified - The verification status.
  * @returns {{
  *     type: PARTICIPANT_VERIFIED,
  *     pId: string,

--- a/react/features/filmstrip/functions.any.ts
+++ b/react/features/filmstrip/functions.any.ts
@@ -57,7 +57,7 @@ export function updateRemoteParticipants(store: IStore, force?: boolean, partici
         remoteParticipants.delete(speaker);
     }
 
-    // Always update the order of the thumnails.
+    // Always update the order of the thubmnails.
     const participantsWithScreenShare = screenShareParticipants.reduce<string[]>((acc, screenshare) => {
         const ownerId = getVirtualScreenshareParticipantOwnerId(screenshare);
 

--- a/react/features/filmstrip/functions.native.ts
+++ b/react/features/filmstrip/functions.native.ts
@@ -254,7 +254,7 @@ export function getFilmstripDimensions({
 /**
  * Returns true if the local thumbnail should be displayed separately and false otherwise.
  *
- * @returns {boolean} - True if the local thumbnail should be displayed separately and flase otherwise.
+ * @returns {boolean} - True if the local thumbnail should be displayed separately and false otherwise.
  */
 export function shouldDisplayLocalThumbnailSeparately() {
     // XXX Our current design is to have the local participant separate from

--- a/react/features/filmstrip/functions.web.ts
+++ b/react/features/filmstrip/functions.web.ts
@@ -322,7 +322,7 @@ export function calculateResponsiveTileViewDimensions({
     for (let c = 1; c <= Math.min(maxColumns, numberOfParticipants, desiredNumberOfVisibleTiles); c++) {
         const r = Math.ceil(numberOfParticipants / c);
 
-        // we want to display as much as possible tumbnails up to desiredNumberOfVisibleTiles
+        // we want to display as much as possible thumbnails up to desiredNumberOfVisibleTiles
         const visibleRows
             = numberOfParticipants <= desiredNumberOfVisibleTiles ? r : Math.floor(desiredNumberOfVisibleTiles / c);
 

--- a/react/features/large-video/actions.any.ts
+++ b/react/features/large-video/actions.any.ts
@@ -84,7 +84,7 @@ export function updateKnownLargeVideoResolution(resolution: number) {
 }
 
 /**
- * Sets the dimenstions of the large video in redux.
+ * Sets the dimensions of the large video in redux.
  *
  * @param {number} height - The height of the large video.
  * @param {number} width - The width of the large video.

--- a/react/features/mobile/full-screen/functions.ts
+++ b/react/features/mobile/full-screen/functions.ts
@@ -9,7 +9,7 @@ import { isLocalVideoTrackDesktop } from '../../base/tracks/functions.any';
  * Checks whether full-screen state should be used or not.
  *
  * @param {IReduxState} state - The redux state.
- * @returns {boolean} - Whether full-screen state shuld be used or not.
+ * @returns {boolean} - Whether full-screen state should be used or not.
  */
 export function shouldUseFullScreen(state: IReduxState) {
     const { enabled: audioOnly } = state['features/base/audio-only'];

--- a/react/features/participants-pane/functions.ts
+++ b/react/features/participants-pane/functions.ts
@@ -286,7 +286,7 @@ export const isMuteAllVisible = (state: IReduxState) => {
  * Returns true if renaming the currently joined breakout room is allowed and false otherwise.
  *
  * @param {IReduxState} state - The redux state.
- * @returns {boolean} - True if reanming the currently joined breakout room is allowed and false otherwise.
+ * @returns {boolean} - True if renaming the currently joined breakout room is allowed and false otherwise.
  */
 export function isCurrentRoomRenamable(state: IReduxState) {
     return isInBreakoutRoom(state) && isBreakoutRoomRenameAllowed(state);

--- a/react/features/prejoin/components/native/Prejoin.tsx
+++ b/react/features/prejoin/components/native/Prejoin.tsx
@@ -117,7 +117,7 @@ const Prejoin: React.FC<IPrejoinProps> = ({ navigation }: IPrejoinProps) => {
 
         return () => BackHandler.removeEventListener('hardwareBackPress', goBack);
 
-    }, []); // dispatch is not in the dependancy list because we want the action to be dispatched only once when
+    }, []); // dispatch is not in the dependency list because we want the action to be dispatched only once when
     // the component is mounted.
 
     const headerLeft = () => {

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -216,11 +216,11 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         if (updatedSessionData?.status === ON) {
 
             // We receive 2 updates of the session status ON. The first one is from jibri when it joins.
-            // The second one is from jicofo which will deliever the initiator value. Since the start
+            // The second one is from jicofo which will deliver the initiator value. Since the start
             // recording notification uses the initiator value we skip the jibri update and show the
             // notification on the update from jicofo.
-            // FIXE: simplify checks when the backend start sending only one status ON update containing the
-            // initiator.
+            // FIXME: simplify checks when the backend start sending only one status ON update containing
+            // the initiator.
             if (initiator && !oldSessionData?.initiator) {
                 if (typeof recordingLimit === 'object') {
                     dispatch(showRecordingLimitNotification(mode));

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -113,7 +113,7 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
  * @param {Array} sessionDatas - The current sessions in the redux store.
  * @param {Object} newSessionData - The updated session data.
  * @private
- * @returns {Array} The session datas with the updated session data added.
+ * @returns {Array} The session data with the updated session data added.
  */
 function _updateSessionDatas(sessionDatas: ISessionData[], newSessionData: ISessionData) {
     const hasExistingSessionData = sessionDatas.find(
@@ -133,7 +133,7 @@ function _updateSessionDatas(sessionDatas: ISessionData[], newSessionData: ISess
         });
     } else {
         // If the session data is not present, then there is nothing to update
-        // and instead it needs to be added to the known session datas.
+        // and instead it needs to be added to the known session data.
         newSessionDatas = [
             ...sessionDatas,
             { ...newSessionData }

--- a/react/features/remote-control/actions.ts
+++ b/react/features/remote-control/actions.ts
@@ -107,7 +107,7 @@ export function requestRemoteControl(userId: string) {
 
         dispatch(setRemoteControlActive(true));
 
-        logger.log(`Requsting remote control permissions from: ${userId}`);
+        logger.log(`Requesting remote control permissions from: ${userId}`);
 
         const { conference } = state['features/base/conference'];
 

--- a/react/features/settings/components/web/MoreTab.tsx
+++ b/react/features/settings/components/web/MoreTab.tsx
@@ -79,7 +79,7 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     showPrejoinSettings: boolean;
 
     /**
-     * Wether or not the stage filmstrip is enabled.
+     * Whether or not the stage filmstrip is enabled.
      */
     stageFilmstripEnabled: boolean;
 }

--- a/react/features/settings/components/web/ShortcutsTab.tsx
+++ b/react/features/settings/components/web/ShortcutsTab.tsx
@@ -25,7 +25,7 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     displayShortcuts: boolean;
 
     /**
-     * Wether the keyboard shortcuts are enabled or not.
+     * Whether the keyboard shortcuts are enabled or not.
      */
     keyboardShortcutsEnabled: boolean;
 

--- a/react/features/toolbox/functions.web.ts
+++ b/react/features/toolbox/functions.web.ts
@@ -202,7 +202,7 @@ export function getVisibleButtons({
     setButtonsNotifyClickMode(allButtons, buttonsWithNotifyClick);
 
     const filteredButtons = Object.keys(allButtons).filter(key =>
-        typeof key !== 'undefined' // filter invalid buttons that may be comming from config.mainToolbarButtons
+        typeof key !== 'undefined' // filter invalid buttons that may be coming from config.mainToolbarButtons
         // override
         && !jwtDisabledButtons.includes(key)
         && isButtonEnabled(key, toolbarButtons));
@@ -264,7 +264,7 @@ interface ICSSTransitionObject {
  * @returns {ICSSTransitionObject}
  */
 export function getTransitionParamsForElementsAboveToolbox(isToolbarVisible: boolean): ICSSTransitionObject {
-    // The transistion time and delay is different to account for the time when the toolbar is about to hide/show but
+    // The transition time and delay is different to account for the time when the toolbar is about to hide/show but
     // the elements don't have to move.
     return isToolbarVisible ? {
         duration: 0.15,

--- a/react/features/toolbox/middleware.web.ts
+++ b/react/features/toolbox/middleware.web.ts
@@ -142,7 +142,7 @@ function _setFullScreen(next: Function, action: AnyAction) {
 /**
  * Common logic to gather buttons that have to notify the api when clicked.
  *
- * @param {Array} buttonsWithNotifyClick - The array of systme buttons that need to notify the api.
+ * @param {Array} buttonsWithNotifyClick - The array of system buttons that need to notify the api.
  * @param {Array} customButtons - The custom buttons.
  * @returns {Array}
  */

--- a/react/features/video-quality/actions.ts
+++ b/react/features/video-quality/actions.ts
@@ -29,7 +29,7 @@ export function setMaxReceiverVideoQualityForLargeVideo(maxReceiverVideoQuality:
 }
 
 /**
- * Sets the max frame height that should be received for the screen sharing filmstrip particpant.
+ * Sets the max frame height that should be received for the screen sharing filmstrip participant.
  *
  * @param {number} maxReceiverVideoQuality - The max video frame height to
  * receive.

--- a/react/features/video-quality/subscriber.ts
+++ b/react/features/video-quality/subscriber.ts
@@ -309,7 +309,7 @@ StateListenerRegistry.register(
     });
 
 /**
- * Returns the source names asociated with the given participants list.
+ * Returns the source names associated with the given participants list.
  *
  * @param {Array<string>} participantList - The list of participants.
  * @param {Object} state - The redux state.

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -80,7 +80,7 @@ function Util.new(module)
         These setups relay on configuration 'muc_domain_base' which holds
         the main domain and we use it to subtract subdomains from the
         virtual addresses.
-        The following confgurations are for multidomain setups and domain name
+        The following configurations are for multidomain setups and domain name
         verification:
      --]]
 
@@ -225,7 +225,7 @@ function Util:get_public_key(keyId)
             self.cache:set(keyId, content);
         else
             if code == nil then
-                -- this is timout after nr_retries retries
+                -- this is timeout after nr_retries retries
                 module:log('warn', 'Timeout retrieving %s from %s', keyId, keyurl);
             end
         end

--- a/tests/wdio.dev.conf.ts
+++ b/tests/wdio.dev.conf.ts
@@ -1,5 +1,5 @@
 // wdio.dev.conf.ts
-// extends te main configuration file for the development environment (make dev)
+// extends the main configuration file for the development environment (make dev)
 // it will connect to the webpack-dev-server running locally on port 8080
 import { deepmerge } from 'deepmerge-ts';
 

--- a/tests/wdio.firefox.conf.ts
+++ b/tests/wdio.firefox.conf.ts
@@ -1,5 +1,5 @@
 // wdio.firefox.conf.ts
-// extends te main configuration file changing first participant to be Firefox
+// extends the main configuration file changing first participant to be Firefox
 import { merge } from 'lodash-es';
 import process from 'node:process';
 

--- a/twa/app/build.gradle
+++ b/twa/app/build.gradle
@@ -114,7 +114,7 @@ android {
         // Trusted Web Activity.
         resValue "color", "backgroundColor", twaManifest.backgroundColor
 
-        // Defines a provider authority fot the Splash Screen
+        // Defines a provider authority for the Splash Screen
         resValue "string", "providerAuthority", twaManifest.applicationId + '.fileprovider'
 
         // The enableNotification resource is used to enable or disable the


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.svg,./lang" -L anser,bu,dialin,goup,miliseconds,nd,vew`

Note: there is one source typo fix