### PR TITLE
fix(spot) make Spot TV detection more resilient

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -442,6 +442,7 @@ export interface IConfig {
     };
     iAmRecorder?: boolean;
     iAmSipGateway?: boolean;
+    iAmSpot?: boolean;
     ignoreStartMuted?: boolean;
     inviteAppName?: string | null;
     inviteServiceCallFlowsUrl?: string;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -170,6 +170,7 @@ export default [
     'hideLobbyButton',
     'iAmRecorder',
     'iAmSipGateway',
+    'iAmSpot',
     'ignoreStartMuted',
     'inviteAppName',
     'liveStreaming.enabled',

--- a/react/features/base/util/spot.ts
+++ b/react/features/base/util/spot.ts
@@ -1,9 +1,16 @@
+import { IReduxState } from '../../app/types';
 
 /**
  * Checks if Jitsi Meet is running on Spot TV.
  *
+ * @param {IReduxState} state - The redux state.
  * @returns {boolean} Whether or not Jitsi Meet is running on Spot TV.
  */
-export function isSpotTV(): boolean {
-    return navigator.userAgent.includes('SpotElectron/');
+export function isSpotTV(state: IReduxState): boolean {
+    const { defaultLocalDisplayName, iAmSpot } = state['features/base/config'] || {};
+
+    return iAmSpot
+        || navigator.userAgent.includes('JitsiSpot/') // Jitsi Spot app
+        || navigator.userAgent.includes('8x8MeetingRooms/') // 8x8 Meeting Rooms app
+        || defaultLocalDisplayName === 'Meeting Room';
 }

--- a/react/features/large-video/components/LargeVideo.web.tsx
+++ b/react/features/large-video/components/LargeVideo.web.tsx
@@ -383,7 +383,7 @@ function _mapStateToProps(state: IReduxState) {
         _customBackgroundColor: backgroundColor,
         _customBackgroundImageUrl: backgroundImageUrl,
         _displayScreenSharingPlaceholder:
-            Boolean(isLocalScreenshareOnLargeVideo && !seeWhatIsBeingShared && !isSpotTV()),
+            Boolean(isLocalScreenshareOnLargeVideo && !seeWhatIsBeingShared && !isSpotTV(state)),
         _hideSelfView: getHideSelfView(state),
         _isChatOpen: isChatOpen,
         _isDisplayNameVisible: isDisplayNameVisible(state),

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -450,7 +450,7 @@ export function shouldRequireRecordingConsent(recorderSession: any, state: IRedu
         return false;
     }
 
-    if (isSpotTV()) {
+    if (isSpotTV(state)) {
         return false;
     }
 


### PR DESCRIPTION
Setting the UA string in Electron doesn't propagate the change to the
iframe where the meeting is loaded (:facepalm:).

Thus make it more resilient by trying different things:

- A freshly introduced "iAmSpot" config option, similar to Jibri
- The app ID is present in the UA string, so we can test for that
- As a last-ditch effort, check if the display name is the default
  "Meeting Room"
