### PR TITLE
feat(rnnoise): update rnnoise-wasm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/v0.0.19/jitsi-excalidraw-0.0.19.tgz",
         "@jitsi/js-utils": "2.2.1",
         "@jitsi/logger": "2.0.2",
-        "@jitsi/rnnoise-wasm": "0.1.0",
+        "@jitsi/rnnoise-wasm": "0.2.0",
         "@jitsi/rtcstats": "9.5.1",
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
         "@microsoft/microsoft-graph-client": "3.0.1",
@@ -4182,9 +4182,9 @@
       "integrity": "sha512-L/gnRjnFxpQqvfILXeFoVTHEtwL01zoSKAIqMVxMmaD0ahozML8uztlxRPlYSbKrT31j3Cm1ss9KdSNeO3f9FQ=="
     },
     "node_modules/@jitsi/rnnoise-wasm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.1.0.tgz",
-      "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.2.0.tgz",
+      "integrity": "sha512-ZpNws6UjbNjkhD68DQu862IjzfjYgLOwknqdlLotPbJqnBTA91vo5uh9+D0aUqSoY/U1aQhPZZB3IRj5ZNfw3Q=="
     },
     "node_modules/@jitsi/rtcstats": {
       "version": "9.5.1",
@@ -27426,9 +27426,9 @@
       "integrity": "sha512-L/gnRjnFxpQqvfILXeFoVTHEtwL01zoSKAIqMVxMmaD0ahozML8uztlxRPlYSbKrT31j3Cm1ss9KdSNeO3f9FQ=="
     },
     "@jitsi/rnnoise-wasm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.1.0.tgz",
-      "integrity": "sha512-JujivPbOUvdRYa2xqByHYKfKGNGa7ZPyNLaNuh8hEp9XsiNfjaJAHdboq6M1VY9TP+765nyxC0LjpAw1VkikOQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.2.0.tgz",
+      "integrity": "sha512-ZpNws6UjbNjkhD68DQu862IjzfjYgLOwknqdlLotPbJqnBTA91vo5uh9+D0aUqSoY/U1aQhPZZB3IRj5ZNfw3Q=="
     },
     "@jitsi/rtcstats": {
       "version": "9.5.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/v0.0.19/jitsi-excalidraw-0.0.19.tgz",
     "@jitsi/js-utils": "2.2.1",
     "@jitsi/logger": "2.0.2",
-    "@jitsi/rnnoise-wasm": "0.1.0",
+    "@jitsi/rnnoise-wasm": "0.2.0",
     "@jitsi/rtcstats": "9.5.1",
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "@microsoft/microsoft-graph-client": "3.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -380,7 +380,7 @@ module.exports = (_env, argv) => {
             ] },
             plugins: [
             ],
-            performance: getPerformanceHints(perfHintOptions, 200 * 1024),
+            performance: getPerformanceHints(perfHintOptions, 1024 * 1024 * 2),
 
             output: {
                 ...config.output,


### PR DESCRIPTION
Updates the rnnoise-wasm version to use the newest release model.
Note,  @jitsi/rnnoise-wasm uses the newest model for actual noise suppression, however it still uses the old model for noise detection, and talk while muted detection as ljm heuristics need to be recalibrated. 
