### PR TITLE
fix(chat): avoid emoji accidents when sending messages

### DIFF
--- a/react/features/base/react/components/web/Message.tsx
+++ b/react/features/base/react/components/web/Message.tsx
@@ -72,8 +72,11 @@ class Message extends Component<IProps> {
                     // Bypass the emojification when urls or matrix ids are involved
                     content.push(token);
                 } else {
-                    const emojified = [...toArray(token, { className: "smiley" })];
-                    content.push(...(emojified.some((item) => typeof item === "string") ? [token] : emojified));
+                    const emojified = [ ...toArray(token, { className: 'smiley' }) ];
+
+                    content.push(
+                        ...emojified.some(item => typeof item === 'string') ? [ token ] : emojified
+                    );
                 }
 
                 content.push(' ');


### PR DESCRIPTION
### Description
The aim of this PR is to avoid some texts accidentally turning into emojis when sending messages. Instead of using RegExp to match specific cases, I found it more efficient to directly check whether the output of toArray contains any non-emoji text. If it does, the original text is preserved; otherwise, the transformed emoji output is used.

Take `20:ssä paikassa` as an example, it will first be seperated by space as an arrray: ["20:ssä", "paikassa"]. Then `20:ssä` will be "emojified" by `...toArray(token, { className: "smiley" })`. During this process, `:s` will be transformed into emoji while other normal string will remain the same. 
After calling `toArray`,it will return an array containing **emoji** element and **string** element(which will be  `["20", 😒 , "sä"]`). If the emojified array containing any string element, we will return the original text right away (which will be  `20:ssä`) By doing so, we can make sure that only those **emoji text** surrounded by spaces can be transformed into **emoji**.  For example, `20 :s sä paikassa` will be succesfully transformed into `20 😒 sä paikassa`.


### Issues Resolved
https://github.com/jitsi/jitsi-meet/issues/15824
https://github.com/jitsi/jitsi-meet/issues/9889
