### PR TITLE
Update main-de.json to include missing translation for lobby.waitForModerator

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -707,7 +707,8 @@
         "notificationTitle": "Lobby",
         "passwordJoinButton": "Beitreten",
         "title": "Lobby",
-        "toggleLabel": "Lobby aktivieren"
+        "toggleLabel": "Lobby aktivieren",
+        "waitForModerator": "Die Konferenz hat noch nicht begonnen, da noch keine Moderatoren eingetroffen sind. Melden Sie sich bitte an, um Moderator zu werden. Andernfalls warten Sie bitte."
     },
     "localRecording": {
         "clientState": {


### PR DESCRIPTION
Included missing German translation for lobby.waitForModerator, i.e. screen displayed prior conference started.