### PR TITLE
feat(android): add support for virtual output devices (TYPE_REMOTE_SUBMIX) 

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioDeviceHandlerConnectionService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioDeviceHandlerConnectionService.java
@@ -72,6 +72,8 @@ class AudioDeviceHandlerConnectionService implements
                 return CallAudioState.ROUTE_WIRED_HEADSET;
             case AudioModeModule.DEVICE_SPEAKER:
                 return CallAudioState.ROUTE_SPEAKER;
+            case AudioModeModule.DEVICE_REMOTE_SUBMIX:
+                return CallAudioState.ROUTE_SPEAKER;
             default:
                 JitsiMeetLogger.e(TAG + " Unsupported device name: " + audioDevice);
                 return CallAudioState.ROUTE_SPEAKER;

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
@@ -110,10 +110,11 @@ class AudioModeModule extends ReactContextBaseJavaModule {
     /**
      * Audio device types.
      */
-    static final String DEVICE_BLUETOOTH  = "BLUETOOTH";
-    static final String DEVICE_EARPIECE   = "EARPIECE";
-    static final String DEVICE_HEADPHONES = "HEADPHONES";
-    static final String DEVICE_SPEAKER    = "SPEAKER";
+    static final String DEVICE_BLUETOOTH     = "BLUETOOTH";
+    static final String DEVICE_EARPIECE      = "EARPIECE";
+    static final String DEVICE_HEADPHONES    = "HEADPHONES";
+    static final String DEVICE_SPEAKER       = "SPEAKER";
+    static final String DEVICE_REMOTE_SUBMIX = "REMOTE_SUBMIX";
 
     /**
      * Device change event.


### PR DESCRIPTION
### Fixes: #16701 

### Summary

This PR adds Android support for virtual audio output devices of type `AudioDeviceInfo.TYPE_REMOTE_SUBMIX`, allowing Jitsi Meet to route audio through third-party voice-changer apps that expose a remote-submix sink.

### What’s Implemented

- Added `DEVICE_REMOTE_SUBMIX` in `AudioModeModule.java`.
- Extended device enumeration in `AudioDeviceHandlerGeneric` to detect
  `TYPE_REMOTE_SUBMIX` (with `isSink()` validation) and expose it to JS.
- Added routing support in `setAudioRoute()`, using:
  - `getAvailableCommunicationDevices()` (API 31+)
  - `setCommunicationDevice()` with full try/catch protection.
- Added ConnectionService fallback mapping to `ROUTE_SPEAKER` for stability.