### PR TITLE
fix(file-sharing) fix computing file sharing percentage

### DIFF
--- a/react/features/file-sharing/middleware.web.ts
+++ b/react/features/file-sharing/middleware.web.ts
@@ -215,7 +215,7 @@ function uploadFile(file: File, store: IStore, token: string): void {
         if (event.lengthComputable) {
             // We use 99% as the max value to avoid showing 100% before the
             // upload is actually finished, that is, when the request is completed.
-            const percent = Math.max((event.loaded / event.total) * 100, 99);
+            const percent = Math.min((event.loaded / event.total) * 100, 99);
 
             store.dispatch(updateFileProgress(fileId, percent));
         }


### PR DESCRIPTION
Actually implement what the comment says: we want to cap the progress at 99% so we wait for the request to complete with 200 before going to 100%.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
