### PR TITLE
feat(toolbox): change toolbox buttons in reduced ui

### DIFF
--- a/react/features/toolbox/components/web/Toolbox.tsx
+++ b/react/features/toolbox/components/web/Toolbox.tsx
@@ -251,10 +251,10 @@ export default function Toolbox({
         reducedUImainToolbarButtons,
     });
 
-    const mainMenuButtons = reducedUI
+    const mainMenuButtons = (reducedUI && reducedUImainToolbarButtons?.length)
         ? reducedUIButtons.mainMenuButtons
         : normalUIButtons.mainMenuButtons;
-    const overflowMenuButtons = reducedUI
+    const overflowMenuButtons = (reducedUI && reducedUImainToolbarButtons?.length)
         ? []
         : normalUIButtons.overflowMenuButtons;
     const raiseHandInOverflowMenu = overflowMenuButtons.some(({ key }) => key === 'raisehand');


### PR DESCRIPTION
We don't want to apply changes around toolbox buttons in reduced UI if reducedUImainToolbarButtons config is not defined.
