### PR TITLE
feat: Show confirmation before meeting exit

### DIFF
--- a/config.js
+++ b/config.js
@@ -625,9 +625,6 @@ var config = {
     // Disables or enables RTX (RFC 4588) (defaults to false).
     // disableRtx: false,
 
-    // Moves all Jitsi Meet 'beforeunload' logic (cleanup, leaving, disconnecting, etc) to the 'unload' event.
-    // disableBeforeUnloadHandlers: true,
-
     // Disables or enables TCC support in this client (default: enabled).
     // enableTcc: true,
 

--- a/react/features/always-on-top/index.tsx
+++ b/react/features/always-on-top/index.tsx
@@ -8,6 +8,6 @@ import AlwaysOnTop from './AlwaysOnTop';
 ReactDOM.render(<AlwaysOnTop />, document.getElementById('react'));
 
 window.addEventListener(
-    'beforeunload',
+    'pagehide',
     /* eslint-disable-next-line react/no-deprecated */
     () => ReactDOM.unmountComponentAtNode(document.getElementById('react') ?? document.body));

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -77,6 +77,11 @@ import { IConferenceMetadata } from './reducer';
 let pageHideHandler: ((e?: any) => void) | undefined;
 
 /**
+ * Handler for before unload event.
+ */
+let beforeUnloadHandler: ((e?: any) => void) | undefined;
+
+/**
  * Implements the middleware of the feature base/conference.
  *
  * @param {Store} store - The redux store.
@@ -314,6 +319,14 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
         dispatch(overwriteConfig({ disableFocus: false }));
     }
 
+    beforeUnloadHandler = (e?: any) => {
+        e.preventDefault();
+
+        // Included for legacy support, e.g. Chrome/Edge < 119
+        e.returnValue = true;
+    };
+
+    window.addEventListener('beforeunload', beforeUnloadHandler);
     window.addEventListener('pagehide', pageHideHandler);
 
     if (requireDisplayName
@@ -575,6 +588,10 @@ function _pinParticipant({ getState }: IStore, next: Function, action: AnyAction
  * @returns {void}
  */
 function _removeHandlers() {
+    if (typeof beforeUnloadHandler !== 'undefined') {
+        window.removeEventListener('beforeunload', beforeUnloadHandler);
+        beforeUnloadHandler = undefined;
+    }
     if (typeof pageHideHandler !== 'undefined') {
         window.removeEventListener('pagehide', pageHideHandler);
         pageHideHandler = undefined;

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -72,9 +72,9 @@ import logger from './logger';
 import { IConferenceMetadata } from './reducer';
 
 /**
- * Handler for before unload event.
+ * Handler for page hide event.
  */
-let beforeUnloadHandler: ((e?: any) => void) | undefined;
+let pageHideHandler: ((e?: any) => void) | undefined;
 
 /**
  * Implements the middleware of the feature base/conference.
@@ -100,7 +100,7 @@ MiddlewareRegistry.register(store => next => action => {
         return _conferenceSubjectChanged(store, next, action);
 
     case CONFERENCE_WILL_LEAVE:
-        _conferenceWillLeave(store);
+        _conferenceWillLeave();
         break;
 
     case P2P_STATUS_CHANGED:
@@ -258,7 +258,7 @@ function _conferenceFailed({ dispatch, getState }: IStore, next: Function, actio
     // conference is handled by /conference.js and appropriate failure handlers
     // are set there.
     if (typeof APP !== 'undefined') {
-        _removeUnloadHandler(getState);
+        _removeHandlers();
     }
 
     if (enableForcedReload && error?.name === JitsiConferenceErrors.CONFERENCE_RESTARTED) {
@@ -286,10 +286,7 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
     const result = next(action);
     const { conference } = action;
     const { pendingSubjectChange } = getState()['features/base/conference'];
-    const {
-        disableBeforeUnloadHandlers = false,
-        requireDisplayName
-    } = getState()['features/base/config'];
+    const { requireDisplayName } = getState()['features/base/config'];
 
     dispatch(removeLobbyChatParticipant(true));
 
@@ -300,7 +297,7 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
     // handles the process of leaving the conference. This is temporary solution
     // that should cover the described use case as part of the effort to
     // implement the conferenceWillLeave action for web.
-    beforeUnloadHandler = (e?: any) => {
+    pageHideHandler = (e?: any) => {
         if (LocalRecordingManager.isRecordingLocally()) {
             dispatch(stopLocalVideoRecording());
             if (e) {
@@ -317,7 +314,7 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
         dispatch(overwriteConfig({ disableFocus: false }));
     }
 
-    window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', beforeUnloadHandler);
+    window.addEventListener('pagehide', pageHideHandler);
 
     if (requireDisplayName
         && !getLocalParticipant(getState)?.name
@@ -446,7 +443,7 @@ function _connectionFailed({ dispatch, getState }: IStore, next: Function, actio
 
     const result = next(action);
 
-    _removeUnloadHandler(getState);
+    _removeHandlers();
 
     forEachConference(getState, conference => {
         // TODO: revisit this
@@ -518,8 +515,8 @@ function _conferenceSubjectChanged({ dispatch, getState }: IStore, next: Functio
  * @param {Object} store - The redux store.
  * @returns {void}
  */
-function _conferenceWillLeave({ getState }: IStore) {
-    _removeUnloadHandler(getState);
+function _conferenceWillLeave() {
+    _removeHandlers();
 }
 
 /**
@@ -572,17 +569,15 @@ function _pinParticipant({ getState }: IStore, next: Function, action: AnyAction
 }
 
 /**
- * Removes the unload handler.
+ * Removes the page hide and before unload handlers.
  *
  * @param {Function} getState - The redux getState function.
  * @returns {void}
  */
-function _removeUnloadHandler(getState: IStore['getState']) {
-    if (typeof beforeUnloadHandler !== 'undefined') {
-        const { disableBeforeUnloadHandlers = false } = getState()['features/base/config'];
-
-        window.removeEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', beforeUnloadHandler);
-        beforeUnloadHandler = undefined;
+function _removeHandlers() {
+    if (typeof pageHideHandler !== 'undefined') {
+        window.removeEventListener('pagehide', pageHideHandler);
+        pageHideHandler = undefined;
     }
 }
 

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -291,7 +291,6 @@ export interface IConfig {
     disableAP?: boolean;
     disableAddingBackgroundImages?: boolean;
     disableAudioLevels?: boolean;
-    disableBeforeUnloadHandlers?: boolean;
     disableCameraTintForeground?: boolean;
     disableChatSmileys?: boolean;
     disableDeepLinking?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -92,7 +92,6 @@ export default [
     'disableAP',
     'disableAddingBackgroundImages',
     'disableAudioLevels',
-    'disableBeforeUnloadHandlers',
     'disableCameraTintForeground',
     'disableChatSmileys',
     'disableDeepLinking',

--- a/react/features/external-api/middleware.ts
+++ b/react/features/external-api/middleware.ts
@@ -237,13 +237,10 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case SET_CONFIG: {
-        const state = store.getState();
-        const { disableBeforeUnloadHandlers = false } = state['features/base/config'];
-
         /**
          * Disposing the API when the user closes the page.
          */
-        window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', () => {
+        window.addEventListener('pagehide', () => {
             APP.API.notifyConferenceLeft(APP.conference.roomName);
             APP.API.dispose();
             getJitsiMeetTransport().dispose();

--- a/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
+++ b/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
     );
 });
 
-window.addEventListener('beforeunload', () => {
+window.addEventListener('pagehide', () => {
     /* eslint-disable-next-line react/no-deprecated */
     ReactDOM.unmountComponentAtNode(document.getElementById('react')!);
 });


### PR DESCRIPTION
This PR does two things:
1. Switch `beforeunload` handlers to listen to `pagehide`.
2. Adds a new event listener to show browser dialog when leaving the page.

The unload and `beforeunload` events are [considered deprecated](https://developer.chrome.com/docs/web-platform/page-lifecycle-api#legacy_lifecycle_apis_to_avoid), instead it is recommended to use `pagehide` or `visibilitychange` to save state.

By moving the handlers to pagehide, we are able to intercept the page close before the connection is closed. This way if the user decides to stay in the meet, their connection is not interrupted. The xmpp event listener must also be moved in order to avoid sending a absence update before the user has a chance to take action.

### Issues
- #15890
- https://community.jitsi.org/t/prompt-before-closing-during-a-call/20081
- https://community.jitsi.org/t/prevent-refresh-or-back-during-call-give-some-confirmation-prompt/84949/2

### Tests

This change has been tested through running a deployment of jitsi-meet and testing the following:
- conference creation
- conference joining
- attempt browser navigation while in meeting
- end call through hangup button

Additional testing on mobile (I could not test on iOS) and native apps may be necessary.

### Screenshots

https://github.com/user-attachments/assets/cc7ba669-7b90-423a-b473-ba8bc568476d


🚨 This PR should NOT be merged until corresponding update in lib-jitsi-meet is not completed.
- https://github.com/jitsi/lib-jitsi-meet/pull/2754
