### PR TITLE
chore(android): add build type separation and debug app

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,7 @@ android {
         debug {
             buildConfigField "boolean", "GOOGLE_SERVICES_ENABLED", "${googleServicesEnabled}"
             buildConfigField "boolean", "LIBRE_BUILD", "${rootProject.ext.libreBuild}"
+            applicationIdSuffix ".debug"
         }
         release {
             // Uncomment the following line for singing a test release build.


### PR DESCRIPTION
Fixes #15827 


Added applicationIdSuffix = ".debug" to the debug build, allowing both release and debug APKs to be installed simultaneously.