### PR TITLE
Hide Android status bar in landscape mode during conferences without immersive mode. 

### DIFF
--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -3,7 +3,6 @@ import React, { useCallback } from 'react';
 import {
     BackHandler,
     NativeModules,
-    SafeAreaView,
     StatusBar,
     View,
     ViewStyle
@@ -92,7 +91,6 @@ interface IProps extends AbstractProps {
      * Set to {@code true} when the filmstrip is currently visible.
      */
     _filmstripVisible: boolean;
-
 
     /**
      * The indicator which determines if the display name is visible.


### PR DESCRIPTION
This PR implements the behavior requested in **#16660**.  
It hides the **Android status bar** when the user is in a conference *and* the device is in **landscape** mode.

Immersive mode is **not** reintroduced (it was removed in #16513 due to Android 15 edge-to-edge issues).  
Only the status bar is hidden, and gesture navigation remains fully functional.

---

## Changes

- Added `isInCall` flag to track whether a conference is active.
- Added `updateStatusBarVisibility()` helper to `JitsiMeetActivity`.
- Hides the **status bar only** when:
  - `isInCall == true`, and  
  - `orientation == ORIENTATION_LANDSCAPE`.
- Restores the status bar when:
  - orientation becomes portrait,
  - the conference ends (`onConferenceTerminated` / `onReadyToClose`),
  - or the activity resumes outside a call.
- Triggered `updateStatusBarVisibility()` from:
  - `onConferenceJoined`
  - `onConferenceTerminated`
  - `onReadyToClose`
  - `onConfigurationChanged`
  - `onResume`
- Uses modern APIs:
  - `WindowInsetsControllerCompat`
  - `WindowInsetsCompat.Type.statusBars()`

---
