### PR TITLE
W.I.P. feat(android): remove and replace SoLoader

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -9,6 +9,19 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         buildConfigField "String", "SDK_VERSION", "\"$sdkVersion\""
+        
+        // Add native library loading configuration
+        ndk {
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+        }
+    }
+
+    // Add native library loading support
+    packagingOptions {
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
     }
 
     buildTypes {

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiInitializer.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiInitializer.java
@@ -22,7 +22,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.startup.Initializer;
 
-import com.facebook.soloader.SoLoader;
 import org.wonday.orientation.OrientationActivityLifecycle;
 
 import java.util.Collections;
@@ -35,7 +34,12 @@ public class JitsiInitializer implements Initializer<Boolean> {
     public Boolean create(@NonNull Context context) {
         Log.d(this.getClass().getCanonicalName(), "create");
 
-        SoLoader.init(context, /* native exopackage */ false);
+        // Initialize native libraries using Android's built-in mechanism
+        try {
+            System.loadLibrary("c++_shared");
+        } catch (UnsatisfiedLinkError e) {
+            Log.e(this.getClass().getCanonicalName(), "Failed to load native libraries", e);
+        }
 
         // Register our uncaught exception handler.
         JitsiMeetUncaughtExceptionHandler.register();


### PR DESCRIPTION
This is regarding the problem we had when certain logged in users join a meeting and the app crashes.

I found that SoLoader should not be used on Android API 24 and above unless the app is delivered as Exopackagerequires Android Native Library Merging or uses Superpack compression(we don't do any). Our minSdkVersion is 26. So maybe we need to rely on Android's built-in System.loadLibrary() mechanism to handle native library loading in a way that's compatible with API 24+.
