### PR TITLE
fix(ios) skip check for manual audio in (de)activateWithAudioSession

### DIFF
--- a/ios/sdk/src/JitsiAudioSession.m
+++ b/ios/sdk/src/JitsiAudioSession.m
@@ -24,15 +24,11 @@
 }
 
 + (void)activateWithAudioSession:(AVAudioSession *)session {
-    if (!self.rtcAudioSession.useManualAudio) {
-        [self.rtcAudioSession audioSessionDidActivate:session];
-    }
+    [self.rtcAudioSession audioSessionDidActivate:session];
 }
 
 + (void)deactivateWithAudioSession:(AVAudioSession *)session {
-    if (!self.rtcAudioSession.useManualAudio) {
-        [self.rtcAudioSession audioSessionDidDeactivate:session];
-    }
+    [self.rtcAudioSession audioSessionDidDeactivate:session];
 }
 
 @end


### PR DESCRIPTION
We don't really rely on this and it may play nicer with those using RTCAudioSession at the same time as a conference.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
