### PR TITLE
fix(recording) prevent multiple consent requests

### DIFF
--- a/react/features/recording/actionTypes.ts
+++ b/react/features/recording/actionTypes.ts
@@ -9,6 +9,16 @@
 export const CLEAR_RECORDING_SESSIONS = 'CLEAR_RECORDING_SESSIONS';
 
 /**
+ * The type of Redux action which marks a session ID as consent requested.
+ *
+ * {
+ *     type: MARK_CONSENT_REQUESTED,
+ *     sessionId: string
+ * }
+ */
+export const MARK_CONSENT_REQUESTED = 'MARK_CONSENT_REQUESTED';
+
+/**
  * The type of Redux action which updates the current known state of a recording
  * session.
  *

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -20,6 +20,7 @@ import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
 
 import {
     CLEAR_RECORDING_SESSIONS,
+    MARK_CONSENT_REQUESTED,
     RECORDING_SESSION_UPDATED,
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
@@ -474,5 +475,19 @@ export function showStartRecordingNotificationWithCallback(openRecordingDialog: 
             } ],
             appearance: NOTIFICATION_TYPE.NORMAL
         }, NOTIFICATION_TIMEOUT_TYPE.EXTRA_LONG));
+    };
+}
+
+/**
+ * Marks the given session as consent requested. No further consent requests will be
+ * made for this session.
+ *
+ * @param {string} sessionId - The session id.
+ * @returns {Object}
+ */
+export function markConsentRequested(sessionId: string) {
+    return {
+        type: MARK_CONSENT_REQUESTED,
+        sessionId
     };
 }

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -442,6 +442,7 @@ export function shouldRequireRecordingConsent(recorderSession: any, state: IRedu
     const { requireRecordingConsent } = state['features/dynamic-branding'] || {};
     const { requireConsent } = state['features/base/config'].recordings || {};
     const { iAmRecorder } = state['features/base/config'];
+    const { consentRequested } = state['features/recording'];
 
     if (iAmRecorder) {
         return false;
@@ -455,10 +456,15 @@ export function shouldRequireRecordingConsent(recorderSession: any, state: IRedu
         return false;
     }
 
-    if (!recorderSession.getInitiator()
-        || recorderSession.getStatus() === JitsiRecordingConstants.status.OFF) {
+    if (consentRequested.has(recorderSession.getID())) {
         return false;
     }
 
-    return recorderSession.getInitiator() !== getLocalParticipant(state)?.id;
+    const initiator = recorderSession.getInitiator();
+
+    if (!initiator || recorderSession.getStatus() === JitsiRecordingConstants.status.OFF) {
+        return false;
+    }
+
+    return initiator !== getLocalParticipant(state)?.id;
 }

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -36,6 +36,7 @@ import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
 import { RECORDING_SESSION_UPDATED, START_LOCAL_RECORDING, STOP_LOCAL_RECORDING } from './actionTypes';
 import {
     clearRecordingSessions,
+    markConsentRequested,
     hidePendingRecordingNotification,
     showPendingRecordingNotification,
     showRecordingError,
@@ -420,6 +421,7 @@ function _showExplicitConsentDialog(recorderSession: any, dispatch: IStore['disp
     }
 
     batch(() => {
+        dispatch(markConsentRequested(recorderSession.getID()));
         dispatch(setAudioUnmutePermissions(true, true));
         dispatch(setVideoUnmutePermissions(true, true));
         dispatch(setAudioMuted(true));

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -2,6 +2,7 @@ import ReducerRegistry from '../base/redux/ReducerRegistry';
 
 import {
     CLEAR_RECORDING_SESSIONS,
+    MARK_CONSENT_REQUESTED,
     RECORDING_SESSION_UPDATED,
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
@@ -11,6 +12,7 @@ import {
 } from './actionTypes';
 
 const DEFAULT_STATE = {
+    consentRequested: new Set(),
     disableHighlightMeetingMoment: false,
     pendingNotificationUids: {},
     selectedRecordingService: '',
@@ -29,6 +31,7 @@ export interface ISessionData {
 }
 
 export interface IRecordingState {
+    consentRequested: Set<any>;
     disableHighlightMeetingMoment: boolean;
     pendingNotificationUids: {
         [key: string]: string | undefined;
@@ -55,6 +58,15 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
             return {
                 ...state,
                 sessionDatas: []
+            };
+
+        case MARK_CONSENT_REQUESTED:
+            return {
+                ...state,
+                consentRequested: new Set([
+                    ...state.consentRequested,
+                    action.sessionId
+                ])
             };
 
         case RECORDING_SESSION_UPDATED:


### PR DESCRIPTION
A given recording should only trigger a single consent request.

The mechanism to notify about recording status updates may fire multiple
times since it's tied to XMPP presence and may send updates such as when
the live stream view URL is set.

Rather than trying to handle all possible corner cases to make sure we
only show the consent dialog once, keep track of the recording session
IDs for which we _have_ asked for consent and skip the dialog in case we
have done it already.
