### PR TITLE
fix: remove adaptV4Theme and migrate to native MUI v5 theme structure

### DIFF
--- a/react/features/base/ui/functions.web.ts
+++ b/react/features/base/ui/functions.web.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { Theme, adaptV4Theme, createTheme } from '@mui/material/styles';
+import { Theme, createTheme } from '@mui/material/styles';
 
 import { ITypography, IPalette as Palette1 } from '../ui/types';
 
@@ -29,7 +29,7 @@ interface ThemeProps {
  * @returns {Object}
  */
 export function createWebTheme({ font, colorMap, shape, spacing, typography, breakpoints }: ThemeProps) {
-    return createTheme(adaptV4Theme({
+    return createTheme({
         spacing,
         palette: createColorTokens(colorMap),
         shape,
@@ -39,7 +39,7 @@ export function createWebTheme({ font, colorMap, shape, spacing, typography, bre
             ...createTypographyTokens(typography)
         },
         breakpoints
-    }));
+    });
 }
 
 /**

--- a/react/features/dynamic-branding/functions.web.ts
+++ b/react/features/dynamic-branding/functions.web.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@mui/material';
-import { adaptV4Theme, createTheme } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
 
 import { breakpoints, colorMap, font, shape, spacing, typography } from '../base/ui/Tokens';
 import { createColorTokens } from '../base/ui/utils';
@@ -52,7 +52,7 @@ export function createMuiBrandingTheme(customTheme: Theme) {
         newSpacing = customSpacing;
     }
 
-    return createTheme(adaptV4Theme({
+    return createTheme({
         spacing: newSpacing,
         palette: newPalette,
         shape: newShape,
@@ -62,7 +62,7 @@ export function createMuiBrandingTheme(customTheme: Theme) {
 
         // @ts-ignore
         breakpoints: newBreakpoints
-    }));
+    });
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

## Summary

This PR removes the usage of the deprecated `adaptV4Theme()` helper and migrates the theme definition to MUI v5's native `createTheme` structure.

## Why

MUI logs the following deprecation warning:

> MUI: `adaptV4Theme()` is deprecated. Follow the upgrade guide on https://mui.com/r/migration-v4#theme.

While `adaptV4Theme()` was useful during the transition from MUI v4 to v5, it is no longer recommended and may be removed in future releases.

## What Changed

- Replaced `createTheme(adaptV4Theme(...))` with direct usage of `createTheme(...)`
- Verified that theme configuration (palette, typography, spacing, etc.) uses MUI v5-compatible keys
- Removed unused `adaptV4Theme` import

## Result

- No more deprecation warning from MUI
- Theme structure is now future-proof and aligned with current MUI best practices

