### PR TITLE
feat(mobile): hide status bar in landscape during conference

### DIFF
--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 import {
     BackHandler,
     NativeModules,
+    StatusBar,
     View,
     ViewStyle
 } from 'react-native';
@@ -267,7 +268,11 @@ class Conference extends AbstractConference<IProps, State> {
     override render() {
         const {
             _brandingStyles,
+            _aspectRatio
         } = this.props;
+
+        const isLandscape = _aspectRatio === ASPECT_RATIO_WIDE;
+        const shouldHideStatusBar = isLandscape;
 
         return (
             <Container
@@ -275,6 +280,11 @@ class Conference extends AbstractConference<IProps, State> {
                     styles.conference,
                     _brandingStyles
                 ] }>
+
+                <StatusBar
+                    animated = { true }
+                    hidden = { shouldHideStatusBar } />
+
                 <BrandingImageBackground />
                 { this._renderContent() }
             </Container>


### PR DESCRIPTION
Fixes #16660 

This implements automatic status bar hiding in landscape during conference on both Android and iOS using the existing responsive aspect ratio (ASPECT_RATIO_WIDE).

This avoids platform checks since Platform.OS is already constrained to native targets.