### PR TITLE
fix(tests) Increase backToP2PDelay to 3 secs.

### DIFF
--- a/tests/specs/media/desktopSharing.spec.ts
+++ b/tests/specs/media/desktopSharing.spec.ts
@@ -18,7 +18,7 @@ describe('Desktop sharing', () => {
         await ensureTwoParticipants({
             configOverwrite: {
                 p2p: {
-                    backToP2PDelay: 1,
+                    backToP2PDelay: 3,
                     enabled: true
                 }
             }
@@ -101,7 +101,7 @@ describe('Desktop sharing', () => {
         await ensureThreeParticipants({
             configOverwrite: {
                 p2p: {
-                    backToP2PDelay: 1,
+                    backToP2PDelay: 3,
                     enabled: true
                 }
             }
@@ -143,7 +143,7 @@ describe('Desktop sharing', () => {
         await ensureThreeParticipants({
             configOverwrite: {
                 p2p: {
-                    backToP2PDelay: 1,
+                    backToP2PDelay: 3,
                     enabled: true
                 }
             }
@@ -167,7 +167,7 @@ describe('Desktop sharing', () => {
         await ensureOneParticipant({
             configOverwrite: {
                 p2p: {
-                    backToP2PDelay: 1,
+                    backToP2PDelay: 3,
                     enabled: true
                 }
             }
@@ -185,7 +185,7 @@ describe('Desktop sharing', () => {
         await ensureThreeParticipants({
             configOverwrite: {
                 p2p: {
-                    backToP2PDelay: 1,
+                    backToP2PDelay: 3,
                     enabled: true
                 }
             }


### PR DESCRIPTION
Setting it to 1 sec was causing p2p connections to be created when it was not needed.