### PR TITLE
fix : Resolved issue #15693 - Added delete Icon in the meeting card

### DIFF
--- a/css/_meetings_list.scss
+++ b/css/_meetings_list.scss
@@ -152,7 +152,7 @@
     }
 
     .delete-meeting {
-        display: none;
+        display: block;
         margin-right: 16px;
         position: absolute;
 


### PR DESCRIPTION
Resolved issue #15698 :- No delete Icon in the meeting card in small screens. 

Basically, previously delete icon appears only when we hover on listed meeting which is not ideal for small devices.
So I have make it appears for small screens visible.

**Old View**

![old_image](https://github.com/user-attachments/assets/ee79ff2a-f467-4fa9-89f4-8bf070404ce1)

**New/Updated View**

<img width="950" alt="new_image" src="https://github.com/user-attachments/assets/b56e498a-56d0-42c8-b91a-a5de1e5afd3e" />

