### PR TITLE
fix: Avoids sending two metadata updates.

### DIFF
--- a/resources/prosody-plugins/mod_av_moderation_component.lua
+++ b/resources/prosody-plugins/mod_av_moderation_component.lua
@@ -166,7 +166,7 @@ function start_av_moderation(room, mediaType, occupant)
     -- We want to keep the previous value of startMuted for this mediaType if av moderation is disabled
     -- to be able to restore
     local av_moderation_startMuted_restore = room.av_moderation_startMuted_restore or {};
-    av_moderation_startMuted_restore = startMutedMetadata[mediaType];
+    av_moderation_startMuted_restore[mediaType] = startMutedMetadata[mediaType];
     room.av_moderation_startMuted_restore = av_moderation_startMuted_restore;
 
     startMutedMetadata[mediaType] = true;

--- a/resources/prosody-plugins/util.lib.lua
+++ b/resources/prosody-plugins/util.lib.lua
@@ -638,6 +638,19 @@ local function table_compare(old_table, new_table)
     return removed, added
 end
 
+local function table_equals(t1, t2)
+    if t1 == nil then
+        return t2 == nil;
+    end
+    if t2 == nil then
+        return t1 == nil;
+    end
+
+    local removed, added = table_compare(t1, t2);
+
+    return next(removed) == nil and next(added) == nil
+end
+
 -- Splits a string using delimiter
 function split_string(str, delimiter)
     str = str .. delimiter;
@@ -747,4 +760,5 @@ return {
     table_compare = table_compare;
     table_shallow_copy = table_shallow_copy;
     table_find = table_find;
+    table_equals = table_equals;
 };


### PR DESCRIPTION
When setting startMuted we are sending two metadata updates.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
