### PR TITLE
Add a test for jaas passcode, refactor tests.

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -13,7 +13,7 @@ import IframeAPI from '../pageobjects/IframeAPI';
 import InviteDialog from '../pageobjects/InviteDialog';
 import LargeVideo from '../pageobjects/LargeVideo';
 import LobbyScreen from '../pageobjects/LobbyScreen';
-import Notifications from '../pageobjects/Notifications';
+import Notifications, { TOKEN_AUTH_FAILED_TEST_ID, TOKEN_AUTH_FAILED_TITLE_TEST_ID } from '../pageobjects/Notifications';
 import ParticipantsPane from '../pageobjects/ParticipantsPane';
 import PasswordDialog from '../pageobjects/PasswordDialog';
 import PreJoinScreen from '../pageobjects/PreJoinScreen';
@@ -340,8 +340,16 @@ export class Participant {
         return this.execute(() => typeof APP !== 'undefined' && APP.conference?.isJoined());
     }
 
-    async waitForMucJoinedOrPasswordPrompt(): Promise<void> {
-        await this.driver.waitUntil(async () => await this.isInMuc() || await this.getPasswordDialog().isOpen(), {
+    /**
+     * Waits until either the MUC is joined, or a password prompt is displayed, or an authentication failure
+     * notification is displayed.
+     */
+    async waitForMucJoinedOrError(): Promise<void> {
+        await this.driver.waitUntil(async () => {
+            return await this.isInMuc() || await this.getPasswordDialog().isOpen()
+                || await this.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TEST_ID)
+                || await this.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TITLE_TEST_ID);
+        }, {
             timeout: 10_000,
             timeoutMsg: 'Timeout waiting for MUC joined or password prompt.'
         });

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -56,6 +56,11 @@ export class Participant {
     private _token?: IToken;
 
     /**
+     * Cache the dial in pin code so that it doesn't have to be read from the UI.
+     */
+    private _dialInPin?: string;
+
+    /**
      * The default config to use when joining.
      *
      * @private
@@ -906,5 +911,20 @@ export class Participant {
      */
     getToken(): IToken | undefined {
         return this._token;
+    }
+
+    /**
+     * Gets the dial in pin for the conference. Reads it from the invite dialog if the pin hasn't been cached yet.
+     */
+    async getDialInPin(): Promise<string> {
+        if (!this._dialInPin) {
+            const dialInPin = await this.getInviteDialog().getPinNumber();
+
+            await this.getInviteDialog().clickCloseButton();
+
+            this._dialInPin = dialInPin;
+        }
+
+        return this._dialInPin;
     }
 }

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -340,6 +340,13 @@ export class Participant {
         return this.execute(() => typeof APP !== 'undefined' && APP.conference?.isJoined());
     }
 
+    async waitForMucJoinedOrPasswordPrompt(): Promise<void> {
+        await this.driver.waitUntil(async () => await this.isInMuc() || await this.getPasswordDialog().isOpen(), {
+            timeout: 10_000,
+            timeoutMsg: 'Timeout waiting for MUC joined or password prompt.'
+        });
+    }
+
     /**
      * Checks if the participant is a moderator in the meeting.
      */

--- a/tests/helpers/types.ts
+++ b/tests/helpers/types.ts
@@ -6,7 +6,6 @@ import type WebhookProxy from './WebhookProxy';
 import { ITokenOptions } from './token';
 
 export type IContext = {
-    data: any;
     /**
      * Whether the configuration specifies a JaaS account for the iFrame API tests.
      */

--- a/tests/pageobjects/Notifications.ts
+++ b/tests/pageobjects/Notifications.ts
@@ -1,11 +1,10 @@
 import BasePageObject from './BasePageObject';
 
-const AV_MODERATION_MUTED_NOTIFICATION_ID = 'notify.moderationInEffectTitle';
 const ASK_TO_UNMUTE_NOTIFICATION_ID = 'notify.hostAskedUnmute';
+const AV_MODERATION_MUTED_NOTIFICATION_ID = 'notify.moderationInEffectTitle';
+const JOIN_MULTIPLE_TEST_ID = 'notify.connectedThreePlusMembers';
 const JOIN_ONE_TEST_ID = 'notify.connectedOneMember';
 const JOIN_TWO_TEST_ID = 'notify.connectedTwoMembers';
-const JOIN_MULTIPLE_TEST_ID = 'notify.connectedThreePlusMembers';
-const YOU_ARE_MUTED_TEST_ID = 'notify.mutedTitle';
 const LOBBY_ACCESS_DENIED_TEST_ID = 'lobby.joinRejectedMessage';
 const LOBBY_ENABLED_TEST_ID = 'lobby.notificationLobbyEnabled';
 const LOBBY_KNOCKING_PARTICIPANT_NOTIFICATION_XPATH
@@ -16,8 +15,12 @@ const LOBBY_PARTICIPANT_ACCESS_GRANTED_TEST_ID = 'lobby.notificationLobbyAccessG
 const LOBBY_PARTICIPANT_ADMIT_TEST_ID = 'participantsPane.actions.admit';
 const LOBBY_PARTICIPANT_REJECT_TEST_ID = 'participantsPane.actions.reject';
 const RAISE_HAND_NOTIFICATION_ID = 'notify.raisedHand';
-const REENABLE_SELF_VIEW_NOTIFICATION_ID = 'notify.selfViewTitle';
 const REENABLE_SELF_VIEW_CLOSE_NOTIFICATION = 'notify.selfViewTitle-dismiss';
+const REENABLE_SELF_VIEW_NOTIFICATION_ID = 'notify.selfViewTitle';
+const YOU_ARE_MUTED_TEST_ID = 'notify.mutedTitle';
+
+export const TOKEN_AUTH_FAILED_TEST_ID = 'dialog.tokenAuthFailed';
+export const TOKEN_AUTH_FAILED_TITLE_TEST_ID = 'dialog.tokenAuthFailedTitle';
 
 /**
  * Gathers all notifications logic in the UI and obtaining those.
@@ -194,6 +197,20 @@ export default class Notifications extends BasePageObject {
         await notificationElement.waitForExist({ timeout: 2_000 });
 
         return await notificationElement.getText();
+    }
+
+    /**
+     * Gets the text from the notification with the given testId, if the notification exists (otherwise returns
+     * undefined).
+     * @param testId
+     * @return the notification text.
+     */
+    async getNotificationText(testId: string) {
+        const notificationElement = this.participant.driver.$(`[data-testid="${testId}"]`);
+
+        if (await notificationElement.isExisting()) {
+            return await notificationElement.getText();
+        }
     }
 
     /**

--- a/tests/pageobjects/Notifications.ts
+++ b/tests/pageobjects/Notifications.ts
@@ -47,7 +47,7 @@ export default class Notifications extends BasePageObject {
     }
 
     /**
-     * Closes the ask to unmute notification.
+     * Closes the muted notification.
      */
     async closeAVModerationMutedNotification(skipNonExisting = false) {
         return this.closeNotification(AV_MODERATION_MUTED_NOTIFICATION_ID, skipNonExisting);
@@ -92,7 +92,7 @@ export default class Notifications extends BasePageObject {
      * The notification on participants page when Lobby is being enabled or disabled.
      */
     getLobbyEnabledText() {
-        return this.getNotificationText(LOBBY_ENABLED_TEST_ID);
+        return this.waitForNotificationText(LOBBY_ENABLED_TEST_ID);
     }
 
     /**
@@ -174,7 +174,7 @@ export default class Notifications extends BasePageObject {
      * The notification that someone's access was approved.
      */
     getLobbyParticipantAccessGranted() {
-        return this.getNotificationText(LOBBY_PARTICIPANT_ACCESS_GRANTED_TEST_ID);
+        return this.waitForNotificationText(LOBBY_PARTICIPANT_ACCESS_GRANTED_TEST_ID);
     }
 
     /**
@@ -185,10 +185,10 @@ export default class Notifications extends BasePageObject {
     }
 
     /**
-     * Returns notification text if the notification is found in the next few seconds.
+     * Waits until a notifications with the given testId is found and returns its text.
      * @return the notification text.
      */
-    private async getNotificationText(testId: string) {
+    private async waitForNotificationText(testId: string) {
         const notificationElement = this.participant.driver.$(`[data-testid="${testId}"]`);
 
         await notificationElement.waitForExist({ timeout: 2_000 });
@@ -212,7 +212,7 @@ export default class Notifications extends BasePageObject {
      * The notification test that someone's access was denied.
      */
     getLobbyParticipantAccessDenied() {
-        return this.getNotificationText(LOBBY_PARTICIPANT_ACCESS_DENIED_TEST_ID);
+        return this.waitForNotificationText(LOBBY_PARTICIPANT_ACCESS_DENIED_TEST_ID);
     }
 
     /**

--- a/tests/pageobjects/PasswordDialog.ts
+++ b/tests/pageobjects/PasswordDialog.ts
@@ -20,6 +20,18 @@ export default class PasswordDialog extends BaseDialog {
         await input.waitForStable();
     }
 
+    async isOpen() {
+        const input = this.participant.driver.$(INPUT_KEY_XPATH);
+
+        try {
+            await input.isExisting();
+
+            return await input.isDisplayed();
+        } catch (e) {
+            return false;
+        }
+    }
+
     /**
      * Sets a password and submits the dialog.
      * @param password

--- a/tests/specs/alone/dialInAudio.spec.ts
+++ b/tests/specs/alone/dialInAudio.spec.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 
 import { ensureOneParticipant } from '../../helpers/participants';
-import { cleanup, dialIn, isDialInEnabled, retrievePin, waitForAudioFromDialInParticipant } from '../helpers/DialIn';
+import { cleanup, dialIn, isDialInEnabled, waitForAudioFromDialInParticipant } from '../helpers/DialIn';
 
 describe('Dial-In', () => {
     it('join participant', async () => {
@@ -21,21 +21,23 @@ describe('Dial-In', () => {
     });
 
     it('retrieve pin', async () => {
+        let dialInPin: string;
+
         try {
-            await retrievePin(ctx.p1);
+            dialInPin = await ctx.p1.getDialInPin();
         } catch (e) {
             console.error('dial-in.test.no-pin');
             ctx.skipSuiteTests = true;
             throw e;
         }
 
-        if (ctx.data.dialInPin === 0) {
+        if (dialInPin.length === 0) {
             console.error('dial-in.test.no-pin');
             ctx.skipSuiteTests = true;
             throw new Error('no pin');
         }
 
-        expect(ctx.data.dialInPin.length >= 8).toBe(true);
+        expect(dialInPin.length >= 8).toBe(true);
     });
 
     it('invite dial-in participant', async () => {

--- a/tests/specs/alone/iFrameApiInvite.spec.ts
+++ b/tests/specs/alone/iFrameApiInvite.spec.ts
@@ -5,7 +5,6 @@ import {
     cleanup,
     dialIn,
     isDialInEnabled,
-    retrievePin,
     waitForAudioFromDialInParticipant
 } from '../helpers/DialIn';
 
@@ -43,10 +42,9 @@ describe('Invite iframeAPI', () => {
         }
 
         const { p1 } = ctx;
+        const dialInPin = await p1.getDialInPin();
 
-        await retrievePin(p1);
-
-        expect(ctx.data.dialInPin.length >= 8).toBe(true);
+        expect(dialInPin.length >= 8).toBe(true);
 
         await dialIn(p1);
 

--- a/tests/specs/alone/iFrameApiInvite.spec.ts
+++ b/tests/specs/alone/iFrameApiInvite.spec.ts
@@ -14,6 +14,10 @@ setTestProperties(__filename, {
 });
 
 describe('Invite iframeAPI', () => {
+    let dialInDisabled: boolean;
+    let dialOutDisabled: boolean;
+    let sipJibriDisabled: boolean;
+
     it('join participant', async () => {
         await ensureOneParticipant(ctx);
 
@@ -27,17 +31,17 @@ describe('Invite iframeAPI', () => {
             return;
         }
 
-        ctx.data.dialOutDisabled = Boolean(!await p1.execute(() => config.dialOutAuthUrl));
-        ctx.data.sipJibriDisabled = Boolean(!await p1.execute(() => config.inviteServiceUrl));
+        dialOutDisabled = Boolean(!await p1.execute(() => config.dialOutAuthUrl));
+        sipJibriDisabled = Boolean(!await p1.execute(() => config.inviteServiceUrl));
 
         // check dial-in is enabled
         if (!await isDialInEnabled(ctx.p1) || !process.env.DIAL_IN_REST_URL) {
-            ctx.data.dialInDisabled = true;
+            dialInDisabled = true;
         }
     });
 
     it('dial-in', async () => {
-        if (ctx.data.dialInDisabled) {
+        if (dialInDisabled) {
             return;
         }
 
@@ -59,7 +63,7 @@ describe('Invite iframeAPI', () => {
     });
 
     it('dial-out', async () => {
-        if (ctx.data.dialOutDisabled || !process.env.DIAL_OUT_URL) {
+        if (dialOutDisabled || !process.env.DIAL_OUT_URL) {
             return;
         }
 
@@ -79,7 +83,7 @@ describe('Invite iframeAPI', () => {
     });
 
     it('sip jibri', async () => {
-        if (ctx.data.sipJibriDisabled || !process.env.SIP_JIBRI_DIAL_OUT_URL) {
+        if (sipJibriDisabled || !process.env.SIP_JIBRI_DIAL_OUT_URL) {
             return;
         }
 

--- a/tests/specs/alone/iFrameApiRecording.spec.ts
+++ b/tests/specs/alone/iFrameApiRecording.spec.ts
@@ -7,6 +7,9 @@ setTestProperties(__filename, {
 });
 
 describe('Recording', () => {
+    let recordingDisabled: boolean;
+    let liveStreamingDisabled: boolean;
+
     it('join participant', async () => {
         await ensureOneParticipant(ctx);
 
@@ -20,13 +23,13 @@ describe('Recording', () => {
             return;
         }
 
-        ctx.data.recordingDisabled = Boolean(!await p1.execute(() => config.recordingService?.enabled));
-        ctx.data.liveStreamingDisabled = Boolean(!await p1.execute(() => config.liveStreaming?.enabled))
+        recordingDisabled = Boolean(!await p1.execute(() => config.recordingService?.enabled));
+        liveStreamingDisabled = Boolean(!await p1.execute(() => config.liveStreaming?.enabled))
             || !process.env.YTUBE_TEST_STREAM_KEY;
     });
 
     it('start/stop function', async () => {
-        if (ctx.data.recordingDisabled) {
+        if (recordingDisabled) {
             return;
         }
 
@@ -38,7 +41,7 @@ describe('Recording', () => {
     });
 
     it('start/stop command', async () => {
-        if (ctx.data.recordingDisabled) {
+        if (recordingDisabled) {
             return;
         }
 
@@ -50,7 +53,7 @@ describe('Recording', () => {
     });
 
     it('start/stop Livestreaming command', async () => {
-        if (ctx.data.liveStreamingDisabled) {
+        if (liveStreamingDisabled) {
             return;
         }
 

--- a/tests/specs/helpers/DialIn.ts
+++ b/tests/specs/helpers/DialIn.ts
@@ -54,18 +54,6 @@ export async function isDialInEnabled(participant: Participant) {
 }
 
 /**
- * Retrieves the dial-in pin number from the invite dialog of the participant.
- * @param participant
- */
-export async function retrievePin(participant: Participant) {
-    const dialInPin = await participant.getInviteDialog().getPinNumber();
-
-    await participant.getInviteDialog().clickCloseButton();
-
-    ctx.data.dialInPin = dialInPin;
-}
-
-/**
  * Sends a request to the REST API to dial in the participant using the provided pin.
  * @param participant
  */
@@ -75,7 +63,9 @@ export async function dialIn(participant: Participant) {
         return;
     }
 
-    const restUrl = process.env.DIAL_IN_REST_URL?.replace('{0}', ctx.data.dialInPin);
+    const dialInPin = await participant.getDialInPin();
+
+    const restUrl = process.env.DIAL_IN_REST_URL?.replace('{0}', dialInPin);
 
     // we have already checked in the first test that DIAL_IN_REST_URL exist so restUrl cannot be ''
     const responseData: string = await new Promise((resolve, reject) => {

--- a/tests/specs/helpers/jaas.ts
+++ b/tests/specs/helpers/jaas.ts
@@ -28,7 +28,17 @@ export async function loadPage(roomName: string, instanceId: 'p1' | 'p2' | 'p3' 
 
     try {
         await newParticipant.driver.setTimeout({ 'pageLoad': 30000 });
-        await newParticipant.driver.url(url);
+
+        // Force a refresh if URL changes only in hash params. TODO: clean this up when reactoring.
+        const currentUrl = await newParticipant.driver.getUrl();
+
+        if (currentUrl.split('#')[0] === url.split('#')[0]) {
+            console.log('Refreshing the page to ensure the URL is loaded correctly');
+            await newParticipant.driver.url(url);
+            await newParticipant.driver.refresh();
+        } else {
+            await newParticipant.driver.url(url);
+        }
         await newParticipant.waitForPageToLoad();
     } catch (error) {
     }
@@ -63,7 +73,7 @@ export async function joinMuc(roomName: string, instanceId: 'p1' | 'p2' | 'p3' |
     const participant = await loadPage(roomName, instanceId, token);
 
     try {
-        await participant.waitToJoinMUC();
+        await participant.waitForMucJoinedOrError();
     } catch (error) {
     }
 

--- a/tests/specs/jaas/joinMuc.spec.ts
+++ b/tests/specs/jaas/joinMuc.spec.ts
@@ -1,4 +1,5 @@
 import { setTestProperties } from '../../helpers/TestProperties';
+import { TOKEN_AUTH_FAILED_TEST_ID, TOKEN_AUTH_FAILED_TITLE_TEST_ID } from '../../pageobjects/Notifications';
 import { joinMuc, generateJaasToken as t } from '../helpers/jaas';
 
 setTestProperties(__filename, {
@@ -7,6 +8,7 @@ setTestProperties(__filename, {
 
 describe('XMPP login and MUC join test', () => {
     it('with a valid token (wildcard room)', async () => {
+        console.log('Joining a MUC with a valid token (wildcard room)');
         const p = await joinMuc(ctx.roomName, 'p1', t({ room: '*' }));
 
         expect(await p.isInMuc()).toBe(true);
@@ -14,6 +16,7 @@ describe('XMPP login and MUC join test', () => {
     });
 
     it('with a valid token (specific room)', async () => {
+        console.log('Joining a MUC with a valid token (specific room)');
         const p = await joinMuc(ctx.roomName, 'p1', t({ room: ctx.roomName }));
 
         expect(await p.isInMuc()).toBe(true);
@@ -21,6 +24,7 @@ describe('XMPP login and MUC join test', () => {
     });
 
     it('with a token with bad signature', async () => {
+        console.log('Joining a MUC with a token with bad signature');
         const token = t({ room: ctx.roomName });
 
         token.jwt = token.jwt + 'badSignature';
@@ -28,31 +32,65 @@ describe('XMPP login and MUC join test', () => {
         const p = await joinMuc(ctx.roomName, 'p1', token);
 
         expect(Boolean(await p.isInMuc())).toBe(false);
+
+        const errorText = await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TEST_ID)
+            || await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TITLE_TEST_ID);
+
+        expect(errorText).toContain('not allowed to join');
     });
 
     it('with an expired token', async () => {
+        console.log('Joining a MUC with an expired token');
         const p = await joinMuc(ctx.roomName, 'p1', t({ exp: '-1m' }));
 
         expect(Boolean(await p.isInMuc())).toBe(false);
+
+        const errorText = await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TITLE_TEST_ID);
+
+        expect(errorText).toContain('Token is expired');
     });
 
     it('with a token using the wrong key ID', async () => {
+        console.log('Joining a MUC with a token using the wrong key ID');
         const p = await joinMuc(ctx.roomName, 'p1', t({ keyId: 'invalid-key-id' }));
 
         expect(Boolean(await p.isInMuc())).toBe(false);
+
+        const errorText = await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TEST_ID);
+
+        expect(errorText).toContain('not allowed to join');
     });
 
     it('with a token for a different room', async () => {
+        console.log('Joining a MUC with a token for a different room');
         const p = await joinMuc(ctx.roomName, 'p1', t({ room: ctx.roomName + 'different' }));
 
         expect(Boolean(await p.isInMuc())).toBe(false);
+
+        const errorText = await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TEST_ID);
+
+        expect(errorText).toContain('not allowed to join');
     });
 
     it('with a moderator token', async () => {
+        console.log('Joining a MUC with a moderator token');
         const p = await joinMuc(ctx.roomName, 'p1', t({ moderator: true }));
 
         expect(await p.isInMuc()).toBe(true);
         expect(await p.isModerator()).toBe(true);
+    });
+
+    // This is dependent on jaas account configuration. All tests under jaas/ expect that "unauthenticated access" is
+    // disabled.
+    it('without a token', async () => {
+        console.log('Joining a MUC without a token');
+        const p = await joinMuc(ctx.roomName, 'p1');
+
+        expect(Boolean(await p.isInMuc())).toBe(false);
+
+        const errorText = await p.getNotifications().getNotificationText(TOKEN_AUTH_FAILED_TEST_ID);
+
+        expect(errorText).toContain('not allowed to join');
     });
 
     // it('without sending a conference-request', async () => {

--- a/tests/specs/jaas/passcode.ts
+++ b/tests/specs/jaas/passcode.ts
@@ -43,12 +43,12 @@ async function joinWithPassword(roomName: string, instanceId: string, token: ITo
     // @ts-ignore
     const p = await loadPage(roomName, instanceId, token);
 
-    await p.waitForMucJoinedOrPasswordPrompt();
+    await p.waitForMucJoinedOrError();
     expect(await p.isInMuc()).toBe(false);
     expect(await p.getPasswordDialog().isOpen()).toBe(true);
 
     await p.getPasswordDialog().submitPassword('wrong password');
-    await p.waitForMucJoinedOrPasswordPrompt();
+    await p.waitForMucJoinedOrError();
     expect(await p.isInMuc()).toBe(false);
     expect(await p.getPasswordDialog().isOpen()).toBe(true);
 

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -192,7 +192,6 @@ export const config: WebdriverIO.MultiremoteConfig = {
         const globalAny: any = global;
 
         globalAny.ctx = {
-            data: {},
             times: {}
         } as IContext;
         globalAny.ctx.keepAlive = [];


### PR DESCRIPTION
- **ref: Don't use global context for local state.**
- **ref: Don't use global context to store the pin.**
- **feat: Add a test for setting passcode via settings provisioning.**
- **Use local state.**
- **Remove "data" from context.**
- **ref: Rename a function.**
- **test: Fail quick when join muc fails, assert specific errors (e.g. "token expired").**