### PR TITLE
feat(notifications) make sticky notifications duration configurable

### DIFF
--- a/config.js
+++ b/config.js
@@ -613,6 +613,7 @@ var config = {
     //     medium: 5000,
     //     long: 10000,
     //     extraLong: 60000,
+    //     sticky: 0,
     // },
 
     // // Options for the recording limit notification.

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -488,6 +488,7 @@ export interface IConfig {
         long?: number;
         medium?: number;
         short?: number;
+        sticky?: number;
     };
     notifications?: Array<string>;
     notifyOnConferenceDestruction?: boolean;

--- a/react/features/notifications/actions.ts
+++ b/react/features/notifications/actions.ts
@@ -38,9 +38,11 @@ function getNotificationTimeout(type?: string, notificationTimeouts?: IConfig['n
         return notificationTimeouts?.long ?? NOTIFICATION_TIMEOUT.LONG;
     } else if (type === NOTIFICATION_TIMEOUT_TYPE.EXTRA_LONG) {
         return notificationTimeouts?.extraLong ?? NOTIFICATION_TIMEOUT.EXTRA_LONG;
+    } else if (type === NOTIFICATION_TIMEOUT_TYPE.STICKY) {
+        return notificationTimeouts?.sticky ?? NOTIFICATION_TIMEOUT.STICKY;
     }
 
-    return NOTIFICATION_TIMEOUT.STICKY;
+    return 0;
 }
 
 /**


### PR DESCRIPTION
Spot is non-interactive, so it will override a timeout.
