### PR TITLE
fix(prejoin): do not show conference info in prejoin or lobby

### DIFF
--- a/react/features/conference/components/web/Conference.tsx
+++ b/react/features/conference/components/web/Conference.tsx
@@ -229,7 +229,7 @@ class Conference extends AbstractConference<IProps, any> {
                     className = { _layoutClassName }
                     id = 'videoconference_page'
                     onMouseMove = { isMobileBrowser() ? undefined : this._onShowToolbar }>
-                    <ConferenceInfo />
+                    { _showPrejoin || _showLobby || <ConferenceInfo /> }
                     <Notice />
                     <div
                         id = 'videospace'

--- a/react/features/conference/components/web/Conference.tsx
+++ b/react/features/conference/components/web/Conference.tsx
@@ -151,7 +151,7 @@ class Conference extends AbstractConference<IProps, any> {
 
         // Bind event handler so it is only bound once for every instance.
         this._onFullScreenChange = this._onFullScreenChange.bind(this);
-        this._onVidespaceTouchStart = this._onVidespaceTouchStart.bind(this);
+        this._onVideospaceTouchStart = this._onVideospaceTouchStart.bind(this);
         this._setBackground = this._setBackground.bind(this);
     }
 
@@ -233,7 +233,7 @@ class Conference extends AbstractConference<IProps, any> {
                     <Notice />
                     <div
                         id = 'videospace'
-                        onTouchStart = { this._onVidespaceTouchStart }>
+                        onTouchStart = { this._onVideospaceTouchStart }>
                         <LargeVideo />
                         {
                             _showPrejoin || _showLobby || (<>
@@ -310,7 +310,7 @@ class Conference extends AbstractConference<IProps, any> {
      * @private
      * @returns {void}
      */
-    _onVidespaceTouchStart() {
+    _onVideospaceTouchStart() {
         this.props.dispatch(toggleToolboxVisible());
     }
 


### PR DESCRIPTION
When navigating via keyboard (tab key) the empty conference info is focus able and will be focused before getting to the name input.

The creation of the component is disabled if the prejoin or lobby screen is active, so navigation can jump right to the name field. 

This is related to [WCAG Success Criterion 2.4.7 Focus Visible](https://www.w3.org/TR/WCAG22/#focus-visible).