### PR TITLE
ref(theme): revert spacing to number and not rem.

### DIFF
--- a/react/features/base/ui/Tokens.ts
+++ b/react/features/base/ui/Tokens.ts
@@ -128,8 +128,7 @@ export const shape = {
     boxShadow: 'inset 0px -1px 0px rgba(255, 255, 255, 0.15)'
 };
 
-export const spacing
-    = [ '0rem', '0.25rem', '0.5rem', '1rem', '1.5rem', '2rem', '2.5rem', '3rem', '3.5rem', '4rem', '4.5rem', '5rem', '5.5rem', '6rem', '6.5rem', '7rem', '7.5rem', '8rem' ];
+export const spacing = [ 0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128 ];
 
 export const typography = {
     labelRegular: 'label01',

--- a/react/features/base/ui/components/web/ContextMenu.tsx
+++ b/react/features/base/ui/components/web/ContextMenu.tsx
@@ -213,7 +213,7 @@ const ContextMenu = ({
 
             if (offsetTop + height > offsetHeight + scrollTop && height > offsetTop) {
                 // top offset and + padding + border
-                container.style.maxHeight = `calc(${offsetTop}px - (${spacing[2]} * 2 + 2px))`;
+                container.style.maxHeight = `${offsetTop - ((spacing[2] * 2) + 2)}px`;
             }
 
             // get the height after style changes

--- a/react/features/base/ui/functions.native.ts
+++ b/react/features/base/ui/functions.native.ts
@@ -42,7 +42,7 @@ export function createNativeTheme({ font, colorMap, shape, spacing, typography }
         ...DefaultTheme,
         palette: createColorTokens(colorMap),
         shape,
-        spacing: spacing.map(remToPixels),
+        spacing,
         typography: {
             font,
             ...convertRemValues(typography)

--- a/react/features/base/ui/functions.web.ts
+++ b/react/features/base/ui/functions.web.ts
@@ -117,5 +117,5 @@ export function operatesWithEnterKey(element: Element): boolean {
  * @returns {number}
  */
 export function getVideospaceFloatingElementsBottomSpacing(theme: Theme, isToolbarVisible: boolean) {
-    return isToolbarVisible ? theme.spacing(12) : theme.spacing(6);
+    return parseInt(isToolbarVisible ? theme.spacing(12) : theme.spacing(6), 10);
 }

--- a/react/features/base/ui/functions.web.ts
+++ b/react/features/base/ui/functions.web.ts
@@ -20,7 +20,7 @@ interface ThemeProps {
     colorMap: Object;
     font: Object;
     shape: Object;
-    spacing: Array<number | string>;
+    spacing: Array<number>;
     typography: Object;
 }
 

--- a/react/features/subtitles/components/web/Captions.tsx
+++ b/react/features/subtitles/components/web/Captions.tsx
@@ -63,7 +63,7 @@ const styles = (theme: Theme, props: IProps) => {
     if (_isLifted) {
         // 10px is the space between the onstage participant display name label and subtitles. We also need
         // to add the padding of the subtitles because it will decrease the gap between the label and subtitles.
-        bottom = `calc(${bottom} + ${getStageParticipantNameLabelHeight(theme, _clientHeight) + 10 + padding}px)`;
+        bottom += getStageParticipantNameLabelHeight(theme, _clientHeight) + 10 + padding;
     }
 
     if (_shiftUp) {
@@ -73,7 +73,7 @@ const styles = (theme: Theme, props: IProps) => {
 
     return {
         transcriptionSubtitles: {
-            bottom,
+            bottom: `${bottom}px`,
             marginBottom: `${marginBottom}px`,
             fontSize: `${fontSize}px`,
             left: '50%',


### PR DESCRIPTION
There are still many places where theme.spacing is expected to be number. Reverting parts of https://github.com/jitsi/jitsi-meet/commit/057dc0e4d251cd8a51e1b711db936adcb71e2a53 .

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
