### PR TITLE
fix(virtual-backgrounds) fix handling empty file list

### DIFF
--- a/react/features/virtual-background/components/UploadImageButton.tsx
+++ b/react/features/virtual-background/components/UploadImageButton.tsx
@@ -91,7 +91,7 @@ function UploadImageButton({
     const uploadImage = useCallback(async e => {
         const imageFile = e.target.files;
 
-        if (!imageFile) {
+        if (imageFile.length === 0) {
             return;
         }
 


### PR DESCRIPTION
The returned object is not an array but array-like. That is, it checks truthy, while having a length of 0.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
