### PR TITLE
feat(participants-pane): hide invite based on add people feature

### DIFF
--- a/react/features/participants-pane/components/native/MeetingParticipantList.tsx
+++ b/react/features/participants-pane/components/native/MeetingParticipantList.tsx
@@ -77,7 +77,8 @@ const MeetingParticipantList = () => {
                 { title }
             </Text>
             {
-                showInviteButton
+                isAddPeopleFeatureEnabled
+                && showInviteButton
                 && <Button
                     accessibilityLabel = 'participantsPane.actions.invite'
                     disabled = { shareDialogVisible }

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -7,7 +7,11 @@ import { IReduxState } from '../../../app/types';
 import { rejectParticipantAudio, rejectParticipantVideo } from '../../../av-moderation/actions';
 import participantsPaneTheme from '../../../base/components/themes/participantsPaneTheme.json';
 import { MEDIA_TYPE } from '../../../base/media/constants';
-import { getParticipantById, isScreenShareParticipant } from '../../../base/participants/functions';
+import {
+    addPeopleFeatureControl,
+    getParticipantById,
+    isScreenShareParticipant
+} from '../../../base/participants/functions';
 import { withPixelLineHeight } from '../../../base/styles/functions.web';
 import Input from '../../../base/ui/components/web/Input';
 import useContextMenu from '../../../base/ui/hooks/useContextMenu.web';
@@ -16,7 +20,7 @@ import { getBreakoutRooms, getCurrentRoomId, isInBreakoutRoom } from '../../../b
 import { isButtonEnabled, showOverflowDrawer } from '../../../toolbox/functions.web';
 import { muteRemote } from '../../../video-menu/actions.web';
 import { getSortedParticipantIds, isCurrentRoomRenamable, shouldRenderInviteButton } from '../../functions';
-import { useParticipantDrawer } from '../../hooks';
+import { useParticipantDrawer } from '../../hooks.web';
 import RenameButton from '../breakout-rooms/components/web/RenameButton';
 
 import { InviteButton } from './InviteButton';
@@ -181,9 +185,12 @@ function _mapStateToProps(state: IReduxState) {
 
         return !isScreenShareParticipant(participant);
     });
-
+    const isAddPeopleFeatureEnabled = addPeopleFeatureControl(state);
     const participantsCount = sortedParticipantIds.length;
-    const showInviteButton = shouldRenderInviteButton(state) && isButtonEnabled('invite', state);
+    const showInviteButton
+        = isAddPeopleFeatureEnabled
+        && shouldRenderInviteButton(state)
+        && isButtonEnabled('invite', state);
     const overflowDrawer = showOverflowDrawer(state);
     const currentRoomId = getCurrentRoomId(state);
     const currentRoom = getBreakoutRooms(state)[currentRoomId];


### PR DESCRIPTION
If add people feature is disabled we shouldn't have the button available for participants to invite other people.
