### PR TITLE
fix(toolbox/native): update SvgCssUri import

### DIFF
--- a/react/features/toolbox/components/native/CustomOptionButton.tsx
+++ b/react/features/toolbox/components/native/CustomOptionButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Image, View, ViewStyle } from 'react-native';
-import { SvgCssUri } from 'react-native-svg';
+import { SvgCssUri } from 'react-native-svg/css';
 import { connect } from 'react-redux';
 
 import { translate } from '../../../base/i18n/functions';


### PR DESCRIPTION
Fixes https://github.com/jitsi/jitsi-meet-flutter-sdk/issues/134#issuecomment-3102470380

SvgCssUri was moved to a react-native-svg submodule called css.