### PR TITLE
fix(visitors): Fix room token verification.

### DIFF
--- a/resources/prosody-plugins/mod_token_verification.lua
+++ b/resources/prosody-plugins/mod_token_verification.lua
@@ -72,6 +72,10 @@ local function verify_user(session, stanza)
     -- allowlist for participants, jigasi (sip & transcriber), jibri (recorder & sip)
     if allowlist:contains(user_domain)
         or allowlist:contains(user_bare_jid)
+
+        -- allow main participants in visitor mode
+        or session.type == 's2sin'
+
         -- Let Jigasi or transcriber pass throw
         or util.is_sip_jigasi(stanza)
         or util.is_transcriber_jigasi(stanza)


### PR DESCRIPTION
When allowUnauthenticatedAccess is enabled we want to allow main prosody participants without verifying their token.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
