### PR TITLE
Missing camera error notification translation

### DIFF
--- a/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
+++ b/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
@@ -185,7 +185,7 @@ class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
             this.props.dispatch(
                 showWarningNotification({
                     titleKey: 'virtualBackground.backgroundEffectError',
-                    description: 'Failed to access camera device.'
+                    description: 'deviceError.cameraError'
                 }, NOTIFICATION_TIMEOUT_TYPE.LONG)
             );
             logger.error('Failed to access camera device. Error on apply background effect.');


### PR DESCRIPTION
Reusing existing translation string for virtual background error notification, instead of current hardcoded english value.