### PR TITLE
fix(video-layout) Possibly fixes auto-pinning of SS in a large call.

### DIFF
--- a/react/features/base/participants/reducer.ts
+++ b/react/features/base/participants/reducer.ts
@@ -27,6 +27,7 @@ import {
     isRemoteScreenshareParticipant,
     isScreenShareParticipant
 } from './functions';
+import logger from './logger';
 import { FakeParticipant, ILocalParticipant, IParticipant, ISourceInfo } from './types';
 
 /**
@@ -352,6 +353,8 @@ ReducerRegistry.register<IParticipantsState>('features/base/participants',
             sortedRemoteVirtualScreenshareParticipants.sort((a, b) => a[1].localeCompare(b[1]));
 
             state.sortedRemoteVirtualScreenshareParticipants = new Map(sortedRemoteVirtualScreenshareParticipants);
+
+            logger.debug('Remote screenshare participant joined', id);
         }
 
         // Exclude the screenshare participant from the fake participant count to avoid duplicates.
@@ -436,6 +439,8 @@ ReducerRegistry.register<IParticipantsState>('features/base/participants',
         if (sortedRemoteVirtualScreenshareParticipants.has(id)) {
             sortedRemoteVirtualScreenshareParticipants.delete(id);
             state.sortedRemoteVirtualScreenshareParticipants = new Map(sortedRemoteVirtualScreenshareParticipants);
+
+            logger.debug('Remote screenshare participant left', id);
         }
 
         if (oldParticipant && !oldParticipant.fakeParticipant && !isLocalScreenShare) {

--- a/react/features/base/participants/subscriber.ts
+++ b/react/features/base/participants/subscriber.ts
@@ -21,6 +21,7 @@ import {
     getRemoteScreensharesBasedOnPresence,
     getVirtualScreenshareParticipantOwnerId
 } from './functions';
+import logger from './logger';
 import { FakeParticipant } from './types';
 
 StateListenerRegistry.register(
@@ -69,14 +70,19 @@ function _createOrRemoveVirtualParticipants(
     const addedScreenshareSourceNames = difference(newScreenshareSourceNames, oldScreenshareSourceNames);
 
     if (removedScreenshareSourceNames.length) {
-        removedScreenshareSourceNames.forEach(id => dispatch(participantLeft(id, conference, {
-            fakeParticipant: FakeParticipant.RemoteScreenShare
-        })));
+        removedScreenshareSourceNames.forEach(id => {
+            logger.debug('Dispatching participantLeft for virtual screenshare', id);
+            dispatch(participantLeft(id, conference, {
+                fakeParticipant: FakeParticipant.RemoteScreenShare
+            }));
+        });
     }
 
     if (addedScreenshareSourceNames.length) {
-        addedScreenshareSourceNames.forEach(id => dispatch(
-            createVirtualScreenshareParticipant(id, false, conference)));
+        addedScreenshareSourceNames.forEach(id => {
+            logger.debug('Creating virtual screenshare participant', id);
+            dispatch(createVirtualScreenshareParticipant(id, false, conference));
+        });
     }
 }
 

--- a/react/features/video-layout/subscriber.ts
+++ b/react/features/video-layout/subscriber.ts
@@ -4,6 +4,7 @@ import { isFollowMeActive } from '../follow-me/functions';
 
 import { virtualScreenshareParticipantsUpdated } from './actions';
 import { getAutoPinSetting, updateAutoPinnedParticipant } from './functions';
+import logger from './logger';
 
 StateListenerRegistry.register(
     /* selector */ state => state['features/base/participants'].sortedRemoteVirtualScreenshareParticipants,
@@ -22,14 +23,18 @@ StateListenerRegistry.register(
         knownSharingParticipantIds.forEach(participantId => {
             if (!newScreenSharesOrder.includes(participantId)) {
                 newScreenSharesOrder.push(participantId);
+                logger.debug('Adding new screenshare to list', participantId);
             }
         });
 
         if (!equals(oldScreenSharesOrder, newScreenSharesOrder)) {
+            logger.debug('Screenshare order changed, dispatching update');
             store.dispatch(virtualScreenshareParticipantsUpdated(newScreenSharesOrder));
 
             if (getAutoPinSetting() && !isFollowMeActive(store)) {
-                updateAutoPinnedParticipant(oldScreenSharesOrder, store);
+                updateAutoPinnedParticipant(oldScreenSharesOrder, newScreenSharesOrder, store);
+            } else {
+                logger.debug('Auto pinning is disabled or Follow Me is active, skipping auto pinning of screenshare.');
             }
         }
     });


### PR DESCRIPTION
When a user joins a very large call with SS, sometime SS is not auto-pinned to stage. This may happen when lot of participant joins are processed at the same time and therefore the state for remoteScreenShares may not get updated in time. Added extra logging to help debug if this issue reproduces.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
