### PR TITLE
fix: deduplicate @emotion/react to prevent multiple instance warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,11 @@
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        }
       }
     },
     "../lib-jitsi-meet": {
@@ -3540,84 +3545,6 @@
       "peerDependencies": {
         "react": "16.10.2 - 18"
       }
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/hash": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-      "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/react": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.9.3.tgz",
-      "integrity": "sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/cache": "^11.9.3",
-        "@emotion/serialize": "^1.0.4",
-        "@emotion/utils": "^1.1.0",
-        "@emotion/weak-memoize": "^0.2.5",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/serialize": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
-      "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
-      "dependencies": {
-        "@emotion/hash": "^0.9.0",
-        "@emotion/memoize": "^0.8.0",
-        "@emotion/unitless": "^0.8.0",
-        "@emotion/utils": "^1.2.0",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/styled": {
-      "version": "11.9.3",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.9.3.tgz",
-      "integrity": "sha512-o3sBNwbtoVz9v7WB1/Y/AmXl69YHmei2mrVnK7JgyBJ//Rst5yqPZCecEJlMlJrFeWHp+ki/54uN265V2pEcXA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@emotion/babel-plugin": "^11.7.1",
-        "@emotion/is-prop-valid": "^1.1.3",
-        "@emotion/serialize": "^1.0.4",
-        "@emotion/utils": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@emotion/react": "^11.0.0-rc.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/unitless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-    },
-    "node_modules/@giphy/react-components/node_modules/@emotion/utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
     },
     "node_modules/@giphy/react-native-sdk": {
       "version": "3.3.1",
@@ -29044,8 +28971,8 @@
       "resolved": "https://registry.npmjs.org/@giphy/react-components/-/react-components-6.9.4.tgz",
       "integrity": "sha512-Ql7dHnfCTgE5qWbzhqDYBwY+sjBlIxBZNGrSTMGOkEFKy9y2JIvJP7UKaXyYPNIluOZNGlnkP7EARY4uAJiDTQ==",
       "requires": {
-        "@emotion/react": "11.9.3",
-        "@emotion/styled": "11.9.3",
+        "@emotion/react": "11.10.6",
+        "@emotion/styled": "11.10.6",
         "@giphy/js-analytics": "*",
         "@giphy/js-brand": "*",
         "@giphy/js-fetch-api": "*",
@@ -29054,61 +28981,6 @@
         "intersection-observer": "^0.12.2",
         "react-use": "17.4.0",
         "throttle-debounce": "^3.0.1"
-      },
-      "dependencies": {
-        "@emotion/hash": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz",
-          "integrity": "sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ=="
-        },
-        "@emotion/react": {
-          "version": "11.9.3",
-          "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.9.3.tgz",
-          "integrity": "sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@emotion/babel-plugin": "^11.7.1",
-            "@emotion/cache": "^11.9.3",
-            "@emotion/serialize": "^1.0.4",
-            "@emotion/utils": "^1.1.0",
-            "@emotion/weak-memoize": "^0.2.5",
-            "hoist-non-react-statics": "^3.3.1"
-          }
-        },
-        "@emotion/serialize": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.1.tgz",
-          "integrity": "sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==",
-          "requires": {
-            "@emotion/hash": "^0.9.0",
-            "@emotion/memoize": "^0.8.0",
-            "@emotion/unitless": "^0.8.0",
-            "@emotion/utils": "^1.2.0",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@emotion/styled": {
-          "version": "11.9.3",
-          "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.9.3.tgz",
-          "integrity": "sha512-o3sBNwbtoVz9v7WB1/Y/AmXl69YHmei2mrVnK7JgyBJ//Rst5yqPZCecEJlMlJrFeWHp+ki/54uN265V2pEcXA==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@emotion/babel-plugin": "^11.7.1",
-            "@emotion/is-prop-valid": "^1.1.3",
-            "@emotion/serialize": "^1.0.4",
-            "@emotion/utils": "^1.1.0"
-          }
-        },
-        "@emotion/unitless": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
-          "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
-        },
-        "@emotion/utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.0.tgz",
-          "integrity": "sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw=="
-        }
       }
     },
     "@giphy/react-native-sdk": {

--- a/package.json
+++ b/package.json
@@ -229,5 +229,14 @@
   "resolutions": {
     "@types/react": "17.0.14",
     "@types/react-dom": "17.0.14"
+  },
+  "overrides": {
+  "@emotion/react": "11.10.6",
+  "@emotion/styled": "11.10.6"
+  },
+  "peerDependenciesMeta": {
+    "@emotion/react": {
+      "optional": true
+    }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,7 +204,9 @@ function getConfig(options = {}) {
         ].filter(Boolean),
         resolve: {
             alias: {
-                'focus-visible': 'focus-visible/dist/focus-visible.min.js'
+                'focus-visible': 'focus-visible/dist/focus-visible.min.js',
+                '@emotion/react': require.resolve('@emotion/react'),
+                '@emotion/styled': require.resolve('@emotion/styled')
             },
             aliasFields: [
                 'browser'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

## Summary

This PR fixes the warning about multiple instances of `@emotion/react` being loaded at runtime:

> You are loading @emotion/react when it is already loaded. Running multiple instances may cause problems.

## Root Cause

The issue was caused by dependencies like `@giphy/react-components` using an older version of `@emotion/react` (`11.9.3`), while the app and other packages use `11.10.6`. This resulted in multiple builds of Emotion being bundled.

## Fix

- Used `overrides` in `package.json` to force a single version (`@emotion/react@11.10.6` and `@emotion/styled@11.10.6`) across all dependencies.
- Added Webpack `resolve.alias` to ensure that all Emotion imports resolve to the same instance in `node_modules`.

## Result

- Eliminated Emotion multiple-instance runtime warning.
- Ensured consistent styling behavior and reduced bundle bloat.
- Confirmed app renders correctly with no UI regressions.

## Notes

- Affected packages: `@giphy/react-components`, `@mui/material`, `tss-react`
- This does not downgrade or alter any functional behavior — only deduplicates Emotion.

