### PR TITLE
fix(mute-modal): restructure mute modal

### DIFF
--- a/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
@@ -28,7 +28,9 @@ class MuteEveryoneDialog extends AbstractMuteEveryoneDialog<IProps> {
                 onSubmit = { this._onSubmit }
                 title = { this.props.title }>
                 <div className = 'mute-dialog'>
-                    {this.state.content}
+                    <p>
+                        {this.state.content}
+                    </p>
                     {
                         this.props.isModerationSupported
                         && this.props.exclude.length === 0


### PR DESCRIPTION
When using a screen reader the mute all modal is not easily perceivable.

This is related to [WCAG Success Criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).

- use a paragraph for the text

Like mentioned in my previous PRs, the usage of raw `<div>`s or `<span>`s is discouraged for assistive technologies.

This should be the final PR concerning paragraph elements :smile: 