### PR TITLE
feat(toolbox): use the same name for screen share button

### DIFF
--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -64,7 +64,7 @@ export const THRESHOLDS = [
 export const NATIVE_THRESHOLDS = [
     {
         width: 560,
-        order: [ 'microphone', 'camera', 'chat', 'screensharing', 'raisehand', 'tileview', 'overflowmenu', 'hangup' ]
+        order: [ 'microphone', 'camera', 'chat', 'desktop', 'raisehand', 'tileview', 'overflowmenu', 'hangup' ]
     },
     {
         width: 500,
@@ -193,7 +193,7 @@ export const NATIVE_TOOLBAR_BUTTONS: NativeToolbarButton[] = [
     'microphone',
     'overflowmenu',
     'raisehand',
-    'screensharing',
+    'desktop',
     'tileview'
 ];
 

--- a/react/features/toolbox/hooks.native.ts
+++ b/react/features/toolbox/hooks.native.ts
@@ -34,7 +34,7 @@ const chat = {
 };
 
 const screensharing = {
-    key: 'screensharing',
+    key: 'desktop',
     Content: ScreenSharingButton,
     group: 1
 };
@@ -149,7 +149,7 @@ export function useNativeToolboxButtons(
         microphone: audioMuteButton,
         camera: videoMuteButton,
         chat: chatButton,
-        screensharing: screenSharingButton,
+        desktop: screenSharingButton,
         raisehand,
         tileview: tileViewButton,
         overflowmenu: overflowMenuButton,

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -84,7 +84,7 @@ export type NativeToolbarButton = 'camera' |
     'chat' |
     'microphone' |
     'raisehand' |
-    'screensharing' |
+    'desktop' |
     'tileview' |
     'overflowmenu' |
     'hangup';


### PR DESCRIPTION
We need to have the same name for screen share button on both web and native to reduce confusion when config options related to toolbox are changed.
