### PR TITLE
Ensure proper callback cleanup in ParticipantsService to improves robustness 

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ParticipantsService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ParticipantsService.java
@@ -70,11 +70,18 @@ public class ParticipantsService extends android.content.BroadcastReceiver {
                         new TypeToken<ArrayList<ParticipantInfo>>() {
                         }.getType());
 
-                    ParticipantsInfoCallback participantsInfoCallback = this.participantsInfoCallbackMap.get(event.getData().get(REQUEST_ID).toString()).get();
+                    Object requestIdObj = event.getData().get(REQUEST_ID);
+                    if (requestIdObj == null) {
+                        return;
+                    }
+                    String requestId = requestIdObj.toString();
 
-                    if (participantsInfoCallback != null) {
-                        participantsInfoCallback.onReceived(participantInfoList);
-                        this.participantsInfoCallbackMap.remove(participantsInfoCallback);
+                    WeakReference<ParticipantsInfoCallback> ref = this.participantsInfoCallbackMap.remove(requestId);
+                    if (ref != null) {
+                        ParticipantsInfoCallback participantsInfoCallback = ref.get();
+                        if (participantsInfoCallback != null) {
+                            participantsInfoCallback.onReceived(participantInfoList);
+                        }
                     }
                 } catch (Exception e) {
                     JitsiMeetLogger.w(TAG + "error parsing participantsList", e);


### PR DESCRIPTION
### Fixes: #16774 

### What this PR does
Ensures callbacks in `ParticipantsService` are cleaned up correctly and safely handled when participant information is delivered.

### Details
- Cleans up callback entries using the request ID associated with the response.
- Safely handles cases where a callback reference is no longer available.

### Impact
- Improves robustness of the Android SDK callback flow.
- No behavior change for valid flows.
