### PR TITLE
fix (lobby): fix error in chat on native

### DIFF
--- a/react/features/lobby/components/native/LobbyChatScreen.tsx
+++ b/react/features/lobby/components/native/LobbyChatScreen.tsx
@@ -39,8 +39,6 @@ class LobbyChatScreen extends
             </JitsiScreen>
         );
     }
-
-    _onSendMessage: () => void;
 }
 
 export default translate(connect(abstractMapStateToProps)(LobbyChatScreen));


### PR DESCRIPTION
Experienced a bug where users of the native app can't respond to chat messages while they're in the lobby.

In our deployment we were able to fix this by removing the _onSendMessage base method from LobbyChatScreen.tsx, which seems to be unused.