### PR TITLE
fix(visitors): Fix s2sout host-unknown errors by skipping domain mapping

### DIFF
--- a/resources/prosody-plugins/mod_muc_domain_mapper.lua
+++ b/resources/prosody-plugins/mod_muc_domain_mapper.lua
@@ -19,7 +19,7 @@ local internal_room_jid_match_rewrite = util.internal_room_jid_match_rewrite;
 
 -- We must filter stanzas in order to hook in to all incoming and outgoing messaging which skips the stanza routers
 function filter_stanza(stanza, session)
-    if stanza.skipMapping then
+    if stanza.skipMapping or session.type == 's2sout' then
         return stanza;
     end
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

### Context

This PR fixes a bug first encountered by and then fixed by [mk35](https://community.jitsi.org/u/mk35/). I am simply opening the PR as he didn't open it back then, but all credits goes to him for finding the solution.

### Summary

`mod_muc_domain_mapper.lua` was incorrectly rewriting **outbound s2s (s2sout)** presence stanzas. Example of the faulty rewrite:  [tenant]room@conference.v1.meet.xxx.com/abc → [v1][tenant]room@conference.meet.xxx.com/abc

This invalid domain caused Prosody-vnode to return **host-unknown** and close the S2S stream.
### Root Cause
The mapper applied domain transformation even on outbound S2S traffic, where mapping should not occur.

### Fix

Add a simple check in `filter_stanza`:
``` lua
if stanza.skipMapping or session.type == 's2sout' then
    return stanza;
end
```
This prevents rewriting S2S outbound stanzas and resolves the disconnects.
