### PR TITLE
Enable strictPropertyInitialization in TypeScript configs

### DIFF
--- a/react/features/always-on-top/AlwaysOnTop.tsx
+++ b/react/features/always-on-top/AlwaysOnTop.tsx
@@ -35,7 +35,7 @@ interface IState {
  * @augments Component
  */
 export default class AlwaysOnTop extends Component<any, IState> {
-    _hovered: boolean;
+    _hovered: boolean = false;
 
     /**
      * Initializes a new {@code AlwaysOnTop} instance.

--- a/react/features/base/app/components/BaseApp.tsx
+++ b/react/features/base/app/components/BaseApp.tsx
@@ -45,7 +45,7 @@ export default class BaseApp<P> extends Component<P, IState> {
     /**
      * The deferred for the initialisation {{promise, resolve, reject}}.
      */
-    _init: PromiseWithResolvers<any>;
+    _init!: PromiseWithResolvers<any>;
 
     /**
      * Initializes a new {@code BaseApp} instance.

--- a/react/features/base/dialog/components/native/AbstractDialog.ts
+++ b/react/features/base/dialog/components/native/AbstractDialog.ts
@@ -28,7 +28,7 @@ export interface IState {
 export default class AbstractDialog<P extends IProps, S extends IState = IState>
     extends Component<P, S> {
 
-    _mounted: boolean;
+    _mounted: boolean = false;
 
     /**
      * Initializes a new {@code AbstractDialog} instance.

--- a/react/features/base/label/components/native/Label.tsx
+++ b/react/features/base/label/components/native/Label.tsx
@@ -69,7 +69,7 @@ export default class Label extends Component<IProps, State> {
     /**
      * A reference to the started animation of this label.
      */
-    animationReference: Animated.CompositeAnimation;
+    animationReference!: Animated.CompositeAnimation;
 
     /**
      * Instantiates a new instance of {@code Label}.

--- a/react/features/base/media/components/native/VideoTransform.tsx
+++ b/react/features/base/media/components/native/VideoTransform.tsx
@@ -134,7 +134,7 @@ class VideoTransform extends Component<IProps, IState> {
     /**
      * The initial position of the finger on touch start.
      */
-    initialPosition: {
+    initialPosition!: {
         x: number;
         y: number;
     };
@@ -147,7 +147,7 @@ class VideoTransform extends Component<IProps, IState> {
     /**
      * Time of the last tap.
      */
-    lastTap: number;
+    lastTap!: number;
 
     /**
      * Constructor of the component.

--- a/react/features/base/media/components/web/Audio.tsx
+++ b/react/features/base/media/components/web/Audio.tsx
@@ -10,7 +10,7 @@ export default class Audio extends AbstractAudio {
     /**
      * Set to <code>true</code> when the whole file is loaded.
      */
-    _audioFileLoaded: boolean;
+    _audioFileLoaded: boolean = false;
 
     /**
      * Reference to the HTML audio element, stored until the file is ready.

--- a/react/features/base/media/components/web/Video.tsx
+++ b/react/features/base/media/components/web/Video.tsx
@@ -175,7 +175,7 @@ interface IProps {
  */
 class Video extends Component<IProps> {
     _videoElement?: HTMLVideoElement | null;
-    _mounted: boolean;
+    _mounted: boolean = false;
 
     /**
      * Default values for {@code Video} component's properties.

--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -152,7 +152,7 @@ class Popover extends Component<IProps, IState> {
      */
     _containerRef: React.RefObject<HTMLDivElement>;
 
-    _contextMenuRef: HTMLElement;
+    _contextMenuRef!: HTMLElement;
 
     /**
      * Initializes a new {@code Popover} instance.

--- a/react/features/base/react/components/native/SlidingView.tsx
+++ b/react/features/base/react/components/native/SlidingView.tsx
@@ -78,7 +78,7 @@ export default class SlidingView extends PureComponent<IProps, IState> {
     /**
      * True if the component is mounted.
      */
-    _mounted: boolean;
+    _mounted: boolean = false;
 
     /**
      * Implements React's {@link Component#getDerivedStateFromProps()}.

--- a/react/features/base/toolbox/components/AbstractButton.tsx
+++ b/react/features/base/toolbox/components/AbstractButton.tsx
@@ -134,7 +134,7 @@ export default class AbstractButton<P extends IProps, S = any> extends Component
      *
      * @abstract
      */
-    accessibilityLabel: string;
+    accessibilityLabel!: string;
 
     /**
      * This is the same as `accessibilityLabel`, replacing it when the button
@@ -142,16 +142,16 @@ export default class AbstractButton<P extends IProps, S = any> extends Component
      *
      * @abstract
      */
-    toggledAccessibilityLabel: string;
+    toggledAccessibilityLabel!: string;
 
-    labelProps: Object;
+    labelProps!: Object;
 
     /**
      * The icon of this button.
      *
      * @abstract
      */
-    icon: Object;
+    icon!: Object;
 
     /**
      * The text associated with this button. When `showLabel` is set to
@@ -159,19 +159,19 @@ export default class AbstractButton<P extends IProps, S = any> extends Component
      *
      * @abstract
      */
-    label: string;
+    label!: string;
 
     /**
      * The label for this button, when toggled.
      */
-    toggledLabel: string;
+    toggledLabel!: string;
 
     /**
      * The icon of this button, when toggled.
      *
      * @abstract
      */
-    toggledIcon: Object;
+    toggledIcon!: Object;
 
     /**
      * The text to display in the tooltip. Used only on web.

--- a/react/features/chat/components/web/MessageContainer.tsx
+++ b/react/features/chat/components/web/MessageContainer.tsx
@@ -63,7 +63,7 @@ export default class MessageContainer extends Component<IProps, IState> {
     /**
      * Intersection observer used to detect intersections of messages with the bottom of the message container.
      */
-    _bottomListObserver: IntersectionObserver;
+    _bottomListObserver!: IntersectionObserver;
 
     static defaultProps = {
         messages: [] as IMessage[]

--- a/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.tsx
+++ b/react/features/invite/components/add-people-dialog/native/AddPeopleDialog.tsx
@@ -106,7 +106,7 @@ class AddPeopleDialog extends AbstractAddPeopleDialog<IProps, IState> {
      */
 
     /* eslint-disable-next-line no-undef */
-    searchTimeout: number;
+    searchTimeout!: number;
 
     /**
      * Constructor of the component.

--- a/react/features/large-video/components/LargeVideoBackground.web.tsx
+++ b/react/features/large-video/components/LargeVideoBackground.web.tsx
@@ -67,7 +67,7 @@ interface IProps {
  * @augments Component
  */
 export class LargeVideoBackground extends Component<IProps> {
-    _canvasEl: HTMLCanvasElement;
+    _canvasEl!: HTMLCanvasElement;
 
     _updateCanvasInterval: number | undefined;
 

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -440,7 +440,7 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
      * @protected
      * @returns {React$Component}
      */
-    _renderDialogContent: () => React.Component;
+    _renderDialogContent!: () => React.Component;
 }
 
 /**

--- a/react/features/screenshot-capture/ScreenshotCaptureSummary.tsx
+++ b/react/features/screenshot-capture/ScreenshotCaptureSummary.tsx
@@ -29,7 +29,7 @@ declare let ImageCapture: any;
 export default class ScreenshotCaptureSummary {
     _state: IReduxState;
     _initializedRegion: boolean;
-    _imageCapture: ImageCapture;
+    _imageCapture!: ImageCapture;
     _streamWorker: Worker;
     _queue: Blob[];
 

--- a/react/features/stream-effects/audio-mixer/AudioMixerEffect.ts
+++ b/react/features/stream-effects/audio-mixer/AudioMixerEffect.ts
@@ -20,12 +20,12 @@ export class AudioMixerEffect {
     /**
      * MediaStreamTrack obtained from mixed stream.
      */
-    _mixedMediaTrack: Object;
+    _mixedMediaTrack!: Object;
 
     /**
      * Original MediaStream from the JitsiLocalTrack that uses this effect.
      */
-    _originalStream: Object;
+    _originalStream!: Object;
 
     /**
      * MediaStreamTrack obtained from the original MediaStream.

--- a/react/features/stream-effects/noise-suppression/NoiseSuppressionEffect.ts
+++ b/react/features/stream-effects/noise-suppression/NoiseSuppressionEffect.ts
@@ -28,12 +28,12 @@ export class NoiseSuppressionEffect {
     /**
      * Source that will be attached to the track affected by the effect.
      */
-    private _audioSource: MediaStreamAudioSourceNode;
+    private _audioSource!: MediaStreamAudioSourceNode;
 
     /**
      * Destination that will contain denoised audio from the audio worklet.
      */
-    private _audioDestination: MediaStreamAudioDestinationNode;
+    private _audioDestination!: MediaStreamAudioDestinationNode;
 
     /**
      * `AudioWorkletProcessor` associated node.
@@ -43,12 +43,12 @@ export class NoiseSuppressionEffect {
     /**
      * Audio track extracted from the original MediaStream to which the effect is applied.
      */
-    private _originalMediaTrack: MediaStreamTrack;
+    private _originalMediaTrack!: MediaStreamTrack;
 
     /**
      * Noise suppressed audio track extracted from the media destination node.
      */
-    private _outputMediaTrack: MediaStreamTrack;
+    private _outputMediaTrack!: MediaStreamTrack;
 
     /**
      * Configured options for noise suppression.

--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
@@ -28,14 +28,14 @@ export default class JitsiStreamBackgroundEffect {
     _stream: any;
     _segmentationPixelCount: number;
     _inputVideoElement: HTMLVideoElement;
-    _maskFrameTimerWorker: Worker;
+    _maskFrameTimerWorker!: Worker;
     _outputCanvasElement: HTMLCanvasElement;
-    _outputCanvasCtx: CanvasRenderingContext2D | null;
-    _segmentationMaskCtx: CanvasRenderingContext2D | null;
-    _segmentationMask: ImageData;
-    _segmentationMaskCanvas: HTMLCanvasElement;
-    _virtualImage: HTMLImageElement;
-    _virtualVideo: HTMLVideoElement;
+    _outputCanvasCtx!: CanvasRenderingContext2D | null;
+    _segmentationMaskCtx!: CanvasRenderingContext2D | null;
+    _segmentationMask!: ImageData;
+    _segmentationMaskCanvas!: HTMLCanvasElement;
+    _virtualImage!: HTMLImageElement;
+    _virtualVideo!: HTMLVideoElement;
 
     /**
      * Represents a modified video MediaStream track.

--- a/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
+++ b/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
@@ -123,7 +123,7 @@ const styles = (theme: Theme) => {
  * @augments PureComponent
  */
 class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
-    _componentWasUnmounted: boolean;
+    _componentWasUnmounted: boolean = false;
 
     /**
      * Initializes a new {@code VirtualBackgroundPreview} instance.

--- a/tsconfig.native.json
+++ b/tsconfig.native.json
@@ -10,7 +10,7 @@
         "moduleResolution": "Node",
         "strict": true,
         "noImplicitAny": true,
-        "strictPropertyInitialization": false,
+        "strictPropertyInitialization": true,
         "resolveJsonModule": true,
         "moduleSuffixes": [".native", ".ios", ".android", ""]
     },

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -11,7 +11,7 @@
         "strict": true,
         "noImplicitAny": true,
         "noImplicitOverride": true,
-        "strictPropertyInitialization": false,
+        "strictPropertyInitialization": true,
         "resolveJsonModule": true,
         "moduleSuffixes": [".web", ""]
     },


### PR DESCRIPTION
## Summary
Enables TypeScript's `strictPropertyInitialization` compiler flag in both web and native configurations to enforce proper class property initialization, improving type safety and catching potential undefined property access at compile time.

## Changes Made

### 1. TypeScript Configuration Updates
- **`tsconfig.web.json`**: Set `strictPropertyInitialization: true`
- **`tsconfig.native.json`**: Set `strictPropertyInitialization: true`

### 2. Property Initialization Fixes (19 files)

All class properties have been updated to satisfy the strict initialization requirement using two approaches:

**Approach A: Direct Initialization** - For properties with simple default values:
```typescript
// Before
_mounted: boolean;

// After
_mounted: boolean = false;
```
**Approach B: Definite Assignment Assertion (!)** - For properties initialized in lifecycle methods or abstract properties:
```typescript
// Before
_init: PromiseWithResolvers<any>;

// After - Property is initialized in componentDidMount
_init!: PromiseWithResolvers<any>;

```