### PR TITLE
W.I.P. feat(responsive-ui): check if both width and height are below threshold

### DIFF
--- a/react/features/base/responsive-ui/actions.ts
+++ b/react/features/base/responsive-ui/actions.ts
@@ -112,7 +112,7 @@ export function setReducedUI(width: number, height: number) {
         const threshold = navigator.product === 'ReactNative'
             ? REDUCED_UI_THRESHOLD
             : WEB_REDUCED_UI_THRESHOLD;
-        const reducedUI = Math.min(width, height) < threshold;
+        const reducedUI = Math.max(width, height) < threshold;
 
         if (reducedUI !== getState()['features/base/responsive-ui'].reducedUI) {
             return dispatch({


### PR DESCRIPTION
Toolbar thresholds values below 320px are useless because reduced ui was applied if width or height is below threshold value. 

Right now reduced UI will be applied only if width and height values are below the default threshold. If not, we use the toolbar thresholds order.