### PR TITLE
refactor(large-video): migrate LargeVideo.native to function componen…

### DIFF
--- a/react/features/large-video/components/LargeVideo.native.tsx
+++ b/react/features/large-video/components/LargeVideo.native.tsx
@@ -1,13 +1,12 @@
-import React, { PureComponent } from 'react';
+import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../app/types';
-import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
 import ParticipantView from '../../base/participants/components/ParticipantView.native';
 import { getParticipantById, isLocalScreenshareParticipant } from '../../base/participants/functions';
-import { trackStreamingStatusChanged } from '../../base/tracks/actions.native';
 import { getVideoTrackByParticipant, isLocalVideoTrackDesktop } from '../../base/tracks/functions.native';
 import { ITrack } from '../../base/tracks/types';
+import { useTrackStreamingStatus } from '../hooks/useTrackStreamingStatus';
 
 import { AVATAR_SIZE } from './styles';
 
@@ -55,61 +54,25 @@ interface IProps {
 }
 
 /**
- * The type of the React {@link Component} state of {@link LargeVideo}.
- */
-interface IState {
-
-    /**
-     * Size for the Avatar. It will be dynamically adjusted based on the
-     * available size.
-     */
-    avatarSize: number;
-
-    /**
-     * Whether the connectivity indicator will be shown or not. It will be true
-     * by default, but it may be turned off if there is not enough space.
-     */
-    useConnectivityInfoLabel: boolean;
-}
-
-const DEFAULT_STATE = {
-    avatarSize: AVATAR_SIZE,
-    useConnectivityInfoLabel: true
-};
-
-/** .
- * Implements a React {@link Component} which represents the large video (a.k.a.
+ * Implements a React function component which represents the large video (a.k.a.
  * The conference participant who is on the local stage) on mobile/React Native.
  *
- * @augments Component
+ * @param {IProps} props - The component props.
+ * @returns {JSX.Element} The LargeVideo component.
  */
-class LargeVideo extends PureComponent<IProps, IState> {
-    /**
-     * Creates new LargeVideo component.
-     *
-     * @param {IProps} props - The props of the component.
-     * @returns {LargeVideo}
-     */
-    constructor(props: IProps) {
-        super(props);
+const LargeVideo: React.FC<IProps> = ({
+    _disableVideo,
+    _height,
+    _participantId,
+    _videoTrack,
+    _width,
+    onClick
+}) => {
+    // Use custom hook to manage track streaming status
+    useTrackStreamingStatus(_videoTrack);
 
-        this.handleTrackStreamingStatusChanged = this.handleTrackStreamingStatusChanged.bind(this);
-    }
-
-    state = {
-        ...DEFAULT_STATE
-    };
-
-    /**
-     * Handles dimension changes. In case we deem it's too
-     * small, the connectivity indicator won't be rendered and the avatar
-     * will occupy the entirety of the available screen state.
-     *
-     * @inheritdoc
-     */
-    static getDerivedStateFromProps(props: IProps) {
-        const { _height, _width } = props;
-
+    // Calculate avatar size and connectivity label based on available dimensions
+    const { avatarSize, useConnectivityInfoLabel } = useMemo(() => {
         // Get the size, rounded to the nearest even number.
         const size = 2 * Math.round(Math.min(_height, _width) / 2);
 
@@ -120,119 +83,24 @@ class LargeVideo extends PureComponent<IProps, IState> {
             };
         }
 
-        return DEFAULT_STATE;
+        return {
+            avatarSize: AVATAR_SIZE,
+            useConnectivityInfoLabel: true
+        };
+    }, [ _height, _width ]);
 
-    }
-
-    /**
-     * Starts listening for track streaming status updates after the initial render.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentDidMount() {
-        // Listen to track streaming status changed event to keep it updated.
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
-
-        if (_videoTrack && !_videoTrack.local) {
-            _videoTrack.jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                this.handleTrackStreamingStatusChanged);
-            dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-        }
-    }
-
-    /**
-     * Stops listening for track streaming status updates on the old track and starts listening instead on the new
-     * track.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentDidUpdate(prevProps: IProps) {
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
-
-        if (prevProps._videoTrack?.jitsiTrack?.getSourceName() !== _videoTrack?.jitsiTrack?.getSourceName()) {
-            if (prevProps._videoTrack && !prevProps._videoTrack.local) {
-                prevProps._videoTrack.jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                    this.handleTrackStreamingStatusChanged);
-                dispatch(trackStreamingStatusChanged(prevProps._videoTrack.jitsiTrack,
-                    prevProps._videoTrack.jitsiTrack.getTrackStreamingStatus()));
-            }
-            if (_videoTrack && !_videoTrack.local) {
-                _videoTrack.jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                    this.handleTrackStreamingStatusChanged);
-                dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                    _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-            }
-        }
-    }
-
-    /**
-     * Remove listeners for track streaming status update.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentWillUnmount() {
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
-
-        if (_videoTrack && !_videoTrack.local) {
-            _videoTrack.jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                this.handleTrackStreamingStatusChanged);
-            dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-        }
-    }
-
-    /**
-     * Handle track streaming status change event by by dispatching an action to update track streaming status for the
-     * given track in app state.
-     *
-     * @param {JitsiTrack} jitsiTrack - The track with streaming status updated.
-     * @param {JitsiTrackStreamingStatus} streamingStatus - The updated track streaming status.
-     * @returns {void}
-     */
-    handleTrackStreamingStatusChanged(jitsiTrack: any, streamingStatus: string) {
-        this.props.dispatch(trackStreamingStatusChanged(jitsiTrack, streamingStatus));
-    }
-
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    override render() {
-        const {
-            avatarSize,
-            useConnectivityInfoLabel
-        } = this.state;
-        const {
-            _disableVideo,
-            _participantId,
-            onClick
-        } = this.props;
-
-        return (
-            <ParticipantView
-                avatarSize = { avatarSize }
-                disableVideo = { _disableVideo }
-                onPress = { onClick }
-                participantId = { _participantId }
-                testHintId = 'org.jitsi.meet.LargeVideo'
-                useConnectivityInfoLabel = { useConnectivityInfoLabel }
-                zOrder = { 0 }
-                zoomEnabled = { true } />
-        );
-    }
-}
+    return (
+        <ParticipantView
+            avatarSize = { avatarSize }
+            disableVideo = { _disableVideo }
+            onPress = { onClick }
+            participantId = { _participantId }
+            testHintId = 'org.jitsi.meet.LargeVideo'
+            useConnectivityInfoLabel = { useConnectivityInfoLabel }
+            zOrder = { 0 }
+            zoomEnabled = { true } />
+    );
+};
 
 /**
  * Maps (parts of) the Redux state to the associated LargeVideo's props.

--- a/react/features/large-video/hooks/useTrackStreamingStatus.ts
+++ b/react/features/large-video/hooks/useTrackStreamingStatus.ts
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
+import { trackStreamingStatusChanged } from '../../base/tracks/actions.native';
+import { ITrack } from '../../base/tracks/types';
+
+/**
+ * Custom hook to manage track streaming status.
+ * Listens to track streaming status changes and dispatches appropriate actions.
+ * Only processes non-local video tracks.
+ *
+ * @param {ITrack | undefined} videoTrack - The video track to monitor.
+ * @returns {void}
+ */
+export function useTrackStreamingStatus(videoTrack: ITrack | undefined): void {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        // Only process non-local tracks
+        if (!videoTrack || videoTrack.local) {
+            return;
+        }
+
+        const { jitsiTrack } = videoTrack;
+
+        /**
+         * Handler for track streaming status changes.
+         * Dispatches an action to update the track streaming status in the app state.
+         *
+         * @param {any} track - The JitsiTrack instance.
+         * @param {string} streamingStatus - The updated streaming status.
+         * @returns {void}
+         */
+        const handleTrackStreamingStatusChanged = (track: any, streamingStatus: string) => {
+            dispatch(trackStreamingStatusChanged(track, streamingStatus));
+        };
+
+        // Subscribe to track streaming status change events
+        jitsiTrack.on(
+            JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
+            handleTrackStreamingStatusChanged
+        );
+
+        // Dispatch initial status update
+        const currentStatus = jitsiTrack.getTrackStreamingStatus();
+
+        dispatch(trackStreamingStatusChanged(jitsiTrack, currentStatus));
+
+        // Cleanup: Remove event listener when component unmounts or track changes
+        return () => {
+            jitsiTrack.off(
+                JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
+                handleTrackStreamingStatusChanged
+            );
+
+            // Dispatch final status update on cleanup
+            const finalStatus = jitsiTrack.getTrackStreamingStatus();
+
+            dispatch(trackStreamingStatusChanged(jitsiTrack, finalStatus));
+        };
+    }, [ videoTrack, dispatch ]);
+}


### PR DESCRIPTION
This pull request refactors the `LargeVideo.native.tsx` component from a class-based implementation to a functional component, improving maintainability and aligning with modern React practices. The logic for handling track streaming status updates is moved from lifecycle methods into a new custom hook, resulting in cleaner and more modular code.

Component refactor:

* Converted `LargeVideo.native.tsx` from a class component to a functional component using React hooks, removing state and lifecycle methods in favor of `useMemo` for derived state. [[1]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL58-R75) [[2]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL123-R90) [[3]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL234-R103)

Track streaming status management:

* Extracted track streaming status handling logic into a new custom hook `useTrackStreamingStatus`, located in `react/features/large-video/hooks/useTrackStreamingStatus.ts`, which manages event subscriptions and dispatches state updates.
* Replaced direct event handling and Redux dispatches in `LargeVideo.native.tsx` with usage of the new `useTrackStreamingStatus` hook for improved separation of concerns. [[1]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL1-R9) [[2]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL58-R75)

Code cleanup:

* Removed unused imports and obsolete state/interface definitions from `LargeVideo.native.tsx` following the refactor. [[1]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL1-R9) [[2]](diffhunk://#diff-941546d83eb20111312cae1f02e503c3e2ccc3844571421eb57293a135a5182bL58-R75)

## Related issues 

#16707  