### PR TITLE
fix(iframeAPI): Fix setSubtitles command language param.

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -492,7 +492,8 @@ function initCommands() {
             APP.store.dispatch(toggleRequestingSubtitles());
         },
         'set-subtitles': (enabled, displaySubtitles, language) => {
-            APP.store.dispatch(setRequestingSubtitles(enabled, displaySubtitles, language));
+            APP.store.dispatch(setRequestingSubtitles(
+                enabled, displaySubtitles, language ? `translation-languages:${language}` : null));
         },
         'toggle-tile-view': () => {
             sendAnalytics(createApiEvent('tile-view.toggled'));


### PR DESCRIPTION
setRequestingSubtitles requires the last parameter in certain format.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
