### PR TITLE
dynamic-branding: Make `dynamicBrandingUrl` behavior match `brandingDataUrl` by adding conferenceFqn

### DIFF
--- a/react/features/dynamic-branding/functions.any.ts
+++ b/react/features/dynamic-branding/functions.any.ts
@@ -46,12 +46,13 @@ export async function getDynamicBrandingUrl(stateful: IStateful) {
     if (baseUrl) {
         // Warn of dynamicBrandingUrl deprecation (even if brandingDataUrl is set too)
         if (config.dynamicBrandingUrl) {
-            logger.warn("Deprecation: dynamicBrandingUrl in configuration will be removed in a future version. Use brandingDataUrl instead for the same behavior.");
+            logger.warn('Deprecation: dynamicBrandingUrl in configuration will be removed in a future version. Use brandingDataUrl instead for the same behavior.');
         }
 
         // Append fqn to the branding url to allow dynamic branding.
         const fqn = extractFqnFromPath(state);
-        return baseUrl + (fqn ? `?conferenceFqn=${encodeURIComponent(fqn)}` : "");
+
+        return baseUrl + (fqn ? `?conferenceFqn=${encodeURIComponent(fqn)}` : '');
     }
 }
 


### PR DESCRIPTION
Make `dynamicBrandingUrl` behavior match `brandingDataUrl` / `baseUrl` oriented behavior by adding the conferenceFqn url variable to it.

The original logic, which this pull request modifies, was only adding the query string `?conferenceFqn={fqn}` to the branding url for `brandingDataUrl` / `baseUrl` were used. When a `dynamicBrandingUrl` is set in the current release, the logic for checking and adding the fqn is omitted.
