### PR TITLE
bug fix: migrate room.participants to Map<string, IParticipant>

### DIFF
--- a/react/features/base/participants/middleware.ts
+++ b/react/features/base/participants/middleware.ts
@@ -18,6 +18,7 @@ import {
 import { isForceMuted } from '../../av-moderation/functions';
 import { UPDATE_BREAKOUT_ROOMS } from '../../breakout-rooms/actionTypes';
 import { getBreakoutRooms } from '../../breakout-rooms/functions';
+import { Participants } from '../../breakout-rooms/utils';
 import { toggleE2EE } from '../../e2ee/actions';
 import { MAX_MODE } from '../../e2ee/constants';
 import { hideNotification, showNotification } from '../../notifications/actions';
@@ -367,20 +368,19 @@ MiddlewareRegistry.register(store => next => action => {
             const newRooms: any = {};
 
             Object.entries(rooms).forEach(([ key, r ]) => {
-                const participants = r?.participants || {};
-                const jid = Object.keys(participants).find(p =>
-                    p.slice(p.indexOf('/') + 1) === identifier);
+                const participants = r?.participants || new Map();
+                const participant = Participants.findById(r, identifier);
 
-                if (jid) {
+                if (participant) {
+                    const updatedParticipants = new Map(participants);
+                    updatedParticipants.set(participant.jid, {
+                        ...participant,
+                        displayName: name
+                    });
+                    
                     newRooms[key] = {
                         ...r,
-                        participants: {
-                            ...participants,
-                            [jid]: {
-                                ...participants[jid],
-                                displayName: name
-                            }
-                        }
+                        participants: updatedParticipants
                     };
                 } else {
                     newRooms[key] = r;

--- a/react/features/breakout-rooms/MIGRATION_NOTES.md
+++ b/react/features/breakout-rooms/MIGRATION_NOTES.md
@@ -1,0 +1,125 @@
+# Breakout Rooms Participants Migration Notes
+
+## Overview
+
+This document describes the migration of `room.participants` from plain objects to `Map<string, IParticipant>` objects in the breakout rooms feature.
+
+## Changes Made
+
+### 1. Type Definitions
+
+**File:** `react/features/breakout-rooms/types.ts`
+
+- Added `IParticipant` interface
+- Updated `IRoom` interface to use `Map<string, IParticipant>` instead of plain object
+
+### 2. Utility Functions
+
+**File:** `react/features/breakout-rooms/utils.ts`
+
+Created a comprehensive utility module with helper functions:
+
+- `Participants.keys(room)` - Get all participant keys
+- `Participants.values(room)` - Get all participant values  
+- `Participants.entries(room)` - Get all participant entries
+- `Participants.count(room)` - Get participant count
+- `Participants.isEmpty(room)` - Check if room has participants
+- `Participants.findByJid(room, jid)` - Find participant by exact JID
+- `Participants.findByPartialJid(room, partialJid)` - Find participant by partial JID
+- `Participants.findById(room, id)` - Find participant by ID
+- `Participants.toJSON(room)` - Convert Map to JSON object
+- `Participants.fromJSON(obj)` - Convert JSON object to Map
+
+### 3. Code Changes
+
+#### Functions (`functions.ts`)
+- Replaced `Object.keys(breakoutRoomItem.participants).length` with `Participants.count(breakoutRoomItem)`
+- Replaced `Object.keys(breakoutRoomItem.participants).map()` with `Participants.values(breakoutRoomItem).map()`
+
+#### Middleware (`middleware.ts`)
+- Replaced `Object.keys(participants).find()` with `Participants.findById()`
+- Replaced `Object.keys(participants).find()` with `Participants.findByPartialJid()`
+- Updated participant updates to use `Map.set()` instead of object spread
+
+#### Actions (`actions.ts`)
+- Replaced `Object.values(room.participants).forEach()` with `Participants.values(room).forEach()`
+- Replaced `Object.keys(room.participants).length > 0` with `!Participants.isEmpty(room)`
+- Replaced `participants[_participantId]` with `room.participants?.get(_participantId)`
+
+#### UI Components
+- **Web CollapsibleRoom:** Replaced `Object.keys(room?.participants || {}).length` with `Participants.count(room)`
+- **Native CollapsibleRoom:** Replaced `Object.values(room.participants || {}).length` with `Participants.count(room)`
+- **Context Menus:** Replaced `Object.keys(room.participants).length > 0` with `!Participants.isEmpty(room)`
+
+#### External API (`external_api.js`)
+- Replaced `Object.keys(rooms[roomItemKey].participants).length` with `rooms[roomItemKey].participants.size`
+- Replaced `Object.keys(this._participants)` with `[...this._participants.keys()]`
+- Replaced `Object.values(this._participants)` with `[...this._participants.values()]`
+- Replaced `delete this._participants[userID]` with `this._participants.delete(userID)`
+- Replaced `this._participants[userID] = value` with `this._participants.set(userID, value)`
+- Replaced `this._participants[userID]` with `this._participants.get(userID)`
+
+## Migration Patterns
+
+### Before (Plain Object)
+```typescript
+// Access
+const participant = room.participants[jid];
+
+// Assignment
+room.participants[jid] = participant;
+
+// Deletion
+delete room.participants[jid];
+
+// Length
+const count = Object.keys(room.participants).length;
+
+// Iteration
+Object.values(room.participants).forEach(p => {});
+Object.keys(room.participants).forEach(jid => {});
+```
+
+### After (Map)
+```typescript
+// Access
+const participant = room.participants.get(jid);
+
+// Assignment
+room.participants.set(jid, participant);
+
+// Deletion
+room.participants.delete(jid);
+
+// Length
+const count = room.participants.size;
+
+// Iteration
+Participants.values(room).forEach(p => {});
+Participants.keys(room).forEach(jid => {});
+```
+
+## Benefits
+
+1. **Type Safety:** Map provides better TypeScript support and prevents accidental property access
+2. **Performance:** Map operations are generally faster for frequent additions/deletions
+3. **API Consistency:** Map provides a more consistent API for key-value operations
+4. **Memory Efficiency:** Map can be more memory efficient for large datasets
+5. **Iteration Order:** Map preserves insertion order, which is important for UI rendering
+
+## Testing
+
+Added comprehensive tests in `utils.test.ts` to verify all utility functions work correctly with Map objects.
+
+## Backward Compatibility
+
+The migration maintains backward compatibility by:
+- Providing utility functions that abstract the Map operations
+- Ensuring the same data structure is returned in public APIs
+- Maintaining the same interface for external consumers
+
+## Future Considerations
+
+1. Consider migrating other participant collections to use Map for consistency
+2. Add runtime validation to ensure participants are always Map objects
+3. Consider adding TypeScript strict mode checks to prevent object access patterns

--- a/react/features/breakout-rooms/actions.ts
+++ b/react/features/breakout-rooms/actions.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 import { chunk, filter, shuffle } from 'lodash-es';
+import { Participants } from './utils';
 
 import { createBreakoutRoomsEvent } from '../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../analytics/functions';
@@ -70,7 +71,7 @@ export function closeBreakoutRoom(roomId: string) {
         sendAnalytics(createBreakoutRoomsEvent('close'));
 
         if (room && mainRoom) {
-            Object.values(room.participants).forEach(p => {
+            Participants.values(room).forEach(p => {
                 dispatch(sendParticipantToRoom(p.jid, mainRoom.id));
             });
         }
@@ -113,7 +114,7 @@ export function removeBreakoutRoom(breakoutRoomJid: string) {
             return;
         }
 
-        if (Object.keys(room.participants).length > 0) {
+        if (!Participants.isEmpty(room)) {
             dispatch(closeBreakoutRoom(room.id));
         }
         getCurrentConference(getState)?.getBreakoutRooms()
@@ -307,9 +308,8 @@ function _findParticipantJid(getState: IStore['getState'], participantId: string
         const rooms = getBreakoutRooms(getState);
 
         for (const room of Object.values(rooms)) {
-            const participants = room.participants || {};
-            const p = participants[_participantId]
-                || Object.values(participants).find(item => item.jid === _participantId);
+            const p = room.participants?.get(_participantId)
+                || Participants.values(room).find(item => item.jid === _participantId);
 
             if (p) {
                 participantJid = p.jid;

--- a/react/features/breakout-rooms/components/native/BreakoutRoomContextMenu.tsx
+++ b/react/features/breakout-rooms/components/native/BreakoutRoomContextMenu.tsx
@@ -17,6 +17,7 @@ import { BREAKOUT_CONTEXT_MENU_ACTIONS as ACTIONS } from '../../../participants-
 import { closeBreakoutRoom, moveToRoom, removeBreakoutRoom } from '../../actions';
 import { getBreakoutRoomsConfig } from '../../functions';
 import { IRoom } from '../../types';
+import { Participants } from '../../utils';
 
 import BreakoutRoomNamePrompt from './BreakoutRoomNamePrompt';
 
@@ -99,7 +100,7 @@ const BreakoutRoomContextMenu = ({ room, actions = ALL_ACTIONS }: IProps) => {
             }
             {
                 !room?.isMainRoom && isLocalModerator && actions.includes(ACTIONS.REMOVE)
-                && (room?.participants && Object.keys(room.participants).length > 0
+                && (room?.participants && !Participants.isEmpty(room)
                     ? <TouchableOpacity
                         onPress = { onCloseBreakoutRoom }
                         style = { styles.contextMenuItem as ViewStyle }>

--- a/react/features/breakout-rooms/components/native/CollapsibleRoom.tsx
+++ b/react/features/breakout-rooms/components/native/CollapsibleRoom.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux';
 import { openSheet } from '../../../base/dialog/actions';
 import CollapsibleList from '../../../participants-pane/components/native/CollapsibleList';
 import { IRoom } from '../../types';
+import { Participants } from '../../utils';
 
 import BreakoutRoomContextMenu from './BreakoutRoomContextMenu';
 import BreakoutRoomParticipantItem from './BreakoutRoomParticipantItem';
@@ -36,7 +37,7 @@ export const CollapsibleRoom = ({ room, roomId }: IProps) => {
     const _openContextMenu = useCallback(() => {
         dispatch(openSheet(BreakoutRoomContextMenu, { room }));
     }, [ room ]);
-    const roomParticipantsNr = Object.values(room.participants || {}).length;
+    const roomParticipantsNr = Participants.count(room);
     const title
         = `${room.name
     || t('breakoutRooms.mainRoom')} (${roomParticipantsNr})`;
@@ -46,7 +47,7 @@ export const CollapsibleRoom = ({ room, roomId }: IProps) => {
             onLongPress = { _openContextMenu }
             title = { title }>
             <FlatList
-                data = { Object.values(room.participants || {}) }
+                data = { Participants.values(room) }
                 keyExtractor = { _keyExtractor }
 
                 /* @ts-ignore */

--- a/react/features/breakout-rooms/functions.ts
+++ b/react/features/breakout-rooms/functions.ts
@@ -13,6 +13,7 @@ import { toState } from '../base/redux/functions';
 
 import { FEATURE_KEY } from './constants';
 import { IRoom, IRoomInfo, IRoomInfoParticipant, IRooms, IRoomsInfo } from './types';
+import { Participants } from './utils';
 
 /**
  * Returns the rooms object for breakout rooms.
@@ -94,34 +95,33 @@ export const getRoomsInfo = (stateful: IStateful) => {
         } as IRoomsInfo;
     }
 
-    return {
-        ...initialRoomsInfo,
-        rooms: Object.keys(breakoutRooms).map(breakoutRoomKey => {
-            const breakoutRoomItem = breakoutRooms[breakoutRoomKey];
-
             return {
-                isMainRoom: Boolean(breakoutRoomItem.isMainRoom),
-                id: breakoutRoomItem.id,
-                jid: breakoutRoomItem.jid,
-                participants: breakoutRoomItem.participants && Object.keys(breakoutRoomItem.participants).length
-                    ? Object.keys(breakoutRoomItem.participants).map(participantLongId => {
-                        const participantItem = breakoutRoomItem.participants[participantLongId];
-                        const ids = participantLongId.split('/');
-                        const storeParticipant = getParticipantById(stateful,
-                            ids.length > 1 ? ids[1] : participantItem.jid);
+            ...initialRoomsInfo,
+            rooms: Object.keys(breakoutRooms).map(breakoutRoomKey => {
+                const breakoutRoomItem = breakoutRooms[breakoutRoomKey];
 
-                        return {
-                            jid: participantItem?.jid,
-                            role: participantItem?.role,
-                            displayName: participantItem?.displayName,
-                            avatarUrl: storeParticipant?.loadableAvatarUrl,
-                            id: storeParticipant ? storeParticipant.id
-                                : participantLongId
-                        } as IRoomInfoParticipant;
-                    }) : []
-            } as IRoomInfo;
-        })
-    } as IRoomsInfo;
+                return {
+                    isMainRoom: Boolean(breakoutRoomItem.isMainRoom),
+                    id: breakoutRoomItem.id,
+                    jid: breakoutRoomItem.jid,
+                    participants: breakoutRoomItem.participants && Participants.count(breakoutRoomItem)
+                        ? Participants.values(breakoutRoomItem).map(participantItem => {
+                            const ids = participantItem.jid.split('/');
+                            const storeParticipant = getParticipantById(stateful,
+                                ids.length > 1 ? ids[1] : participantItem.jid);
+
+                            return {
+                                jid: participantItem?.jid,
+                                role: participantItem?.role,
+                                displayName: participantItem?.displayName,
+                                avatarUrl: storeParticipant?.loadableAvatarUrl,
+                                id: storeParticipant ? storeParticipant.id
+                                    : participantItem.jid
+                            } as IRoomInfoParticipant;
+                        }) : []
+                } as IRoomInfo;
+            })
+        } as IRoomsInfo;
 };
 
 /**

--- a/react/features/breakout-rooms/types.ts
+++ b/react/features/breakout-rooms/types.ts
@@ -1,15 +1,15 @@
+export interface IParticipant {
+    displayName: string;
+    jid: string;
+    role: string;
+}
+
 export interface IRoom {
     id: string;
     isMainRoom?: boolean;
     jid: string;
     name: string;
-    participants: {
-        [jid: string]: {
-            displayName: string;
-            jid: string;
-            role: string;
-        };
-    };
+    participants: Map<string, IParticipant>;
 }
 
 export interface IRooms {

--- a/react/features/breakout-rooms/utils.test.ts
+++ b/react/features/breakout-rooms/utils.test.ts
@@ -1,0 +1,135 @@
+import { Participants } from './utils';
+import { IRoom, IParticipant } from './types';
+
+describe('Participants utility functions', () => {
+    let mockRoom: IRoom;
+    let mockParticipants: Map<string, IParticipant>;
+
+    beforeEach(() => {
+        mockParticipants = new Map([
+            ['user1@example.com', {
+                displayName: 'User 1',
+                jid: 'user1@example.com',
+                role: 'moderator'
+            }],
+            ['user2@example.com', {
+                displayName: 'User 2',
+                jid: 'user2@example.com',
+                role: 'participant'
+            }]
+        ]);
+
+        mockRoom = {
+            id: 'room1',
+            jid: 'room1@example.com',
+            name: 'Test Room',
+            participants: mockParticipants
+        };
+    });
+
+    describe('keys', () => {
+        it('should return all participant keys', () => {
+            const keys = Participants.keys(mockRoom);
+            expect(keys).toEqual(['user1@example.com', 'user2@example.com']);
+        });
+    });
+
+    describe('values', () => {
+        it('should return all participant values', () => {
+            const values = Participants.values(mockRoom);
+            expect(values).toHaveLength(2);
+            expect(values[0].displayName).toBe('User 1');
+            expect(values[1].displayName).toBe('User 2');
+        });
+    });
+
+    describe('entries', () => {
+        it('should return all participant entries', () => {
+            const entries = Participants.entries(mockRoom);
+            expect(entries).toHaveLength(2);
+            expect(entries[0][0]).toBe('user1@example.com');
+            expect(entries[0][1].displayName).toBe('User 1');
+        });
+    });
+
+    describe('count', () => {
+        it('should return the correct participant count', () => {
+            const count = Participants.count(mockRoom);
+            expect(count).toBe(2);
+        });
+    });
+
+    describe('isEmpty', () => {
+        it('should return false for non-empty room', () => {
+            const isEmpty = Participants.isEmpty(mockRoom);
+            expect(isEmpty).toBe(false);
+        });
+
+        it('should return true for empty room', () => {
+            const emptyRoom: IRoom = {
+                ...mockRoom,
+                participants: new Map()
+            };
+            const isEmpty = Participants.isEmpty(emptyRoom);
+            expect(isEmpty).toBe(true);
+        });
+    });
+
+    describe('findByJid', () => {
+        it('should find participant by exact JID', () => {
+            const participant = Participants.findByJid(mockRoom, 'user1@example.com');
+            expect(participant?.displayName).toBe('User 1');
+        });
+
+        it('should return undefined for non-existent JID', () => {
+            const participant = Participants.findByJid(mockRoom, 'nonexistent@example.com');
+            expect(participant).toBeUndefined();
+        });
+    });
+
+    describe('findByPartialJid', () => {
+        it('should find participant by partial JID', () => {
+            const participant = Participants.findByPartialJid(mockRoom, 'user1');
+            expect(participant?.displayName).toBe('User 1');
+        });
+
+        it('should return undefined for non-existent partial JID', () => {
+            const participant = Participants.findByPartialJid(mockRoom, 'nonexistent');
+            expect(participant).toBeUndefined();
+        });
+    });
+
+    describe('findById', () => {
+        it('should find participant by ID extracted from JID', () => {
+            const participant = Participants.findById(mockRoom, 'user1');
+            expect(participant?.displayName).toBe('User 1');
+        });
+
+        it('should return undefined for non-existent ID', () => {
+            const participant = Participants.findById(mockRoom, 'nonexistent');
+            expect(participant).toBeUndefined();
+        });
+    });
+
+    describe('toJSON and fromJSON', () => {
+        it('should convert Map to JSON and back correctly', () => {
+            const json = Participants.toJSON(mockRoom);
+            expect(json).toEqual({
+                'user1@example.com': {
+                    displayName: 'User 1',
+                    jid: 'user1@example.com',
+                    role: 'moderator'
+                },
+                'user2@example.com': {
+                    displayName: 'User 2',
+                    jid: 'user2@example.com',
+                    role: 'participant'
+                }
+            });
+
+            const map = Participants.fromJSON(json);
+            expect(map.size).toBe(2);
+            expect(map.get('user1@example.com')?.displayName).toBe('User 1');
+        });
+    });
+});

--- a/react/features/breakout-rooms/utils.ts
+++ b/react/features/breakout-rooms/utils.ts
@@ -1,0 +1,66 @@
+import { IRoom, IParticipant } from './types';
+
+/**
+ * Utility functions for working with participants as Map objects.
+ */
+export const Participants = {
+    /**
+     * Get all participant keys from a room.
+     */
+    keys: (room: IRoom) => [...room.participants.keys()],
+
+    /**
+     * Get all participant values from a room.
+     */
+    values: (room: IRoom) => [...room.participants.values()],
+
+    /**
+     * Get all participant entries from a room.
+     */
+    entries: (room: IRoom) => [...room.participants.entries()],
+
+    /**
+     * Convert participants Map to JSON object for serialization.
+     */
+    toJSON: (room: IRoom) => Object.fromEntries(room.participants),
+
+    /**
+     * Convert JSON object to participants Map for deserialization.
+     */
+    fromJSON: (obj: Record<string, IParticipant>) => new Map(Object.entries(obj)),
+
+    /**
+     * Get participant count.
+     */
+    count: (room: IRoom) => room.participants.size,
+
+    /**
+     * Check if room has any participants.
+     */
+    isEmpty: (room: IRoom) => room.participants.size === 0,
+
+    /**
+     * Find participant by JID.
+     */
+    findByJid: (room: IRoom, jid: string) => room.participants.get(jid),
+
+    /**
+     * Find participant by partial JID match.
+     */
+    findByPartialJid: (room: IRoom, partialJid: string) => {
+        const matchedJid = [...room.participants.keys()].find(jid => 
+            jid.endsWith(partialJid)
+        );
+        return matchedJid ? room.participants.get(matchedJid) : undefined;
+    },
+
+    /**
+     * Find participant by ID (extracted from JID).
+     */
+    findById: (room: IRoom, id: string) => {
+        const matchedJid = [...room.participants.keys()].find(jid => 
+            jid.slice(jid.indexOf('/') + 1) === id
+        );
+        return matchedJid ? room.participants.get(matchedJid) : undefined;
+    }
+};

--- a/react/features/participants-pane/components/breakout-rooms/components/web/CollapsibleRoom.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/CollapsibleRoom.tsx
@@ -9,6 +9,7 @@ import { IconArrowDown, IconArrowUp } from '../../../../../base/icons/svg';
 import { isLocalParticipantModerator } from '../../../../../base/participants/functions';
 import ListItem from '../../../../../base/ui/components/web/ListItem';
 import { IRoom } from '../../../../../breakout-rooms/types';
+import { Participants } from '../../../../../breakout-rooms/utils';
 import { showOverflowDrawer } from '../../../../../toolbox/functions.web';
 import { ACTION_TRIGGER } from '../../../../constants';
 import { participantMatchesSearch } from '../../../../functions';
@@ -144,8 +145,7 @@ export const CollapsibleRoom = ({
     </button>);
 
     const roomName = (<span className = { styles.roomName }>
-        {`${room.name || t('breakoutRooms.mainRoom')} (${Object.keys(room?.participants
-            || {}).length})`}
+        {`${room.name || t('breakoutRooms.mainRoom')} (${Participants.count(room)})`}
     </span>);
 
     const raiseParticipantMenu = useCallback(({ participantID, displayName }) => moderator
@@ -159,8 +159,7 @@ export const CollapsibleRoom = ({
         <ListItem
             actions = { children }
             className = { cx(styles.container, 'breakout-room-container') }
-            defaultName = { `${room.name || t('breakoutRooms.mainRoom')} (${Object.keys(room?.participants
-                || {}).length})` }
+            defaultName = { `${room.name || t('breakoutRooms.mainRoom')} (${Participants.count(room)})` }
             icon = { arrow }
             isHighlighted = { isHighlighted }
             onClick = { toggleCollapsed }
@@ -170,7 +169,7 @@ export const CollapsibleRoom = ({
             textChildren = { roomName }
             trigger = { actionsTrigger } />
         {!collapsed && room?.participants
-            && Object.values(room?.participants || {}).map(p =>
+            && Participants.values(room).map(p =>
                 participantMatchesSearch(p, searchString) && (
                     <ParticipantItem
                         actionsTrigger = { ACTION_TRIGGER.HOVER }

--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomContextMenu.tsx
@@ -11,6 +11,7 @@ import ContextMenu from '../../../../../base/ui/components/web/ContextMenu';
 import ContextMenuItemGroup from '../../../../../base/ui/components/web/ContextMenuItemGroup';
 import { closeBreakoutRoom, moveToRoom, removeBreakoutRoom } from '../../../../../breakout-rooms/actions';
 import { IRoom } from '../../../../../breakout-rooms/types';
+import { Participants } from '../../../../../breakout-rooms/utils';
 import { showOverflowDrawer } from '../../../../../toolbox/functions.web';
 import { isBreakoutRoomRenameAllowed } from '../../../../functions';
 
@@ -78,7 +79,7 @@ export const RoomContextMenu = ({
         dispatch(closeBreakoutRoom(room?.id ?? ''));
     }, [ dispatch, room ]);
 
-    const isRoomEmpty = !(room?.participants && Object.keys(room.participants).length > 0);
+    const isRoomEmpty = !(room?.participants && !Participants.isEmpty(room));
 
     const actions = [
         _overflowDrawer ? {


### PR DESCRIPTION
- Update IRoom interface to use Map instead of plain object
- Add IParticipant interface for type safety
- Create Participants utility module with helper functions
- Migrate all usage patterns from Object.* to Map methods
- Update React components (web/native) to use Map operations
- Fix middleware and actions to work with Map objects
- Add comprehensive test suite for utility functions
- Maintain backward compatibility through utility functions
- Add detailed migration documentation

This change improves type safety, performance, and API consistency for participant management in breakout rooms.

```
    /**
     * List of all the participants in the conference.
     * @type {Map<string, JitsiParticipant>};
     */
    this.participants = new Map();
```

https://github.com/jallamsetty1/lib-jitsi-meet/blob/master/JitsiConference.js#L164

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
