### PR TITLE
feat: quality slider accessibility text

### DIFF
--- a/react/features/video-quality/components/Slider.web.tsx
+++ b/react/features/video-quality/components/Slider.web.tsx
@@ -9,6 +9,11 @@ interface IProps {
     ariaLabel: string;
 
     /**
+     * The 'aria-valuetext' text.
+     */
+    ariaValuetext?: string;
+
+    /**
      * The maximum value for slider value.
      */
     max: number;
@@ -135,9 +140,9 @@ const useStyles = makeStyles()(theme => {
 /**
  *  Custom slider.
  *
- *  @returns {ReactElement}
+ *  @returns {JSX.Element}
  */
-function Slider({ ariaLabel, max, min, onChange, step, value }: IProps) {
+function Slider({ ariaLabel, ariaValuetext, max, min, onChange, step, value }: IProps) {
     const { classes, cx } = useStyles();
     const knobs = [ ...Array(Math.floor((max - min) / step) + 1) ];
 
@@ -154,6 +159,10 @@ function Slider({ ariaLabel, max, min, onChange, step, value }: IProps) {
             <div className = { classes.track } />
             <input
                 aria-label = { ariaLabel }
+                aria-valuemax = { max }
+                aria-valuemin = { min }
+                aria-valuenow = { value }
+                aria-valuetext = { ariaValuetext }
                 className = { cx(classes.slider, 'custom-slider') }
                 max = { max }
                 min = { min }

--- a/react/features/video-quality/components/VideoQualitySlider.web.tsx
+++ b/react/features/video-quality/components/VideoQualitySlider.web.tsx
@@ -184,7 +184,8 @@ class VideoQualitySlider extends Component<IProps> {
     override render() {
         const { t } = this.props;
         const classes = withStyles.getClasses(this.props);
-        const activeSliderOption = this._mapCurrentQualityToSliderValue();
+        const activeSliderOptionIndex = this._mapCurrentQualityToSliderValue();
+        const activeSliderOption = this._sliderOptions[activeSliderOptionIndex];
 
         return (
             <div className = { clsx('video-quality-dialog', classes.dialog) }>
@@ -202,11 +203,12 @@ class VideoQualitySlider extends Component<IProps> {
                     </div>
                     <Slider
                         ariaLabel = { t('videoStatus.callQuality') }
+                        ariaValuetext = { t(activeSliderOption.textKey) }
                         max = { this._sliderOptions.length - 1 }
                         min = { 0 }
                         onChange = { this._onSliderChange }
                         step = { 1 }
-                        value = { activeSliderOption } />
+                        value = { activeSliderOptionIndex } />
                 </div>
             </div>
         );


### PR DESCRIPTION
Adding the [slider role attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/slider_role#common_attributes) for the [`<input type="range">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#technical_summary) used in video quality to help assistive technologies like screen readers to determine the set value and its meaning.