### PR TITLE
External api expose shared document url

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1050,6 +1050,11 @@ function initCommands() {
             callback(getRoomsInfo(APP.store.getState()));
             break;
         }
+        case 'get-shared-document-url': {
+            const { etherpad } = APP.store.getState()["features/etherpad"];
+            callback(etherpad?.documentUrl || '');
+            break;
+        }
         case 'get-p2p-status': {
             callback(isP2pActive(APP.store.getState()));
             break;

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1051,7 +1051,8 @@ function initCommands() {
             break;
         }
         case 'get-shared-document-url': {
-            const { etherpad } = APP.store.getState()["features/etherpad"];
+            const { etherpad } = APP.store.getState()['features/etherpad'];
+
             callback(etherpad?.documentUrl || '');
             break;
         }

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -683,6 +683,17 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns the Shared Document Url of the conference.
+     *
+     * @returns {Object} Rooms info.
+     */
+    async getSharedDocumentUrl() {
+        return this._transport.sendRequest({
+            name: 'get-shared-document-url'
+        });
+    }
+
+    /**
      * Returns whether the conference is P2P.
      *
      * @returns {Promise}


### PR DESCRIPTION
As there is a Jicofo option to use a random name in the Jitsi embedded Etherpad, it could be nice to be able to get it from the iframe API.
So, I propose to add a getSharedDocumentUrl function in the external API to get it.
Regards