### PR TITLE
fix(premeeting): device status indicator size when label is long

### DIFF
--- a/react/features/prejoin/components/web/preview/DeviceStatus.tsx
+++ b/react/features/prejoin/components/web/preview/DeviceStatus.tsx
@@ -41,7 +41,8 @@ const useStyles = makeStyles<{ deviceStatusType?: string; }>()((theme, { deviceS
             width: '16px',
             height: '16px',
             borderRadius: '100%',
-            backgroundColor: deviceStatusType === 'ok' ? theme.palette.success01 : ColorPalette.darkGrey
+            backgroundColor: deviceStatusType === 'ok' ? theme.palette.success01 : ColorPalette.darkGrey,
+            flexShrink: 0
         }
     };
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

For certain languages when the device status label is long the indicator icon gets squished.  


|  before  |  after  |
|----|----|
| <img width="424" height="296" alt="before" src="https://github.com/user-attachments/assets/74a48cc3-6bc9-4fb5-8177-cff62ea28cdb" /> | <img width="424" height="296" alt="after" src="https://github.com/user-attachments/assets/41c0851e-f08a-4167-892c-0e2ae3b608aa" /> |