### PR TITLE
Android SDK: Add event support for participantKickedOut 

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastEvent.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastEvent.java
@@ -83,6 +83,7 @@ public class BroadcastEvent {
         AUDIO_MUTED_CHANGED("org.jitsi.meet.AUDIO_MUTED_CHANGED"),
         PARTICIPANT_JOINED("org.jitsi.meet.PARTICIPANT_JOINED"),
         PARTICIPANT_LEFT("org.jitsi.meet.PARTICIPANT_LEFT"),
+        PARTICIPANT_KICKED_OUT("org.jitsi.meet.PARTICIPANT_KICKED_OUT"),
         ENDPOINT_TEXT_MESSAGE_RECEIVED("org.jitsi.meet.ENDPOINT_TEXT_MESSAGE_RECEIVED"),
         SCREEN_SHARE_TOGGLED("org.jitsi.meet.SCREEN_SHARE_TOGGLED"),
         PARTICIPANTS_INFO_RETRIEVED("org.jitsi.meet.PARTICIPANTS_INFO_RETRIEVED"),
@@ -103,6 +104,7 @@ public class BroadcastEvent {
         private static final String AUDIO_MUTED_CHANGED_NAME = "AUDIO_MUTED_CHANGED";
         private static final String PARTICIPANT_JOINED_NAME = "PARTICIPANT_JOINED";
         private static final String PARTICIPANT_LEFT_NAME = "PARTICIPANT_LEFT";
+        private static final String PARTICIPANT_KICKED_OUT_NAME = "PARTICIPANT_KICKED_OUT";
         private static final String ENDPOINT_TEXT_MESSAGE_RECEIVED_NAME = "ENDPOINT_TEXT_MESSAGE_RECEIVED";
         private static final String SCREEN_SHARE_TOGGLED_NAME = "SCREEN_SHARE_TOGGLED";
         private static final String PARTICIPANTS_INFO_RETRIEVED_NAME = "PARTICIPANTS_INFO_RETRIEVED";
@@ -152,6 +154,8 @@ public class BroadcastEvent {
                     return PARTICIPANT_JOINED;
                 case PARTICIPANT_LEFT_NAME:
                     return PARTICIPANT_LEFT;
+                case PARTICIPANT_KICKED_OUT_NAME:
+                    return PARTICIPANT_KICKED_OUT;
                 case ENDPOINT_TEXT_MESSAGE_RECEIVED_NAME:
                     return ENDPOINT_TEXT_MESSAGE_RECEIVED;
                 case SCREEN_SHARE_TOGGLED_NAME:

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -299,6 +299,14 @@ public class JitsiMeetActivity extends AppCompatActivity
         }
     }
 
+    protected void onParticipantKickedOut(HashMap<String, Object> extraData) {
+        try {
+            JitsiMeetLogger.i("Participant kicked out: ", extraData);
+        } catch (Exception e) {
+            JitsiMeetLogger.w("Invalid participant kicked out extraData", e);
+        }
+    }
+
     protected void onReadyToClose() {
         JitsiMeetLogger.i("SDK is ready to close");
         isReadyToClose = true;
@@ -400,6 +408,9 @@ public class JitsiMeetActivity extends AppCompatActivity
                     break;
                 case PARTICIPANT_LEFT:
                     onParticipantLeft(event.getData());
+                    break;
+                case PARTICIPANT_KICKED_OUT:
+                    onParticipantKickedOut(event.getData());
                     break;
                 case READY_TO_CLOSE:
                     onReadyToClose();

--- a/ios/sdk/src/JitsiMeetViewDelegate.h
+++ b/ios/sdk/src/JitsiMeetViewDelegate.h
@@ -70,6 +70,14 @@
 - (void)participantLeft:(NSDictionary *)data;
 
 /**
+ * Called when a participant has been kicked out of the conference.
+ *
+ * The `data` dictionary contains a `kicked` key with the kicked participant info
+ * and a `kicker` key with the kicker's participantId and name.
+ */
+- (void)participantKickedOut:(NSDictionary *)data;
+
+/**
  * Called when audioMuted state changed.
  *
  * The `data` dictionary contains a `muted` key with state of the audioMuted for the localParticipant.

--- a/react-native-sdk/index.tsx
+++ b/react-native-sdk/index.tsx
@@ -33,6 +33,7 @@ interface IEventListeners {
     onEnterPictureInPicture?: Function;
     onEndpointMessageReceived?: Function;
     onParticipantJoined?: Function;
+    onParticipantKickedOut?: Function;
     onParticipantLeft?: ({ id }: { id: string }) => void;
     onReadyToClose?: Function;
 }
@@ -143,6 +144,7 @@ export const JitsiMeeting = forwardRef<JitsiRefProps, IAppProps>((props, ref) =>
                     onEnterPictureInPicture: eventListeners?.onEnterPictureInPicture,
                     onEndpointMessageReceived: eventListeners?.onEndpointMessageReceived,
                     onParticipantJoined: eventListeners?.onParticipantJoined,
+                    onParticipantKickedOut: eventListeners?.onParticipantKickedOut,
                     onParticipantLeft: eventListeners?.onParticipantLeft,
                     onReadyToClose: eventListeners?.onReadyToClose
                 },

--- a/react/features/mobile/external-api/middleware.ts
+++ b/react/features/mobile/external-api/middleware.ts
@@ -18,6 +18,7 @@ import {
     CONFERENCE_UNIQUE_ID_SET,
     CONFERENCE_WILL_JOIN,
     ENDPOINT_MESSAGE_RECEIVED,
+    KICKED_OUT,
     SET_ROOM
 } from '../../base/conference/actionTypes';
 import { JITSI_CONFERENCE_URL_KEY } from '../../base/conference/constants';
@@ -239,6 +240,28 @@ externalAPIEnabled && MiddlewareRegistry.register(store => next => action => {
                 });
         }
 
+        break;
+    }
+
+    case KICKED_OUT: {
+        const { participant: kicker } = action;
+        const state = store.getState();
+        const localParticipant = getLocalParticipant(state);
+
+        sendEvent(
+            store,
+            'PARTICIPANT_KICKED_OUT',
+            /* data */ {
+                kicked: localParticipant
+                    ? participantToParticipantInfo(localParticipant)
+                    : undefined,
+                kicker: kicker
+                    ? {
+                        participantId: kicker.getId(),
+                        name: kicker.getDisplayName()
+                    }
+                    : undefined
+            });
         break;
     }
 

--- a/react/features/mobile/react-native-sdk/middleware.js
+++ b/react/features/mobile/react-native-sdk/middleware.js
@@ -7,10 +7,12 @@ import {
     CONFERENCE_JOINED,
     CONFERENCE_LEFT,
     CONFERENCE_WILL_JOIN,
-    ENDPOINT_MESSAGE_RECEIVED
+    ENDPOINT_MESSAGE_RECEIVED,
+    KICKED_OUT
 } from '../../base/conference/actionTypes';
 import { SET_AUDIO_MUTED, SET_VIDEO_MUTED } from '../../base/media/actionTypes';
 import { PARTICIPANT_JOINED, PARTICIPANT_LEFT } from '../../base/participants/actionTypes';
+import { getLocalParticipant } from '../../base/participants/functions';
 import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../../base/redux/StateListenerRegistry';
 import { READY_TO_CLOSE } from '../external-api/actionTypes';
@@ -79,6 +81,24 @@ const { JMOngoingConference } = NativeModules;
         const { id } = participant ?? {};
 
         rnSdkHandlers?.onParticipantLeft?.({ id });
+        break;
+    }
+    case KICKED_OUT: {
+        const { participant: kicker } = action;
+        const state = store.getState();
+        const localParticipant = getLocalParticipant(state);
+
+        rnSdkHandlers?.onParticipantKickedOut?.({
+            kicked: localParticipant
+                ? participantToParticipantInfo(localParticipant)
+                : undefined,
+            kicker: kicker
+                ? {
+                    participantId: kicker.getId(),
+                    name: kicker.getDisplayName()
+                }
+                : undefined
+        });
         break;
     }
     case READY_TO_CLOSE:


### PR DESCRIPTION
### Fixes: #16738

### Summary

This PR adds full Android SDK support for the `participant-kicked-out` External API event, enabling Android apps to detect when a participant is removed from a meeting.

This achieves feature parity with existing participant events such as:
- `PARTICIPANT_JOINED`
- `PARTICIPANT_LEFT`

---

### What’s included

- Added new broadcast event type  
  `BroadcastEvent.Type.PARTICIPANT_KICKED_OUT`
- Added correct broadcast action  
  `"org.jitsi.meet.PARTICIPANT_KICKED_OUT"`
- Added JitsiMeetActivity callback for parity  
  `onParticipantKickedOut(Map<String, Object> data)`
- Hooked event into broadcast handling flow in `JitsiMeetActivity`

No existing behavior was modified.

---

### Why this is needed

The Web/IFrame External API already emits the `participant-kicked-out` event, but the Android SDK previously did not expose it - so native apps could not respond to users being kicked out.

This closes the functional gap and maintains platform consistency.

Resolves: #16738

---