### PR TITLE
fix(tests): Avoid error after tests.

### DIFF
--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -221,11 +221,8 @@ export const config: WebdriverIO.MultiremoteConfig = {
     after() {
         const { ctx }: any = global;
 
-        if (ctx?.webhooksProxy) {
-            ctx.webhooksProxy.disconnect();
-        }
-
-        ctx.keepAlive?.forEach(clearInterval);
+        ctx?.webhooksProxy?.disconnect();
+        ctx?.keepAlive?.forEach(clearInterval);
     },
 
     beforeSession(c, capabilities, specs, cid) {


### PR DESCRIPTION
In newer versions of wdio this is handled, but now in case of error at this level the test is missing from the result xmls.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
