### PR TITLE
fix(file-sharing) rework sync

### DIFF
--- a/react/features/file-sharing/constants.ts
+++ b/react/features/file-sharing/constants.ts
@@ -1,4 +1,4 @@
 /**
- * The key for file sharing metadata in the conference.
+ * The key prefix for file sharing metadata in the conference.
  */
-export const FILE_SHARING_ID = 'files';
+export const FILE_SHARING_PREFIX = 'files';

--- a/react/features/file-sharing/middleware.web.ts
+++ b/react/features/file-sharing/middleware.web.ts
@@ -10,7 +10,7 @@ import { DOWNLOAD_FILE, REMOVE_FILE, UPLOAD_FILES } from './actionTypes';
 import { addFile, removeFile, updateFileProgress } from './actions';
 import { getFileExtension } from './functions.any';
 import logger from './logger';
-import { FILE_SHARING_ID } from './constants';
+import { FILE_SHARING_PREFIX } from './constants';
 import { IFileMetadata } from './types';
 
 /**
@@ -93,14 +93,7 @@ MiddlewareRegistry.register(store => next => action => {
 
                     const metadataHandler = conference?.getMetadataHandler();
 
-                    if (metadataHandler) {
-                        const existingMetadata = metadataHandler.getMetadata()[FILE_SHARING_ID] ?? {};
-
-                        metadataHandler.setMetadata(FILE_SHARING_ID, {
-                            ...existingMetadata,
-                            [fileId]: fileMetadata
-                        });
-                    }
+                    metadataHandler?.setMetadata(`${FILE_SHARING_PREFIX}.${fileId}`, fileMetadata);
                 } else {
                     handleError();
                 }
@@ -126,13 +119,12 @@ MiddlewareRegistry.register(store => next => action => {
         const metadataHandler = conference?.getMetadataHandler();
 
         if (metadataHandler) {
-            const existingMetadata = metadataHandler.getMetadata()[FILE_SHARING_ID] ?? {};
-            const fileMetadata = existingMetadata[action.fileId];
+            const metadataId = `${FILE_SHARING_PREFIX}.${action.fileId}`;
+            const existingMetadata = metadataHandler.getMetadata()[metadataId] ?? {};
 
-            doDelete = (fileMetadata?.process ?? 100) === 100;
+            doDelete = (existingMetadata?.process ?? 100) === 100;
 
-            delete existingMetadata[action.fileId];
-            metadataHandler.setMetadata(FILE_SHARING_ID, existingMetadata);
+            metadataHandler.setMetadata(metadataId, {});
         }
 
         if (!doDelete) {


### PR DESCRIPTION
Rework sync so uploading multiple files at once or several moderators uploading files simultaneously doesn't break synchronization.

The current room metadata plugin operates on <key,value> pairs and we were using a generic "files" key and using a nested object as our value. Since with every operation the entire object is replaced it's easy to get out of sync because one needs to be sure to have the full state before overwriting it.

This is not realistic.

We'll look into making the metadata plugin more flexible in order to support add / delete operations also on nested objects, but for the time being the following will suffice:

Use a key prefix, so each file has en entry in the room metadata, like so: "files.<the file ID> -> file metadata". This means that when a file is deleted we just empty the metadata. The metadata plugin doesn't currently support removing existing keys.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
