### PR TITLE
chore(android/sdk): check also for sdk version that the app targets

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -136,7 +136,8 @@ public class JitsiMeetActivity extends AppCompatActivity
 
         setContentView(R.layout.activity_jitsi_meet);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
+            && getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             addTopBottomInsets(getWindow(), findViewById(android.R.id.content));
         }
 


### PR DESCRIPTION
We need to check for the Android OS that the device targets and the Android OS that the app targets to apply insets.
Update #16536  