### PR TITLE
Updated Jitsi Meet README – Added Ubuntu/Debian installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,37 @@ Advanced users also have the possibility of building all the components from sou
 
 You can check the latest releases [here](https://jitsi.github.io/handbook/docs/releases).
 
+## Detailed Installation Guide for specific systems
+
+Jitsi Meet supports multiple deployment methods. For Users with Ubuntu/Debian, below is a step by step installation guide with specific commands. These instructions should provide a clear description of the process to help 
+
+## Ubuntu/Debian Installation
+## to install Ubuntu/Debian, follow the steps below
+
+```sh
+sudo apt update && sudo apt upgrade
+sudo apt install -y gnupg2 wget
+wget -qO - https://download.jitsi.org/jitsi-key.gpg.key | sudo tee /usr/share/keyrings/jitsi-keyring.asc > /dev/null
+echo 'deb [signed-by=/usr/share/keyrings/jitsi-keyring.asc] https://download.jitsi.org stable/' | sudo tee /etc/apt/sources.list.d/jitsi-stable.list
+sudo apt update
+sudo apt install -y jitsi-meet
+
+### After you have completed the installation setup, follow these steps:
+### To enable "Let's Encrypt SSL Certificates", run:
+
+sudo /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh
+
+### configuring your firewall:
+
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw allow 10000/udp
+sudo ufw reload
+
+## References
+## https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart
+## https://github.com/jitsi/jitsi-meet
+
 ## Jitsi as a Service
 
 If you like the branding capabilities of running your own instance but you'd like


### PR DESCRIPTION
The goal of this pull request is to improve the README.md section of Jitsi Meet.

This pull request enhances the "## Running your own instance" section of the README.md file in Jitsi Meet. By adding detailed installation steps for Ubuntu/Debian, new users will be able to quickly start the setup process without looking through complex files. Providing specific firewall configuration commands will enable new users for better setup security. Additionally, this update includes post-installation SSL setup instructions to enhance encryption and security.

The current documentation only somewhat mentions installation but is missing step by step instructions. Many users, especially new users, struggle with setting up Jitsi Meet due to missing or incomplete details in the README. This will help readability, usability, and troubleshooting for users trying to self-host. 

References
- [Jitsi Handbook](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart)
- [Jitsi GitHub Repo](https://github.com/jitsi/jitsi-meet)

