### PR TITLE
fix(turnserver): no dtls

### DIFF
--- a/doc/debian/jitsi-meet-turn/turnserver.conf
+++ b/doc/debian/jitsi-meet-turn/turnserver.conf
@@ -10,6 +10,7 @@ no-cli
 no-loopback-peers
 no-tcp-relay
 no-tcp
+no-dtls
 listening-port=3478
 tls-listening-port=5349
 no-tlsv1


### PR DESCRIPTION
The current config allows DTLS (`UDP/5349`) that is not usable for Jitsi. It should be disabled with `no-dtls` like `no-tcp` in the same config file.

In this case, only TURN's UDP (`UDP/3478`)  and TURNS' TCP (`TCP/5349`) will be available which are the correct settings for Jitsi.