### PR TITLE
fix: layout issue when only chat tab is visible

### DIFF
--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -447,7 +447,7 @@ const Chat = ({
      * @returns {ReactElement}
      */
     function renderTabs() {
-        const tabs = [
+        let tabs = [
             {
                 accessibilityLabel: t('chat.tabs.chat'),
                 countBadge:
@@ -486,6 +486,10 @@ const Chat = ({
                 controlsId: `${ChatTabs.FILE_SHARING}-panel`,
                 icon: IconShareDoc
             });
+        }
+
+        if (tabs.length === 1) {
+            tabs = [];
         }
 
         return (


### PR DESCRIPTION
Before:
<img width="434" alt="Screenshot 2025-06-26 at 14 14 02" src="https://github.com/user-attachments/assets/e82ed2aa-cee3-43b4-bd97-ee3a5e569f80" />

After:

<img width="494" alt="Screenshot 2025-06-26 at 14 12 39" src="https://github.com/user-attachments/assets/eee8052f-1058-4ad3-b4e8-db8c99fe716b" />
