### PR TITLE
fix(chat): accessive smiley panel

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -162,6 +162,7 @@
     transition: max-height 0.3s;
 
     #smileysContainer {
+        padding-left: 0;
         background-color: $chatBackgroundColor;
         border-top: 1px solid #A4B8D1;
     }

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -127,6 +127,7 @@
         "noMessagesMessage": "Es gibt noch keine Nachricht in dieser Konferenz. Starten Sie hier eine Unterhaltung!",
         "privateNotice": "Private Nachricht an {{recipient}}",
         "sendButton": "Senden",
+        "smileySymbol": "Emojis",
         "smileysPanel": "Emoji-Auswahl",
         "systemDisplayName": "System",
         "tabs": {

--- a/lang/main.json
+++ b/lang/main.json
@@ -127,6 +127,7 @@
         "noMessagesMessage": "There are no messages in the meeting yet. Start a conversation here!",
         "privateNotice": "Private message to {{recipient}}",
         "sendButton": "Send",
+        "smileySymbol": "Emojis",
         "smileysPanel": "Emoji panel",
         "systemDisplayName": "System",
         "tabs": {

--- a/react/features/base/ui/components/web/Input.tsx
+++ b/react/features/base/ui/components/web/Input.tsx
@@ -14,6 +14,7 @@ interface IProps extends IInputProps {
     autoFocus?: boolean;
     bottomLabel?: string;
     className?: string;
+    iconAccessibilityLabel?: string;
     iconClick?: () => void;
 
     /**
@@ -160,6 +161,7 @@ const Input = React.forwardRef<any, IProps>(({
     disabled,
     error,
     icon,
+    iconAccessibilityLabel,
     iconClick,
     id,
     label,
@@ -201,8 +203,10 @@ const Input = React.forwardRef<any, IProps>(({
             <div className = { styles.fieldContainer }>
                 {icon && <Icon
                     { ...(iconClick ? { tabIndex: 0 } : {}) }
+                    ariaLabel = { iconAccessibilityLabel }
                     className = { cx(styles.icon, iconClick && styles.iconClickable) }
                     onClick = { iconClick }
+                    role = { iconClick ? 'button' : undefined }
                     size = { 20 }
                     src = { icon } />}
                 {textarea ? (

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -60,6 +60,7 @@ interface IState {
  * @augments Component
  */
 class ChatInput extends Component<IProps, IState> {
+    _smileysContainerRef: RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
     _textArea?: RefObject<HTMLTextAreaElement>;
 
     override state = {
@@ -169,6 +170,18 @@ class ChatInput extends Component<IProps, IState> {
     }
 
     /**
+     * Place cursor focus on the smiley panel.
+     *
+     * @private
+     * @returns {void}
+     */
+    _focusSmileysPanel() {
+        setTimeout(() => {
+            this._smileysContainerRef?.current && this._smileysContainerRef.current.focus();
+        }, 25);
+    }
+
+    /**
      * Submits the message to the chat window.
      *
      * @returns {void}
@@ -264,6 +277,8 @@ class ChatInput extends Component<IProps, IState> {
     _toggleSmileysPanel() {
         if (this.state.showSmileysPanel) {
             this._focus();
+        } else {
+            this._focusSmileysPanel();
         }
         this.setState({ showSmileysPanel: !this.state.showSmileysPanel });
     }

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -125,7 +125,10 @@ class ChatInput extends Component<IProps, IState> {
                         <div
                             className = 'smiley-input'>
                             <div
-                                className = 'smileys-panel' >
+                                aria-label = { this.props.t('chat.smileysPanel') }
+                                className = 'smileys-panel'
+                                ref = { this._smileysContainerRef }
+                                tabIndex = { 0 } >
                                 <SmileysPanel
                                     onSmileySelect = { this._onSmileySelect } />
                             </div>

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -137,6 +137,7 @@ class ChatInput extends Component<IProps, IState> {
                     <Input
                         className = 'chat-input'
                         icon = { this.props._areSmileysDisabled ? undefined : IconFaceSmile }
+                        iconAccessibilityLabel = { this.props.t('chat.smileySymbol') }
                         iconClick = { this._toggleSmileysPanel }
                         id = 'chat-input-messagebox'
                         maxRows = { 5 }

--- a/react/features/chat/components/web/SmileysPanel.tsx
+++ b/react/features/chat/components/web/SmileysPanel.tsx
@@ -60,7 +60,7 @@ class SmileysPanel extends PureComponent<IProps> {
      *
      * @returns {void}
      */
-    _onKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
+    _onKeyPress(e: React.KeyboardEvent<HTMLLIElement>) {
         if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault(); // @ts-ignore
             this.props.onSmileySelect(e.target.id && smileys[e.target.id]);
@@ -87,7 +87,7 @@ class SmileysPanel extends PureComponent<IProps> {
      */
     override render() {
         const smileyItems = Object.keys(smileys).map(smileyKey => (
-            <div
+            <li
                 className = 'smileyContainer'
                 id = { smileyKey }
                 key = { smileyKey }
@@ -101,18 +101,18 @@ class SmileysPanel extends PureComponent<IProps> {
                         onlyEmojiClassName = 'smiley'
                         text = { smileys[smileyKey as keyof typeof smileys] } />
                 </Tooltip>
-            </div>
+            </li>
         ));
 
         return (
-            <div
+            <ul
                 aria-orientation = 'horizontal'
                 id = 'smileysContainer'
                 onKeyDown = { this._onEscKey }
                 role = 'listbox'
                 tabIndex = { -1 }>
                 { smileyItems }
-            </div>
+            </ul>
         );
     }
 }


### PR DESCRIPTION
Using the chat emoji panel with keyboard navigation and assistive flagged as lacking some functionalities.
In our tests the screen reader did not mention the clickable icon and tabbing through all elements to get to the panel was not optimal.

- Rework panel to be handled as a list.
- Add accessibility label and role to the input icon.
- Autofocus emoji panel after open.