### PR TITLE
Webpack hot-reload for SCSS fixed(#6677) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ deploy-local:
 dev: deploy-init deploy-css deploy-rnnoise-binary deploy-tflite deploy-meet-models deploy-lib-jitsi-meet deploy-olm deploy-tf-wasm deploy-excalidraw-dev deploy-face-landmarks
 	$(WEBPACK_DEV_SERVER)
 
+# Development with SCSS hot-reload: run this in a separate terminal alongside 'make dev'
+# Watches SCSS files and automatically recompiles to css/all.css when changes are detected
+dev-css: deploy-css
+	$(NPM) run watch-css
+
 source-package: compile deploy
 	mkdir -p source_package/jitsi-meet/css && \
 	cp -r *.js *.html resources/*.txt fonts images libs static sounds LICENSE lang source_package/jitsi-meet && \

--- a/app.js
+++ b/app.js
@@ -61,6 +61,12 @@ window.APP = {
     UI
 };
 
+// Import compiled CSS in development mode for hot-reload support.
+// In production, CSS is loaded via <link> tag in HTML.
+if (__DEV__) {
+    require('./css/all.css');
+}
+
 // TODO The execution of the mobile app starts from react/index.native.js.
 // Similarly, the execution of the Web app should start from react/index.web.js
 // for the sake of consistency and ease of understanding. Temporarily though

--- a/package.json
+++ b/package.json
@@ -215,6 +215,7 @@
     "lint-fix": "eslint --ext .js,.ts,.tsx --max-warnings 0 --fix .",
     "postinstall": "patch-package --error-on-fail && jetify",
     "validate": "npm ls",
+    "watch-css": "sass --watch css/main.scss:css/all.css --no-source-map",
     "start": "make dev",
     "test": "DOTENV_CONFIG_PATH=tests/.env wdio run tests/wdio.conf.ts",
     "test-single": "DOTENV_CONFIG_PATH=tests/.env wdio run tests/wdio.conf.ts --spec",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -157,7 +157,12 @@ function getConfig(options = {}) {
                 test: /\.css$/,
                 use: [
                     'style-loader',
-                    'css-loader'
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            url: false
+                        }
+                    }
                 ]
             }, {
                 test: /\.svg$/,


### PR DESCRIPTION
## Fixes: #6677

## What this PR does

Enables hot reload for SCSS changes when running the development server.

## Why

SCSS in Jitsi Meet is compiled via `deploy-css`, which runs only once. As a result, changes to `.scss` files do not regenerate `css/all.css`, so webpack never detects any updates and HMR does not trigger.

## How it works

- In development mode, the compiled `css/all.css` is imported into the webpack entry so it becomes part of the dependency graph.
- A dev-only SCSS watch command is added to continuously rebuild `css/all.css` whenever `.scss` files change.
- Webpack then detects the updated CSS file and applies hot reload automatically.

## Development workflow

```bash
# Terminal 1
make dev

# Terminal 2
make dev-css
     or
npm run watch-css