### PR TITLE
fix(UploadImageButton): add accessibility role

### DIFF
--- a/react/features/virtual-background/components/UploadImageButton.tsx
+++ b/react/features/virtual-background/components/UploadImageButton.tsx
@@ -144,6 +144,7 @@ function UploadImageButton({
                 id = 'file-upload'
                 onChange = { uploadImage }
                 ref = { uploadImageButton }
+                role = 'button'
                 type = 'file' />
         </>
     );


### PR DESCRIPTION
Add the `button` role to `<input type="file">` for image upload. Most browsers render this type of input as a button, but there is no default role for this. As the `UploadImageButton` is a button, this role makes the most sense.
