### PR TITLE
fix(device-selection) hide framerate selection on mobile browsers

### DIFF
--- a/react/features/device-selection/components/VideoDeviceSelection.web.tsx
+++ b/react/features/device-selection/components/VideoDeviceSelection.web.tsx
@@ -46,6 +46,11 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     desktopShareFramerates: Array<number>;
 
     /**
+     * True if desktop share settings should be hidden (mobile browsers).
+     */
+    disableDesktopShareSettings: boolean;
+
+    /**
      * True if device changing is configured to be disallowed. Selectors
      * will display as disabled.
      */
@@ -208,6 +213,7 @@ class VideoDeviceSelection extends AbstractDialogTab<IProps, IState> {
      */
     render() {
         const {
+            disableDesktopShareSettings,
             disableLocalVideoFlip,
             hideAdditionalSettings,
             hideVideoInputPreview,
@@ -240,7 +246,7 @@ class VideoDeviceSelection extends AbstractDialogTab<IProps, IState> {
                                     onChange = { () => super._onChange({ localFlipX: !localFlipX }) } />
                             </div>
                         )}
-                        {this._renderFramerateSelect()}
+                        {!disableDesktopShareSettings && this._renderFramerateSelect()}
                     </>
                 )}
             </div>

--- a/react/features/device-selection/functions.web.ts
+++ b/react/features/device-selection/functions.web.ts
@@ -126,6 +126,7 @@ export function getVideoDeviceSelectionDialogProps(stateful: IStateful, isDispla
     return {
         currentFramerate: framerate,
         desktopShareFramerates: SS_SUPPORTED_FRAMERATES,
+        disableDesktopShareSettings: isMobileBrowser(),
         disableDeviceChange: !JitsiMeetJS.mediaDevices.isDeviceChangeAvailable(),
         disableVideoInputSelect,
         disableLocalVideoFlip,


### PR DESCRIPTION
Screen-sharing is not supported there.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
