### PR TITLE
fix: Fixes wrong state in password dialog.

### DIFF
--- a/react/features/room-lock/components/PasswordRequiredPrompt.web.tsx
+++ b/react/features/room-lock/components/PasswordRequiredPrompt.web.tsx
@@ -149,7 +149,7 @@ class PasswordRequiredPrompt extends Component<IProps, IState> {
 
         // We have used the password so let's clean it.
         this.setState({
-            password: undefined
+            password: ''
         });
 
         return true;


### PR DESCRIPTION
Fixes the following: Warning: A component is changing a controlled input to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components

Detected due to failure while moving locked room test.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
