### PR TITLE
fix(DesktopPicker): Stops displaying if closed too fast.

### DIFF
--- a/react/features/desktop-picker/components/DesktopPicker.tsx
+++ b/react/features/desktop-picker/components/DesktopPicker.tsx
@@ -275,7 +275,7 @@ class DesktopPicker extends PureComponent<IProps, IState> {
         const { sources } = this.state;
 
         // @ts-ignore
-        const source = sources.screen.concat(sources.window).find(s => s.id === id);
+        const source = (sources?.screen ?? []).concat(sources?.window ?? []).find(s => s.id === id);
 
         this.props.onSourceChoose(id, type, screenShareAudio, source);
         this.props.dispatch(hideDialog());


### PR DESCRIPTION
If the desktop picker window is closed before we load the sources, a JS error is thrown. From there the app goes into a broken state where when the screen sharing button is pressed nothing happens.  Explanation:
When the error from the _onCloseModal handler is thrown we don't reach the line to call the onSourceChoose callback. The result is that we never call the callback received by setDisplayMediaRequestHandler. It seems that when this happens on subsequent gDM calls electron won't call the setDisplayMediaRequestHandler and therefore we don't display the desktop picker.