### PR TITLE
fix(logging): Keeps the log storage ready when there is conference er…

### DIFF
--- a/react/features/base/logging/JitsiMeetLogStorage.ts
+++ b/react/features/base/logging/JitsiMeetLogStorage.ts
@@ -39,9 +39,10 @@ export default class JitsiMeetLogStorage {
      * <tt>false</tt> otherwise.
      */
     isReady() {
-        const { conference } = this.getState()['features/base/conference'];
+        const { conference, error: conferenceError } = this.getState()['features/base/conference'];
+        const { error: connectionError } = this.getState()['features/base/connection'];
 
-        return Boolean(conference);
+        return Boolean(conference || conferenceError || connectionError);
     }
 
     /**

--- a/react/features/base/logging/middleware.ts
+++ b/react/features/base/logging/middleware.ts
@@ -4,7 +4,7 @@ import { AnyAction } from 'redux';
 
 import { IStore } from '../../app/types';
 import { APP_WILL_MOUNT } from '../app/actionTypes';
-import { CONFERENCE_JOINED } from '../conference/actionTypes';
+import { CONFERENCE_FAILED, CONFERENCE_JOINED } from '../conference/actionTypes';
 import { getCurrentConference } from '../conference/functions';
 import { SET_CONFIG } from '../config/actionTypes';
 import JitsiMeetJS, {
@@ -34,6 +34,15 @@ MiddlewareRegistry.register(store => next => action => {
 
     case CONFERENCE_JOINED:
         return _conferenceJoined(store, next, action);
+
+    case CONFERENCE_FAILED: {
+        const result = next(action);
+        const { logCollector } = store.getState()['features/base/logging'];
+
+        logCollector?.flush();
+
+        return result;
+    }
 
     case LIB_WILL_INIT:
         return _libWillInit(store, next, action);


### PR DESCRIPTION
…ror.

LogCollector stops saving logs the moment we leave the room, although we take care to stop statistics from ljm and throw events so we can flush the logs.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
