### PR TITLE
fix: check if asapKeyServer is empty string

### DIFF
--- a/resources/prosody-plugins/mod_muc_end_meeting.lua
+++ b/resources/prosody-plugins/mod_muc_end_meeting.lua
@@ -94,7 +94,7 @@ function module.add_host(host_module)
 
         token_util = module:require "token/util".new(host_module);
 
-        if asapKeyServer then
+        if asapKeyServer ~= "" then
             -- init token util with our asap keyserver
             token_util:set_asap_key_server(asapKeyServer)
         end


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Empt string is true in lua.