### PR TITLE
fix(CC): Disable when config.transcription.enable=false

### DIFF
--- a/react/features/subtitles/functions.any.ts
+++ b/react/features/subtitles/functions.any.ts
@@ -55,7 +55,7 @@ export function getAvailableSubtitlesLanguages(stateful: IStateful, selectedLang
 export function areClosedCaptionsEnabled(state: IReduxState) {
     const { transcription } = state['features/base/config'];
 
-    return !transcription?.disableClosedCaptions;
+    return !transcription?.disableClosedCaptions && Boolean(transcription?.enabled);
 }
 
 /**


### PR DESCRIPTION
Disable the new CC tab when transcription.enable flag is false in config.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
