### PR TITLE
chore(android/sdk): fix compileOnly set dependency related to rn-video

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'com.squareup.duktape:duktape-android:1.3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'androidx.startup:startup-runtime:1.1.0'
+    implementation 'com.google.j2objc:j2objc-annotations:3.0.0'
 
     // Only add these packages if we are NOT doing a LIBRE_BUILD
     if (!rootProject.ext.libreBuild) {


### PR DESCRIPTION
Execution failed for task ':app:preBaseDebugBuild'.
The following Android dependencies are set to compileOnly which is not supported:
com.google.j2objc:j2objc-annotations:2.8
<img width="1119" height="439" alt="Screenshot 2025-07-11 at 15 31 20" src="https://github.com/user-attachments/assets/16b69304-f91e-43ae-9dc1-c4918820a3f5" />
