### PR TITLE
fix(audio-devices): fix index as pos in set

### DIFF
--- a/react/features/settings/components/web/audio/MicrophoneEntry.tsx
+++ b/react/features/settings/components/web/audio/MicrophoneEntry.tsx
@@ -29,9 +29,10 @@ interface IProps {
     hasError?: boolean;
 
     /**
-     * Flag indicating if there is a problem with the device.
+     * Index of the device item used to generate this entry.
+     * Indexes are 0 based.
      */
-    index?: number;
+    index: number;
 
     /**
      * Flag indicating the selection state.
@@ -190,7 +191,7 @@ const MicrophoneEntry = ({
     return (
         <li
             aria-checked = { isSelected }
-            aria-posinset = { index }
+            aria-posinset = { index + 1 } // Add one to offset the 0 based index.
             aria-setsize = { length }
             className = { classes.container }
             onClick = { onClick }

--- a/react/features/settings/components/web/audio/SpeakerEntry.tsx
+++ b/react/features/settings/components/web/audio/SpeakerEntry.tsx
@@ -25,7 +25,8 @@ interface IProps {
     deviceId: string;
 
     /**
-     * Flag controlling the selection state of the entry.
+     * Index of the device item used to generate this entry.
+     * Indexes are 0 based.
      */
     index: number;
 
@@ -139,7 +140,7 @@ const SpeakerEntry = (props: IProps) => {
     return (
         <li
             aria-checked = { isSelected }
-            aria-posinset = { index }
+            aria-posinset = { index + 1 } // Add one to offset the 0 based index.
             aria-setsize = { length }
             className = { classes.container }
             onClick = { _onClick }


### PR DESCRIPTION
The used `aria-posinset` and `aria-setsize` combination is based on a starting count of 1, but the used index is based on a 0 starting count.

With 3 devices:

Device 0 out of 3.
Device 1 out of 3.
Device 2 out of 3.

The index gets one added to correct to:

Device 1 out of 3.
Device 2 out of 3.
Device 3 out of 3.