### PR TITLE
fix(react-native-sdk): resolve Android build configuration issues

### DIFF
--- a/react-native-sdk/README.md
+++ b/react-native-sdk/README.md
@@ -70,6 +70,7 @@ cd ios && pod install && cd ..
 ## Android
 
 - In your build.gradle have at least `minSdkVersion = 26`
+- In your build.gradle have `gradlePluginVersion = "8.4.2"` or higher
 - In `android/app/src/debug/AndroidManifest.xml` and `android/app/src/main/AndroidManifest.xml`, under the `</application>` tag, include
   ```xml
     <uses-permission android:name="android.permission.RECORD_AUDIO" />

--- a/react-native-sdk/android/build.gradle
+++ b/react-native-sdk/android/build.gradle
@@ -7,7 +7,6 @@ buildscript {
   dependencies {
     classpath "com.android.tools.build:gradle:$rootProject.ext.gradlePluginVersion"
   }
-  namespace 'org.jitsi.meet.reactnativesdk'
 }
 
 def isNewArchitectureEnabled() {
@@ -29,6 +28,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace 'org.jitsi.meet.sdk'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
   defaultConfig {

--- a/react-native-sdk/android/src/main/AndroidManifest.xml
+++ b/react-native-sdk/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.jitsi.meet.sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>


### PR DESCRIPTION
- Move namespace declaration to correct location in build.gradle
- Remove deprecated package attribute from AndroidManifest.xml
- Update README with gradle plugin version requirement
- Fix Android namespace configuration for React Native SDK

These changes resolve installation and build errors when integrating the Jitsi Meet React Native SDK into new projects.

Fixes: SDK installation failures on Android with newer Gradle versions

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
