### PR TITLE
fix(muc_rate_limit): Check connection when processing rate limited events.

### DIFF
--- a/resources/prosody-plugins/mod_muc_rate_limit.lua
+++ b/resources/prosody-plugins/mod_muc_rate_limit.lua
@@ -118,9 +118,12 @@ module:hook("muc-occupant-pre-join", function (event)
                     join_rate_per_conference,
                     room.join_rate_presence_queue,
                     function(ev)
-                        -- we mark what we pass here so we can skip it on the next muc-occupant-pre-join event
-                        ev.stanza.delayed_join_skip = true;
-                        room:handle_normal_presence(ev.origin, ev.stanza);
+                        -- if the connection was closed while waiting in the queue, ignore
+                        if ev.origin.conn then
+                            -- we mark what we pass here so we can skip it on the next muc-occupant-pre-join event
+                            ev.stanza.delayed_join_skip = true;
+                            room:handle_normal_presence(ev.origin, ev.stanza);
+                        end
                     end,
                     function() -- empty callback
                         room.join_rate_queue_timer = false;


### PR DESCRIPTION
If it happens that a connection was closed during waiting in the rate limited queue, we want to ignore those occupant events.
