### PR TITLE
fix(file-sharing) fix resetting the state for share file input

### DIFF
--- a/react/features/file-sharing/components/web/FileSharing.tsx
+++ b/react/features/file-sharing/components/web/FileSharing.tsx
@@ -234,6 +234,7 @@ const FileSharing = () => {
     const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         if (e.target.files) {
             processFiles(e.target.files as FileList, store);
+            e.target.value = ''; // Reset the input value to allow re-uploading the same file
         }
     }, [ processFiles ]);
 


### PR DESCRIPTION
Otherwise re-uploading the same file would not work because the input element doesn't change state, as the value would remain the same.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
