### PR TITLE
fix(recording) fix matching initiator

### DIFF
--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -469,11 +469,14 @@ export function shouldRequireRecordingConsent(recorderSession: any, state: IRedu
         return false;
     }
 
+    // lib-jitsi-meet may set a JitsiParticipant as the initiator of the recording session or the
+    // JID resource in case it cannot find it. We need to handle both cases.
     const initiator = recorderSession.getInitiator();
+    const initiatorId = initiator?.getId?.() ?? initiator;
 
-    if (!initiator || recorderSession.getStatus() === JitsiRecordingConstants.status.OFF) {
+    if (!initiatorId || recorderSession.getStatus() === JitsiRecordingConstants.status.OFF) {
         return false;
     }
 
-    return initiator !== getLocalParticipant(state)?.id;
+    return initiatorId !== getLocalParticipant(state)?.id;
 }


### PR DESCRIPTION
LJM will use either a JitsiParticipant object or a string for the recording session initiator, handle both cases when checking if it's ourselves.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
