### PR TITLE
feat(tests): Fixes the checks when to use token.

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -619,8 +619,8 @@ export class Participant {
         await this.driver.waitUntil(
             async () => current !== await this.driver.getUrl(),
             {
-                timeout: 5000,
-                timeoutMsg: `${this.name} did not leave the muc in 5s`
+                timeout: 8000,
+                timeoutMsg: `${this.name} did not leave the muc in 8s`
             }
         );
 

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -234,7 +234,7 @@ export class Participant {
 
         let urlToLoad = url.startsWith('/') ? url.substring(1) : url;
 
-        if (options.forceGenerateToken && !ctx.iframeAPI && ctx.isJaasAvailable() && process.env.IFRAME_TENANT) {
+        if (options.preferGenerateToken && !ctx.iframeAPI && ctx.isJaasAvailable() && process.env.IFRAME_TENANT) {
             // This to enables tests like invite, which can force using the jaas auth instead of the provided token
             urlToLoad = `/${process.env.IFRAME_TENANT}/${urlToLoad}`;
         }

--- a/tests/helpers/participants.ts
+++ b/tests/helpers/participants.ts
@@ -169,7 +169,8 @@ async function joinTheModeratorAsP1(ctx: IContext, options?: IJoinOptions) {
         // we prioritize the access token when iframe is not used and private key is set,
         // otherwise if private key is not specified we use the access token if set
         if (process.env.JWT_ACCESS_TOKEN
-            && (ctx.jwtPrivateKeyPath && !ctx.iframeAPI && !options?.forceGenerateToken)) {
+            && ((ctx.jwtPrivateKeyPath && !ctx.iframeAPI && !options?.preferGenerateToken)
+                || !ctx.jwtPrivateKeyPath)) {
             token = process.env.JWT_ACCESS_TOKEN;
         } else if (ctx.jwtPrivateKeyPath) {
             token = getModeratorToken(p1DisplayName);

--- a/tests/helpers/participants.ts
+++ b/tests/helpers/participants.ts
@@ -168,8 +168,8 @@ async function joinTheModeratorAsP1(ctx: IContext, options?: IJoinOptions) {
     if (!options?.skipFirstModerator) {
         // we prioritize the access token when iframe is not used and private key is set,
         // otherwise if private key is not specified we use the access token if set
-        if (process.env.JWT_ACCESS_TOKEN && (!ctx.jwtPrivateKeyPath || !ctx.iframeAPI
-            || !options?.forceGenerateToken)) {
+        if (process.env.JWT_ACCESS_TOKEN
+            && (ctx.jwtPrivateKeyPath && !ctx.iframeAPI && !options?.forceGenerateToken)) {
             token = process.env.JWT_ACCESS_TOKEN;
         } else if (ctx.jwtPrivateKeyPath) {
             token = getModeratorToken(p1DisplayName);

--- a/tests/helpers/types.ts
+++ b/tests/helpers/types.ts
@@ -38,7 +38,7 @@ export type IJoinOptions = {
      * When joining the first participant and jwt singing material is available and a provided token
      * is available, prefer generating a new token for the first participant.
      */
-    forceGenerateToken?: boolean;
+    preferGenerateToken?: boolean;
 
     /**
      * Whether to skip setting display name.

--- a/tests/specs/alone/invite.spec.ts
+++ b/tests/specs/alone/invite.spec.ts
@@ -2,7 +2,7 @@ import { ensureOneParticipant } from '../../helpers/participants';
 import { isDialInEnabled } from '../helpers/DialIn';
 
 describe('Invite', () => {
-    it('join participant', () => ensureOneParticipant(ctx, { forceGenerateToken: true }));
+    it('join participant', () => ensureOneParticipant(ctx, { preferGenerateToken: true }));
 
     it('url displayed', async () => {
         const { p1 } = ctx;


### PR DESCRIPTION
We have few options:
- iframeAPI tests generating tokens via jwtPrivateKeyPath
- tests that just use provided JWT_ACCESS_TOKEN for the first participant to avoid deployments where initial authentication is required
- tests that does not use iframeAPI, but want to use the jwtPrivateKeyPath for a meeting (invite test as JWT_ACCESS_TOKEN does not satisfy some services)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
