### PR TITLE
fix(participants): fix dynamic participants count in german translation

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -1270,7 +1270,7 @@
             "muteGUMPending": "Verbinde Ihr Mikrofon",
             "noiseSuppression": "Rauschunterdrückung",
             "openChat": "Chat öffnen",
-            "participants": "Anwesende",
+            "participants": "Teilnehmerpanel öffnen. {{participantsCount}} Teilnehmer",
             "pip": "Bild-in-Bild-Modus ein-/ausschalten",
             "privateMessage": "Private Nachricht senden",
             "profile": "Profil bearbeiten",

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -1270,7 +1270,7 @@
             "muteGUMPending": "Verbinde Ihr Mikrofon",
             "noiseSuppression": "Rauschunterdrückung",
             "openChat": "Chat öffnen",
-            "participants": "Teilnehmerpanel öffnen. {{participantsCount}} Teilnehmer",
+            "participants": "Anwesenheitsliste öffnen. {{participantsCount}} anwesend",
             "pip": "Bild-in-Bild-Modus ein-/ausschalten",
             "privateMessage": "Private Nachricht senden",
             "profile": "Profil bearbeiten",


### PR DESCRIPTION
The German translation didn't announce the participants count in the accessibility label. This is now more in line with the English source.