### PR TITLE
fix(prosody): Order room-destroyed event.

### DIFF
--- a/resources/prosody-plugins/mod_measure_message_count.lua
+++ b/resources/prosody-plugins/mod_measure_message_count.lua
@@ -153,7 +153,7 @@ end
 module:hook('message/full', on_message); -- private messages
 module:hook('message/bare', on_message); -- room messages
 
-module:hook('muc-room-destroyed', room_destroyed, -1);
+module:hook('muc-room-destroyed', room_destroyed, 1); -- prosody handles it at 0
 module:hook("muc-occupant-left", function(event)
     local occupant, room = event.occupant, event.room;
     local session = event.origin;

--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -15,7 +15,6 @@
 --     muc_room_locking = false
 --     muc_room_default_public_jids = true
 --
-
 module:depends('room_destroy');
 
 -- we use async to detect Prosody 0.10 and earlier
@@ -650,7 +649,7 @@ function process_main_muc_loaded(main_muc, host_module)
     module:log("info", "Hook to muc events on %s", main_muc_component_config);
     host_module:hook('muc-occupant-joined', on_occupant_joined);
     host_module:hook('muc-occupant-left', on_occupant_left);
-    host_module:hook('muc-room-destroyed', on_main_room_destroyed);
+    host_module:hook('muc-room-destroyed', on_main_room_destroyed, 1);  -- prosody handles it at 0
 end
 
 -- process or waits to process the main muc component

--- a/resources/prosody-plugins/mod_muc_cleanup_backend_services.lua
+++ b/resources/prosody-plugins/mod_muc_cleanup_backend_services.lua
@@ -54,5 +54,4 @@ module:hook('muc-room-destroyed', function (event)
         room.empty_destroy_timer:stop();
         room.empty_destroy_timer = nil;
     end
-end);
-
+end, 1); -- prosody handles it at 0

--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -512,7 +512,7 @@ process_host_module(main_muc_component_config, function(host_module, host)
         if room._data.lobbyroom then
             destroy_lobby_room(room, nil);
         end
-    end);
+    end, 1); -- prosody handles it at 0
     host_module:hook('muc-disco#info', function (event)
         local room = event.room;
         if (room._data.lobbyroom and room:get_members_only()) then

--- a/resources/prosody-plugins/mod_muc_rate_limit.lua
+++ b/resources/prosody-plugins/mod_muc_rate_limit.lua
@@ -164,7 +164,7 @@ module:hook('muc-room-destroyed',function(event)
     if event.room.leave_rate_presence_queue then
         event.room.leave_rate_presence_queue.empty = true;
     end
-end);
+end, 1);  -- prosody handles it at 0
 
 module:hook('muc-occupant-pre-leave', function (event)
     local occupant, room, stanza = event.occupant, event.room, event.stanza;

--- a/resources/prosody-plugins/mod_speakerstats_component.lua
+++ b/resources/prosody-plugins/mod_speakerstats_component.lua
@@ -331,7 +331,7 @@ function process_main_muc_loaded(main_muc, host_module)
     host_module:hook("muc-room-created", room_created, -1);
     host_module:hook("muc-occupant-joined", occupant_joined, -1);
     host_module:hook("muc-occupant-pre-leave", occupant_leaving, -1);
-    host_module:hook("muc-room-destroyed", room_destroyed, -1);
+    host_module:hook("muc-room-destroyed", room_destroyed, 1); -- prosody handles it at 0
 end
 
 function process_breakout_muc_loaded(breakout_muc, host_module)
@@ -340,7 +340,7 @@ function process_breakout_muc_loaded(breakout_muc, host_module)
     host_module:hook("muc-room-created", breakout_room_created, -1);
     host_module:hook("muc-occupant-joined", occupant_joined, -1);
     host_module:hook("muc-occupant-pre-leave", occupant_leaving, -1);
-    host_module:hook("muc-room-destroyed", room_destroyed, -1);
+    host_module:hook("muc-room-destroyed", room_destroyed, 1); -- prosody handles it at 0
 end
 
 -- process or waits to process the conference muc component

--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -329,7 +329,7 @@ process_host_module(main_muc_component_config, function(host_module, host)
 
             visitors_nodes[room.jid] = nil;
         end
-    end);
+    end, 1); -- prosody handles it at 0
 
     -- detects new participants joining main room and sending them to the visitor nodes
     host_module:hook('muc-occupant-joined', function (event)

--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -582,7 +582,7 @@ process_host_module(muc_domain_prefix..'.'..muc_domain_base, function(host_modul
     host_module:hook('muc-room-destroyed', function (event)
         visitors_promotion_map[event.room.jid] = nil;
         visitors_promotion_requests[event.room.jid] = nil;
-    end);
+    end, 1); -- prosody handles it at 0
 
     host_module:hook('muc-occupant-joined', function (event)
         local room, occupant = event.room, event.occupant;
@@ -754,7 +754,7 @@ function handle_occupant_leaving_breakout(event)
     local main_room, occupant, stanza = event.main_room, event.occupant, event.stanza;
     local presence_status = stanza:get_child_text('status');
 
-    if presence_status ~= 'switch_room' or not visitors_promotion_map[main_room.jid] then
+    if presence_status ~= 'switch_room' or not main_room or not visitors_promotion_map[main_room.jid] then
         return;
     end
 


### PR DESCRIPTION
Make sure we execute before prosody cleans it up from the list of room. If we try to look it up after that we will not find it. If we also add at 0 we cannot guarantee the order of hook execution.
