### PR TITLE
Extend .editorconfig to include Android and iOS indentation rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,12 @@ trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab
+
+[*.{java,kt}]
+indent_size = 4
+
+[*.xml]
+indent_size = 2
+
+[*.{swift,m,mm,h}]
+indent_size = 4


### PR DESCRIPTION
This PR updates the root .editorconfig to include indentation rules for Android (Java/XML)
and iOS (Swift/Obj-C) submodules, ensuring consistent formatting across all parts of the project.
