### PR TITLE
fix(deps) use Olm from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@jitsi/js-utils": "2.6.7",
         "@jitsi/logger": "2.1.1",
         "@jitsi/rnnoise-wasm": "0.2.1",
-        "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
+        "@matrix-org/olm": "3.2.15",
         "@microsoft/microsoft-graph-client": "3.0.1",
         "@mui/material": "5.12.1",
         "@react-native-async-storage/async-storage": "1.23.1",
@@ -4690,9 +4690,9 @@
       "dev": true
     },
     "node_modules/@matrix-org/olm": {
-      "version": "3.2.3",
-      "resolved": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
-      "integrity": "sha512-OhC9wwZ/ox9vputA1MR2A7QlYlvfXCV+tdbADOR7Jn7o9qoXh3HWf+AbSpXTK3daF0GIHA69Ws8XOnWqu5n53A==",
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@matrix-org/olm/-/olm-3.2.15.tgz",
+      "integrity": "sha512-S7lOrndAK9/8qOtaTq/WhttJC/o4GAzdfK0MUPpo8ApzsJEC0QjtwrkC3KBXdFP1cD1MXi/mlKR7aaoVMKgs6Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@microsoft/microsoft-graph-client": {
@@ -30122,8 +30122,9 @@
       "dev": true
     },
     "@matrix-org/olm": {
-      "version": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
-      "integrity": "sha512-OhC9wwZ/ox9vputA1MR2A7QlYlvfXCV+tdbADOR7Jn7o9qoXh3HWf+AbSpXTK3daF0GIHA69Ws8XOnWqu5n53A=="
+      "version": "3.2.15",
+      "resolved": "https://registry.npmjs.org/@matrix-org/olm/-/olm-3.2.15.tgz",
+      "integrity": "sha512-S7lOrndAK9/8qOtaTq/WhttJC/o4GAzdfK0MUPpo8ApzsJEC0QjtwrkC3KBXdFP1cD1MXi/mlKR7aaoVMKgs6Q=="
     },
     "@microsoft/microsoft-graph-client": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@jitsi/js-utils": "2.6.7",
     "@jitsi/logger": "2.1.1",
     "@jitsi/rnnoise-wasm": "0.2.1",
-    "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.3.tgz",
+    "@matrix-org/olm": "3.2.15",
     "@microsoft/microsoft-graph-client": "3.0.1",
     "@mui/material": "5.12.1",
     "@react-native-async-storage/async-storage": "1.23.1",


### PR DESCRIPTION
The Matrix GitLab repo was behind CF and thus affected by today's outage.

Since they released the last Olm version to npm, let's consume that one.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
