### PR TITLE
fix(android) drop old JSC dependency

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -44,9 +44,6 @@ dependencies {
     api "com.facebook.react:react-android:$rootProject.ext.rnVersion"
     api "com.facebook.react:hermes-android:$rootProject.ext.rnVersion"
 
-    //noinspection GradleDynamicVersion
-    implementation 'org.webkit:android-jsc:+'
-
     implementation 'com.facebook.fresco:animated-gif:2.5.0'
     implementation 'com.dropbox.core:dropbox-core-sdk:4.0.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'


### PR DESCRIPTION
We only use Hermes now.
