### PR TITLE
fix(mod_jitsi_permissions): Use correct session on moderator revocation

### DIFF
--- a/resources/prosody-plugins/mod_jitsi_permissions.lua
+++ b/resources/prosody-plugins/mod_jitsi_permissions.lua
@@ -85,7 +85,7 @@ function process_set_affiliation(event)
         occupant_session.granted_jitsi_meet_context_group_id = nil;
 
         -- on revoke
-        if not session.auth_token then
+        if not occupant_session.auth_token then
             occupant_session.jitsi_meet_context_features = nil;
         end
     end


### PR DESCRIPTION
In the `process_set_affiliation` function, an undefined `session` variable was used when revoking moderator privileges. This prevented the `jitsi_meet_context_features` from being cleared for the occupant.

This commit corrects the issue by replacing the undefined `session` variable with `occupant_session`, ensuring the permissions are properly reset.