### PR TITLE
chore(android/sdk): invoke permissionListener immediately

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivityDelegate.java
@@ -37,7 +37,6 @@ public class JitsiMeetActivityDelegate {
      * React Native module.
      */
     private static PermissionListener permissionListener;
-    private static Callback permissionsCallback;
 
     /**
      * Tells whether or not the permissions request is currently in progress.
@@ -142,11 +141,6 @@ public class JitsiMeetActivityDelegate {
         if (reactInstanceManager != null) {
             reactInstanceManager.onHostResume(activity, new DefaultHardwareBackBtnHandlerImpl(activity));
         }
-
-        if (permissionsCallback != null) {
-            permissionsCallback.invoke();
-            permissionsCallback = null;
-        }
     }
 
     /**
@@ -169,15 +163,10 @@ public class JitsiMeetActivityDelegate {
 
     public static void onRequestPermissionsResult(
             final int requestCode, final String[] permissions, final int[] grantResults) {
-        permissionsCallback = new Callback() {
-            @Override
-            public void invoke(Object... args) {
-                if (permissionListener != null
-                        && permissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
-                    permissionListener = null;
-                }
-            }
-        };
+        // Invoke the callback immediately
+        if (permissionListener != null && permissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {  
+            permissionListener = null;
+        }
     }
 
     public static void requestPermissions(Activity activity, String[] permissions, int requestCode, PermissionListener listener) {


### PR DESCRIPTION
Instead of calling permissionListener.onRequestPermissionsResult() immediately when Android returns the permission result, it stores it and waits for onHostResume(). But onHostResume() never gets called again, because activity is already resumed.

Fix #16430