### PR TITLE
feat(settings): better keyboard navigation

### DIFF
--- a/react/features/base/ui/components/web/DialogWithTabs.tsx
+++ b/react/features/base/ui/components/web/DialogWithTabs.tsx
@@ -320,9 +320,11 @@ const DialogWithTabs = ({
             titleKey = { titleKey }>
             {(!isMobile || !selectedTab) && (
                 <div
+                    aria-label = { titleKey ? t(titleKey) : undefined }
                     aria-orientation = 'vertical'
                     className = { classes.sidebar }
-                    role = { isMobile ? undefined : 'tablist' }>
+                    role = { isMobile ? undefined : 'tablist' }
+                    tabIndex = { 0 }>
                     <div className = { classes.titleContainer }>
                         <h1
                             className = { classes.title }
@@ -384,8 +386,7 @@ const DialogWithTabs = ({
                             className = { cx(classes.content, tab.name !== selectedTab && 'hide') }
                             id = { `dialogtab-content-${tab.name}` }
                             key = { tab.name }
-                            role = { isMobile ? undefined : 'tabpanel' }
-                            tabIndex = { isMobile ? -1 : 0 }>
+                            role = { isMobile ? undefined : 'tabpanel' }>
                             { tab.name === selectedTab && selectedTabComponent }
                         </div>
                     ))}


### PR DESCRIPTION
Improve keyboard navigation on settings (and all other that use `<DialogWithTabs>`).

Focus the tab list first and give output to a screen reader, then focus the tab buttons. When a tab is selected next focus jump is to content instead of of the tab itself.