### PR TITLE
Removes BackHandler.removeEventListener

### DIFF
--- a/react/features/base/react/components/native/SlidingView.tsx
+++ b/react/features/base/react/components/native/SlidingView.tsx
@@ -71,6 +71,11 @@ interface IState {
  */
 export default class SlidingView extends PureComponent<IProps, IState> {
     /**
+     * Initializes hardwareBackPressSubscription
+     */
+    _hardwareBackPressSubscription: any;
+
+    /**
      * True if the component is mounted.
      */
     _mounted: boolean;
@@ -120,7 +125,7 @@ export default class SlidingView extends PureComponent<IProps, IState> {
      * @inheritdoc
      */
     override componentDidMount() {
-        BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
+        this._hardwareBackPressSubscription = BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
 
         this._mounted = true;
         this._setShow(this.props.show);
@@ -145,7 +150,7 @@ export default class SlidingView extends PureComponent<IProps, IState> {
      * @inheritdoc
      */
     override componentWillUnmount() {
-        BackHandler.removeEventListener('hardwareBackPress', this._onHardwareBackPress);
+        this._hardwareBackPressSubscription?.remove();
 
         this._mounted = false;
     }

--- a/react/features/base/react/components/native/SlidingView.tsx
+++ b/react/features/base/react/components/native/SlidingView.tsx
@@ -71,7 +71,7 @@ interface IState {
  */
 export default class SlidingView extends PureComponent<IProps, IState> {
     /**
-     * Initializes hardwareBackPressSubscription
+     * Initializes hardwareBackPress subscription.
      */
     _hardwareBackPressSubscription: any;
 

--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -181,7 +181,7 @@ class Conference extends AbstractConference<IProps, State> {
     _expandedLabelTimeout: any;
 
     /**
-     * Initializes hardwareBackPressSubscription
+     * Initializes hardwareBackPress subscription.
      */
     _hardwareBackPressSubscription: any;
 

--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -181,6 +181,11 @@ class Conference extends AbstractConference<IProps, State> {
     _expandedLabelTimeout: any;
 
     /**
+     * Initializes hardwareBackPressSubscription
+     */
+    _hardwareBackPressSubscription: any;
+
+    /**
      * Initializes a new Conference instance.
      *
      * @param {Object} props - The read-only properties with which the new
@@ -216,7 +221,7 @@ class Conference extends AbstractConference<IProps, State> {
             navigation
         } = this.props;
 
-        BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
+        this._hardwareBackPressSubscription = BackHandler.addEventListener('hardwareBackPress', this._onHardwareBackPress);
 
         if (_audioOnlyEnabled && _startCarMode) {
             navigation.navigate(screen.conference.carmode);
@@ -258,7 +263,7 @@ class Conference extends AbstractConference<IProps, State> {
      */
     override componentWillUnmount() {
         // Tear handling any hardware button presses for back navigation down.
-        BackHandler.removeEventListener('hardwareBackPress', this._onHardwareBackPress);
+        this._hardwareBackPressSubscription?.remove();
 
         clearTimeout(this._expandedLabelTimeout.current ?? 0);
     }

--- a/react/features/prejoin/components/native/Prejoin.tsx
+++ b/react/features/prejoin/components/native/Prejoin.tsx
@@ -109,14 +109,13 @@ const Prejoin: React.FC<IPrejoinProps> = ({ navigation }: IPrejoinProps) => {
     const { PRIMARY, TERTIARY } = BUTTON_TYPES;
 
     useEffect(() => {
-        BackHandler.addEventListener('hardwareBackPress', goBack);
+        const hardwareBackPressSubscription = BackHandler.addEventListener('hardwareBackPress', goBack);
 
         dispatch(setPermanentProperty({
             wasPrejoinDisplayed: true
         }));
 
-        return () => BackHandler.removeEventListener('hardwareBackPress', goBack);
-
+        return () => hardwareBackPressSubscription.remove();
     }, []); // dispatch is not in the dependency list because we want the action to be dispatched only once when
     // the component is mounted.
 


### PR DESCRIPTION
Removes BackHandler.removeEventListener to support react-native 0.77+.

Resolves https://github.com/jitsi/jitsi-meet/issues/15864.