### PR TITLE
fix(overlay|prejoin) Added level to items with heading role

### DIFF
--- a/react/features/overlay/components/web/PageReloadOverlay.tsx
+++ b/react/features/overlay/components/web/PageReloadOverlay.tsx
@@ -33,6 +33,7 @@ class PageReloadOverlay extends AbstractPageReloadOverlay<IProps> {
                     className = 'inlay'
                     role = 'dialog'>
                     <span
+                        aria-level = { 1 }
                         className = 'reload_overlay_title'
                         id = 'reload_overlay_title'
                         role = 'heading'>

--- a/react/features/prejoin/components/web/preview/DeviceStatus.tsx
+++ b/react/features/prejoin/components/web/preview/DeviceStatus.tsx
@@ -67,7 +67,9 @@ function DeviceStatus() {
             role = 'alert'
             tabIndex = { -1 }>
             {!hasError && <div className = { classes.indicator } />}
-            <span role = 'heading'>
+            <span
+                aria-level = { 3 }
+                role = 'heading'>
                 {hasError ? t('prejoin.errorNoPermissions') : t(deviceStatusText ?? '')}
             </span>
         </div>


### PR DESCRIPTION
Items with `role="heading"` were missing the mandatory complementary attribute `aria-level`.
