### PR TITLE
feat(tests): Checks for mute icon in filmstrip and participants pane.

### DIFF
--- a/react/features/participants-pane/constants.tsx
+++ b/react/features/participants-pane/constants.tsx
@@ -68,11 +68,13 @@ export const AudioStateIcons = {
     [MEDIA_STATE.FORCE_MUTED]: (
         <Icon
             color = '#E04757'
+            id = 'audioMuted'
             size = { 16 }
             src = { IconMicSlash } />
     ),
     [MEDIA_STATE.MUTED]: (
         <Icon
+            id = 'audioMuted'
             size = { 16 }
             src = { IconMicSlash } />
     ),

--- a/tests/helpers/participants.ts
+++ b/tests/helpers/participants.ts
@@ -273,6 +273,10 @@ export async function muteAudioAndCheck(testee: Participant, observer: Participa
 
     await observer.getFilmstrip().assertAudioMuteIconIsDisplayed(testee);
     await testee.getFilmstrip().assertAudioMuteIconIsDisplayed(testee);
+
+    await observer.getParticipantsPane().assertAudioMuteIconIsDisplayed(testee);
+    await testee.getParticipantsPane().assertAudioMuteIconIsDisplayed(testee);
+
 }
 
 /**
@@ -285,8 +289,12 @@ export async function unmuteAudioAndCheck(testee: Participant, observer: Partici
     await testee.getNotifications().closeAskToUnmuteNotification(true);
     await testee.getNotifications().closeAVModerationMutedNotification(true);
     await testee.getToolbar().clickAudioUnmuteButton();
+
     await testee.getFilmstrip().assertAudioMuteIconIsDisplayed(testee, true);
     await observer.getFilmstrip().assertAudioMuteIconIsDisplayed(testee, true);
+
+    await testee.getParticipantsPane().assertAudioMuteIconIsDisplayed(testee, true);
+    await observer.getParticipantsPane().assertAudioMuteIconIsDisplayed(testee, true);
 }
 
 /**

--- a/tests/pageobjects/ParticipantsPane.ts
+++ b/tests/pageobjects/ParticipantsPane.ts
@@ -75,13 +75,47 @@ export default class ParticipantsPane extends BasePageObject {
         await this.participant.driver.$(mutedIconXPath).waitForDisplayed({
             reverse,
             timeout: 2000,
-            timeoutMsg: `Video mute icon is${reverse ? '' : ' not'} displayed for ${testee.name}`
+            timeoutMsg: `Video mute icon is${reverse ? '' : ' not'} displayed for ${testee.displayName} at ${
+                this.participant.displayName} side.`
         });
 
         if (!isOpen) {
             await this.close();
         }
     }
+
+    /**
+     * Asserts that {@code participant} shows or doesn't show the video mute icon for the conference participant
+     * identified by {@code testee}.
+     *
+     * @param {Participant} testee - The {@code Participant} for whom we're checking the status of audio muted icon.
+     * @param {boolean} reverse - If {@code true}, the method will assert the absence of the "mute" icon;
+     * otherwise, it will assert its presence.
+     * @returns {Promise<void>}
+     */
+    async assertAudioMuteIconIsDisplayed(testee: Participant, reverse = false): Promise<void> {
+        const isOpen = await this.isOpen();
+
+        if (!isOpen) {
+            await this.open();
+        }
+
+        const id = `participant-item-${await testee.getEndpointId()}`;
+        const mutedIconXPath
+            = `//div[@id='${id}']//div[contains(@class, 'indicators')]//*[local-name()='svg' and @id='audioMuted']`;
+
+        await this.participant.driver.$(mutedIconXPath).waitForDisplayed({
+            reverse,
+            timeout: 2000,
+            timeoutMsg: `Audio mute icon is${reverse ? '' : ' not'} displayed for ${testee.displayName} at ${
+                this.participant.displayName} side.`
+        });
+
+        if (!isOpen) {
+            await this.close();
+        }
+    }
+
 
     /**
      * Clicks the context menu button in the participants pane.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
