### PR TITLE
feat(build,config) disable config whitelist in dev mode

### DIFF
--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -193,6 +193,13 @@ export function overrideConfigJSON(config: IConfig, interfaceConfig: any, json: 
  * that are whitelisted.
  */
 export function getWhitelistedJSON(configName: 'interfaceConfig' | 'config', configJSON: any): Object {
+    // Disable whitelisting in dev mode.
+    if (typeof __DEV__ !== 'undefined' && __DEV__) {
+        logger.warn('Whitelisting is disabled in dev mode, accepting any overrides');
+
+        return configJSON;
+    }
+
     if (configName === 'interfaceConfig') {
         return pick(configJSON, INTERFACE_CONFIG_WHITELIST);
     } else if (configName === 'config') {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -288,6 +288,9 @@ module.exports = (_env, argv) => {
             plugins: [
                 ...config.plugins,
                 ...getBundleAnalyzerPlugin(analyzeBundle, 'app'),
+                new webpack.DefinePlugin({
+                    '__DEV__': !isProduction
+                }),
                 new webpack.IgnorePlugin({
                     resourceRegExp: /^canvas$/,
                     contextRegExp: /resemblejs$/


### PR DESCRIPTION
Webpack will replace the code so the added condition because `if (true)` in dev mode, which helps when one wants to override anything for testing.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
