### PR TITLE
feat(recording) add ability to skip consent in-meeting

### DIFF
--- a/config.js
+++ b/config.js
@@ -401,6 +401,8 @@ var config = {
     //    // If true, mutes audio and video when a recording begins and displays a dialog
     //    // explaining the effect of unmuting.
     //    // requireConsent: true,
+    //    // If true consent will be skipped for users who are already in the meeting.
+    //    // skipConsentInMeeting: true,
     // },
 
     // recordingService: {

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -546,6 +546,7 @@ export interface IConfig {
         requireConsent?: boolean;
         showPrejoinWarning?: boolean;
         showRecordingLink?: boolean;
+        skipConsentInMeeting?: boolean;
         suggestRecording?: boolean;
     };
     remoteVideoMenu?: {

--- a/react/features/dynamic-branding/reducer.ts
+++ b/react/features/dynamic-branding/reducer.ts
@@ -180,6 +180,7 @@ export interface IDynamicBrandingState {
     requireRecordingConsent?: boolean;
     sharedVideoAllowedURLDomains?: Array<string>;
     showGiphyIntegration?: boolean;
+    skipRecordingConsentInMeeting?: boolean;
     supportUrl?: string;
     useDynamicBrandingData: boolean;
     virtualBackgrounds: Array<Image>;
@@ -206,9 +207,10 @@ ReducerRegistry.register<IDynamicBrandingState>(STORE_NAME, (state = DEFAULT_STA
             muiBrandedTheme,
             pollCreationRequiresPermission,
             premeetingBackground,
+            requireRecordingConsent,
             sharedVideoAllowedURLDomains,
             showGiphyIntegration,
-            requireRecordingConsent,
+            skipRecordingConsentInMeeting,
             supportUrl,
             virtualBackgrounds
         } = action.value;
@@ -228,9 +230,10 @@ ReducerRegistry.register<IDynamicBrandingState>(STORE_NAME, (state = DEFAULT_STA
             muiBrandedTheme,
             pollCreationRequiresPermission,
             premeetingBackground,
+            requireRecordingConsent,
             sharedVideoAllowedURLDomains,
             showGiphyIntegration,
-            requireRecordingConsent,
+            skipRecordingConsentInMeeting,
             supportUrl,
             customizationFailed: false,
             customizationReady: true,

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -439,8 +439,10 @@ export function isLiveStreamingButtonVisible({
  * @returns {boolean}
  */
 export function shouldRequireRecordingConsent(recorderSession: any, state: IReduxState) {
-    const { requireRecordingConsent } = state['features/dynamic-branding'] || {};
-    const { requireConsent } = state['features/base/config'].recordings || {};
+    const { requireRecordingConsent, skipRecordingConsentInMeeting }
+        = state['features/dynamic-branding'] || {};
+    const { conference } = state['features/base/conference'] || {};
+    const { requireConsent, skipConsentInMeeting } = state['features/base/config'].recordings || {};
     const { iAmRecorder } = state['features/base/config'];
     const { consentRequested } = state['features/recording'];
 
@@ -457,6 +459,13 @@ export function shouldRequireRecordingConsent(recorderSession: any, state: IRedu
     }
 
     if (consentRequested.has(recorderSession.getID())) {
+        return false;
+    }
+
+    // If we join a meeting that has an ongoing recording `conference` will be undefined since
+    // we get the recording state through the initial presence which happens in between the
+    // WILL_JOIN and JOINED events.
+    if (conference && (skipConsentInMeeting || skipRecordingConsentInMeeting)) {
         return false;
     }
 


### PR DESCRIPTION
When turned on, the consent dialog won't be displayed for the users who
are already in the meeting, it will only be displayed to those who join
after the recording was started.
