### PR TITLE
fix(share-video): Hide element when not shown on large.

### DIFF
--- a/react/features/shared-video/components/web/SharedVideo.tsx
+++ b/react/features/shared-video/components/web/SharedVideo.tsx
@@ -4,7 +4,9 @@ import { connect } from 'react-redux';
 // @ts-expect-error
 import Filmstrip from '../../../../../modules/UI/videolayout/Filmstrip';
 import { IReduxState } from '../../../app/types';
+import { FakeParticipant } from '../../../base/participants/types';
 import { getVerticalViewMaxWidth } from '../../../filmstrip/functions.web';
+import { getLargeVideoParticipant } from '../../../large-video/functions';
 import { getToolboxHeight } from '../../../toolbox/functions.web';
 import { isSharedVideoEnabled } from '../../functions';
 
@@ -39,9 +41,14 @@ interface IProps {
     isEnabled: boolean;
 
     /**
-     * Whether or not the user is actively resizing the filmstrip.
+     * Whether the user is actively resizing the filmstrip.
      */
     isResizing: boolean;
+
+    /**
+     * Whether the shared video should be shown on stage.
+     */
+    onStage: boolean;
 
     /**
      * The shared video url.
@@ -118,17 +125,23 @@ class SharedVideo extends Component<IProps> {
      * @returns {React$Element}
      */
     render() {
-        const { isEnabled, isResizing } = this.props;
+        const { isEnabled, isResizing, onStage } = this.props;
 
         if (!isEnabled) {
             return null;
+        }
+
+        const style: any = this.getDimensions();
+
+        if (!onStage) {
+            style.display = 'none';
         }
 
         return (
             <div
                 className = { (isResizing && 'disable-pointer') || '' }
                 id = 'sharedVideo'
-                style = { this.getDimensions() }>
+                style = { style }>
                 {this.getManager()}
             </div>
         );
@@ -147,6 +160,7 @@ function _mapStateToProps(state: IReduxState) {
     const { videoUrl } = state['features/shared-video'];
     const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
     const { visible, isResizing } = state['features/filmstrip'];
+    const onStage = getLargeVideoParticipant(state)?.fakeParticipant === FakeParticipant.SharedVideo;
 
     return {
         clientHeight,
@@ -155,6 +169,7 @@ function _mapStateToProps(state: IReduxState) {
         filmstripWidth: getVerticalViewMaxWidth(state),
         isEnabled: isSharedVideoEnabled(state),
         isResizing,
+        onStage,
         videoUrl
     };
 }

--- a/react/features/shared-video/components/web/SharedVideo.tsx
+++ b/react/features/shared-video/components/web/SharedVideo.tsx
@@ -8,7 +8,7 @@ import { FakeParticipant } from '../../../base/participants/types';
 import { getVerticalViewMaxWidth } from '../../../filmstrip/functions.web';
 import { getLargeVideoParticipant } from '../../../large-video/functions';
 import { getToolboxHeight } from '../../../toolbox/functions.web';
-import { isSharedVideoEnabled } from '../../functions';
+import { isSharedVideoEnabled, isVideoPlaying } from '../../functions';
 
 import VideoManager from './VideoManager';
 import YoutubeVideoManager from './YoutubeVideoManager';
@@ -44,6 +44,11 @@ interface IProps {
      * Whether the user is actively resizing the filmstrip.
      */
     isResizing: boolean;
+
+    /**
+     * Whether the shared video is currently playing.
+     */
+    isVideoShared: boolean;
 
     /**
      * Whether the shared video should be shown on stage.
@@ -125,9 +130,9 @@ class SharedVideo extends Component<IProps> {
      * @returns {React$Element}
      */
     render() {
-        const { isEnabled, isResizing, onStage } = this.props;
+        const { isEnabled, isResizing, isVideoShared, onStage } = this.props;
 
-        if (!isEnabled) {
+        if (!isEnabled || !isVideoShared) {
             return null;
         }
 
@@ -161,6 +166,7 @@ function _mapStateToProps(state: IReduxState) {
     const { clientHeight, clientWidth } = state['features/base/responsive-ui'];
     const { visible, isResizing } = state['features/filmstrip'];
     const onStage = getLargeVideoParticipant(state)?.fakeParticipant === FakeParticipant.SharedVideo;
+    const isVideoShared = isVideoPlaying(state);
 
     return {
         clientHeight,
@@ -169,6 +175,7 @@ function _mapStateToProps(state: IReduxState) {
         filmstripWidth: getVerticalViewMaxWidth(state),
         isEnabled: isSharedVideoEnabled(state),
         isResizing,
+        isVideoShared,
         onStage,
         videoUrl
     };

--- a/react/features/shared-video/functions.ts
+++ b/react/features/shared-video/functions.ts
@@ -112,16 +112,6 @@ export function isSharedVideoEnabled(stateful: IStateful) {
 }
 
 /**
- * Checks if you youtube URLs should be allowed for shared videos.
- *
- * @param {Array<string>} allowedUrlDomains - The allowed URL domains for shared video.
- * @returns {boolean}
- */
-export function areYoutubeURLsAllowedForSharedVideo(allowedUrlDomains?: Array<string>) {
-    return Boolean(allowedUrlDomains?.includes(YOUTUBE_URL_DOMAIN));
-}
-
-/**
  * Returns true if the passed url is allowed to be used for shared video or not.
  *
  * @param {string} url - The URL.


### PR DESCRIPTION
Fixes two issues:
- disabling mouse for all large video types, including local shared desktop and prevents clicking link to show content
- as z-index is on top of everything does not allow local shared video to be shared when thumbnail is clicked

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
