### PR TITLE
fix(recording): use cloned tracks for local recording; reset flags on…

### DIFF
--- a/react/features/recording/components/Recording/LocalRecordingManager.web.ts
+++ b/react/features/recording/components/Recording/LocalRecordingManager.web.ts
@@ -180,8 +180,8 @@ const LocalRecordingManager: ILocalRecordingManager = {
             this.selfRecording.withVideo = Boolean(videoTrack);
             const localTracks: MediaStreamTrack[] = [];
 
-            audioTrack && localTracks.push(audioTrack);
-            videoTrack && localTracks.push(videoTrack);
+            audioTrack && localTracks.push(audioTrack.clone());
+            videoTrack && localTracks.push(videoTrack.clone());
             this.stream = new MediaStream(localTracks);
         } else {
             if (supportsCaptureHandle) {
@@ -279,6 +279,9 @@ const LocalRecordingManager: ILocalRecordingManager = {
             this.audioContext = undefined;
             this.audioDestination = undefined;
             this.startTime = undefined;
+            this.stream = undefined;
+            this.selfRecording.on = false;
+            this.selfRecording.withVideo = false;
 
             if (this.writableStream) {
                 try {


### PR DESCRIPTION
### Title
fix(recording): keep UI camera alive after stopping local recording by using cloned tracks

### Summary
Stopping a local recording with “Record only my audio and video streams” was ending the initiator’s live camera track, resulting in a black self-view and an unresponsive camera toggle. This change records from cloned gUM tracks and resets local-recording flags on stop so the UI track remains live.

### Related issue
- Issue: [Recording with 'Record only my audio and video streams' option results in black video stream for the initiator #16491](https://github.com/jitsi/jitsi-meet/issues/16491)

### Problem
- After stopping local recording (self-only), the initiator’s video turns black.
- Camera cannot be re-enabled without a page reload.
- Reproducible on meet.jit.si and stable 10314.

### Root cause
- In `react/features/recording/components/Recording/LocalRecordingManager.web.ts`, the local-recording stream was built from the app’s live gUM tracks.
- On recorder stop, all tracks in `this.stream` were stopped, which also ended the same live camera track used by the UI (readyState → ended).
- `selfRecording` flags could linger and affect mute interception.

### Fix
- Build the recording stream from cloned tracks:
  - Use `audioTrack.clone()` / `videoTrack.clone()` when creating `this.stream` in the self-only path.
- Reset local-recording state on stop:
  - Clear `this.recorder`, `this.stream`, audio context/destination.
  - Set `selfRecording.on = false` and `selfRecording.withVideo = false`.


