### PR TITLE
fix(rn,embed) remove 8x8 apps from isEmbedded check

### DIFF
--- a/react/features/base/util/embedUtils.native.ts
+++ b/react/features/base/util/embedUtils.native.ts
@@ -12,13 +12,7 @@ const JITSI_MEET_APPS = [
     'org.jitsi.meet',
 
     // Android debug app.
-    'org.jitsi.meet.debug',
-
-    // 8x8 Work (Android).
-    'org.vom8x8.sipua',
-
-    // 8x8 Work (iOS).
-    'com.yourcompany.Virtual-Office'
+    'org.jitsi.meet.debug'
 ];
 
 /**


### PR DESCRIPTION
For all intents and purposes 8x8 apps are integrating the SDK as a 3rd party.

Yes, we are a 1st party of sorts, but that's ok because 8x8.vc allows embedding.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
