### PR TITLE
fix(lobby): Fixes wrong password going back to knocking.

### DIFF
--- a/react/features/lobby/reducer.ts
+++ b/react/features/lobby/reducer.ts
@@ -58,12 +58,14 @@ ReducerRegistry.register<ILobbyState>('features/lobby', (state = DEFAULT_STATE, 
                 ...state,
                 isDisplayNameRequiredError: true
             };
+        } else if (action.error.name === JitsiConferenceErrors.CONFERENCE_ACCESS_DENIED) {
+            return {
+                ...state,
+                knocking: false
+            };
         }
 
-        return {
-            ...state,
-            knocking: false
-        };
+        return state;
     }
     case CONFERENCE_JOINED:
     case CONFERENCE_LEFT:


### PR DESCRIPTION
Fixes the case when someone enters a wrong password to access the meeting and then clicks back to continue knocking and not showing the knocking state, while still in the Lobby room. The problem was introduced in 721bb4e, on access denied we are being kicked out of lobby room and then knocking state should be cleared.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
