### PR TITLE
fix(android): resolve duplicate librnworklets.so in AAR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
         "react-native-video": "6.13.0",
         "react-native-webrtc": "124.0.7",
         "react-native-webview": "13.13.5",
-        "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
+        "react-native-worklets-core": "github:jitsi/react-native-worklets-core#8c5dfab2a5907305da8971696a781b60f0f9cb18",
         "react-native-youtube-iframe": "2.3.0",
         "react-redux": "7.2.9",
         "react-textarea-autosize": "8.3.0",
@@ -23122,7 +23122,7 @@
     "node_modules/react-native-worklets-core": {
       "version": "1.6.2",
       "resolved": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
-      "integrity": "sha512-SW47DvuNLjhoj8PJK8haq0B/69//ChG+/3WyK9NkhwUSM1kqZLle1O7SqGeLFp2f37qyBXH5X+cXPDaabJ8CHA==",
+      "integrity": "sha512-YHHTgO/85oFpyAv3ipFwZ3TIw7+l6rTnkxUydojpk9v1O8mYxJ5pI5qBMHMRtjxRodWhXcKsPYmAQWw7iH2rGg==",
       "license": "MIT",
       "dependencies": {
         "string-hash-64": "^1.0.3"
@@ -43740,8 +43740,8 @@
     },
     "react-native-worklets-core": {
       "version": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
-      "integrity": "sha512-SW47DvuNLjhoj8PJK8haq0B/69//ChG+/3WyK9NkhwUSM1kqZLle1O7SqGeLFp2f37qyBXH5X+cXPDaabJ8CHA==",
-      "from": "react-native-worklets-core@https://github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
+      "integrity": "sha512-YHHTgO/85oFpyAv3ipFwZ3TIw7+l6rTnkxUydojpk9v1O8mYxJ5pI5qBMHMRtjxRodWhXcKsPYmAQWw7iH2rGg==",
+      "from": "react-native-worklets-core@github:jitsi/react-native-worklets-core#8c5dfab2a5907305da8971696a781b60f0f9cb18",
       "requires": {
         "string-hash-64": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "react-native-video": "6.13.0",
     "react-native-webrtc": "124.0.7",
     "react-native-webview": "13.13.5",
-    "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8c5dfab2a5907305da8971696a781b60f0f9cb18",
+    "react-native-worklets-core": "github:jitsi/react-native-worklets-core#8c5dfab2a5907305da8971696a781b60f0f9cb18",
     "react-native-youtube-iframe": "2.3.0",
     "react-redux": "7.2.9",
     "react-textarea-autosize": "8.3.0",

--- a/patches/react-native-worklets-core+1.6.2.patch
+++ b/patches/react-native-worklets-core+1.6.2.patch
@@ -1,27 +1,25 @@
 diff --git a/node_modules/react-native-worklets-core/android/build.gradle b/node_modules/react-native-worklets-core/android/build.gradle
-index 1234567..abcdefg 100644
+index 1d77e2a..4b8f3e1 100644
 --- a/node_modules/react-native-worklets-core/android/build.gradle
 +++ b/node_modules/react-native-worklets-core/android/build.gradle
-@@ -72,6 +72,14 @@ task deleteCmakeCache() {
- android {
-   namespace "com.worklets"
-   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
-+
-+  // Disable lint to avoid bundleReleaseLocalLintAar conflicts
-+  // This library uses both Prefab and JNI libs which cause conflicts during lint AAR packaging
-+  lintOptions {
-+    checkReleaseBuilds false
-+    abortOnError false
-+  }
-+
-   
-   defaultConfig {
-     minSdkVersion getExtOrIntegerDefault("minSdkVersion")
-@@ -158,6 +166,7 @@ android {
+@@ -166,6 +166,7 @@ android {
        "**/libreact_nativemodule_core.so",
        "**/libjscexecutor.so",
      ]
 +    pickFirst "**/librnworklets.so"
    }
- 
+
    buildFeatures {
+@@ -195,3 +196,12 @@ tasks.configureEach { task ->
+     task.dependsOn(deleteCmakeCache)
+   }
+ }
++
++// Disable lint AAR tasks to avoid Prefab/JNI library conflicts
++// This library publishes librnworklets.so via both Prefab and regular JNI,
++// causing duplicate file errors during lint AAR packaging
++tasks.whenTaskAdded { task ->
++  if (task.name == 'bundleReleaseLocalLintAar' || task.name == 'bundleDebugLocalLintAar') {
++    task.enabled = false
++  }
++}


### PR DESCRIPTION
This pull request introduces a packaging configuration to the Android SDK build process to resolve conflicts with native libraries during packaging.

Packaging configuration:

* Added a `packagingOptions` block in `android/sdk/build.gradle` to use `pickFirst` for the `librnworklets.so` native library, ensuring that only one copy is packaged when multiple are present.

---
Related issue #16680 