### PR TITLE
help button in the settings menu is hidden `help.enabled` is set to false.

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -254,8 +254,8 @@ var interfaceConfig = {
     // Allow all above example options to include a trailing comma and
     // prevent fear when commenting out the last value.
     // eslint-disable-next-line sort-keys
-    makeJsonParserHappy: 'even if last key had a trailing comma'
-
+    makeJsonParserHappy: 'even if last key had a trailing comma',
+    DISABLE_HELP_BUTTON: true,
     // No configuration value should follow this line.
 };
 

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { getFeatureFlag } from '../../../base/flags/functions';
 
+
 import { IReduxState, IStore } from '../../../app/types';
 import {
     IconBell,
@@ -324,14 +325,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
             icon: IconGear
         });
     }
-    if (helpEnabled) { 
-        tabs.push({
-            name: SETTINGS_TABS.HELP,
-            component: MoreTab,
-            labelKey: 'settings.help',
-            icon: IconGear
-        });
-    }
+
 
     return { _tabs: tabs };
 }

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
+import { getFeatureFlag } from '../../../base/flags/functions';
 
 import { IReduxState, IStore } from '../../../app/types';
 import {
@@ -142,6 +143,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
     const showNotificationsSettings = Object.keys(enabledNotifications).length > 0;
     const virtualBackgroundSupported = checkBlurSupport();
     const enableVirtualBackground = checkVirtualBackgroundEnabled(state);
+    const helpEnabled = getFeatureFlag(state, 'help.enabled', true);
     const tabs: IDialogTab<any>[] = [];
     const _iAmVisitor = iAmVisitor(state);
 
@@ -319,6 +321,14 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
                 };
             },
             submit: submitMoreTab,
+            icon: IconGear
+        });
+    }
+    if (helpEnabled) { 
+        tabs.push({
+            name: SETTINGS_TABS.HELP,
+            component: MoreTab,
+            labelKey: 'settings.help',
             icon: IconGear
         });
     }

--- a/react/features/settings/constants.ts
+++ b/react/features/settings/constants.ts
@@ -2,12 +2,13 @@ export const SETTINGS_TABS = {
     AUDIO: 'audio_tab',
     CALENDAR: 'calendar_tab',
     MORE: 'more_tab',
-    MODERATOR: 'moderator-tab',
+     MODERATOR: 'moderator-tab',
     NOTIFICATIONS: 'notifications_tab',
     PROFILE: 'profile_tab',
     SHORTCUTS: 'shortcuts_tab',
     VIDEO: 'video_tab',
-    VIRTUAL_BACKGROUND: 'virtual-background_tab'
+    VIRTUAL_BACKGROUND: 'virtual-background_tab',
+    HELP: 'help'
 };
 
 /**


### PR DESCRIPTION
Fixes #15455 

This PR ensures that the Help button in the settings menu is hidden when the feature flag `help.enabled` is set to false.

- Added Help tab in `SettingsDialog.js` inside a feature flag check

- Added `HELP` to `SETTINGS_TABS` in `constants.js` to prevent TypeScript errors.

**Testing:**

- Make`.setFeatureFlag("help.enabled", false)`.

- check the Help button is removed from the settings screen.
