### PR TITLE
fix(test): VP9 is enabled in Firefox 136.

### DIFF
--- a/tests/specs/3way/codecSelection.spec.ts
+++ b/tests/specs/3way/codecSelection.spec.ts
@@ -30,7 +30,9 @@ describe('Codec selection', () => {
 
         // Check if p1 is sending VP9 and p2 is sending VP8 as per their codec preferences.
         // Except on Firefox because it doesn't support VP9 encode.
-        if (p1.driver.isFirefox) {
+        const majorVersion = parseInt(p1.driver.capabilities.browserVersion || '0', 10);
+
+        if (p1.driver.isFirefox && majorVersion < 136) {
             expect(await p1.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp8())).toBe(true);
         } else {
             expect(await p1.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp9())).toBe(true);
@@ -54,7 +56,9 @@ describe('Codec selection', () => {
 
         // Check if p1 is encoding in VP9, p2 in VP8 and p3 in AV1 as per their codec preferences.
         // Except on Firefox because it doesn't support AV1/VP9 encode and AV1 decode.
-        if (p1.driver.isFirefox) {
+        const majorVersion = parseInt(p1.driver.capabilities.browserVersion || '0', 10);
+
+        if (p1.driver.isFirefox && majorVersion < 136) {
             expect(await p1.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp8())).toBe(true);
         } else {
             expect(await p1.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp9())).toBe(true);
@@ -63,7 +67,7 @@ describe('Codec selection', () => {
         expect(await p2.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp8())).toBe(true);
 
         // If there is a Firefox ep in the call, all other eps will switch to VP9.
-        if (p1.driver.isFirefox) {
+        if (p1.driver.isFirefox && majorVersion < 136) {
             expect(await p3.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingVp9())).toBe(true);
         } else {
             expect(await p3.execute(() => JitsiMeetJS.app.testing.isLocalCameraEncodingAv1())).toBe(true);
@@ -83,7 +87,9 @@ describe('Codec selection', () => {
         const { p1, p2 } = ctx;
 
         // Disable this test on Firefox because it doesn't support VP9 encode.
-        if (p1.driver.isFirefox) {
+        const majorVersion = parseInt(p1.driver.capabilities.browserVersion || '0', 10);
+
+        if (p1.driver.isFirefox && majorVersion < 136) {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
