### PR TITLE
fixed wrong documentation

### DIFF
--- a/config.js
+++ b/config.js
@@ -839,8 +839,7 @@ var config = {
     // some other values in config.js to be enabled. Also, the "profile" button will
     // not display for users with a JWT.
     // Notes:
-    // - it's impossible to choose which buttons go in the "More actions" menu
-    // - it's impossible to control the placement of buttons
+    // - it's possible to reorder the buttons in the maintoolbar by changing the order of the mainToolbarButtons
     // - 'desktop' controls the "Share your screen" button
     // - if `toolbarButtons` is undefined, we fallback to enabling all buttons on the UI
     // toolbarButtons: [


### PR DESCRIPTION
This small change fixes an error in the documentation which claims that it is impossible to change the order of toolbar buttons and their spot on the maintoolbar, which is not true