### PR TITLE
Fix analytics loadscript call to match new function signature

### DIFF
--- a/react/features/base/util/loadScript.web.ts
+++ b/react/features/base/util/loadScript.web.ts
@@ -9,10 +9,10 @@ export function loadScript(url: string): Promise<void> {
     return new Promise((resolve, reject) =>
         JitsiMeetJS.util.ScriptUtil.loadScript(
             { src: url,
-               async: true,
-               prepend: false,
-               relativeURL: false,
-               loadCallback: resolve,
-               errorCallback: reject
-             }))
+                async: true,
+                prepend: false,
+                relativeURL: false,
+                loadCallback: resolve,
+                errorCallback: reject
+            }));
 }

--- a/react/features/base/util/loadScript.web.ts
+++ b/react/features/base/util/loadScript.web.ts
@@ -8,10 +8,11 @@
 export function loadScript(url: string): Promise<void> {
     return new Promise((resolve, reject) =>
         JitsiMeetJS.util.ScriptUtil.loadScript(
-            url,
-            /* async */ true,
-            /* prepend */ false,
-            /* relativeURL */ false,
-            /* loadCallback */ resolve,
-            /* errorCallback */ reject));
+            { src: url,
+               async: true,
+               prepend: false,
+               relativeURL: false,
+               loadCallback: resolve,
+               errorCallback: reject
+             }))
 }


### PR DESCRIPTION
Hi,

Since this commit — [ https://github.com/jitsi/lib-jitsi-meet/commit/e7bed00e84e9958d6e9d9dc8ce0a1c9f1cee68b3](url) — and the migration of the JitsiMeetJS.util.ScriptUtil.loadScript function to TypeScript, the scriptURLs feature in analytics is broken.

The loadScript function signature has changed and now expects an object implementing the ILoadScriptOptions interface, rather than a list of parameters.

This patch updates the code accordingly to restore the expected behavior.

Best regards,
Damien Fetis