### PR TITLE
Respect explicit user A/V preferences when prejoin is disabled while preserving privacy behavior

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -90,8 +90,7 @@ import {
 } from './react/features/base/media/actions';
 import { MEDIA_TYPE, VIDEO_MUTISM_AUTHORITY, VIDEO_TYPE } from './react/features/base/media/constants';
 import {
-    getStartWithAudioMuted,
-    getStartWithVideoMuted,
+    getInitialMediaMutedState,
     isVideoMutedByUser
 } from './react/features/base/media/functions';
 import { IGUMPendingState } from './react/features/base/media/types';
@@ -531,11 +530,14 @@ export default {
      */
     async init({ roomName, shouldDispatchConnect }) {
         const state = APP.store.getState();
+        const { audioMuted: startWithAudioMuted, videoMuted: startWithVideoMuted }
+            = getInitialMediaMutedState(state);
+
         const initialOptions = {
             startAudioOnly: config.startAudioOnly,
             startScreenSharing: config.startScreenSharing,
-            startWithAudioMuted: getStartWithAudioMuted(state) || isUserInteractionRequiredForUnmute(state),
-            startWithVideoMuted: getStartWithVideoMuted(state) || isUserInteractionRequiredForUnmute(state)
+            startWithAudioMuted,
+            startWithVideoMuted
         };
         const connectionTimes = getJitsiMeetGlobalNSConnectionTimes();
         const startTime = window.performance.now();

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -40,6 +40,11 @@ const DEFAULT_STATE: ISettingsState = {
     startCarMode: false,
     startWithAudioMuted: false,
     startWithVideoMuted: false,
+    userDevicePreferences: {
+        hasExplicitChoice: false,
+        audioMuted: true,
+        videoMuted: true
+    },
     userSelectedAudioOutputDeviceId: undefined,
     userSelectedCameraDeviceId: undefined,
     userSelectedMicDeviceId: undefined,
@@ -86,6 +91,11 @@ export interface ISettingsState {
     startCarMode?: boolean;
     startWithAudioMuted?: boolean;
     startWithVideoMuted?: boolean;
+    userDevicePreferences?: {
+        audioMuted: boolean;
+        hasExplicitChoice: boolean;
+        videoMuted: boolean;
+    };
     userSelectedAudioOutputDeviceId?: string;
     userSelectedAudioOutputDeviceLabel?: string;
     userSelectedCameraDeviceId?: string;


### PR DESCRIPTION
## Fixes: #16720 

## Summary

This PR updates the Jitsi Meet web client to better balance privacy with user control over audio/video state.

Recently, the web client was hardened so that when the prejoin screen is disabled (e.g. `config.prejoinPageEnabled=false` / `config.prejoinConfig.enabled=false`), the local user always joins with microphone and camera muted. This prevents “ambush” meetings where existing permissions plus URL flags could join a user directly with devices on, without showing prejoin.

However, this also caused regressions like:

- #16676 – After authentication redirects which disable prejoin (because the user has already seen it), the moderator always joins muted, even if they enabled mic/camera on the prejoin screen.
- #16686 – When a moderator starts screen sharing, new participants always join with mic and camera off, even if there is a stored camera preference indicating it should be on.

## Behavior changes

The new behavior is:

- If the user **has never explicitly chosen** a mic/camera state and prejoin is disabled or skipped, we keep the **existing privacy behavior** and always start with audio and video muted.
- If the user **has explicitly toggled** mic and/or camera (either on prejoin or in the in-conference toolbar) and that choice is stored locally, future joins will respect that explicit preference, even when prejoin is disabled or skipped.

In other words:

- **No explicit choice + prejoin disabled/skipped**
  → `audioMuted = true`, `videoMuted = true` (unchanged).
- **Explicit choice exists**
  → initial A/V state is taken from the stored preference and is not overridden by the “force mute when prejoin disabled” rule.