### PR TITLE
fix(subtitles) fix skipping transcription messages

### DIFF
--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -196,7 +196,7 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
         // Regex to filter out all possible country codes after language code:
         // this should catch all notations like 'en-GB' 'en_GB' and 'enGB'
         // and be independent of the country code length
-        if (_getPrimaryLanguageCode(json.language) !== _getPrimaryLanguageCode(language)) {
+        if (!language || (_getPrimaryLanguageCode(json.language) !== _getPrimaryLanguageCode(language))) {
             return next(action);
         }
 


### PR DESCRIPTION
If we are not requesting any transcription, `language` will be `null` so take that into consideration when checking if we should stop processing a transcription message after firing the API event.

Fixes: https://github.com/jitsi/docker-jitsi-meet/issues/1997

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
