### PR TITLE
fix(android): update locale detection to reflect system language change (#15348)

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/LocaleDetector.java
@@ -21,12 +21,15 @@
 package org.jitsi.meet.sdk;
 
 import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Locale;
 
 /**
  * Module which provides information about the system locale.
@@ -35,6 +38,22 @@ class LocaleDetector extends ReactContextBaseJavaModule {
 
     public LocaleDetector(ReactApplicationContext reactContext) {
         super(reactContext);
+    }
+
+    // Configuration.locale is deprecated (API 24); on N+ use Configuration.getLocales().get(0)
+    // and continue returning full language tags via Locale.toLanguageTag() for JS compatibility.
+    private String getCurrentLocaleTag(Context context) {
+        Configuration config = context.getResources().getConfiguration();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (config.getLocales() != null && !config.getLocales().isEmpty()) {
+                // Use the first locale from the LocaleList
+                return config.getLocales().get(0).toLanguageTag();
+            }
+        }
+
+        Locale locale = config.locale != null ? config.locale : Locale.getDefault();
+        return locale.toLanguageTag();
     }
 
     /**
@@ -47,7 +66,7 @@ class LocaleDetector extends ReactContextBaseJavaModule {
     public Map<String, Object> getConstants() {
         Context context = getReactApplicationContext();
         HashMap<String,Object> constants = new HashMap<>();
-        constants.put("locale", context.getResources().getConfiguration().locale.toLanguageTag());
+        constants.put("locale", getCurrentLocaleTag(context));
         return constants;
     }
 


### PR DESCRIPTION
### Fixes Issue

Resolves #15348 - **Android Jitsi app and SDK do not reflect system language changes**.

### Summary

LocaleDetector used the deprecated `Configuration.locale`, which doesn’t reflect updated system language on Android N+. This caused translations to remain in the old language.

### This PR:

- Switches to `Configuration.getLocales().get(0)` on API 24+

- Falls back to `config.locale / Locale.getDefault()` for safety

- Still returns full language tags `Locale.toLanguageTag()`

- Keeps the same public API (`"locale"` constant)