### PR TITLE
fix(prejoin) no initial tracks when using URL override to disable it

### DIFF
--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -7,6 +7,7 @@ import { isEmpty, mergeWith, pick } from 'lodash-es';
 
 import { IReduxState } from '../../app/types';
 import { getLocalParticipant } from '../participants/functions';
+import { isEmbedded } from '../util/embedUtils';
 import { parseURLParams } from '../util/parseURLParams';
 
 import { IConfig } from './configType';
@@ -335,7 +336,7 @@ export function setConfigFromURLParams(
 
     overrideConfigJSON(config, interfaceConfig, json);
 
-    // Print warning about depricated URL params
+    // Print warning about deprecated URL params
     if ('interfaceConfig.SUPPORT_URL' in params) {
         logger.warn('Using SUPPORT_URL interfaceConfig URL overwrite is deprecated.'
             + ' Please use supportUrl from advanced branding!');
@@ -370,6 +371,14 @@ export function setConfigFromURLParams(
             )) {
         logger.warn('Using liveStreaming config URL overwrite and/or LIVE_STREAMING_HELP_LINK interfaceConfig URL'
             + ' overwrite is deprecated. Please use liveStreaming from advanced branding!');
+    }
+
+    // When not in an iframe, start without media if the pre-join page is not enabled.
+    if (!isEmbedded()
+            && ('config.prejoinConfig.enabled' in params || 'config.prejoinPageEnabled' in params)
+            && (config.prejoinConfig?.enabled === false || config.prejoinPageEnabled === false)) {
+        logger.warn('Using prejoinConfig.enabled config URL overwrite implies starting without media.');
+        config.disableInitialGUM = true;
     }
 }
 

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -406,9 +406,7 @@ function _translateLegacyConfig(oldValue: IConfig) {
     }
 
     newValue.prejoinConfig = oldValue.prejoinConfig || {};
-    if (oldValue.hasOwnProperty('prejoinPageEnabled')
-        && !newValue.prejoinConfig.hasOwnProperty('enabled')
-    ) {
+    if (oldValue.hasOwnProperty('prejoinPageEnabled')) {
         newValue.prejoinConfig.enabled = oldValue.prejoinPageEnabled;
     }
 


### PR DESCRIPTION
It's still possible to disable it, but when not in an iframe, audio and video tracks will not be created.

When in an iframe, it's ok to let it happen, since the host sit is the one where permissions need to be granted, thanks to permission delegation.

Fixes: https://github.com/jitsi/jitsi-meet/issues/16262
Ref: https://zimzi.substack.com/p/jitsi-privacy-flaw-that-enables-one

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
