### PR TITLE
fix(tests): Fixes error because of not waiting for conference left ev…

### DIFF
--- a/tests/specs/iframe/participantsPresence.spec.ts
+++ b/tests/specs/iframe/participantsPresence.spec.ts
@@ -225,6 +225,7 @@ describe('Participants presence', () => {
 
     it('kick participant', async () => {
         // we want to join second participant with token, so we can check info in webhook
+        await ctx.p2.getIframeAPI().clearEventResults('videoConferenceLeft');
         await ctx.p2.getIframeAPI().addEventListener('videoConferenceLeft');
         await ctx.p2.switchToMainFrame();
         await ctx.p2.getIframeAPI().executeCommand('hangup');


### PR DESCRIPTION
…ent.

Try to fix the error we see: 
Error: waitUntil condition failed with the following reason: Command script.callFunction with id 116 (with the following parameter: {"functionDeclaration":"function anonymous(\n) {\nreturn (/* __wdio script__ */()=>typeof APP!==\"undefined\"&&APP.conference?.isJoined()/* __wdio script end__ */).apply(this, arguments);\n}","awaitPromise":true,"arguments":[],"target":{"context":"10352FFE685AC1D0503E1ECA3BFD33B2"}}) timed out

Seems like we do not wait for all checks to happen and start joining again in the middle of switching/checking.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
