### PR TITLE
chore: align react native docker version with package json version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   android-sdk-build:
     name: Build mobile SDK (Android)
     runs-on: ubuntu-latest
-    container: reactnativecommunity/react-native-android:v18.0
+    container: reactnativecommunity/react-native-android:v15.0
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
Align CI react native android docker with package.json dependency because of  https://github.com/react-native-community/cli/issues/2733#issuecomment-3502424164.

Fix #16680 