### PR TITLE
fix(chat): restructure chat messages

### DIFF
--- a/react/features/base/react/components/web/Message.tsx
+++ b/react/features/base/react/components/web/Message.tsx
@@ -16,6 +16,11 @@ interface IProps {
     gifEnabled: boolean;
 
     /**
+     * Message decoration for screen reader.
+     */
+    screenReaderHelpText?: string;
+
+    /**
      * The body of the message.
      */
     text: string;
@@ -91,10 +96,18 @@ class Message extends Component<IProps> {
      * @returns {ReactElement}
      */
     render() {
+        const { screenReaderHelpText } = this.props;
+
         return (
-            <>
+            <p>
+                { screenReaderHelpText && (
+                    <span className = 'sr-only'>
+                        {screenReaderHelpText}
+                    </span>
+                ) }
+
                 { this._processMessage() }
-            </>
+            </p>
         );
     }
 }

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -254,7 +254,9 @@ const ChatMessage = ({
     function _renderTimestamp() {
         return (
             <div className = { cx('timestamp', classes.timestamp) }>
-                {getFormattedTimestamp(message)}
+                <p>
+                    {getFormattedTimestamp(message)}
+                </p>
             </div>
         );
     }
@@ -285,15 +287,17 @@ const ChatMessage = ({
                     <div
                         className = { classes.reactionItem }
                         key = { reaction }>
-                        <span>{reaction}</span>
-                        <span>{participants.size}</span>
+                        <p>
+                            <span>{reaction}</span>
+                            <span>{participants.size}</span>
+                        </p>
                         <div className = { classes.participantList }>
                             {Array.from(participants).map(participantId => (
-                                <div
+                                <p
                                     className = { classes.participant }
                                     key = { participantId }>
                                     {state && getParticipantDisplayName(state, participantId)}
-                                </div>
+                                </p>
                             ))}
                         </div>
                     </div>
@@ -311,12 +315,12 @@ const ChatMessage = ({
                 visible = { isReactionsOpen }>
                 <div className = { classes.reactionBox }>
                     {reactionsArray.slice(0, numReactionsDisplayed).map(({ reaction }, index) =>
-                        <span key = { index }>{reaction}</span>
+                        <p key = { index }>{reaction}</p>
                     )}
                     {reactionsArray.length > numReactionsDisplayed && (
-                        <span className = { classes.reactionCount }>
+                        <p className = { classes.reactionCount }>
                             +{totalReactions - numReactionsDisplayed}
-                        </span>
+                        </p>
                     )}
                 </div>
             </Popover>
@@ -352,14 +356,13 @@ const ChatMessage = ({
                         <div className = { cx('messagecontent', classes.messageContent) }>
                             {showDisplayName && _renderDisplayName()}
                             <div className = { cx('usermessage', classes.userMessage) }>
-                                <span className = 'sr-only'>
-                                    {message.displayName === message.recipient
-                                        ? t('chat.messageAccessibleTitleMe')
-                                        : t('chat.messageAccessibleTitle', {
+                                <Message
+                                    screenReaderHelpText = { message.displayName === message.recipient
+                                        ? t<string>('chat.messageAccessibleTitleMe')
+                                        : t<string>('chat.messageAccessibleTitle', {
                                             user: message.displayName
-                                        })}
-                                </span>
-                                <Message text = { getMessageText(message) } />
+                                        }) }
+                                    text = { getMessageText(message) } />
                                 {(message.privateMessage || (message.lobbyChat && !knocking))
                                     && _renderPrivateNotice()}
                                 <div className = { classes.chatMessageFooter }>


### PR DESCRIPTION
When using a screen reader the chat is not easily perceivable.

This is related to [WCAG Success Criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).

- Move screen reader helper text in the message to link it  to the message
- Messages in paragraphs
- Reactions in paragraphs