### PR TITLE
feat(permissions): Clear up granted-permissions.

### DIFF
--- a/resources/prosody-plugins/mod_filter_iq_jibri.lua
+++ b/resources/prosody-plugins/mod_filter_iq_jibri.lua
@@ -38,7 +38,6 @@ module:hook("pre-iq/full", function(event)
             local is_allowed = is_feature_allowed(
                 feature,
                 session.jitsi_meet_context_features,
-                session.granted_jitsi_meet_context_features,
                 occupant.role == 'moderator');
 
             if jibri.attr.action == 'start' or jibri.attr.action == 'stop' then

--- a/resources/prosody-plugins/mod_filter_iq_rayo.lua
+++ b/resources/prosody-plugins/mod_filter_iq_rayo.lua
@@ -107,7 +107,6 @@ module:hook("pre-iq/full", function(event)
             local is_session_allowed = is_feature_allowed(
                 feature,
                 session.jitsi_meet_context_features,
-                session.granted_jitsi_meet_context_features,
                 room:get_affiliation(stanza.attr.from) == 'owner');
 
             if roomName == nil

--- a/resources/prosody-plugins/mod_jitsi_permissions.lua
+++ b/resources/prosody-plugins/mod_jitsi_permissions.lua
@@ -71,7 +71,7 @@ function process_set_affiliation(event)
     end
 
     if previous_affiliation == 'none' and affiliation == 'owner' then
-        occupant_session.granted_jitsi_meet_context_features = actor_session.jitsi_meet_context_features;
+        occupant_session.jitsi_meet_context_features = actor_session.jitsi_meet_context_features;
         if actor_session.jitsi_meet_context_user then
             occupant_session.granted_jitsi_meet_context_user_id = actor_session.jitsi_meet_context_user['id']
                 or actor_session.granted_jitsi_meet_context_user_id;
@@ -79,7 +79,6 @@ function process_set_affiliation(event)
         occupant_session.granted_jitsi_meet_context_group_id = actor_session.jitsi_meet_context_group
             or actor_session.granted_jitsi_meet_context_group_id;
     elseif previous_affiliation == 'owner' and ( affiliation == 'member' or affiliation == 'none' ) then
-        occupant_session.granted_jitsi_meet_context_features = nil;
         occupant_session.granted_jitsi_meet_context_user_id = nil;
         occupant_session.granted_jitsi_meet_context_group_id = nil;
 
@@ -154,22 +153,16 @@ function filter_stanza(stanza, session)
 
     session.force_permissions_update = false;
 
-    local permissions_to_send
-        = session.jitsi_meet_context_features or session.granted_jitsi_meet_context_features or default_permissions;
+    if not session.jitsi_meet_context_features then
+        session.jitsi_meet_context_features = default_permissions;
+    end
 
     room.send_default_permissions_to[bare_to] = nil;
 
-    if not session.granted_jitsi_meet_context_features and not session.jitsi_meet_context_features then
-        session.jitsi_meet_context_features = {};
-    end
-
     stanza:tag('permissions', { xmlns='http://jitsi.org/jitmeet' });
-    for k, v in pairs(permissions_to_send) do
+    for k, v in pairs(session.jitsi_meet_context_features) do
         local val = tostring(v);
         stanza:tag('p', { name = k, val = val }):up();
-        if session.jitsi_meet_context_features then
-            session.jitsi_meet_context_features[k] = val;
-        end
     end
     stanza:up();
 

--- a/resources/prosody-plugins/mod_short_lived_token.lua
+++ b/resources/prosody-plugins/mod_short_lived_token.lua
@@ -69,7 +69,7 @@ function generateToken(session, audience, room, occupant)
                 email = presence:get_child_text("email") or nil,
                 nick = jid.resource(occupant.nick)
             },
-            features = session.jitsi_meet_context_features or session.granted_jitsi_meet_context_features
+            features = session.jitsi_meet_context_features
         },
         room = session.jitsi_web_query_room,
         meeting_id = room._data.meetingId,

--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -259,13 +259,10 @@ end
 -- Utility function to check whether feature is present and enabled. Allow
 -- a feature if there are features present in the session(coming from
 -- the token) and the value of the feature is true.
--- If features are missing but we have granted_features check that
 -- if features are missing from the token we check whether it is moderator
-function is_feature_allowed(ft, features, granted_features, is_moderator)
+function is_feature_allowed(ft, features, is_moderator)
     if features then
         return features[ft] == "true" or features[ft] == true;
-    elseif granted_features then
-        return granted_features[ft] == "true" or granted_features[ft] == true;
     else
         return is_moderator;
     end


### PR DESCRIPTION
We do not need to keep granted permissions in separate field. We can always check the granted user-id or whether the current participant has a token (session.auth_token).

Fixes a problem with features when a participant that was granted moderator rights grants moderation to another one.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
