### PR TITLE
timestamps displaying on individual messages

### DIFF
--- a/react/features/chat/components/native/ChatMessageGroup.tsx
+++ b/react/features/chat/components/native/ChatMessageGroup.tsx
@@ -75,7 +75,7 @@ export default class ChatMessageGroup extends Component<IProps> {
                     this.props.messages[0].messageType === MESSAGE_TYPE_REMOTE
                         && index === this.props.messages.length - 1
                 }
-                showTimestamp = { index === 0 } />
+                showTimestamp = { true } />
         );
     }
 }


### PR DESCRIPTION
Fixes: #15951

Displaying each messages its own time.
![WhatsApp Image 2025-04-22 at 16 56 27_8c381413](https://github.com/user-attachments/assets/3639f7b9-8288-4abe-9cff-39b7faf17c46)

