### PR TITLE
Fixed The setSubtitles command of IFrame API

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -492,6 +492,10 @@ function initCommands() {
         },
         'set-subtitles': (enabled, displaySubtitles, language) => {
             APP.store.dispatch(setRequestingSubtitles(enabled, displaySubtitles, language));
+        
+            if (enabled) {
+                APP.store.dispatch({ type: 'START_TRANSCRIPTION', language });
+            }
         },
         'toggle-tile-view': () => {
             sendAnalytics(createApiEvent('tile-view.toggled'));

--- a/react/features/subtitles/actions.any.ts
+++ b/react/features/subtitles/actions.any.ts
@@ -52,6 +52,13 @@ export function removeCachedTranscriptMessage(transcriptMessageID: string) {
  *      newTranscriptMessage: Object
  * }}
  */
+export function startTranscription(language: string) {
+    return {
+        type: 'START_TRANSCRIPTION',
+        language
+    };
+}
+
 export function updateTranscriptMessage(transcriptMessageID: string,
         newTranscriptMessage: Object) {
     return {
@@ -91,10 +98,12 @@ export function setRequestingSubtitles(
         enabled: boolean,
         displaySubtitles = true,
         language: string | null = `translation-languages:${DEFAULT_LANGUAGE}`) {
-    return {
+    return (dispatch, getState) => {
+        dispatch({
         type: SET_REQUESTING_SUBTITLES,
         displaySubtitles,
         enabled,
         language
-    };
-}
+    });
+
+}}

--- a/react/features/transcribing/actions.ts
+++ b/react/features/transcribing/actions.ts
@@ -15,7 +15,7 @@ import {
 export function transcriberJoined(participantId: string) {
     return {
         type: TRANSCRIBER_JOINED,
-        transcriberJID: participantId
+        transcriberJID: participantId,
     };
 }
 

--- a/react/features/transcribing/middleware.ts
+++ b/react/features/transcribing/middleware.ts
@@ -2,9 +2,9 @@ import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { showErrorNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 
-import { TRANSCRIBER_LEFT } from './actionTypes';
+import { TRANSCRIBER_LEFT, TRANSCRIBER_JOINED } from './actionTypes';
+import { startTranscription } from '../subtitles/actions.any';;
 import './subscriber';
-
 /**
  * Implements the middleware of the feature transcribing.
  *
@@ -12,7 +12,16 @@ import './subscriber';
  * @returns {Function}
  */
 MiddlewareRegistry.register(({ dispatch }) => next => action => {
-    switch (action.type) {
+    switch (action.type) {  case TRANSCRIBER_JOINED: {
+        const { transcriberJID, language } = action;
+
+        if (language) {
+            
+            dispatch(startTranscription(language));
+        }
+
+        break;
+    }
     case TRANSCRIBER_LEFT:
         if (action.abruptly) {
             dispatch(showErrorNotification({

--- a/react/features/transcribing/reducer.ts
+++ b/react/features/transcribing/reducer.ts
@@ -36,6 +36,7 @@ function _getInitialState() {
 export interface ITranscribingState {
     isTranscribing: boolean;
     transcriberJID?: string | null;
+    language?: string | null;
 }
 
 /**
@@ -48,13 +49,15 @@ ReducerRegistry.register<ITranscribingState>('features/transcribing',
             return {
                 ...state,
                 isTranscribing: true,
-                transcriberJID: action.transcriberJID
+                transcriberJID: action.transcriberJID,
+                language: action.language || state.language
             };
         case TRANSCRIBER_LEFT:
             return {
                 ...state,
                 isTranscribing: false,
-                transcriberJID: undefined
+                transcriberJID: undefined,
+                language: null
             };
         default:
             return state;


### PR DESCRIPTION
Fixes #15614 

Added a new action startTranscription(language) in **actions.any.ts** which is dispatched when subtitles are enabled.

now subtitles automatically trigger transcription.

changes made in **middleware.ts**

Transcription now starts when a transcriber joins the meeting.

in **reducer.ts**

the language remained even after the transcriber left.
Now, we reset the language when transcription stops.

tested this command (api.executeCommand('setSubtitles', true, true, 'ru');

The transcription started automatically 
The language was correctly applied