### PR TITLE
chore(deps) update react-native-webrtc

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1473,7 +1473,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-webrtc (124.0.4):
+  - react-native-webrtc (124.0.7):
     - JitsiWebRTC (~> 124.0.0)
     - React-Core
   - react-native-webview (13.13.5):
@@ -2274,7 +2274,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 0f7bf11598f9a61b7ceac8dc3f59ef98697e99e1
   react-native-slider: 1205801a8d29b28cacc14eef08cb120015cdafcb
   react-native-video: eb861d67a71dfef1bbf6086a811af5f338b13781
-  react-native-webrtc: 2261a482150195092246fe70b3aff976f2e11ec5
+  react-native-webrtc: e8f0ce746353adc2744a2b933645e1aeb41eaa74
   react-native-webview: 079eca50edf657503318b66687dadfb903731aa8
   react-native-worklets-core: b59cf88762c8fb6132d8796babd4cec15217d6f0
   React-nativeconfig: ecf4dc92c40b97e2b3f0c619938f78bfd6507b08

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "react-native-tab-view": "3.5.2",
         "react-native-url-polyfill": "2.0.0",
         "react-native-video": "6.13.0",
-        "react-native-webrtc": "124.0.4",
+        "react-native-webrtc": "124.0.7",
         "react-native-webview": "13.13.5",
         "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
         "react-native-youtube-iframe": "2.3.0",
@@ -22471,9 +22471,10 @@
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "124.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.4.tgz",
-      "integrity": "sha512-ZbhSz1f+kc1v5VE0B84+v6ujIWTHa2fIuocrYzGUIFab7E5izmct7PNHb9dzzs0xhBGqh4c2rUa49jbL+P/e2w==",
+      "version": "124.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
+      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
+      "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",
         "debug": "4.3.4",
@@ -42684,9 +42685,9 @@
       "integrity": "sha512-eY6jgLcmYKAAlAZhsZbp8wfCVrGu7jmUYTTspn8udN8j4jqr4Fq90ROOM/QegGkwNs4waclL0IkzGuq61kT4DQ=="
     },
     "react-native-webrtc": {
-      "version": "124.0.4",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.4.tgz",
-      "integrity": "sha512-ZbhSz1f+kc1v5VE0B84+v6ujIWTHa2fIuocrYzGUIFab7E5izmct7PNHb9dzzs0xhBGqh4c2rUa49jbL+P/e2w==",
+      "version": "124.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
+      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
       "requires": {
         "base64-js": "1.5.1",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-tab-view": "3.5.2",
     "react-native-url-polyfill": "2.0.0",
     "react-native-video": "6.13.0",
-    "react-native-webrtc": "124.0.4",
+    "react-native-webrtc": "124.0.7",
     "react-native-webview": "13.13.5",
     "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
     "react-native-youtube-iframe": "2.3.0",


### PR DESCRIPTION
- Fixes a crash in iOS 26 simulator
- Avoid NPE on Android
