### PR TITLE
fix(android,ios) set native view background matching JS

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -33,10 +33,9 @@ import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 public class JitsiMeetView extends FrameLayout {
 
     /**
-     * Background color used by {@code BaseReactView} and the React Native root
-     * view.
+     * Background color. Should match the background color set in JS.
      */
-    private static final int BACKGROUND_COLOR = 0xFF111111;
+    private static final int BACKGROUND_COLOR = 0xFF040404;
 
     /**
      * React Native root view.

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -17,6 +17,8 @@
 
 #include <mach/mach_time.h>
 
+#import <UIKit/UIKit.h>
+
 #import "ExternalAPI.h"
 #import "JitsiMeet+Private.h"
 #import "JitsiMeetConferenceOptions+Private.h"
@@ -24,6 +26,33 @@
 #import "ReactUtils.h"
 #import "RNRootView.h"
 
+
+#pragma mark UIColor helpers
+
+@interface UIColor (Hex)
+
++ (UIColor *)colorWithHex:(uint32_t)hex;
++ (UIColor *)colorWithHex:(uint32_t)hex alpha:(CGFloat)alpha;
+
+@end
+
+@implementation UIColor (Hex)
+
++ (UIColor *)colorWithHex:(uint32_t)hex {
+    return [self colorWithHex:hex alpha:1.0];
+}
+
++ (UIColor *)colorWithHex:(uint32_t)hex alpha:(CGFloat)alpha {
+    CGFloat red   = ((hex >> 16) & 0xFF) / 255.0;
+    CGFloat green = ((hex >> 8) & 0xFF) / 255.0;
+    CGFloat blue  = (hex & 0xFF) / 255.0;
+
+    return [UIColor colorWithRed:red green:green blue:blue alpha:alpha];
+}
+
+@end
+
+#pragma mark UIColor helpers end
 
 /**
  * Backwards compatibility: turn the boolean prop into a feature flag.
@@ -70,11 +99,8 @@ static NSString *recordingModeToString(RecordingMode mode);
  * - registers necessary observers
  */
 - (void)doInitialize {
-    // Set a background color which is in accord with the JavaScript and Android
-    // parts of the application and causes less perceived visual flicker than
-    // the default background color.
-    self.backgroundColor
-        = [UIColor colorWithRed:.07f green:.07f blue:.07f alpha:1];
+    // Set a background color which matches the one used in JS.
+    self.backgroundColor = [UIColor colorWithHex:0x040404 alpha:1];
     
     [self registerObservers];
 }

--- a/react/features/base/ui/Tokens.ts
+++ b/react/features/base/ui/Tokens.ts
@@ -49,7 +49,9 @@ export const colors = {
 export const colorMap = {
     // ----- Surfaces -----
 
-    // Default page background
+    // Default page background. If this changes, make sure to adapt the native side as well:
+    //  - JitsiMeetView.m
+    //  - JitsiMeetView.java
     uiBackground: 'surface01',
 
     // Container backgrounds


### PR DESCRIPTION
Avoids a "flicker" effect when the SDK is launched and assets are being loaded.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
