### PR TITLE
Removed info type

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -590,7 +590,7 @@ function initCommands() {
          * @param { string } arg.title - Notification title.
          * @param { string } arg.description - Notification description.
          * @param { string } arg.uid - Optional unique identifier for the notification.
-         * @param { string } arg.type - Notification type, either `error`, `info`, `normal`, `success` or `warning`.
+         * @param { string } arg.type - Notification type, either `error`, `normal`, `success` or `warning`.
          * Defaults to "normal" if not provided.
          * @param { string } arg.timeout - Timeout type, either `short`, `medium`, `long` or `sticky`.
          * Defaults to "short" if not provided.


### PR DESCRIPTION
There is no `info` type in `showNotificantion` IFrame API command.

https://github.com/jitsi/jitsi-meet/blob/9846228210d99122710a4a2144aba03478df5775/react/features/notifications/constants.ts#L26

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
