### PR TITLE
feat(conference/native): hide LonelyMeetingExperience button

### DIFF
--- a/react/features/conference/components/native/LonelyMeetingExperience.tsx
+++ b/react/features/conference/components/native/LonelyMeetingExperience.tsx
@@ -82,6 +82,7 @@ class LonelyMeetingExperience extends PureComponent<IProps> {
     render() {
         const {
             _inviteOthersControl,
+            _isAddPeopleFeatureEnabled,
             _isInBreakoutRoom,
             _isInviteFunctionsDisabled,
             _isLonelyMeeting,
@@ -89,7 +90,7 @@ class LonelyMeetingExperience extends PureComponent<IProps> {
         } = this.props;
         const { color, shareDialogVisible } = _inviteOthersControl;
 
-        if (!_isLonelyMeeting) {
+        if (!_isLonelyMeeting || !_isAddPeopleFeatureEnabled) {
             return null;
         }
 


### PR DESCRIPTION
Hiding this button if add people feature flag is disabled or if there are > 1 participants in the meeting