### PR TITLE
fix(transcribing) fix overriding transcribing state

### DIFF
--- a/react/features/transcribing/reducer.ts
+++ b/react/features/transcribing/reducer.ts
@@ -46,13 +46,17 @@ ReducerRegistry.register<ITranscribingState>('features/transcribing',
     (state = _getInitialState(), action): ITranscribingState => {
         switch (action.type) {
         case CONFERENCE_PROPERTIES_CHANGED: {
-            const audioRecordingEnabled = action.properties?.['audio-recording-enabled'] === 'true';
+            const audioRecording = action.properties?.['audio-recording-enabled'];
 
-            if (state.isTranscribing !== audioRecordingEnabled) {
-                return {
-                    ...state,
-                    isTranscribing: audioRecordingEnabled
-                };
+            if (typeof audioRecording !== 'undefined') {
+                const audioRecordingEnabled = audioRecording === 'true';
+
+                if (state.isTranscribing !== audioRecordingEnabled) {
+                    return {
+                        ...state,
+                        isTranscribing: audioRecordingEnabled
+                    };
+                }
             }
 
             return state;


### PR DESCRIPTION
Skip updating the transcribing state when the 'audio-recording-enabled' property is not provided.

This fixes a race when a transcriber is already in the room, we'll see it before properties are updated (sometimes) and without checking for undefined we'd flip the local value to false.

![Screenshot 2025-07-04 at 15 15 32](https://github.com/user-attachments/assets/53910401-799a-4c97-b3a2-314d014de3eb)
