### PR TITLE
Enable text selection for readable content on the welcome page (fixed #4814)

### DIFF
--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -13,6 +13,21 @@ body.welcome-page {
     min-height: 100dvh;
     position: relative;
 
+    /**
+     * Enable text selection only for key welcome-page text.
+     * Overrides global user-select: none for user-facing readable content.
+     */
+     div,
+    .header-text-title,
+    .header-text-subtitle,
+    .welcome-footer-row-1-text,
+    .not-allow-title-character-text,
+    .insecure-room-name-warning span {
+        user-select: text;
+        -webkit-user-select: text;
+        -moz-user-select: text;
+    }
+
     .header {
         background-image: $welcomePageHeaderBackground;
         background-position: $welcomePageHeaderBackgroundPosition;
@@ -48,6 +63,7 @@ body.welcome-page {
             margin-bottom: $welcomePageHeaderTextTitleMarginBottom;
             max-width: $welcomePageHeaderTitleMaxWidth;
             opacity: $welcomePageHeaderTextTitleOpacity;
+            position: relative;
             text-align: $welcomePageHeaderTextAlign;
         }
 
@@ -57,6 +73,7 @@ body.welcome-page {
             font-weight: 600;
             line-height: 1.625rem;
             margin: 16px 0 32px 0;
+            position: relative;
             text-align: $welcomePageHeaderTextAlign;
 
         }


### PR DESCRIPTION
## Fixes: #4814

## What this PR does

Enables text selection for user-facing, readable content on the welcome (landing) page.

This overrides the global `user-select: none` rule only for specific text elements such as headings, descriptive text, and warnings, allowing users to copy and select meaningful content without affecting interactive UI behavior.

## Why

Text selection on the welcome page has been disabled for a long time, making it difficult to:
- copy descriptive or informational text,
- share or bookmark the page with context,
- copy warning or validation messages.

This issue has been reported previously and is still reproducible on the current welcome page.

## Scope

- Scoped strictly to the welcome page
- CSS-only change
- No global behavior changes
- No impact on in-call UI or interactions
