### PR TITLE
Feature : Add config to disable camera tint foreground

### DIFF
--- a/config.js
+++ b/config.js
@@ -1857,6 +1857,9 @@ var config = {
 
     // Hide login button on auth dialog, you may want to enable this if you are using JWT tokens to authenticate users
     // hideLoginButton: true,
+
+    // If true remove the tint foreground on focused user camera in filmstrip
+    // disableCameraTintForeground: false,
 };
 
 // Set the default values for JaaS customers

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -292,6 +292,7 @@ export interface IConfig {
     disableAddingBackgroundImages?: boolean;
     disableAudioLevels?: boolean;
     disableBeforeUnloadHandlers?: boolean;
+    disableCameraTintForeground?: boolean;
     disableChatSmileys?: boolean;
     disableDeepLinking?: boolean;
     disableFilmstripAutohiding?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -91,6 +91,7 @@ export default [
     'disableAddingBackgroundImages',
     'disableAudioLevels',
     'disableBeforeUnloadHandlers',
+    'disableCameraTintForeground',
     'disableChatSmileys',
     'disableDeepLinking',
     'disabledNotifications',

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -1363,6 +1363,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any): Object {
 
         // skip showing tint for owner participants that are screensharing.
         && !screenshareParticipantIds.includes(id);
+    const disableTintForeground = state['features/base/config'].disableCameraTintForeground ?? false;
 
     return {
         _audioTrack,
@@ -1384,7 +1385,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any): Object {
         _raisedHand: hasRaisedHand(participant),
         _stageFilmstripLayout: isStageFilmstripAvailable(state),
         _stageParticipantsVisible: _currentLayout === LAYOUTS.STAGE_FILMSTRIP_VIEW,
-        _shouldDisplayTintBackground: shouldDisplayTintBackground,
+        _shouldDisplayTintBackground: !disableTintForeground && shouldDisplayTintBackground,
         _thumbnailType: tileType,
         _videoObjectPosition: getVideoObjectPosition(state, participant?.id),
         _videoTrack,


### PR DESCRIPTION
Add a new parameter in config.js to disable camera tint foreground of focused user

Linked to https://github.com/jitsi/jitsi-meet/issues/15513
Handbook PR : https://github.com/jitsi/handbook/pull/559/files

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
