### PR TITLE
fix(prosody): Add consider_websocket_secure into Prosody config

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -15,6 +15,7 @@ external_services = {
 
 cross_domain_bosh = false;
 consider_bosh_secure = true;
+consider_websocket_secure = true;
 -- https_ports = { }; -- Remove this line to prevent listening on port 5284
 
 -- by default prosody 0.12 sends cors headers, if you want to disable it uncomment the following (the config is available on 0.12.1)


### PR DESCRIPTION
The fix allows Jibri to work through websocket.

See [the related topic](https://community.jitsi.org/t/possible-bug-bosh-doesnt-work-by-default/138391/12) in forum for more details.