### PR TITLE
refactor: replace deprecated .substr() with .substring()

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -160,7 +160,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
      */
     _animateRoomNameChanging(word: string) {
         let animateTimeoutId;
-        const roomPlaceholder = this.state.roomPlaceholder + word.substr(0, 1);
+        const roomPlaceholder = this.state.roomPlaceholder + word.substring(0, 1);
 
         if (word.length > 1) {
             animateTimeoutId


### PR DESCRIPTION
The .substr() method has been replaced with .substring() as .substr() is deprecated.  

Reference: [Mozilla Developer Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr)

This update ensures better compatibility with modern web standards and prevents potential issues in future browser updates.