### PR TITLE
feat(screen-share): support both the React Native SDK and native SDK

### DIFF
--- a/ios/sdk/src/ScheenshareEventEmiter.h
+++ b/ios/sdk/src/ScheenshareEventEmiter.h
@@ -15,10 +15,11 @@
  */
 
 #import <Foundation/Foundation.h>
-
+#import <React/RCTEventEmitter.h>
+ 
 NS_ASSUME_NONNULL_BEGIN
-
-@interface ScheenshareEventEmiter : NSObject
+ 
+@interface ScheenshareEventEmiter : RCTEventEmitter <RCTBridgeModule>
 
 @end
 

--- a/ios/sdk/src/ScheenshareEventEmiter.m
+++ b/ios/sdk/src/ScheenshareEventEmiter.m
@@ -15,14 +15,33 @@
  */
 
 #import "ScheenshareEventEmiter.h"
-#import "JitsiMeet+Private.h"
-#import "ExternalAPI.h"
+#import <React/RCTLog.h>
+#import <React/RCTBridge.h>
 
 NSNotificationName const kBroadcastStartedNotification = @"iOS_BroadcastStarted";
 NSNotificationName const kBroadcastStoppedNotification = @"iOS_BroadcastStopped";
 
+static NSString * const toggleScreenShareAction = @"org.jitsi.meet.TOGGLE_SCREEN_SHARE";
+
+
 @implementation ScheenshareEventEmiter {
     CFNotificationCenterRef _notificationCenter;
+}
+
+RCT_EXPORT_MODULE();
+
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
+- (NSDictionary *)constantsToExport {
+    return @{
+        @"TOGGLE_SCREEN_SHARE": toggleScreenShareAction,
+    };
+};
+
+- (NSArray<NSString *> *)supportedEvents {
+    return @[toggleScreenShareAction];
 }
 
 - (instancetype)init {
@@ -56,8 +75,10 @@ void broadcastStartedNotificationCallback(CFNotificationCenterRef center,
                                           CFStringRef name,
                                           const void *object,
                                           CFDictionaryRef userInfo) {
-    ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
-    [externalAPI toggleScreenShare:true];
+    ScheenshareEventEmiter *self = (__bridge ScheenshareEventEmiter *)observer;
+    if (self.bridge) {        
+        [self sendEventWithName:toggleScreenShareAction body:@{@"enabled": @TRUE}];
+    }
 }
 
 void broadcastStoppedNotificationCallback(CFNotificationCenterRef center,
@@ -65,8 +86,10 @@ void broadcastStoppedNotificationCallback(CFNotificationCenterRef center,
                                           CFStringRef name,
                                           const void *object,
                                           CFDictionaryRef userInfo) {
-    ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
-    [externalAPI toggleScreenShare:false];
+    ScheenshareEventEmiter *self = (__bridge ScheenshareEventEmiter *)observer;
+    if (self.bridge) {
+        [self sendEventWithName:toggleScreenShareAction body:@{@"enabled": @FALSE}];
+    }
 }
 
 @end

--- a/react-native-sdk/prepare_sdk.js
+++ b/react-native-sdk/prepare_sdk.js
@@ -128,6 +128,14 @@ fs.copyFileSync(
     `${iosSrcPath}/Proximity.m`,
     `${iosDestPath}/Proximity.m`
 );
+fs.copyFileSync(
+    `${iosSrcPath}/ScheenshareEventEmiter.h`,
+    `${iosDestPath}/ScheenshareEventEmiter.h`
+);
+fs.copyFileSync(
+    `${iosSrcPath}/ScheenshareEventEmiter.m`,
+    `${iosDestPath}/ScheenshareEventEmiter.m`
+);
 copyFolderRecursiveSync(
     `${androidSourcePath}/log`,
      `${androidTargetPath}/log`

--- a/react/features/app/middlewares.native.ts
+++ b/react/features/app/middlewares.native.ts
@@ -11,6 +11,7 @@ import '../mobile/proximity/middleware';
 import '../mobile/wake-lock/middleware';
 import '../mobile/react-native-sdk/middleware';
 import '../mobile/watchos/middleware';
+import '../mobile/screen-share/middleware';
 import '../share-room/middleware';
 import '../shared-video/middleware';
 import '../toolbox/middleware.native';

--- a/react/features/mobile/screen-share/functions.ts
+++ b/react/features/mobile/screen-share/functions.ts
@@ -1,0 +1,12 @@
+import { NativeModules } from 'react-native';
+
+/**
+ * Determines if the ScreenShareEventEmitter native module is available.
+ *
+ * @returns {boolean} If yes {@code true} otherwise {@code false}.
+ */
+export function isScreenShareAPIAvailable() {
+    const { ScreenShareEventEmitter } = NativeModules;
+
+    return ScreenShareEventEmitter !== null;
+}

--- a/react/features/mobile/screen-share/functions.ts
+++ b/react/features/mobile/screen-share/functions.ts
@@ -1,12 +1,12 @@
 import { NativeModules } from 'react-native';
 
 /**
- * Determines if the ScreenShareEventEmitter native module is available.
+ * Determines if the ScheenshareEventEmiter native module is available.
  *
  * @returns {boolean} If yes {@code true} otherwise {@code false}.
  */
 export function isScreenShareAPIAvailable() {
-    const { ScreenShareEventEmitter } = NativeModules;
+    const { ScheenshareEventEmiter } = NativeModules;
 
-    return ScreenShareEventEmitter !== null;
+    return ScheenshareEventEmiter !== null;
 }

--- a/react/features/mobile/screen-share/middleware.ts
+++ b/react/features/mobile/screen-share/middleware.ts
@@ -1,0 +1,70 @@
+/* eslint-disable lines-around-comment */
+
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../../base/app/actionTypes';
+import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
+import { toggleScreensharing } from '../../base/tracks/actions.native';
+
+import { isScreenShareAPIAvailable } from './functions';
+
+const screenShareApi = isScreenShareAPIAvailable();
+
+let screenShareEventEmitter: any;
+
+// Get the native module
+const { ScheenshareEventEmiter } = NativeModules;
+
+// Create an event emitter
+
+if (screenShareApi) {
+    screenShareEventEmitter = new NativeEventEmitter(ScheenshareEventEmiter);
+}
+
+/**
+ * Middleware that captures Redux actions and uses the ExternalAPI module to
+ * turn them into native events so the application knows about them.
+ *
+ * @param {Store} store - Redux store.
+ * @returns {Function}
+ */
+screenShareEventEmitter && MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+    const { type } = action;
+
+    switch (type) {
+    case APP_WILL_MOUNT:
+        _registerForNativeEvents(store);
+        break;
+    case APP_WILL_UNMOUNT:
+        _unregisterForNativeEvents();
+        break;
+    }
+
+    return result;
+});
+
+/**
+ * Registers for events sent from the native side via NativeEventEmitter.
+ *
+ * @param {Store} store - The redux store.
+ * @private
+ * @returns {void}
+ */
+function _registerForNativeEvents(store) {
+    const { dispatch } = store;
+
+    screenShareEventEmitter.addListener(ScheenshareEventEmiter.TOGGLE_SCREEN_SHARE, ({ enabled }) => {
+        dispatch(toggleScreensharing(enabled));
+    });
+}
+
+/**
+ * Unregister for events sent from the native side via NativeEventEmitter.
+ *
+ * @private
+ * @returns {void}
+ */
+function _unregisterForNativeEvents() {
+    screenShareEventEmitter.removeAllListeners(ScheenshareEventEmiter.TOGGLE_SCREEN_SHARE);
+}


### PR DESCRIPTION
This PR builds on the previous attempt to add iOS screen sharing support in [react-native-sdk](https://github.com/jitsi/jitsi-meet/pull/14929), which became stale and was not merged.

I've improved and completed the implementation to support screen sharing functionality for both the React Native SDK and the native iOS SDK.