### PR TITLE
Update jitsi-meet-rnsdk.podspec

### DIFF
--- a/react-native-sdk/jitsi-meet-rnsdk.podspec
+++ b/react-native-sdk/jitsi-meet-rnsdk.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
           SOURCE_PATH="${PODS_TARGET_SRCROOT}/sounds/"
           TARGET_PATH=$(dirname "${CONFIGURATION_BUILD_DIR}")
           PROJECT_NAME=$(basename $(dirname $(dirname "${PROJECT_DIR}"))).app
-          cp -R "${SOURCE_PATH}" "${TARGET_PATH}/${PROJECT_NAME}"
+          ditto "${SOURCE_PATH}" "${TARGET_PATH}/${PROJECT_NAME}/sounds"
       ',
   }
 end


### PR DESCRIPTION
This PR addresses a sporadic issue where cp would fail with a "directory not found" error during file operations. Replaced cp with ditto, which handles directory copying more reliably on macOS and resolves the random failures observed.
