### PR TITLE
Fix External Links Opening in Same Tab

### DIFF
--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -383,8 +383,8 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                         <a
                             className = 'welcome-badge'
                             href = { iosDownloadLink }
-                            target="_blank"
-                            rel="noopener noreferrer">
+                            rel = 'noopener noreferrer'
+                            target = '_blank'>
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkIos') }
                                 src = './images/app-store-badge.png' />
@@ -392,8 +392,8 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                         <a
                             className = 'welcome-badge'
                             href = { androidDownloadLink }
-                            target="_blank"
-                            rel="noopener noreferrer">
+                            rel = 'noopener noreferrer'
+                            target = '_blank'>
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkAndroid') }
                                 src = './images/google-play-badge.png' />
@@ -401,8 +401,8 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                         <a
                             className = 'welcome-badge'
                             href = { fDroidUrl }
-                            target="_blank"
-                            rel="noopener noreferrer">
+                            rel = 'noopener noreferrer'
+                            target = '_blank'>
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkFDroid') }
                                 src = './images/f-droid-badge.png' />

--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -382,21 +382,27 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                         <div className = 'welcome-footer-row-1-text'>{t('welcomepage.jitsiOnMobile')}</div>
                         <a
                             className = 'welcome-badge'
-                            href = { iosDownloadLink }>
+                            href = { iosDownloadLink }
+                            target="_blank"
+                            rel="noopener noreferrer">
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkIos') }
                                 src = './images/app-store-badge.png' />
                         </a>
                         <a
                             className = 'welcome-badge'
-                            href = { androidDownloadLink }>
+                            href = { androidDownloadLink }
+                            target="_blank"
+                            rel="noopener noreferrer">
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkAndroid') }
                                 src = './images/google-play-badge.png' />
                         </a>
                         <a
                             className = 'welcome-badge'
-                            href = { fDroidUrl }>
+                            href = { fDroidUrl }
+                            target="_blank"
+                            rel="noopener noreferrer">
                             <img
                                 alt = { t('welcomepage.mobileDownLoadLinkFDroid') }
                                 src = './images/f-droid-badge.png' />


### PR DESCRIPTION
### Summary

This PR fixes an issue where external links (e.g., App Store, Google Play, and F-Droid links) were opening in the same tab instead of a new one.

### Changes Made

Added target="_blank" to open external links in a new tab.

Included rel="noopener noreferrer" for security and performance improvements.

### Screenshots 
(from [meet.jit.si](https://meet.jit.si/))
![image](https://github.com/user-attachments/assets/9989fd58-ce01-4903-a2dd-a7d5d080def6)
 