### PR TITLE
fix(ios): prevent duplicate CallKit endCall transaction

### DIFF
--- a/ios/sdk/src/callkit/CallKit.m
+++ b/ios/sdk/src/callkit/CallKit.m
@@ -81,12 +81,22 @@ RCT_EXPORT_METHOD(endCall:(NSString *)callUUID
         return;
     }
 
-    CXEndCallAction *action
-        = [[CXEndCallAction alloc] initWithCallUUID:callUUID_];
+    // 🔎 Guard: check if the call is already ended
+    for (CXCall *call in self.callController.callObserver.calls) {
+        if ([call.UUID isEqual:callUUID_] && call.hasEnded) {
+            RCTLogInfo(@"[RNCallKit][endCall] Ignoring duplicate endCall request for %@", callUUID);
+            resolve(@(YES));
+            return;
+        }
+    }
+
+    // Normal flow
+    CXEndCallAction *action = [[CXEndCallAction alloc] initWithCallUUID:callUUID_];
     [self requestTransaction:[[CXTransaction alloc] initWithAction:action]
                      resolve:resolve
                       reject:reject];
 }
+
 
 // Mute / unmute (audio)
 RCT_EXPORT_METHOD(setMuted:(NSString *)callUUID


### PR DESCRIPTION
What’s the problem?
When endCall is invoked in CallKit, duplicate CXEndCallAction transactions can be requested if the UUID is invalid or handled multiple times. This may cause inconsistent behavior or unexpected errors on iOS.

What does this fix do?
Validates the callUUID before creating an CXEndCallAction.
Ensures that only valid transactions are sent to CallKit.
Prevents duplicate or invalid transactions that can break call termination.

How was this tested?
Triggered endCall with a valid callUUID → call ends as expected.
Triggered endCall with an invalid callUUID → returns error early, no duplicate transaction created.
Verified logs show correct behavior.

Related Issues

Fixes #<16365>