### PR TITLE
fix(settings): trying to access getMetadata() of undefined

### DIFF
--- a/react/features/settings/functions.any.ts
+++ b/react/features/settings/functions.any.ts
@@ -145,7 +145,8 @@ export function getModeratorTabProps(stateful: IStateful) {
     const followMeActive = isFollowMeActive(state);
     const followMeRecorderActive = isFollowMeRecorderActive(state);
     const showModeratorSettings = shouldShowModeratorSettings(state);
-    const disableChatWithPermissions = !conference?.getMetadataHandler().getMetadata().allownersEnabled;
+    const conferenceMetadata = conference?.getMetadataHandler()?.getMetadata();
+    const disableChatWithPermissions = !conferenceMetadata?.allownersEnabled;
     const isAudioModerationEnabled = isEnabledFromState(MEDIA_TYPE.AUDIO, state);
     const isVideoModerationEnabled = isEnabledFromState(MEDIA_TYPE.VIDEO, state);
 


### PR DESCRIPTION
When a participant gets kicked out of the meeting, the conference object becomes undefined, so the app crashes and throws 

E  [features/base/app] Error(TypeError){“message”:“Cannot read property ‘getMetadata’ of undefined\nThe error may be correlated with this previous error:\nTypeError: Cannot read property ‘getMetadata’ of undefined\n    at anonymous
