### PR TITLE
Add ToolTip to the chat message display name and enclose the content in span element instead of div element.

### DIFF
--- a/react/features/base/avatar/functions.ts
+++ b/react/features/base/avatar/functions.ts
@@ -66,7 +66,7 @@ export function getInitials(s?: string) {
     const initialsBasis = split(s, '@')[0];
     const [ firstWord, ...remainingWords ] = initialsBasis.split(wordSplitRegex).filter(Boolean);
 
-    return getFirstGraphemeUpper(firstWord) + getFirstGraphemeUpper(remainingWords.pop() || "");
+    return getFirstGraphemeUpper(firstWord) + getFirstGraphemeUpper(remainingWords.pop() || '');
 }
 
 /**

--- a/react/features/base/avatar/functions.ts
+++ b/react/features/base/avatar/functions.ts
@@ -64,9 +64,9 @@ function getFirstGraphemeUpper(word: string) {
 export function getInitials(s?: string) {
     // We don't want to use the domain part of an email address, if it is one
     const initialsBasis = split(s, '@')[0];
-    const [ firstWord, secondWord ] = initialsBasis.split(wordSplitRegex).filter(Boolean);
+    const [ firstWord, ...remainingWords ] = initialsBasis.split(wordSplitRegex).filter(Boolean);
 
-    return getFirstGraphemeUpper(firstWord) + getFirstGraphemeUpper(secondWord);
+    return getFirstGraphemeUpper(firstWord) + getFirstGraphemeUpper(remainingWords.pop() || "");
 }
 
 /**


### PR DESCRIPTION
This PR adds the Tooltip to the chat message displayName when text is elided, previously the element was wrapped in a div element which is a bad option as the eliding css was added to the div, this PR also encloses the displayName in a span and adds the tooltip.

**After:**
https://github.com/user-attachments/assets/c499ceba-b01e-40a9-bbcc-079501ce1be6

<!--


Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
