### PR TITLE
fixed the ui of E2EE when OLM fails

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,10 @@ window.$ = window.jQuery = $;
 import '@matrix-org/olm';
 
 import 'focus-visible';
+import { toggleE2EE } from './react/features/e2ee/actions';  
+import { Store } from 'redux';
+
+
 
 // We need to setup the jitsi-local-storage as early as possible so that we can start using it.
 // NOTE: If jitsi-local-storage is used before the initial setup is performed this will break the use case when we use
@@ -22,10 +26,12 @@ import translation from './modules/translation/translation';
 
 // Initialize Olm as early as possible.
 if (window.Olm) {
-    window.Olm.init().catch(e => {
-        console.error('Failed to initialize Olm, E2EE will be disabled', e);
-        delete window.Olm;
-    });
+  window.Olm.init().catch(e => {
+    console.error('Failed to initialize Olm, E2EE will be disabled', e);
+    delete window.Olm;
+    // Use toggleE2EE(false) to disable E2EE
+    store.dispatch(toggleE2EE(false)); 
+  });
 }
 
 window.APP = {
@@ -42,3 +48,5 @@ window.APP = {
 // the execution of the Web app to start from app.js in order to reduce the
 // complexity of the beginning step.
 import './react';
+
+

--- a/lang/main.json
+++ b/lang/main.json
@@ -504,7 +504,9 @@
         "title": "Shared Document"
     },
     "e2ee": {
-        "labelToolTip": "Audio and Video Communication on this call is end-to-end encrypted"
+        "labelToolTip": "Audio and Video Communication on this call is end-to-end encrypted",
+        "errorTitle": "Encryption Error",
+        "olmMissing": "Encryption requires Olm support. Update your browser!"
     },
     "embedMeeting": {
         "title": "Embed this meeting"

--- a/react/features/e2ee/components/E2EELabel.tsx
+++ b/react/features/e2ee/components/E2EELabel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
@@ -24,18 +24,25 @@ export interface IProps extends WithTranslation {
 
 
 const E2EELabel = ({ _e2eeLabels, _showLabel, t }: IProps) => {
-    if (!_showLabel) {
-        return null;
+    const [olmAvailable, setOlmAvailable] = useState(Boolean(window.Olm)); 
+
+    useEffect(() => {
+        const checkOlm = () => setOlmAvailable(Boolean(window.Olm)); 
+
+        const interval = setInterval(checkOlm, 1000); 
+
+        return () => clearInterval(interval); 
+    }, []);
+
+    if (!_showLabel || !olmAvailable) { 
+        return null; 
     }
+
     const content = _e2eeLabels?.tooltip || t('e2ee.labelToolTip');
 
     return (
-        <Tooltip
-            content = { content }
-            position = { 'bottom' }>
-            <Label
-                color = { COLORS.green }
-                icon = { IconE2EE } />
+        <Tooltip content={content} position="bottom">
+            <Label color={COLORS.green} icon={IconE2EE} />
         </Tooltip>
     );
 };

--- a/react/features/e2ee/components/E2EESection.tsx
+++ b/react/features/e2ee/components/E2EESection.tsx
@@ -10,6 +10,7 @@ import Switch from '../../base/ui/components/web/Switch';
 import { toggleE2EE } from '../actions';
 import { MAX_MODE } from '../constants';
 import { doesEveryoneSupportE2EE } from '../functions';
+import { showErrorNotification } from '../../notifications/actions';
 
 interface IProps {
 
@@ -100,7 +101,14 @@ const E2EESection = ({
      */
     const _onToggle = useCallback(() => {
         const newValue = !toggled;
-
+        if (newValue && !window.Olm) {
+            dispatch(showErrorNotification({
+              titleKey: 'e2ee.errorTitle',
+              descriptionKey: 'e2ee.olmMissing'
+            }));
+            return;
+          }
+        
         setToggled(newValue);
 
         sendAnalytics(createE2EEEvent(`enabled.${String(newValue)}`));
@@ -172,3 +180,4 @@ function mapStateToProps(state: IReduxState) {
 }
 
 export default connect(mapStateToProps)(E2EESection);
+


### PR DESCRIPTION
Fixes #15655 

PR fixes two issues related to End-to-End Encryption 

Case 1: Missing User Notification When Olm Initialization Fails

Previously, when Olm failed to initialize, the error was only logged to the console, and users were not notified.
Fix:
Added a notification when Olm fails to initialize, informing users that E2EE will be disabled.
Automatically disables the E2EE toggle if Olm is missing.

https://github.com/user-attachments/assets/3758c181-928b-4753-b2d2-52076e591477


Case 2: Lock Icon Persists After Olm is Removed

When E2EE was enabled and Olm was removed during a meeting, the lock icon remained visible, misleading users into thinking encryption was still active.
Fix:
Automatically removes the lock icon if Olm is missing.
Disables the E2EE toggle when Olm is unavailable.


https://github.com/user-attachments/assets/ec2a0975-2f7f-4bc4-811e-b9a7ce8adde7


**app.js**

Modified the Olm initialization logic to show an error notification when it fails.

 **E2EELabel.tsx**

Updated logic to remove the lock icon when Olm is missing.

below is the issue i am trying to fix 


https://github.com/user-attachments/assets/920f45aa-3fb1-4531-b7ca-78ef2fc0c3a5



