### PR TITLE
Fix Android Screen Sharing Notifications and Stop Behavior

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -56,6 +56,8 @@ public class JitsiMeetActivity extends AppCompatActivity
 
     private static final int SCREEN_SHARE_NOTIFICATION_ID = 1001;
 
+    private static boolean notificationChannelCreated = false;
+
     private boolean isReadyToClose;
 
     private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
@@ -422,15 +424,18 @@ public class JitsiMeetActivity extends AppCompatActivity
     }
 
     private void onShowNotification(Bundle data) {
-        // Create notification channel for Android 8.0+
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        // Create notification channel for Android 8.0+ (only once)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !notificationChannelCreated) {
             android.app.NotificationChannel channel = new android.app.NotificationChannel(
                 "screen_share_channel",
                 "Screen Sharing",
                 android.app.NotificationManager.IMPORTANCE_HIGH);
             channel.setDescription("Notifications for screen sharing controls");
             android.app.NotificationManager notificationManager = getSystemService(android.app.NotificationManager.class);
-            notificationManager.createNotificationChannel(channel);
+            if (notificationManager != null) {
+                notificationManager.createNotificationChannel(channel);
+                notificationChannelCreated = true;
+            }
         }
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "screen_share_channel")

--- a/react/features/base/tracks/actions.native.ts
+++ b/react/features/base/tracks/actions.native.ts
@@ -46,9 +46,6 @@ async function _startScreenSharing(dispatch: IStore['dispatch'], state: IReduxSt
         const currentLocalDesktopTrack = getLocalDesktopTrack(getTrackState(state));
         const currentJitsiTrack = currentLocalDesktopTrack?.jitsiTrack;
 
-        // Ensure we react when the system stops screen capture (e.g. Android red chip).
-        track.on(JitsiTrackEvents.LOCAL_TRACK_STOPPED, () => dispatch(toggleScreensharing(false)));
-
         // The first time the user shares the screen we add the track and create the transceiver.
         // Afterwards, we just replace the old track, so the transceiver will be reused.
         if (currentJitsiTrack) {


### PR DESCRIPTION
This PR successfully adds two new features for android users:

- Stop screen sharing
- Hide option

Fixes #16759 