### PR TITLE
feat(participants) : add config flag to disable automatic participant resorting (#16249)

### DIFF
--- a/config.js
+++ b/config.js
@@ -151,6 +151,11 @@ var config = {
     // Disables self-view settings in UI
     // disableSelfViewSettings: false,
 
+    // When true, the participants list will NOT automatically resort
+    // when someone speaks or becomes dominant speaker.
+    // Default: false (current behavior - list reorders dynamically).
+    // disableAutoResortParticipants: false,
+
     // screenshotCapture : {
     //      Enables the screensharing capture feature.
     //      enabled: false,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -283,6 +283,7 @@ export interface IConfig {
     disableAP?: boolean;
     disableAddingBackgroundImages?: boolean;
     disableAudioLevels?: boolean;
+    disableAutoResortParticipants?: boolean;
     disableBeforeUnloadHandlers?: boolean;
     disableCameraTintForeground?: boolean;
     disableChat?: boolean;

--- a/react/features/filmstrip/functions.any.ts
+++ b/react/features/filmstrip/functions.any.ts
@@ -20,6 +20,7 @@ export function updateRemoteParticipants(store: IStore, force?: boolean, partici
     const state = store.getState();
     let reorderedParticipants = [];
     const { sortedRemoteVirtualScreenshareParticipants } = state['features/base/participants'];
+    const disableAutoResort = Boolean(state['features/base/config']?.disableAutoResortParticipants);
 
     if (!isFilmstripScrollVisible(state) && !sortedRemoteVirtualScreenshareParticipants.size && !force) {
         if (participantId) {
@@ -40,7 +41,9 @@ export function updateRemoteParticipants(store: IStore, force?: boolean, partici
     const screenShareParticipants = sortedRemoteVirtualScreenshareParticipants
         ? [ ...sortedRemoteVirtualScreenshareParticipants.keys() ] : [];
     const sharedVideos = fakeParticipants ? Array.from(fakeParticipants.keys()) : [];
-    const speakers = getActiveSpeakersToBeDisplayed(state);
+
+    // When disableAutoResortParticipants is true, use empty speakers list to preserve stable order
+    const speakers = disableAutoResort ? new Map() : getActiveSpeakersToBeDisplayed(state);
 
     for (const screenshare of screenShareParticipants) {
         const ownerId = getVirtualScreenshareParticipantOwnerId(screenshare);

--- a/react/features/participants-pane/functions.ts
+++ b/react/features/participants-pane/functions.ts
@@ -189,12 +189,14 @@ export const shouldRenderInviteButton = (state: IReduxState) => {
  * @returns {Array<string>}
  */
 export function getSortedParticipantIds(stateful: IStateful) {
+    const state = toState(stateful);
     const id = getLocalParticipant(stateful)?.id;
     const remoteParticipants = getRemoteParticipantsSorted(stateful);
     const reorderedParticipants = new Set(remoteParticipants);
     const raisedHandParticipants = getRaiseHandsQueue(stateful).map(({ id: particId }) => particId);
     const remoteRaisedHandParticipants = new Set(raisedHandParticipants || []);
     const dominantSpeaker = getDominantSpeakerParticipant(stateful);
+    const disableAutoResort = Boolean(state['features/base/config']?.disableAutoResortParticipants);
 
     for (const participant of remoteRaisedHandParticipants.keys()) {
         // Avoid duplicates.
@@ -204,11 +206,12 @@ export function getSortedParticipantIds(stateful: IStateful) {
     }
 
     const dominant = [];
-    const dominantId = dominantSpeaker?.id;
+    const dominantId = disableAutoResort ? undefined : dominantSpeaker?.id;
     const local = remoteRaisedHandParticipants.has(id ?? '') ? [] : [ id ];
 
     // In case dominat speaker has raised hand, keep the order in the raised hand queue.
     // In case they don't have raised hand, goes first in the participants list.
+    // (Only when disableAutoResortParticipants is false)
     if (dominantId && dominantId !== id && !remoteRaisedHandParticipants.has(dominantId)) {
         reorderedParticipants.delete(dominantId);
         dominant.push(dominantId);


### PR DESCRIPTION
### Fixes: #16249 

### What this PR does
Adds a new configuration flag `disableAutoResortParticipants` (default: `false`) that allows deployments to disable the automatic resorting of the Meeting Participants list.  
When set to `true`, the participants list remains in a stable order instead of dynamically reordering based on active/dominant speakers.  
Raised-hand and pinned participant behaviors remain unchanged.

### Why
Automatic participant resorting (based on who is speaking) can make moderation tasks difficult - especially in workflows where moderators must quickly locate and move newly joined users into breakout rooms.  
This flag provides administrators the flexibility to keep a stable participant list when needed.

### Implementation
- Added new config flag in `config.js`:
  ```js
  disableAutoResortParticipants: false

- Updated filmstrip ordering logic (`functions.any.ts`) to skip dynamic speaker-based sorting when the flag is enabled.

- Updated Participants Pane (`functions.ts`) to avoid promoting the dominant speaker when the flag is enabled.

- Added TypeScript field `disableAutoResortParticipants?: boolean;` to `configType.ts` for proper typing.


