### PR TITLE
refactor(large-video): convert class component to function component and extract track streaming hook (#16707)

### DIFF
--- a/react/features/large-video/LargeVideo.native.tsx
+++ b/react/features/large-video/LargeVideo.native.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { IReduxState } from '../../app/types';
+import ParticipantView from '../../base/participants/components/ParticipantView.native';
+import {
+    getParticipantById,
+    isLocalScreenshareParticipant
+} from '../../base/participants/functions';
+import {
+    getVideoTrackByParticipant,
+    isLocalVideoTrackDesktop
+} from '../../base/tracks/functions.native';
+import { AVATAR_SIZE } from './styles';
+import { useTrackStreamingStatus } from './useTrackStreamingStatus.native';
+
+interface IProps {
+    onClick?: Function;
+}
+
+function calculateDisplaySettings(height: number, width: number) {
+    const shortestSide = Math.min(height, width);
+    const rounded = 2 * Math.round(shortestSide / 2);
+
+    if (rounded < AVATAR_SIZE * 1.5) {
+        return {
+            avatarSize: rounded - 15,
+            useConnectivityInfoLabel: false
+        };
+    }
+
+    return {
+        avatarSize: AVATAR_SIZE,
+        useConnectivityInfoLabel: true
+    };
+}
+
+function LargeVideo({ onClick }: IProps): JSX.Element {
+    const {
+        participantId,
+        height,
+        width,
+        disableVideo,
+        videoTrack
+    } = useSelector((state: IReduxState) => {
+        const { participantId: pid } = state['features/large-video'];
+        const participant = getParticipantById(state, pid ?? '');
+
+        const { clientHeight, clientWidth } =
+            state['features/base/responsive-ui'];
+
+        const vTrack = getVideoTrackByParticipant(state, participant);
+
+        let disable = false;
+
+        if (isLocalScreenshareParticipant(participant)) {
+            disable = true;
+        } else if (participant?.local) {
+            disable = isLocalVideoTrackDesktop(state);
+        }
+
+        return {
+            participantId: pid ?? '',
+            height: clientHeight,
+            width: clientWidth,
+            disableVideo: disable,
+            videoTrack: vTrack
+        };
+    });
+
+    useTrackStreamingStatus(videoTrack);
+
+    const { avatarSize, useConnectivityInfoLabel } = useMemo(() => {
+        return calculateDisplaySettings(height, width);
+    }, [height, width]);
+
+    return (
+        <ParticipantView
+            avatarSize={avatarSize}
+            disableVideo={disableVideo}
+            onPress={onClick}
+            participantId={participantId}
+            testHintId="org.jitsi.meet.LargeVideo"
+            useConnectivityInfoLabel={useConnectivityInfoLabel}
+            zOrder={0}
+            zoomEnabled={true}
+        />
+    );
+}
+
+export default LargeVideo;
+

--- a/react/features/large-video/useTrackStreamingStatus.native.ts
+++ b/react/features/large-video/useTrackStreamingStatus.native.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
+import { trackStreamingStatusChanged } from '../../base/tracks/actions.native';
+import { ITrack } from '../../base/tracks/types';
+
+export function useTrackStreamingStatus(videoTrack?: ITrack): void {
+    const dispatch = useDispatch();
+    const jitsiTrack = videoTrack?.local ? undefined : videoTrack?.jitsiTrack;
+
+    const sourceName = useMemo(() => {
+        return jitsiTrack?.getSourceName?.();
+    }, [jitsiTrack]);
+
+    useEffect(() => {
+        if (!jitsiTrack) {
+            return;
+        }
+
+        const handle = (_ignored: any, status: string) => {
+            dispatch(trackStreamingStatusChanged(jitsiTrack, status));
+        };
+
+        jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, handle);
+
+        dispatch(
+            trackStreamingStatusChanged(
+                jitsiTrack,
+                jitsiTrack.getTrackStreamingStatus()
+            )
+        );
+
+        return () => {
+            jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, handle);
+
+            dispatch(
+                trackStreamingStatusChanged(
+                    jitsiTrack,
+                    jitsiTrack.getTrackStreamingStatus()
+                )
+            );
+        };
+    }, [sourceName, dispatch]);
+}
+


### PR DESCRIPTION
This PR updates LargeVideo.native.tsx by replacing an old-style React class component with a modern function component. It also moves all the track-streaming event logic into a separate custom hook so the code is easier to understand, reuse, and maintain.

What this change does (explained simply):

The old component used componentDidMount, componentDidUpdate, and componentWillUnmount.
Function components don’t use these, so I replaced them with a clean React hook.

All the logic for listening to streaming-status events is now inside a new file:
useTrackStreamingStatus.native.ts.

The hook automatically subscribes and unsubscribes to the Jitsi track’s streaming events,
just like the original class did, but with much clearer code.

The behavior stays exactly the same — only the implementation is modernized.

The hook follows the same rules as the original code by using the track’s getSourceName()
to determine when to reattach listeners.

Why this change matters:

This refactor removes legacy React patterns, makes the code easier to read,
and resolves the existing TODO comments in the file.
It also brings this part of Jitsi Meet in line with the rest of the project,
which has been moving toward React hooks.

In simple terms:
The code now does the same thing, but is cleaner, smaller, easier to maintain,
and easier for new contributors to understand.