### PR TITLE
feat(logging): start collecting logs at appMount

### DIFF
--- a/react/features/base/logging/reducer.ts
+++ b/react/features/base/logging/reducer.ts
@@ -57,6 +57,7 @@ export interface ILoggingState {
     config: ILoggingConfig;
     logCollector?: {
         flush: () => void;
+        maxEntryLength?: number;
         start: () => void;
         stop: () => void;
     };


### PR DESCRIPTION
Logs that would happen before SET_CONFIG logging middleware wouldn't be captured by the logger (which sends the data to rtcstats), logs such as 
```2025-08-11T08:28:49.586Z [features/base/config] Extending config with: {"videoQuality":{"preferredCodec":"VP9"}}```
This moves the init of the logger to app mount, allowing it to capture more logs, even before the config is completely merged.
