### PR TITLE
fix(participants-pane): restore scrolling capability when content exceeds viewable area

### DIFF
--- a/react/features/participants-pane/components/web/ParticipantsPane.tsx
+++ b/react/features/participants-pane/components/web/ParticipantsPane.tsx
@@ -71,6 +71,7 @@ const useStyles = makeStyles<IStylesProps>()((theme, { isChatOpen }) => {
         container: {
             boxSizing: 'border-box',
             flex: 1,
+            overflowY: 'auto',
             position: 'relative',
             padding: `0 ${participantsPaneTheme.panePadding}px`,
             display: 'flex',
@@ -78,6 +79,21 @@ const useStyles = makeStyles<IStylesProps>()((theme, { isChatOpen }) => {
 
             '&::-webkit-scrollbar': {
                 display: 'none'
+            },
+
+            // Temporary fix: Limit context menu width to prevent clipping
+            // TODO: Long-term fix would be to portal context menus outside the scrollable container
+            '& [class*="contextMenu"]': {
+                maxWidth: '285px',
+
+                '& [class*="contextMenuItem"]': {
+                    whiteSpace: 'normal',
+
+                    '& span': {
+                        whiteSpace: 'normal',
+                        wordBreak: 'break-word'
+                    }
+                }
             }
         },
 


### PR DESCRIPTION
## Summary
- Restores scrolling functionality to the participant pane when content exceeds the viewable area
- Fixes context menu clipping issue by constraining menu width and allowing text wrapping
- Preserves all moderation functionality while making UI elements fully accessible

## Root Cause
The screen-sharing moderation feature (commit 2305ae85a) removed `overflowY: 'auto'` from the participant pane container, which inadvertently broke scrolling functionality. The removal was done because longer menu items (like "Stop screen-sharing for everyone else") were being clipped by the overflow constraints.

## Solution
This PR implements a balanced solution that addresses both issues:

1. **Restored scrolling**: Added back `overflowY: 'auto'` to enable vertical scrolling
2. **Fixed menu clipping**: Limited context menu width to 285px and enabled text wrapping
3. **Preserved readability**: Long menu items now wrap to multiple lines instead of being cut off

### Technical Details
- Context menus that are children of scrollable containers will always be clipped due to CSS overflow behavior
- The proper long-term fix would be to portal context menus outside the scrollable container
- This temporary solution provides a good user experience until architectural changes can be made

## Screenshots
<img width="557" height="809" alt="Screenshot 2025-07-31 at 4 32 01 PM" src="https://github.com/user-attachments/assets/9e58d692-13f9-4b13-a2d1-8c9d4c254228" />


## Test Plan
- [x] Verify scrolling works with long participant lists
- [x] Verify scrolling works with multiple breakout rooms
- [x] Verify scrolling works with extended visitors lists
- [x] Confirm context menus display fully without horizontal clipping
- [x] Verify long menu items wrap to multiple lines
- [x] Confirm all moderation actions remain functional
- [x] ESLint and TypeScript checks pass