### PR TITLE
docs(lang): update Spanish translation for recording warning

### DIFF
--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -885,6 +885,7 @@
         "or": "o",
         "premeeting": "Pre-reunión",
         "proceedAnyway": "Continuar de todos modos",
+        "recordingWarning": "Otros participantes pueden estar grabando esta llamada",
         "screenSharingError": "Error al compartir pantalla:",
         "startWithPhone": "Iniciar con audio de llamada telefónica",
         "unsafeRoomConsent": "Comprendo los riesgos, quiero unirme a la reunión",


### PR DESCRIPTION
Added Spanish translation for the string "Other participants may be recording this call" in lang/main-es.json. Updated to: "Otros participantes pueden estar grabando esta llamada".

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
