### PR TITLE
fix(prosody): Fixes extracting domain when more cases.

### DIFF
--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -279,7 +279,12 @@ function extract_subdomain(room_node)
         return ret.subdomain, ret.room, ret.customer_id;
     end
 
-    local subdomain, room_name = room_node:match("^%[([^%]]+)%](.+)$") or nil, room_node;
+    local subdomain, room_name = room_node:match("^%[([^%]]+)%](.+)$");
+
+    if not subdomain then
+        room_name = room_node;
+    end
+
     local _, customer_id = subdomain and subdomain:match("^(vpaas%-magic%-cookie%-)(.*)$") or nil, nil;
     local cache_value = { subdomain=subdomain, room=room_name, customer_id=customer_id };
     extract_subdomain_cache:set(room_node, cache_value);


### PR DESCRIPTION
This was broken and was passing as room_node as room_name even for tenant meetings.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
