### PR TITLE
feat(external_api): set and get jitsi participant properties

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -898,6 +898,11 @@ function initCommands() {
                 backgroundType: VIRTUAL_BACKGROUND_TYPE.IMAGE,
                 virtualSource: backgroundImage
             }, jitsiTrack));
+        },
+        'set-property': (key, value) => {
+            const conference = getCurrentConference(APP.store.getState());
+
+            conference.setLocalParticipantProperty(key, value);
         }
     };
     transport.on('event', ({ data, name }) => {
@@ -1085,6 +1090,15 @@ function initCommands() {
 
             dispatch(showDesktopPicker(options, onSourceChoose));
 
+            break;
+        }
+        case 'get-property': {
+            const { participantId, key } = request;
+
+            const conference = getCurrentConference(APP.store.getState());
+            const participant = conference?.getParticipantById(participantId);
+
+            callback(participant?.getProperty(key) || '');
             break;
         }
         default:

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -71,6 +71,7 @@ const commands = {
     setTileView: 'set-tile-view',
     setVideoQuality: 'set-video-quality',
     setVirtualBackground: 'set-virtual-background',
+    setProperty: 'set-property',
     showNotification: 'show-notification',
     startRecording: 'start-recording',
     startShareVideo: 'start-share-video',
@@ -1476,6 +1477,22 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     _openDesktopPicker() {
         return this._transport.sendRequest({
             name: 'open-desktop-picker'
+        });
+    }
+
+    /**
+     * Returns jitsi participant property.
+     *
+     * @param {string} participantId - The id of the participant.
+     * @param {string} key - The key of participant property to be fetched.
+     *
+     * @returns {Promise}
+     */
+    getProperty(participantId, key) {
+        return this._transport.sendRequest({
+            name: 'get-property',
+            participantId,
+            key
         });
     }
 }


### PR DESCRIPTION
Workaround for https://github.com/jitsi/jitsi-meet/issues/7995
Workaround for https://github.com/jitsi/jitsi-meet/issues/12142

Adds support to JitsiParticipant properties for external api.

Uses `setLocalParticipantProperty` from `JitsiConference` to set properties and `getProperty` from `JitsiParticipant` to fetch properties.

With this developers who've implemented external api can add custom properties like user id from their own system to link JitsiParticipant against their own data.