### PR TITLE
Make the English header more idiomatic

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1541,7 +1541,7 @@
         "getHelp": "Get help",
         "go": "GO",
         "goSmall": "GO",
-        "headerSubtitle": "Secure and high quality meetings",
+        "headerSubtitle": "Secure high quality meetings",
         "headerTitle": "Jitsi Meet",
         "info": "Dial-in info",
         "jitsiOnMobile": "Jitsi on mobile – download our apps and start a meeting from anywhere",


### PR DESCRIPTION
Unless the "and" is there for a good reason, removing it will make the text more idiomatic to people who master English.