### PR TITLE
fix(go-live): waiting not updated correctly.

### DIFF
--- a/react/features/visitors/reducer.ts
+++ b/react/features/visitors/reducer.ts
@@ -63,7 +63,7 @@ ReducerRegistry.register<IVisitorsState>('features/visitors', (state = DEFAULT_S
         };
     }
     case UPDATE_VISITORS_IN_QUEUE_COUNT: {
-        if (state.count === action.count) {
+        if (state.inQueueCount === action.count) {
             return state;
         }
 


### PR DESCRIPTION
We were comparing if the number of waiting participants have changed with the wrong property from the state - the number of visitors. The result was that we won't update the state when the new waiting value matches the number of visitors already in the state. Most of the times this will be 0 and we would never go to 0.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
