### PR TITLE
fix: Fix hideDisplayNameForAll.

### DIFF
--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -113,7 +113,7 @@ local function filter_stanza_nick_if_needed(stanza, room)
     end
 
     -- if hideDisplayNameForGuests we want to drop any display name from the presence stanza
-    if room and room._data.hideDisplayNameForGuests == true then
+    if room and (room._data.hideDisplayNameForGuests or room._data.hideDisplayNameForAll) then
         return filter_identity_from_presence(stanza);
     end
 


### PR DESCRIPTION
Remove filtering on the receive side, because:
1. It's not applied to visitors, and should be for the "all" case
2. We don't want to strip stats-id from stanzas sent to jicofo
