### PR TITLE
changes video permission text for non-moderators 

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -358,7 +358,7 @@
         "micTimeoutError": "Could not start audio source. Timeout occurred!",
         "micUnknownError": "Cannot use microphone for an unknown reason.",
         "moderationAudioLabel": "Allow attendees to unmute themselves",
-        "moderationVideoLabel": "Allow attendees to start their video",
+        "moderationVideoLabel": "Allow non-moderators to start their video",
         "muteEveryoneDialog": "The participants can unmute themselves at any time.",
         "muteEveryoneDialogModerationOn": "The participants can send a request to speak at any time.",
         "muteEveryoneElseDialog": "Once muted, you won't be able to unmute them, but they can unmute themselves at any time.",


### PR DESCRIPTION

changed the text 

**allow attendees to start their video** ---> **allow non-moderators to start their video** 

![Screenshot 2025-03-12 232744](https://github.com/user-attachments/assets/4ba63033-cbdf-4e04-9e10-17d7f69a9c99)

this fix was proposed by @Calinteodor in pr #15764 
