### PR TITLE
fix(rtcstats) drop unnecessary dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@jitsi/js-utils": "2.2.1",
         "@jitsi/logger": "2.0.2",
         "@jitsi/rnnoise-wasm": "0.2.1",
-        "@jitsi/rtcstats": "9.5.1",
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.12.1",
@@ -4203,16 +4202,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.2.1.tgz",
       "integrity": "sha512-iEj77www43pS2Yq+cfLZb+hFuI7L5ccisBzzPMcOjjLsG4/LAlkD1CY58/8gc84nHdLBGmD/OPIWGnvYnXvB0A=="
-    },
-    "node_modules/@jitsi/rtcstats": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
-      "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
-      "dependencies": {
-        "@jitsi/js-utils": "^2.0.0",
-        "sdp": "^3.0.3",
-        "uuid": "^8.3.2"
-      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -28382,16 +28371,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@jitsi/rnnoise-wasm/-/rnnoise-wasm-0.2.1.tgz",
       "integrity": "sha512-iEj77www43pS2Yq+cfLZb+hFuI7L5ccisBzzPMcOjjLsG4/LAlkD1CY58/8gc84nHdLBGmD/OPIWGnvYnXvB0A=="
-    },
-    "@jitsi/rtcstats": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@jitsi/rtcstats/-/rtcstats-9.5.1.tgz",
-      "integrity": "sha512-UDcsNwPvweQ6owV/chwabd6DsQd2aB4qjqrOB+BlJnETZ+zssGYAey3ezaiNK6nxevwBkbHj980/S9v+2y4btg==",
-      "requires": {
-        "@jitsi/js-utils": "^2.0.0",
-        "sdp": "^3.0.3",
-        "uuid": "^8.3.2"
-      }
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@jitsi/js-utils": "2.2.1",
     "@jitsi/logger": "2.0.2",
     "@jitsi/rnnoise-wasm": "0.2.1",
-    "@jitsi/rtcstats": "9.5.1",
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.12.1",

--- a/react/features/rtcstats/RTCStats.ts
+++ b/react/features/rtcstats/RTCStats.ts
@@ -1,11 +1,3 @@
-/* eslint-disable lines-around-comment */
-import {
-    PC_CON_STATE_CHANGE,
-    PC_STATE_CONNECTED,
-    PC_STATE_FAILED
-    // @ts-expect-error
-} from '@jitsi/rtcstats/events';
-
 import JitsiMeetJS, { RTCStatsEvents } from '../base/lib-jitsi-meet';
 
 import logger from './logger';
@@ -15,6 +7,11 @@ import {
     FaceLandmarksData,
     VideoTypeData
 } from './types';
+
+// TODO(saghul): expose these in libn-jitsi-meet?
+const PC_CON_STATE_CHANGE = 'connectionstatechange';
+const PC_STATE_CONNECTED = 'connected';
+const PC_STATE_FAILED = 'failed';
 
 /**
  * Handle lib-jitsi-meet rtcstats events and send jitsi-meet specific statistics.


### PR DESCRIPTION
We either expose those events in LJM or live with strings since they match standard WebRTC states, but depending on the package just for 3 events is just not right.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
