### PR TITLE
fix(Android): Stop Screen sharing from Android System notification fixed

### DIFF
--- a/react/features/base/tracks/actions.native.ts
+++ b/react/features/base/tracks/actions.native.ts
@@ -1,7 +1,7 @@
 import { IReduxState, IStore } from '../../app/types';
 import { showNotification } from '../../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../../notifications/constants';
-import JitsiMeetJS, { JitsiTrackEvents } from '../lib-jitsi-meet';
+import JitsiMeetJS from '../lib-jitsi-meet';
 import { setScreenshareMuted } from '../media/actions';
 
 import { addLocalTrack, replaceLocalTrack } from './actions.any';
@@ -45,9 +45,6 @@ async function _startScreenSharing(dispatch: IStore['dispatch'], state: IReduxSt
         const track = tracks[0];
         const currentLocalDesktopTrack = getLocalDesktopTrack(getTrackState(state));
         const currentJitsiTrack = currentLocalDesktopTrack?.jitsiTrack;
-
-        // Ensure we react when the system stops screen capture (e.g. Android red chip).
-        track.on(JitsiTrackEvents.LOCAL_TRACK_STOPPED, () => dispatch(toggleScreensharing(false)));
 
         // The first time the user shares the screen we add the track and create the transceiver.
         // Afterwards, we just replace the old track, so the transceiver will be reused.

--- a/react/features/base/tracks/middleware.native.ts
+++ b/react/features/base/tracks/middleware.native.ts
@@ -7,6 +7,7 @@ import {
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 
 import {
+    TRACK_STOPPED,
     TRACK_UPDATED
 } from './actionTypes';
 import {
@@ -37,6 +38,16 @@ MiddlewareRegistry.register(store => next => action => {
 
         if (local && jitsiTrack.isMuted()
                     && jitsiTrack.type === MEDIA_TYPE.VIDEO && jitsiTrack.videoType === VIDEO_TYPE.DESKTOP) {
+            store.dispatch(toggleScreensharing(false));
+        }
+        break;
+    }
+    case TRACK_STOPPED: {
+        // When Android system stops screen capture (via MediaProjection.Callback.onStop),
+        // the desktop track fires TRACK_STOPPED. Treat this the same as the in-app stop button.
+        const { jitsiTrack, local } = action.track;
+
+        if (local && jitsiTrack.type === MEDIA_TYPE.VIDEO && jitsiTrack.videoType === VIDEO_TYPE.DESKTOP) {
             store.dispatch(toggleScreensharing(false));
         }
         break;


### PR DESCRIPTION
### Fixes: #16746

#### What was the issue?

When screen sharing on Android, if the user stops sharing using the **Android system “Stop sharing” UI** (red system chip), the MediaProjection stops and the local frames stop updating - but Jitsi still considers the user to be screen sharing. Remote participants continue to see a **frozen screen-share tile** until the user presses the in-app “Stop sharing” button.

#### Root cause

The underlying `JitsiLocalTrack` for desktop capture emits `JitsiTrackEvents.LOCAL_TRACK_STOPPED` when MediaProjection is terminated by the OS.

However, on React Native (Android/iOS), we were **not listening** for this event in `actions.native.ts`, so the existing `toggleScreensharing(false)` cleanup flow was never triggered.

#### Solution

Added a listener for `LOCAL_TRACK_STOPPED` on the desktop track when starting screensharing:

```ts
track.on(JitsiTrackEvents.LOCAL_TRACK_STOPPED, () => {
    dispatch(toggleScreensharing(false));
});
