### PR TITLE
Fix local recording issues with iframe embeds by relaxing capture handle validation

### DIFF
--- a/react/features/recording/components/Recording/LocalRecordingManager.web.ts
+++ b/react/features/recording/components/Recording/LocalRecordingManager.web.ts
@@ -213,6 +213,7 @@ const LocalRecordingManager: ILocalRecordingManager = {
             });
 
             const gdmVideoTrack = gdmStream.getVideoTracks()[0];
+
             if (supportsCaptureHandle) {
                 const isBrowser = gdmVideoTrack.getSettings().displaySurface === 'browser';
                 const matchesHandle = (supportsCaptureHandle // @ts-ignore
@@ -223,6 +224,7 @@ const LocalRecordingManager: ILocalRecordingManager = {
                     throw new Error('WrongSurfaceSelected');
                 }
             }
+
             this.initializeAudioMixer();
 
             const gdmAudioTrack = gdmStream.getAudioTracks()[0];


### PR DESCRIPTION
Hi,
Since the recent local recording modifications, local recording no longer works in embedded iframes, even if the iframe and parent page are served from the same domain.

When running inside an iframe, setCaptureHandle and getCaptureHandle do not work, resulting in a WrongSurfaceSelected error.

This patch relaxes the capture handle validation to ensure local recording continues to work when the service is embedded in an iframe from the same domain.

With this change:
- The capture handle validation (isBrowser + matchesHandle) is applied only if supportsCaptureHandle is true.
- In iframe contexts where the capture handle is not available, the validation is skipped, allowing recording to work properly.

Additionally, since getDisplayMedia is already called with:
preferCurrentTab: true,
surfaceSwitching: 'exclude',
it might be worth considering whether the explicit surface validation is still needed at all.

Best Regards,
Damien Fetis