### PR TITLE
feat(rtcstats): attach LogCollector storage to rtcstats lifecycle

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -190,6 +190,7 @@ export interface IConfig {
         obfuscateRoomName?: boolean;
         rtcstatsEnabled?: boolean;
         rtcstatsEndpoint?: string;
+        rtcstatsLogFlushSizeBytes?: number;
         rtcstatsPollInterval?: number;
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -194,7 +194,6 @@ export interface IConfig {
         rtcstatsPollInterval?: number;
         rtcstatsSendSdp?: boolean;
         rtcstatsStoreLogs?: boolean;
-        rtcstatsUseLegacy?: boolean;
         scriptURLs?: Array<string>;
         watchRTCEnabled?: boolean;
         whiteListedEvents?: string[];

--- a/react/features/base/config/functions.native.ts
+++ b/react/features/base/config/functions.native.ts
@@ -24,7 +24,6 @@ export function _cleanupConfig(config: IConfig) {
         delete config.analytics?.rtcstatsEndpoint;
         delete config.analytics?.rtcstatsPollInterval;
         delete config.analytics?.rtcstatsSendSdp;
-        delete config.analytics?.rtcstatsUseLegacy;
         delete config.analytics?.obfuscateRoomName;
         delete config.analytics?.watchRTCEnabled;
         delete config.watchRTCConfigParams;


### PR DESCRIPTION
Attach LogCollector rtcstats storage to the ljm rtcstats service lifecycle.
Logs will only get sent once the trace connection is available, otherwise they will be cached.
Add a configurable max cache size, so that we don't miss out on any logs in between flush intervals.
