### PR TITLE
refactor(react): Migrated ReactDOM.render to createRoot in all components

### DIFF
--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -3,7 +3,7 @@
 import Logger from '@jitsi/logger';
 import $ from 'jquery';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client'
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 
@@ -143,6 +143,9 @@ export default class LargeVideoManager {
 
         this._dominantSpeakerAvatarContainer
             = document.getElementById('dominantSpeakerAvatarContainer');
+
+        this.avatarRoot = null;
+        this.presenceRoot = null;
     }
 
     /**
@@ -166,7 +169,10 @@ export default class LargeVideoManager {
 
         this.removePresenceLabel();
 
-        ReactDOM.unmountComponentAtNode(this._dominantSpeakerAvatarContainer);
+        if (this.avatarRoot) {
+            this.avatarRoot.unmount();
+            this.avatarRoot = null; 
+        }
 
         this.container.style.display = 'none';
     }
@@ -516,15 +522,21 @@ export default class LargeVideoManager {
      * Updates the src of the dominant speaker avatar
      */
     updateAvatar() {
-        ReactDOM.render(
+        if(!this.avatarRoot && this._dominantSpeakerAvatarContainer) {
+            this.avatarRoot = createRoot(this._dominantSpeakerAvatarContainer);
+        }
+        if(this.avatarRoot) {
+            this.avatarRoot.render(
             <Provider store = { APP.store }>
                 <Avatar
                     id = "dominantSpeakerAvatar"
                     participantId = { this.id }
                     size = { 200 } />
-            </Provider>,
-            this._dominantSpeakerAvatarContainer
-        );
+            </Provider>
+            );
+        } else {
+            console.log("Root element not found!"); 
+        }
     }
 
     /**
@@ -557,15 +569,18 @@ export default class LargeVideoManager {
         const presenceLabelContainer = document.getElementById('remotePresenceMessage');
 
         if (presenceLabelContainer) {
-            ReactDOM.render(
+            if(!this.presenceRoot) {
+                this.presenceRoot = createRoot(presenceLabelContainer);
+            }
+            this.presenceRoot.render(
                 <Provider store = { APP.store }>
-                    <I18nextProvider i18n = { i18next }>
-                        <PresenceLabel
-                            participantID = { id }
-                            className = 'presence-label' />
-                    </I18nextProvider>
-                </Provider>,
-                presenceLabelContainer);
+                <I18nextProvider i18n = { i18next }>
+                    <PresenceLabel
+                        participantID = { id }
+                        className = 'presence-label' />
+                </I18nextProvider>
+            </Provider> 
+            );
         }
     }
 
@@ -575,10 +590,9 @@ export default class LargeVideoManager {
      * @returns {void}
      */
     removePresenceLabel() {
-        const presenceLabelContainer = document.getElementById('remotePresenceMessage');
-
-        if (presenceLabelContainer) {
-            ReactDOM.unmountComponentAtNode(presenceLabelContainer);
+        if (this.presenceRoot) {
+            this.presenceRoot.unmount();
+            this.presenceRoot = null;
         }
     }
 

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -4,7 +4,7 @@
 import Logger from '@jitsi/logger';
 import $ from 'jquery';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { browser } from '../../../react/features/base/lib-jitsi-meet';
 import { FILMSTRIP_BREAKPOINT } from '../../../react/features/filmstrip/constants';
@@ -210,6 +210,7 @@ export class VideoContainer extends LargeContainer {
         this.videoType = null;
         this.localFlipX = true;
         this.resizeContainer = resizeContainer;
+        this.largeVideoBackgroundRoot = null;
 
         /**
          * Whether the background should fit the height of the container
@@ -659,8 +660,14 @@ export class VideoContainer extends LargeContainer {
             return;
         }
 
-        ReactDOM.render(
-            <LargeVideoBackground
+        if(!this.largeVideoBackgroundRoot) {
+            const container = document.getElementById('largeVideoBackgroundContainer');
+            if(container) {
+                this.largeVideoBackgroundRoot = createRoot(container);
+            }
+        } else {
+            this.largeVideoBackgroundRoot.render(
+              <LargeVideoBackground
                 hidden = { this._hideBackground || this._isHidden }
                 mirror = {
                     this.stream
@@ -669,8 +676,9 @@ export class VideoContainer extends LargeContainer {
                 }
                 orientationFit = { this._backgroundOrientation }
                 videoElement = { this.video }
-                videoTrack = { this.stream } />,
-            document.getElementById('largeVideoBackgroundContainer')
-        );
+                videoTrack = { this.stream } />
+            );
+        }
+        
     }
 }

--- a/react/features/always-on-top/AlwaysOnTop.tsx
+++ b/react/features/always-on-top/AlwaysOnTop.tsx
@@ -188,7 +188,7 @@ export default class AlwaysOnTop extends Component<any, IState> {
                         iconUser = { DEFAULT_ICON.IconUser }
                         id = 'avatar'
                         initials = { getInitials(displayName) }
-                        url = { avatarURL } />)
+                        url = { avatarURL } />
                 </div>
                 <div
                     className = 'displayname'

--- a/react/features/always-on-top/index.tsx
+++ b/react/features/always-on-top/index.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import AlwaysOnTop from './AlwaysOnTop';
 
 // Render the main/root Component.
 /* eslint-disable-next-line react/no-deprecated */
-ReactDOM.render(<AlwaysOnTop />, document.getElementById('react'));
+const container = document.getElementById('react');
+const root = container ? createRoot(container) : null;
+
+if (root) {
+    root.render(<AlwaysOnTop />);
+}
 
 window.addEventListener(
     'beforeunload',
     /* eslint-disable-next-line react/no-deprecated */
-    () => ReactDOM.unmountComponentAtNode(document.getElementById('react') ?? document.body));
+    () => {
+        if(root) {
+            root.unmount();
+        }   
+    });

--- a/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
+++ b/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { I18nextProvider } from 'react-i18next';
 
 import { isMobileBrowser } from '../../../base/environment/utils';
@@ -9,11 +9,16 @@ import { DIAL_IN_INFO_PAGE_PATH_NAME } from '../../constants';
 import DialInSummary from '../dial-in-summary/web/DialInSummary';
 
 import NoRoomError from './NoRoomError.web';
+import { any } from 'core-js/fn/promise';
+
+let root;
 
 /**
  * TODO: This seems unused, so we can drop it.
  */
 document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('react');
+    if(container) {
     // @ts-ignore
     const { room } = parseURLParams(window.location, true, 'search');
     const { href } = window.location;
@@ -21,7 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const url = (ix > 0 ? href.substring(0, ix) : href) + room;
 
     /* eslint-disable-next-line react/no-deprecated */
-    ReactDOM.render(
+    if(!root) {
+        root = createRoot(container);
+    }
+    root.render(
         <I18nextProvider i18n = { i18next }>
             { room
                 ? <DialInSummary
@@ -30,12 +38,17 @@ document.addEventListener('DOMContentLoaded', () => {
                     room = { decodeURIComponent(room) }
                     url = { url } />
                 : <NoRoomError className = 'dial-in-page' /> }
-        </I18nextProvider>,
-        document.getElementById('react')
+        </I18nextProvider>
     );
+} else {
+    console.error("Root container with Id react not found.")
+}
 });
 
 window.addEventListener('beforeunload', () => {
     /* eslint-disable-next-line react/no-deprecated */
-    ReactDOM.unmountComponentAtNode(document.getElementById('react')!);
+    if(root) {
+        root.unmount();
+        root = null;
+    }
 });

--- a/react/index.web.js
+++ b/react/index.web.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import { App } from './features/app/components/App.web';
 import { getLogger } from './features/base/logging/functions';
@@ -68,14 +68,22 @@ globalNS.entryPoints = {
     WHITEBOARD: WhiteboardApp
 };
 
+const roots = {};
+
 globalNS.renderEntryPoint = ({
     Component,
     props = {},
     elementId = 'react'
 }) => {
     /* eslint-disable-next-line react/no-deprecated */
-    ReactDOM.render(
-        <Component { ...props } />,
-        document.getElementById(elementId)
+    
+    const container = document.getElementById(elementId);
+    if(container) {
+        if(!roots[elementId]) {
+            roots[elementId] = createRoot(container);
+        }
+        roots[elementId].render(
+        <Component { ...props } />
     );
+    }
 };


### PR DESCRIPTION
In this PR  -> 

1. I have ensured that createRoot is called only once for the same DOM element.
2. Removed ReactDOM.unmountComponentAtNode as it is not compatible with the new createRoot API introduced in React 18.
3. Have ensured that components are rendered correctly.

