### PR TITLE
feat(react-native): Add support for `defaultLanguage` option in config

### DIFF
--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -80,6 +80,7 @@ export default [
     'customToolbarButtons',
     'deeplinking.disabled',
     'deeplinking.desktop.enabled',
+    'defaultLanguage',
     'defaultLocalDisplayName',
     'defaultRemoteDisplayName',
     'desktopSharingFrameRate',


### PR DESCRIPTION
I don't know why, but this option was not allowed (even though all its functionality is already implemented inside). As a result, when trying to install it, it was ignored.