### PR TITLE
Fix: Chat input and send button slightly hidden behind keyboard

### DIFF
--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -119,7 +119,8 @@ export default {
      * A special padding to avoid issues on some devices (such as Android devices with custom suggestions bar).
      */
     extraBarPadding: {
-        paddingBottom: 30
+        paddingBottom: 30,
+        marginBottom:20
     },
 
     inputBarNarrow: {

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -120,7 +120,7 @@ export default {
      */
     extraBarPadding: {
         paddingBottom: 30,
-        marginBottom:20
+        marginBottom: 20
     },
 
     inputBarNarrow: {


### PR DESCRIPTION
Fixes: #15956
Added marginBottom in existing style.
![solved](https://github.com/user-attachments/assets/77a3c459-b62c-4a56-adc3-745a4b384d4d)


