### PR TITLE
fix(test) use filmstrip to audio mute in av moderation

### DIFF
--- a/tests/specs/3way/audioVideoModeration.spec.ts
+++ b/tests/specs/3way/audioVideoModeration.spec.ts
@@ -173,7 +173,7 @@ describe('AVModeration', () => {
         await unmuteByModerator(p1, p2, true, false);
 
         // p1 mute audio on p2 and check
-        await p1.getParticipantsPane().muteAudio(p2);
+        await p1.getFilmstrip().muteAudio(p2);
         await p1.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
         await p2.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
 
@@ -213,7 +213,7 @@ describe('AVModeration', () => {
         await unmuteByModerator(p1, p2, false, false);
 
         // mute and check
-        await p1.getParticipantsPane().muteAudio(p2);
+        await p1.getFilmstrip().muteAudio(p2);
         await p1.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
         await p2.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
 


### PR DESCRIPTION
Avoids a race in the participants pane.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
