### PR TITLE
fix(breakout-room): button layout for keyboard navigation

### DIFF
--- a/react/features/participants-pane/components/web/ParticipantsPane.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsPane.tsx
@@ -178,8 +178,8 @@ const ParticipantsPane = () => {
                 <MeetingParticipants
                     searchString = { searchString }
                     setSearchString = { setSearchString } />
-                {isBreakoutRoomsSupported && <RoomList searchString = { searchString } />}
                 {showAddRoomButton && <AddBreakoutRoomButton />}
+                {isBreakoutRoomsSupported && <RoomList searchString = { searchString } />}
             </div>
             {showFooter && (
                 <div className = { classes.footer }>


### PR DESCRIPTION
In our tests with WCAG compliance it was noted that having the button on the bottom and rooms being added on top is counter intuitive for people using assistive technologies, as they don't know that they now have to navigate backwards.

Switching the position of the button and the room list eliminates this problem with minimal change.

Now the new breakout rooms are appended after the button and are next in the navigation. 