### PR TITLE
fix: add missing aria-labels to toolbar buttons to improve accessibility

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -275,6 +275,7 @@ export default function Toolbox({
                         {Boolean(overflowMenuButtons.length) && (
                             <OverflowMenuButton
                                 ariaControls = 'overflow-menu'
+                                ariaLabel = { t('toolbar.accessibilityLabel.moreActionsMenu') }
                                 buttons = { overflowMenuButtons.reduce<Array<IToolboxButton[]>>((acc, val) => {
                                     if (val.key === 'reactions' && showReactionsInOverflowMenu) {
                                         return acc;
@@ -311,6 +312,7 @@ export default function Toolbox({
                             endConferenceSupported
                                 ? <HangupMenuButton
                                     ariaControls = 'hangup-menu'
+                                    ariaLabel = { t('toolbar.accessibilityLabel.hangup') }
                                     isOpen = { hangupMenuVisible }
                                     key = 'hangup-menu'
                                     notifyMode = { buttonsWithNotifyClick?.get('hangup-menu') }


### PR DESCRIPTION
This PR adds missing aria-labels to OverflowMenuButton and HangupMenuButton. 
This improves accessibility and screen reader support without altering UI behavior.
