### PR TITLE
feat(conference): Adds option to silently reconnect.

### DIFF
--- a/react/features/base/conference/middleware.native.ts
+++ b/react/features/base/conference/middleware.native.ts
@@ -6,8 +6,8 @@ import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import { CONFERENCE_FAILED } from './actionTypes';
 import { conferenceLeft } from './actions.native';
 import { TRIGGER_READY_TO_CLOSE_REASONS } from './constants';
-
 import './middleware.any';
+import { processDestroyConferenceEvent } from './functions';
 
 MiddlewareRegistry.register(store => next => action => {
     const { dispatch } = store;
@@ -20,6 +20,10 @@ MiddlewareRegistry.register(store => next => action => {
         const { notifyOnConferenceDestruction = true } = state['features/base/config'];
 
         if (error?.name !== JitsiConferenceErrors.CONFERENCE_DESTROYED) {
+            break;
+        }
+
+        if (processDestroyConferenceEvent(state, dispatch, error.params)) {
             break;
         }
 

--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -24,8 +24,8 @@ import {
     KICKED_OUT
 } from './actionTypes';
 import { TRIGGER_READY_TO_CLOSE_REASONS } from './constants';
+import { processDestroyConferenceEvent } from './functions';
 import logger from './logger';
-
 import './middleware.any';
 
 let screenLock: WakeLockSentinel | undefined;
@@ -127,6 +127,11 @@ MiddlewareRegistry.register(store => next => action => {
             const state = getState();
             const { notifyOnConferenceDestruction = true } = state['features/base/config'];
             const [ reason ] = action.error.params;
+
+            if (processDestroyConferenceEvent(state, dispatch, action.error.params)) {
+                break;
+            }
+
             const titlekey = Object.keys(TRIGGER_READY_TO_CLOSE_REASONS)[
                 Object.values(TRIGGER_READY_TO_CLOSE_REASONS).indexOf(reason)
             ];

--- a/resources/prosody-plugins/mod_muc_end_meeting.lua
+++ b/resources/prosody-plugins/mod_muc_end_meeting.lua
@@ -6,6 +6,7 @@ module:set_global();
 
 local util = module:require "util";
 local async_handler_wrapper = util.async_handler_wrapper;
+local internal_room_jid_match_rewrite = util.internal_room_jid_match_rewrite;
 local room_jid_match_rewrite = util.room_jid_match_rewrite;
 local get_room_from_jid = util.get_room_from_jid;
 local starts_with = util.starts_with;
@@ -17,6 +18,8 @@ local parse = neturl.parseQuery;
 local token_util;
 
 local muc_domain_base = module:get_option_string("muc_mapper_domain_base");
+local muc_domain_prefix = module:get_option_string('muc_mapper_domain_prefix', 'conference');
+local muc_domain = muc_domain_prefix..'.'..muc_domain_base;
 
 local asapKeyServer = module:get_option_string("prosody_password_public_key_repo_url", "");
 
@@ -47,6 +50,7 @@ function handle_terminate_meeting (event)
     end
     local params = parse(event.request.url.query);
     local conference = params["conference"];
+    local silent_reconnect = params['silent-reconnect'];
     local room_jid;
 
     if conference then
@@ -78,8 +82,13 @@ function handle_terminate_meeting (event)
         module:log("warn", "Room not found")
         return { status_code = 404 };
     else
-        module:log("info", "Destroy room jid %s", room.jid)
-        room:destroy(nil, "The meeting has been terminated")
+        if silent_reconnect == 'true' then
+            module:log('info', 'Setting silent_reconnect on room %s', room.jid);
+            room:destroy(internal_room_jid_match_rewrite(room.jid), 'The meeting has been terminated silently')
+        else
+            module:log("info", "Destroy room jid %s", room.jid)
+            room:destroy(nil, "The meeting has been terminated")
+        end
     end
     event_count_success()
     return { status_code = 200 };


### PR DESCRIPTION
Uses the end_meeting endpoint to trigger a silent reconnect by destroying the current conference and passing its jid.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
