### PR TITLE
fix(input): restructure bottom label

### DIFF
--- a/react/features/base/ui/components/web/Input.tsx
+++ b/react/features/base/ui/components/web/Input.tsx
@@ -260,11 +260,13 @@ const Input = React.forwardRef<any, IProps>(({
                 </button>}
             </div>
             {bottomLabel && (
-                <span
+                <div
                     className = { cx(styles.bottomLabel, isMobile && 'is-mobile', error && 'error') }
                     id = { `${id}-description` }>
-                    {bottomLabel}
-                </span>
+                    <p>
+                        {bottomLabel}
+                    </p>
+                </div>
             )}
         </div>
     );


### PR DESCRIPTION
For assistive technologies, like screen readers, there should not be any floating `<span>` s.