### PR TITLE
fix(conference): show hours in duration instead of undefined

### DIFF
--- a/react/features/base/i18n/dateUtil.ts
+++ b/react/features/base/i18n/dateUtil.ts
@@ -107,7 +107,7 @@ export function getLocalizedDurationFormatter(duration: number) {
     const d = dayjs.duration(duration);
 
     if (d.hours() !== 0) {
-        return d.format('h:mm:ss');
+        return d.format('H:mm:ss');
     }
 
     return d.format('mm:ss');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
Replaces `h` in the `format` call found in `getLocalizedDurationFormatter` with `H` so that the conference timer correctly shows hours instead of `undefined` (see https://day.js.org/docs/en/durations/format for more information).
![image](https://github.com/user-attachments/assets/e4455ed9-9899-40d1-b68a-3ceedfcc3e91)