### PR TITLE
Visitor list fixes.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -906,6 +906,7 @@
         "headings": {
             "lobby": "Lobby ({{count}})",
             "participantsList": "Meeting participants ({{count}})",
+            "viewerRequests": "Viewers requests {{count}}",
             "visitorInQueue": " (waiting {{count}})",
             "visitorRequests": " (requests {{count}})",
             "visitors": "Viewers {{count}}",

--- a/react/features/participants-pane/components/web/VisitorsList.tsx
+++ b/react/features/participants-pane/components/web/VisitorsList.tsx
@@ -9,7 +9,8 @@ import {
     getPromotionRequests,
     getVisitorsCount,
     getVisitorsInQueueCount,
-    isVisitorsLive
+    isVisitorsLive,
+    shouldDisplayCurrentVisitorsList
 } from '../../../visitors/functions';
 
 import { VisitorsItem } from './VisitorsItem';
@@ -74,6 +75,7 @@ export default function VisitorsList() {
     const visitorsInQueueCount = useSelector(getVisitorsInQueueCount);
     const isLive = useSelector(isVisitorsLive);
     const showVisitorsInQueue = visitorsInQueueCount > 0 && isLive === false;
+    const showCurrentVisitorsList = useSelector(shouldDisplayCurrentVisitorsList);
 
     const { t } = useTranslation();
     const { classes, cx } = useStyles();
@@ -91,15 +93,19 @@ export default function VisitorsList() {
         return null;
     }
 
+    if (showCurrentVisitorsList && requests.length <= 0 && !showVisitorsInQueue) {
+        return null;
+    }
+
     return (
         <>
             <div className = { classes.headingContainer }>
                 <div
                     className = { cx(classes.heading, classes.headingW) }
                     id = 'visitor-list-header' >
-                    { t('participantsPane.headings.visitors', { count: visitorsCount })}
+                    { !showCurrentVisitorsList && t('participantsPane.headings.visitors', { count: visitorsCount })}
                     { requests.length > 0
-                        && t('participantsPane.headings.visitorRequests', { count: requests.length }) }
+                        && t(`participantsPane.headings.${showCurrentVisitorsList ? 'viewerRequests' : 'visitorRequests'}`, { count: requests.length }) }
                     { showVisitorsInQueue
                         && t('participantsPane.headings.visitorInQueue', { count: visitorsInQueueCount }) }
                 </div>
@@ -116,17 +122,19 @@ export default function VisitorsList() {
                         onClick = { goLiveCb }>{ t('participantsPane.actions.goLive') }</div>
                 }
             </div>
-            <div
-                className = { classes.container }
-                id = 'visitor-list'>
-                {
-                    requests.map(r => (
-                        <VisitorsItem
-                            key = { r.from }
-                            request = { r } />)
-                    )
-                }
-            </div>
+            { requests.length > 0
+                && <div
+                    className = { classes.container }
+                    id = 'visitor-list'>
+                    {
+                        requests.map(r => (
+                            <VisitorsItem
+                                key = { r.from }
+                                request = { r } />)
+                        )
+                    }
+                </div>
+            }
         </>
     );
 }

--- a/react/features/visitors/VisitorsListWebsocketClient.ts
+++ b/react/features/visitors/VisitorsListWebsocketClient.ts
@@ -1,0 +1,127 @@
+import { Client } from '@stomp/stompjs';
+
+import logger from './logger';
+import { WebsocketClient } from './websocket-client';
+
+/**
+ * Websocket client impl, used for visitors list.
+ * Uses STOMP for authenticating (https://stomp.github.io/).
+ */
+export class VisitorsListWebsocketClient extends WebsocketClient {
+    private static client: VisitorsListWebsocketClient;
+
+    /**
+     * Creates a new instance of the VisitorsListWebsocketClient.
+     *
+     * @static
+     * @returns {VisitorsListWebsocketClient}
+     */
+    static override getInstance(): VisitorsListWebsocketClient {
+        if (!this.client) {
+            this.client = new VisitorsListWebsocketClient();
+        }
+
+        return this.client;
+    }
+
+    /**
+     * Connects to the visitors list with initial queue subscription, then switches to topic deltas.
+     *
+     * @param {string} queueServiceURL - The service URL to use.
+     * @param {string} queueEndpoint - The queue endpoint for initial list.
+     * @param {string} topicEndpoint - The topic endpoint for deltas.
+     * @param {Function} initialCallback - Callback executed with initial visitors list.
+     * @param {Function} deltaCallback - Callback executed with delta updates.
+     * @param {string} token - The token to be used for authorization.
+     * @param {Function?} connectCallback - Callback executed when connected.
+     * @returns {void}
+     */
+    connectVisitorsList(queueServiceURL: string,
+            queueEndpoint: string,
+            topicEndpoint: string,
+            initialCallback: (visitors: Array<{ n: string; r: string; }>) => void,
+            deltaCallback: (updates: Array<{ n: string; r: string; s: string; }>) => void,
+            token: string | undefined,
+            connectCallback?: () => void) {
+        this.stompClient = new Client({
+            brokerURL: queueServiceURL,
+            forceBinaryWSFrames: true,
+            appendMissingNULLonIncoming: true
+        });
+
+        const errorConnecting = (error: any) => {
+            if (this.retriesCount > 3) {
+                this.stompClient?.deactivate();
+                this.stompClient = undefined;
+
+                return;
+            }
+
+            this.retriesCount++;
+
+            logger.error(`Error connecting to ${queueServiceURL} ${JSON.stringify(error)}`);
+        };
+
+        this.stompClient.onWebSocketError = errorConnecting;
+
+        this.stompClient.onStompError = frame => {
+            logger.error('STOMP error received', frame);
+            errorConnecting(frame.headers.message);
+        };
+
+        if (token) {
+            this.stompClient.connectHeaders = {
+                Authorization: `Bearer ${token}`
+            };
+        }
+
+        this.stompClient.onConnect = () => {
+            if (!this.stompClient) {
+                return;
+            }
+
+            logger.debug('Connected to visitors list websocket');
+            connectCallback?.();
+
+            let initialReceived = false;
+            const cachedDeltas: Array<{ n: string; r: string; s: string; }> = [];
+
+            // Subscribe first for deltas so we don't miss any while waiting for the initial list
+            this.stompClient.subscribe(topicEndpoint, deltaMessage => {
+                try {
+                    const updates: Array<{ n: string; r: string; s: string; }> = JSON.parse(deltaMessage.body);
+
+                    if (!initialReceived) {
+                        cachedDeltas.push(...updates);
+                    } else {
+                        deltaCallback(updates);
+                    }
+                } catch (e) {
+                    logger.error(`Error parsing visitors delta response: ${deltaMessage}`, e);
+                }
+            });
+
+            // Subscribe for the initial list after topic subscription is active
+            const queueSubscription = this.stompClient.subscribe(queueEndpoint, message => {
+                try {
+                    const visitors: Array<{ n: string; r: string; }> = JSON.parse(message.body);
+
+                    logger.debug(`Received initial visitors list with ${visitors.length} visitors`);
+                    initialReceived = true;
+                    initialCallback(visitors);
+
+                    queueSubscription.unsubscribe();
+
+                    if (cachedDeltas.length) {
+                        deltaCallback(cachedDeltas);
+                        cachedDeltas.length = 0;
+                    }
+                } catch (e) {
+                    logger.error(`Error parsing initial visitors response: ${message}`, e);
+                }
+            });
+        };
+
+        this.stompClient.activate();
+    }
+}

--- a/react/features/visitors/websocket-client.ts
+++ b/react/features/visitors/websocket-client.ts
@@ -20,11 +20,11 @@ export interface VisitorResponse extends QueueServiceResponse {
  * Uses STOMP for authenticating (https://stomp.github.io/).
  */
 export class WebsocketClient {
-    private stompClient: Client | undefined;
+    protected stompClient: Client | undefined;
 
     private static instance: WebsocketClient;
 
-    private retriesCount = 0;
+    protected retriesCount = 0;
 
     private _connectCount = 0;
 
@@ -146,97 +146,5 @@ export class WebsocketClient {
      */
     get connectCount(): number {
         return this._connectCount;
-    }
-
-    /**
-     * Connects to the visitors list with initial queue subscription, then switches to topic deltas.
-     *
-     * @param {string} queueServiceURL - The service URL to use.
-     * @param {string} queueEndpoint - The queue endpoint for initial list.
-     * @param {string} topicEndpoint - The topic endpoint for deltas.
-     * @param {Function} initialCallback - Callback executed with initial visitors list.
-     * @param {Function} deltaCallback - Callback executed with delta updates.
-     * @param {string} token - The token to be used for authorization.
-     * @param {Function?} connectCallback - Callback executed when connected.
-     * @returns {void}
-     */
-    connectVisitorsListWithInitial(queueServiceURL: string,
-            queueEndpoint: string,
-            topicEndpoint: string,
-            initialCallback: (visitors: Array<{ n: string; r: string; }>) => void,
-            deltaCallback: (updates: Array<{ n: string; r: string; s: string; }>) => void,
-            token: string | undefined,
-            connectCallback?: () => void) {
-        this.stompClient = new Client({
-            brokerURL: queueServiceURL,
-            forceBinaryWSFrames: true,
-            appendMissingNULLonIncoming: true
-        });
-
-        const errorConnecting = (error: any) => {
-            logger.error(`Error connecting to ${queueServiceURL} ${JSON.stringify(error)}`);
-        };
-
-        this.stompClient.onWebSocketError = errorConnecting;
-
-        this.stompClient.onStompError = frame => {
-            logger.error('STOMP error received', frame);
-            errorConnecting(frame.headers.message);
-        };
-
-        if (token) {
-            this.stompClient.connectHeaders = {
-                Authorization: `Bearer ${token}`
-            };
-        }
-
-        this.stompClient.onConnect = () => {
-            if (!this.stompClient) {
-                return;
-            }
-
-            logger.debug('Connected to visitors list websocket');
-            connectCallback?.();
-
-            let initialReceived = false;
-            const cachedDeltas: Array<{ n: string; r: string; s: string; }> = [];
-
-            // Subscribe first for deltas so we don't miss any while waiting for the initial list
-            this.stompClient.subscribe(topicEndpoint, deltaMessage => {
-                try {
-                    const updates: Array<{ n: string; r: string; s: string; }> = JSON.parse(deltaMessage.body);
-
-                    if (!initialReceived) {
-                        cachedDeltas.push(...updates);
-                    } else {
-                        deltaCallback(updates);
-                    }
-                } catch (e) {
-                    logger.error(`Error parsing visitors delta response: ${deltaMessage}`, e);
-                }
-            });
-
-            // Subscribe for the initial list after topic subscription is active
-            const queueSubscription = this.stompClient.subscribe(queueEndpoint, message => {
-                try {
-                    const visitors: Array<{ n: string; r: string; }> = JSON.parse(message.body);
-
-                    logger.debug(`Received initial visitors list with ${visitors.length} visitors`);
-                    initialReceived = true;
-                    initialCallback(visitors);
-
-                    queueSubscription.unsubscribe();
-
-                    if (cachedDeltas.length) {
-                        deltaCallback(cachedDeltas);
-                        cachedDeltas.length = 0;
-                    }
-                } catch (e) {
-                    logger.error(`Error parsing initial visitors response: ${message}`, e);
-                }
-            });
-        };
-
-        this.stompClient.activate();
     }
 }


### PR DESCRIPTION
- make sure we don't loose any updates for the visitors list between the time we receive the initial list and suibscribe for updates.
-  fixes an issue where a shared instance of the stomp client was used for the visitors list and the visitors queue. now we use 2 different stomp clients.
- Resolves UI issue that the "Viewers" label appears twice - One for the VisitorsList component (promotion request list) and one for the CurrentVisitorsList component (the list with visitors). Now only one of the labels will be displayed!

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
