### PR TITLE
feat(jwt): Support JWKS endpoint and improve JWT aud claim handling

### DIFF
--- a/resources/prosody-plugins/luajwtjitsi.lib.lua
+++ b/resources/prosody-plugins/luajwtjitsi.lib.lua
@@ -122,6 +122,27 @@ local function verify_claim(claim, acceptedClaims)
   return false;
 end
 
+-- Verifies 'aud' claim (supports string or array)
+-- Checks if claim contains atleast one matching allowed claim. Catch all wildcard '*' is supported.
+-- @param claim The claim to be verified.
+-- @param acceptedClaims A table of accepted claims.
+-- @return True if the claim is allowed, false otherwise.
+local function verify_aud_claim(claim, acceptedClaims)
+	if type(claim) == "string" then
+		return verify_claim(claim, acceptedClaims)
+	elseif type(claim) == "table" then
+		for _, value in ipairs(claim) do
+			if verify_claim(value, acceptedClaims) then
+				return true
+			end
+		end
+
+		return false
+	end
+
+	return false -- Invalid type
+end
+
 local M = {}
 
 -- Encodes the data into a signed JWT token.
@@ -252,7 +273,7 @@ function M.verify(token, expectedAlgo, key, acceptedIssuers, acceptedAudiences)
 		if audClaim == nil then
         return nil, "'aud' claim is missing";
     end
-    if not verify_claim(audClaim, acceptedAudiences) then
+    if not verify_aud_claim(audClaim, acceptedAudiences) then
         return nil, "invalid 'aud' claim";
     end
 	end

--- a/resources/prosody-plugins/token/util.lib.lua
+++ b/resources/prosody-plugins/token/util.lib.lua
@@ -19,6 +19,7 @@ local cjson_safe  = require 'cjson.safe'
 local timer = require "util.timer";
 local async = require "util.async";
 local inspect = require 'inspect';
+local pkey = require "openssl.pkey"
 
 local nr_retries = 3;
 local ssl = require "ssl";
@@ -145,14 +146,46 @@ function Util.new(module)
             content, code, cache_for = http_get_with_retry(self.cacheKeysUrl, nr_retries);
             if content ~= nil then
                 local keys_to_delete = table_shallow_copy(self.cachedKeys);
-                -- Let's convert any certificate to public key
-                for k, v in pairs(cjson_safe.decode(content)) do
-                    if starts_with(v, '-----BEGIN CERTIFICATE-----') then
+                local decoded_content = cjson_safe.decode(content);
+
+                -- Process the decoded content
+                for k, v in pairs(decoded_content) do
+                    -- JWKS format
+                    if k == "keys" and type(v) == "table" then
+                        for _, key in ipairs(v) do
+                            if key.kid then
+                                local _pubkey
+                                -- Handle x5c (X.509 certificate chain)
+                                if key.x5c and key.x5c[1] then
+                                    local cert = "-----BEGIN CERTIFICATE-----\n" ..
+                                            key.x5c[1] ..
+                                            "\n-----END CERTIFICATE-----";
+                                    _pubkey = ssl.loadcertificate(cert):pubkey();
+                                -- Handle n, e (RSA public key components)
+                                elseif key.n and key.e and key.kty == "RSA" then
+                                    -- Create public key using OpenSSL's pkey
+                                    local rsa_params = {
+                                        n = basexx.from_base64(key.n:gsub("-", "+"):gsub("_", "/")),
+                                        e = basexx.from_base64(key.e:gsub("-", "+"):gsub("_", "/"))
+                                    }
+                                    _pubkey = pkey.new(rsa_params);
+                                end
+                                if _pubkey then
+                                    self.cachedKeys[key.kid] = _pubkey;
+                                    -- do not clean this key if it already exists
+                                    keys_to_delete[key.kid] = nil;
+                                end
+                            end
+                        end
+                    -- direct PEM mapping (Firebase)
+                    elseif starts_with(v, '-----BEGIN CERTIFICATE-----') then
+                        -- Let's convert any certificate to public key
                         self.cachedKeys[k] = ssl.loadcertificate(v):pubkey();
                         -- do not clean this key if it already exists
                         keys_to_delete[k] = nil;
                     end
                 end
+
                 -- let's schedule the clean in an hour and a half, current tokens will be valid for an hour
                 timer.add_task(90*60, function ()
                     for k, _ in pairs(keys_to_delete) do


### PR DESCRIPTION
This PR addresses issue #15182  by adding support for JWKS (JSON Web Key Set) endpoints and improving the handling of JWT aud claims. The changes include:

**Support for JWKS Endpoint:**
- Added functionality to fetch and process public keys in JWKS format (RFC 7517 section 5).
- Keys are now cached and managed dynamically, allowing for automatic key rotation and expiration.
- Certificates in JWKS format are converted to public keys for JWT verification.

**JWT aud Claim Handling Improvement:**
- Enhanced the verify_aud_claim function to support both string and array-based aud claims.
- Maintain support for wildcard (*) matching in aud claims.

These changes `maintain backward compatibility` with existing key cache endpoints and 'aud' claim handling, while enhancing standards compatibility. These changes enable Jitsi Meet to work seamlessly with identity providers that use JWKS for key distribution and improve compliance with OIDC standards.

Changes have been manually tested on Jitsi Debian Setup.