### PR TITLE
fix(livestream): add YouTube “Go Live” reminder in Start Live Stream dialog

### DIFF
--- a/css/_recording.scss
+++ b/css/_recording.scss
@@ -196,4 +196,14 @@
         color:#FFD740;
         font-size: 0.75rem;
     }
+
+    .youtube-go-live-warning {
+        margin-bottom: 16px;
+        padding: 8px 12px;
+        background-color: rgba(248, 174, 26, 0.1);
+        border-left: 3px solid #FFD740;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        color: #FFD740;
+    }
 }

--- a/lang/main.json
+++ b/lang/main.json
@@ -724,6 +724,7 @@
         "streamIdHelp": "What's this?",
         "title": "Live Stream",
         "unavailableTitle": "Live Streaming unavailable",
+        "youTubeGoLiveWarning": "Remember to click 'Go Live' in YouTube Studio if Auto-Start/Auto-Stop are disabled. Otherwise the stream will not begin recording.",
         "youtubeTerms": "YouTube terms of services"
     },
     "lobby": {

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.tsx
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.tsx
@@ -80,7 +80,7 @@ class StartLiveStreamDialog
      * @inheritdoc
      */
     override render() {
-        const { _googleApiApplicationClientID } = this.props;
+        const { _googleApiApplicationClientID, t } = this.props;
 
         return (
             <Dialog
@@ -91,6 +91,9 @@ class StartLiveStreamDialog
                 <div className = 'live-stream-dialog'>
                     { _googleApiApplicationClientID
                         ? this._renderYouTubePanel() : null }
+                    <div className = 'youtube-go-live-warning'>
+                        { t('liveStreaming.youTubeGoLiveWarning') }
+                    </div>
                     <StreamKeyForm
                         onChange = { this._onStreamKeyChange }
                         value = {


### PR DESCRIPTION
## Fixes: #16011 

## What this PR does

Adds a reminder message to the **Start Live Stream** dialog advising users to click **“Go Live”** in YouTube Studio when Auto-Start / Auto-Stop are disabled. This prevents silent loss of YouTube recordings when YouTube has not yet started the event.

This is a small, UI-only improvement based on issue [#16011](https://github.com/jitsi/jitsi-meet/issues/16011).

## Changes

- Adds new translation key `liveStreaming.youTubeGoLiveWarning` to `lang/main.json` (canonical English only).
- Renders the warning in `StartLiveStreamDialog.tsx`.
- Adds lightweight styling via `.youtube-go-live-warning` in `_recording.scss`.

## Notes

Other locale files are intentionally left unchanged and will fall back to English until translators update them.
