### PR TITLE
feat(local-recordings) remove recording time limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
         "util": "0.12.1",
         "uuid": "8.3.2",
         "wasm-check": "2.0.1",
-        "webm-duration-fix": "1.0.4",
         "windows-iana": "3.1.0",
         "zxcvbn": "4.4.2"
       },
@@ -11926,11 +11925,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
-    "node_modules/ebml-block": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ebml-block/-/ebml-block-1.1.2.tgz",
-      "integrity": "sha512-HgNlIsRFP6D9VKU5atCeHRJY7XkJP8bOe8yEhd8NB7B3b4++VWTyauz6g650iiPmLfPLGlVpoJmGSgMfXDYusg=="
-    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -15144,14 +15138,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/int64-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.0.1.tgz",
-      "integrity": "sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==",
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/internal-slot": {
@@ -24797,40 +24783,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
-    "node_modules/webm-duration-fix": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/webm-duration-fix/-/webm-duration-fix-1.0.4.tgz",
-      "integrity": "sha512-kvhmSmEnuohtK+j+mJswqCCM2ViKb9W8Ch0oAxcaeUvpok5CsMORQLnea+CYKDXPG6JH12H0CbRK85qhfeZLew==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "ebml-block": "^1.1.2",
-        "events": "^3.3.0",
-        "int64-buffer": "^1.0.1"
-      }
-    },
-    "node_modules/webm-duration-fix/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.95.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.95.0.tgz",
@@ -33901,11 +33853,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
-    "ebml-block": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ebml-block/-/ebml-block-1.1.2.tgz",
-      "integrity": "sha512-HgNlIsRFP6D9VKU5atCeHRJY7XkJP8bOe8yEhd8NB7B3b4++VWTyauz6g650iiPmLfPLGlVpoJmGSgMfXDYusg=="
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -36202,11 +36149,6 @@
         "run-async": "^3.0.0",
         "rxjs": "^7.8.1"
       }
-    },
-    "int64-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.0.1.tgz",
-      "integrity": "sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw=="
     },
     "internal-slot": {
       "version": "1.1.0",
@@ -42978,28 +42920,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "webm-duration-fix": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/webm-duration-fix/-/webm-duration-fix-1.0.4.tgz",
-      "integrity": "sha512-kvhmSmEnuohtK+j+mJswqCCM2ViKb9W8Ch0oAxcaeUvpok5CsMORQLnea+CYKDXPG6JH12H0CbRK85qhfeZLew==",
-      "requires": {
-        "buffer": "^6.0.3",
-        "ebml-block": "^1.1.2",
-        "events": "^3.3.0",
-        "int64-buffer": "^1.0.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
-      }
     },
     "webpack": {
       "version": "5.95.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "util": "0.12.1",
     "uuid": "8.3.2",
     "wasm-check": "2.0.1",
-    "webm-duration-fix": "1.0.4",
     "windows-iana": "3.1.0",
     "zxcvbn": "4.4.2"
   },

--- a/react/features/recording/components/Recording/LocalRecordingManager.native.ts
+++ b/react/features/recording/components/Recording/LocalRecordingManager.native.ts
@@ -3,6 +3,7 @@ import { IStore } from '../../../app/types';
 interface ILocalRecordingManager {
     addAudioTrackToLocalRecording: (track: any) => void;
     isRecordingLocally: () => boolean;
+    isSupported: () => boolean;
     selfRecording: {
         on: boolean;
         withVideo: boolean;
@@ -39,6 +40,15 @@ const LocalRecordingManager: ILocalRecordingManager = {
      * @returns {void}
      */
     async startLocalRecording() { }, // eslint-disable-line @typescript-eslint/no-empty-function
+
+    /**
+     * Whether or not local recording is supported.
+     *
+     * @returns {boolean}
+     */
+    isSupported() {
+        return false;
+    },
 
     /**
      * Whether or not we're currently recording locally.

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -1,10 +1,9 @@
 import i18next from 'i18next';
 
 import { IReduxState, IStore } from '../app/types';
-import { isMobileBrowser } from '../base/environment/utils';
 import { MEET_FEATURES } from '../base/jwt/constants';
 import { isJwtFeatureEnabled } from '../base/jwt/functions';
-import { JitsiRecordingConstants, browser } from '../base/lib-jitsi-meet';
+import { JitsiRecordingConstants } from '../base/lib-jitsi-meet';
 import { getSoundFileSrc } from '../base/media/functions';
 import { getLocalParticipant, getRemoteParticipants } from '../base/participants/functions';
 import { registerSound, unregisterSound } from '../base/sounds/actions';
@@ -151,8 +150,7 @@ export function getSessionStatusToShow(state: IReduxState, mode: string): string
  * @returns {boolean} - Whether local recording is supported or not.
  */
 export function supportsLocalRecording() {
-    return browser.isChromiumBased() && !browser.isElectron() && !isMobileBrowser()
-        && navigator.product !== 'ReactNative';
+    return LocalRecordingManager.isSupported();
 }
 
 /**


### PR DESCRIPTION
Use the `showSaveFilePicker` File System Access API to pre-select the file for download and stream the contents there. The browser uses a temporary file as the buffer, thus not requiring us to buffer the contents in memory.

Also change the container to MP4, since we have no way to fix the seeking problem since we don't have the file in memory. Good news is that it's supported since Chrome 126 and we can feature detect it!

Finally, add a helper `isSupprted` method which feature-detects everything we need to make this work.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker
Ref: https://groups.google.com/a/chromium.org/g/blink-dev/c/p1OMVj1FrMI/m/6FdLk7rZAQAJ

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
