### PR TITLE
fix(prosody): Avoid using stale room instances.

### DIFF
--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -48,6 +48,7 @@ local NOTIFY_LOBBY_ACCESS_DENIED = 'LOBBY-ACCESS-DENIED';
 local util = module:require "util";
 local ends_with = util.ends_with;
 local get_room_by_name_and_subdomain = util.get_room_by_name_and_subdomain;
+local get_room_from_jid = util.get_room_from_jid;
 local is_healthcheck_room = util.is_healthcheck_room;
 local presence_check_status = util.presence_check_status;
 local process_host_module = util.process_host_module;
@@ -105,7 +106,7 @@ end
 
 -- Sends a json message notifying that the jid was granted/denied access in lobby
 -- the message from is the actor that did the operation
-function notify_lobby_access(room, actor, jid, display_name, granted)
+function notify_lobby_access(room_jid, actor, jid, display_name, granted)
     local notify_json = {
         value = jid,
         name = display_name
@@ -114,6 +115,12 @@ function notify_lobby_access(room, actor, jid, display_name, granted)
         notify_json.event = NOTIFY_LOBBY_ACCESS_GRANTED;
     else
         notify_json.event = NOTIFY_LOBBY_ACCESS_DENIED;
+    end
+
+    local room = get_room_from_jid(room_jid);
+    if not room then
+        module:log('error', 'Room not found for %s', room_jid)
+        return;
     end
 
     broadcast_json_msg(room, actor, notify_json);
@@ -227,7 +234,7 @@ function attach_lobby_room(room, actor)
         -- avoid lobby destroy while it is enabled
         new_room:set_persistent(true);
         module:log("info","Lobby room jid = %s created from:%s", lobby_room_jid, actor);
-        new_room.main_room = room;
+        new_room.main_room_jid = room.jid;
         room._data.lobbyroom = new_room.jid;
         room:save(true);
         return true
@@ -245,6 +252,8 @@ function destroy_lobby_room(room, newjid, message)
         if lobby_room_obj then
             lobby_room_obj:set_persistent(false);
             lobby_room_obj:destroy(newjid, message);
+
+            module:log('info', 'Lobby room destroyed %s', lobby_room_obj.jid)
         end
         room._data.lobbyroom = nil;
         room._data.lobby_extra_reason = nil;
@@ -412,13 +421,18 @@ function process_lobby_muc_loaded(lobby_muc, host_module)
     local room_mt = lobby_muc_service.room_mt;
     -- we base affiliations (roles) in lobby muc component to be based on the roles in the main muc
     room_mt.get_affiliation = function(room, jid)
-        if not room.main_room then
+        if not room.main_room_jid then
             module:log('error', 'No main room(%s) for %s!', room.jid, jid);
             return 'none';
         end
 
         -- moderators in main room are moderators here
-        local role = room.main_room.get_affiliation(room.main_room, jid);
+        local main_room = get_room_from_jid(room.main_room_jid);
+        if not main_room then
+            module:log('error', 'Main room not found for %s!', room.main_room_jid);
+            return 'none';
+        end
+        local role = main_room.get_affiliation(main_room, jid);
         if role then
             return role;
         end
@@ -433,7 +447,7 @@ function process_lobby_muc_loaded(lobby_muc, host_module)
             local display_name = occupant:get_presence():get_child_text(
                 'nick', 'http://jabber.org/protocol/nick');
             -- we need to notify in the main room
-            notify_lobby_access(room.main_room, actor, occupant.nick, display_name, false);
+            notify_lobby_access(room.main_room_jid, actor, occupant.nick, display_name, false);
         end
     end);
 end
@@ -589,7 +603,7 @@ process_host_module(main_muc_component_config, function(host_module, host)
                     local display_name = occupant:get_presence():get_child_text(
                             'nick', 'http://jabber.org/protocol/nick');
 
-                    notify_lobby_access(room, from, occupant.nick, display_name, true);
+                    notify_lobby_access(room.jid, from, occupant.nick, display_name, true);
                 end
             end
         end

--- a/resources/prosody-plugins/mod_muc_meeting_id.lua
+++ b/resources/prosody-plugins/mod_muc_meeting_id.lua
@@ -132,12 +132,7 @@ module:hook('muc-occupant-pre-join', function (event)
 end, 8); -- just after the rate limit
 
 function handle_jicofo_unlock(event)
-    local room = get_room_from_jid(event.room.jid);
-
-    if not room then
-        module:log('error', 'Something is terribly wrong, room is missing at this point %s', event.room.jid);
-        return;
-    end
+    local room = event.room;
 
     room._data.jicofo_lock = false;
     if not room.pre_join_queue then

--- a/resources/prosody-plugins/mod_muc_meeting_id.lua
+++ b/resources/prosody-plugins/mod_muc_meeting_id.lua
@@ -132,7 +132,12 @@ module:hook('muc-occupant-pre-join', function (event)
 end, 8); -- just after the rate limit
 
 function handle_jicofo_unlock(event)
-    local room = event.room;
+    local room = get_room_from_jid(event.room.jid);
+
+    if not room then
+        module:log('error', 'Something is terribly wrong, room is missing at this point %s', event.room.jid);
+        return;
+    end
 
     room._data.jicofo_lock = false;
     if not room.pre_join_queue then


### PR DESCRIPTION
In very rare cases a participant can request a room and jicofo join there, but the participant don't show up (waiting for host) so jicofo leaves and in the mean time if someone tries to use the room instance just before and after the room is being destroyed, strange things can occur like web connected and joined to a stale room where nothing is received exchanged compared to the live meeting room.

