### PR TITLE
fix(polls) halt processing of malformed polls

### DIFF
--- a/resources/prosody-plugins/mod_polls.lua
+++ b/resources/prosody-plugins/mod_polls.lua
@@ -72,7 +72,7 @@ module:hook('jitsi-endpoint-message-received', function(event)
 
     if string.len(event.raw_message) >= POLL_PAYLOAD_LIMIT then
         module:log('error', 'Poll payload too large, discarding. Sender: %s to:%s', stanza.attr.from, stanza.attr.to);
-        return nil;
+        return true;
     end
 
     if data.type == "new-poll" then
@@ -86,7 +86,7 @@ module:hook('jitsi-endpoint-message-received', function(event)
 
         if room.polls.count >= POLLS_LIMIT then
             module:log("error", "Too many polls created in %s", room.jid)
-            return
+            return true;
         end
 
         if room.polls.by_id[data.pollId] ~= nil then


### PR DESCRIPTION
We need to return something other than nil in order to halt the processing of the event.

https://prosody.im/doc/developers/moduleapi#modulehook_event_name_handler_priority

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
