### PR TITLE
fix(chat): be explicit about screen navigation when polls are disabled

### DIFF
--- a/react/features/chat/actions.native.ts
+++ b/react/features/chat/actions.native.ts
@@ -21,8 +21,9 @@ export function openChat(participant?: IParticipant | undefined | Object, disabl
     return (dispatch: IStore['dispatch']) => {
         if (disablePolls) {
             navigate(screen.conference.chat);
+        } else {
+            navigate(screen.conference.chatandpolls.main);
         }
-        navigate(screen.conference.chatandpolls.main);
 
         dispatch(setFocusedTab(ChatTabs.CHAT));
         dispatch({


### PR DESCRIPTION
Not reproducible, but most probably both screens were added to the navigation stack if polls are disabled.
