### PR TITLE
chore(typos): Fix various typos

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
@@ -122,7 +122,7 @@ public class JitsiMeetActivityDelegate {
                 // There seems to be a problem in RN when resuming an Activity when
                 // rotation is involved and the planets align. There doesn't seem to
                 // be a proper solution, but since the activity is going away anyway,
-                // we'll YOLO-ignore the exception and hope fo the best.
+                // we'll YOLO-ignore the exception and hope for the best.
                 // Ref: https://github.com/facebook/react-native/search?q=Pausing+an+activity+that+is+not+the+current+activity%2C+this+is+incorrect%21&type=issues
                 JitsiMeetLogger.e(e, "Error running onHostPause, ignoring");
             }

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfo.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfo.java
@@ -29,7 +29,7 @@ import java.net.UnknownHostException;
  */
 public class NAT64AddrInfo {
     /**
-     * Coverts bytes array to upper case HEX string.
+     * Converts bytes array to upper case HEX string.
      *
      * @param bytes an array of bytes to be converted
      * @return ex. "010AFF" for an array of {1, 10, 255}.

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfoModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/net/NAT64AddrInfoModule.java
@@ -40,7 +40,7 @@ public class NAT64AddrInfoModule
     public final static String NAME = "NAT64AddrInfo";
 
     /**
-     * The host for which the module wil try to resolve both IPv4 and IPv6
+     * The host for which the module will try to resolve both IPv4 and IPv6
      * addresses in order to figure out the NAT64 prefix.
      */
     private final static String HOST = "ipv4only.arpa";

--- a/config.js
+++ b/config.js
@@ -1593,13 +1593,13 @@ var config = {
     // The default type of desktop sharing sources that will be used in the electron app.
     // desktopSharingSources: ['screen', 'window'],
 
-    // Disables the echo cancelation for local audio tracks.
+    // Disables the echo cancellation for local audio tracks.
     // disableAEC: true,
 
     // Disables the auto gain control for local audio tracks.
     // disableAGC: true,
 
-    // Disables the audio processing (echo cancelation, auto gain control and noise suppression) for local audio tracks.
+    // Disables the audio processing (echo cancellation, auto gain control and noise suppression) for local audio tracks.
     // disableAP: true,
 
     // Disables the anoise suppression for local audio tracks.

--- a/config.js
+++ b/config.js
@@ -1599,7 +1599,7 @@ var config = {
     // Disables the auto gain control for local audio tracks.
     // disableAGC: true,
 
-    // Disables the audio processing (echo cancellation, auto gain control and noise suppression) for local audio tracks.
+    // Disables the audio processing (echo cancellation, auto gain control + noise suppression) for local audio tracks.
     // disableAP: true,
 
     // Disables the anoise suppression for local audio tracks.

--- a/react-native-sdk/README.md
+++ b/react-native-sdk/README.md
@@ -16,7 +16,7 @@ node node_modules/@jitsi/react-native-sdk/update_dependencies.js
 This will check and update all your dependencies.<br/><br/>
 After that you need to ```npm i```, if some dependency versions were updated.
 
- [comment]: # (These deps definitely need to be added manually, more could be neccesary)
+ [comment]: # (These deps definitely need to be added manually, more could be necessary)
 
 Because of SVG use in react native, you need to update metro.config your project's file:
 
@@ -56,7 +56,7 @@ module.exports = (async () => {
 - Add a *Privacy - Microphone Usage Description*
 
 #### General
-- Signing & capabilites:
+- Signing & capabilities:
     - Add Background modes
         - Audio
         - Voice over IP

--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -328,7 +328,7 @@ export function setConfigFromURLParams(
 
     overrideConfigJSON(config, interfaceConfig, json);
 
-    // Print warning about depricated URL params
+    // Print warning about deprecated URL params
     if ('interfaceConfig.SUPPORT_URL' in params) {
         logger.warn('Using SUPPORT_URL interfaceConfig URL overwrite is deprecated.'
             + ' Please use supportUrl from advanced branding!');

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -130,7 +130,7 @@ export class Participant {
         try {
             return await this.driver.execute(script, ...args);
         } catch (error) {
-            console.error('An error occured while trying to execute a script: ', error);
+            console.error('An error occurred while trying to execute a script: ', error);
             throw error;
         }
     }
@@ -398,7 +398,7 @@ export class Participant {
      * Waits for send and receive data.
      *
      * @param {Object} options
-     * @param {boolean} options.checkSend - If true we will chec
+     * @param {boolean} options.checkSend - If true we will check
      * @returns {Promise<void>}
      */
     waitForSendReceiveData({

--- a/tests/pageobjects/ParticipantsPane.ts
+++ b/tests/pageobjects/ParticipantsPane.ts
@@ -98,7 +98,7 @@ export default class ParticipantsPane extends BasePageObject {
     }
 
     /**
-     * Trys to click allow video button.
+     * Tries to click allow video button.
      * @param participantToUnmute
      */
     async allowVideo(participantToUnmute: Participant) {
@@ -119,7 +119,7 @@ export default class ParticipantsPane extends BasePageObject {
     }
 
     /**
-     * Trys to click ask to unmute button.
+     * Tries to click ask to unmute button.
      * @param participantToUnmute
      * @param fromContextMenu
      */

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -166,7 +166,7 @@ export const config: WebdriverIO.MultiremoteConfig = {
     /**
      * Gets executed before test execution begins. At this point you can access to all global
      * variables like `browser`. It is the perfect place to define custom commands.
-     * We have overriden this function in beforeSession to be able to pass cid as first param.
+     * We have overridden this function in beforeSession to be able to pass cid as first param.
      *
      * @returns {Promise<void>}
      */

--- a/tests/wdio.firefox.conf.ts
+++ b/tests/wdio.firefox.conf.ts
@@ -28,7 +28,7 @@ const ffExcludes = [
     'specs/4way/desktopSharing.spec.ts',
     'specs/4way/lastN.spec.ts',
 
-    // when unmuting a participant, we see the presence in debug logs imidiately,
+    // when unmuting a participant, we see the presence in debug logs immediately,
     // but for 15 seconds it is not received/processed by the client
     // (also menu disappears after clicking one of the moderation option, does not happen manually)
     'specs/3way/audioVideoModeration.spec.ts'


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.svg,./lang" -L anser,bu,dialin,goup,miliseconds,nd,re-use,re-used,thirdparty,vew`
