### PR TITLE
feat(external_api) facilitate gDM Electron

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -172,7 +172,9 @@ let room;
 
 /*
  * Logic to open a desktop picker put on the window global for
- * lib-jitsi-meet to detect and invoke
+ * lib-jitsi-meet to detect and invoke.
+ *
+ * TODO: remove once the Electron SDK supporting gDM has been out for a while.
  */
 window.JitsiMeetScreenObtainer = {
     openDesktopPicker(options, onSourceChoose) {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -75,6 +75,7 @@ import {
     toggleChat
 } from '../../react/features/chat/actions';
 import { openChat } from '../../react/features/chat/actions.web';
+import { showDesktopPicker } from '../../react/features/desktop-picker/actions';
 import {
     processExternalDeviceRequest
 } from '../../react/features/device-selection/functions';
@@ -1048,6 +1049,23 @@ function initCommands() {
         }
         case '_new_electron_screensharing_supported': {
             callback(true);
+
+            break;
+        }
+        case 'open-desktop-picker': {
+            const { desktopSharingSources } = APP.store.getState()['features/base/config'];
+            const options = {
+                desktopSharingSources: desktopSharingSources ?? [ 'screen', 'window' ]
+            };
+            const onSourceChoose = (_streamId, _type, screenShareAudio, source) => {
+                callback({
+                    screenShareAudio,
+                    source
+                });
+            };
+
+            dispatch(showDesktopPicker(options, onSourceChoose));
+
             break;
         }
         default:

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1243,7 +1243,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {Promise}
      *
      * TODO: should be removed after we make sure that all Electron clients use only versions
-     * after with the legacy SS suport was removed from the electron SDK. If we remove it now the SS for Electron
+     * after with the legacy SS support was removed from the electron SDK. If we remove it now the SS for Electron
      * clients with older versions wont work.
      */
     _isNewElectronScreensharingSupported() {
@@ -1454,5 +1454,16 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     */
     setVirtualBackground(enabled, backgroundImage) {
         this.executeCommand('setVirtualBackground', enabled, backgroundImage);
+    }
+
+    /**
+     * Opens the desktop picker. This is invoked by the Electron SDK when gDM is used.
+     *
+     * @returns {Promise}
+     */
+    _openDesktopPicker() {
+        return this._transport.sendRequest({
+            name: 'open-desktop-picker'
+        });
     }
 }

--- a/react/features/base/tracks/actions.web.ts
+++ b/react/features/base/tracks/actions.web.ts
@@ -159,7 +159,7 @@ async function _toggleScreenSharing(
             } catch (error) {
                 dispatch(handleScreenSharingError(error));
 
-                throw error;
+                return;
             }
         }
 
@@ -173,7 +173,7 @@ async function _toggleScreenSharing(
             if (!desktopAudioTrack) {
                 dispatch(handleScreenSharingError(AUDIO_ONLY_SCREEN_SHARE_NO_TRACK));
 
-                throw new Error(AUDIO_ONLY_SCREEN_SHARE_NO_TRACK);
+                return;
             }
         } else if (desktopVideoTrack) {
             if (localScreenshare) {

--- a/react/features/desktop-picker/components/DesktopPicker.tsx
+++ b/react/features/desktop-picker/components/DesktopPicker.tsx
@@ -270,7 +270,14 @@ class DesktopPicker extends PureComponent<IProps, IState> {
      * @returns {void}
      */
     _onCloseModal(id = '', type?: string, screenShareAudio = false) {
-        this.props.onSourceChoose(id, type, screenShareAudio);
+        // Find the entire source object from the id. We need the name in order
+        // to get getDisplayMedia working in Electron.
+        const { sources } = this.state;
+
+        // @ts-ignore
+        const source = sources.screen.concat(sources.window).find(s => s.id === id);
+
+        this.props.onSourceChoose(id, type, screenShareAudio, source);
         this.props.dispatch(hideDialog());
     }
 


### PR DESCRIPTION
In order to use gDM in Electron the flow is somewhat reversed. It starts from the Electron main process, so we need an API in the external_api that can trigger the builtin picker. The picker is still necessary.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
