### PR TITLE
fix(chat): remove debug console.log statements from resize handlers

### DIFF
--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -298,8 +298,6 @@ const Chat = ({
 
         // Disable text selection during resize
         document.body.style.userSelect = 'none';
-
-        console.log('Chat resize: Mouse down', { clientX: e.clientX, initialWidth: _width });
     }, [ _width, dispatch ]);
 
     /**
@@ -315,8 +313,6 @@ const Chat = ({
             // Restore cursor and text selection
             document.body.style.cursor = '';
             document.body.style.userSelect = '';
-
-            console.log('Chat resize: Mouse up');
         }
     }, [ isMouseDown, dispatch ]);
 
@@ -327,7 +323,6 @@ const Chat = ({
      * @returns {void}
      */
     const onChatResize = useCallback(throttle((e: MouseEvent) => {
-        // console.log('Chat resize: Mouse move', { clientX: e.clientX, isMouseDown, mousePosition, _width });
         if (isMouseDown && mousePosition !== null && dragChatWidth !== null) {
             // For chat panel resizing on the left edge:
             // - Dragging left (decreasing X coordinate) should make the panel wider


### PR DESCRIPTION
This pull request removes several `console.log` debugging statements from the chat resizing logic in the `Chat.tsx` component. These changes help clean up the code by eliminating unnecessary console output.

Code cleanup:

* Removed `console.log` statements from the mouse down, mouse up, and mouse move handlers related to chat resizing in `react/features/chat/components/web/Chat.tsx`. [[1]](diffhunk://#diff-4a34e907ee6dcd7aa30eb4d6203da612e570ad66ab8505019ae9050645a126a2L301-L302) [[2]](diffhunk://#diff-4a34e907ee6dcd7aa30eb4d6203da612e570ad66ab8505019ae9050645a126a2L318-L319) [[3]](diffhunk://#diff-4a34e907ee6dcd7aa30eb4d6203da612e570ad66ab8505019ae9050645a126a2L330)

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
