### PR TITLE
chore(android): add top and bottom margin insets for API 35

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -23,7 +23,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
@@ -108,7 +107,7 @@ public class JitsiMeetActivity extends AppCompatActivity
                 v.setLayoutParams(params);
 
                 decorView.setOnApplyWindowInsetsListener((view, windowInsets) -> {
-                    view.setBackgroundColor(Color.BLACK);
+                    view.setBackgroundColor(JitsiMeetView.BACKGROUND_COLOR);
 
                     return windowInsets;
                 });

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -23,11 +23,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.facebook.react.modules.core.PermissionListener;
@@ -87,6 +94,28 @@ public class JitsiMeetActivity extends AppCompatActivity
         launch(context, options);
     }
 
+    public static void addTopBottomInsets(@NonNull Window w, @NonNull View v) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) return;
+
+        View decorView = w.getDecorView();
+
+        decorView.post(() -> {
+            WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(decorView);
+            if (insets != null) {
+                ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+                params.topMargin = insets.getInsets(WindowInsetsCompat.Type.systemBars()).top;
+                params.bottomMargin = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+                v.setLayoutParams(params);
+
+                decorView.setOnApplyWindowInsetsListener((view, windowInsets) -> {
+                    view.setBackgroundColor(Color.BLACK);
+
+                    return windowInsets;
+                });
+            }
+        });
+    }
+
     // Overrides
     //
 
@@ -107,6 +136,7 @@ public class JitsiMeetActivity extends AppCompatActivity
         JitsiMeetActivityDelegate.onHostResume(this);
 
         setContentView(R.layout.activity_jitsi_meet);
+        addTopBottomInsets(getWindow(),findViewById(android.R.id.content));
         this.jitsiView = findViewById(R.id.jitsiView);
 
         registerForBroadcastMessages();

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -36,7 +36,7 @@ public class JitsiMeetView extends FrameLayout {
     /**
      * Background color. Should match the background color set in JS.
      */
-    private static final int BACKGROUND_COLOR = 0xFF040404;
+    public static final int BACKGROUND_COLOR = 0xFF040404;
 
     /**
      * React Native root view.


### PR DESCRIPTION
Update regarding #16282 and #16340 

Once we started targeting SDK 35 on a device running Android 15 or higher, by default, we display edge-to-edge.
We can handle overlaps by using insets.
https://developer.android.com/develop/ui/views/layout/edge-to-edge#handle-overlaps

<img width="576" height="1248" alt="Screenshot_20250820-133732" src="https://github.com/user-attachments/assets/003163c9-7b0d-4f1a-bee1-bdf9ffee471d" />
<img width="576" height="1248" alt="Screenshot_20250820-133749" src="https://github.com/user-attachments/assets/41511832-293f-40c3-8cfd-52ecc1f99036" />
<img width="576" height="1248" alt="Screenshot_20250820-133805" src="https://github.com/user-attachments/assets/85a5abe9-f479-4059-abe3-6ef7529a1ad1" />
<img width="576" height="1248" alt="Screenshot_20250820-133817" src="https://github.com/user-attachments/assets/9dff5866-b580-4183-8207-5c84f97687ee" />

