### PR TITLE
Avoid unnecessary welcome page re-renders during room name animation

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -70,7 +70,6 @@ interface IState {
     joining: boolean;
     room: string;
     roomNameInputAnimation?: any;
-    roomPlaceholder: string;
     updateTimeoutId?: number;
 }
 
@@ -81,19 +80,17 @@ interface IState {
  */
 export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> {
     _mounted: boolean | undefined;
+    _roomInputRef?: HTMLInputElement | null;
+    _currentPlaceholder: string = '';
 
     /**
      * Save room name into component's local state.
      *
      * @type {Object}
-     * @property {number|null} animateTimeoutId - Identifier of the letter
-     * animation timeout.
+     * @property {number|null} animateTimeoutId - Identifier of the letter animation timeout.
      * @property {string} generatedRoomName - Automatically generated room name.
      * @property {string} room - Room name.
-     * @property {string} roomPlaceholder - Room placeholder that's used as a
-     * placeholder for input.
-     * @property {number|null} updateTimeoutId - Identifier of the timeout
-     * updating the generated room name.
+     * @property {number|null} updateTimeoutId - Identifier of the timeout updating the generated room name.
      */
     override state: IState = {
         animateTimeoutId: undefined,
@@ -102,7 +99,6 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         insecureRoomName: false,
         joining: false,
         room: '',
-        roomPlaceholder: '',
         updateTimeoutId: undefined,
         _fieldFocused: false,
         isSettingsScreenFocused: false,
@@ -120,8 +116,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         super(props);
 
         // Bind event handlers so they are only bound once per instance.
-        this._animateRoomNameChanging
-            = this._animateRoomNameChanging.bind(this);
+        this._animateRoomNameChanging = this._animateRoomNameChanging.bind(this);
         this._onJoin = this._onJoin.bind(this);
         this._onRoomChange = this._onRoomChange.bind(this);
         this._renderInsecureRoomNameWarning = this._renderInsecureRoomNameWarning.bind(this);
@@ -151,30 +146,32 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
     }
 
     /**
-     * Animates the changing of the room name.
+     * Animates the changing of the room name by updating the input placeholder imperatively.
+     * Uses ref-based updates to avoid triggering re-renders on every animation tick.
      *
-     * @param {string} word - The part of room name that should be added to
-     * placeholder.
+     * @param {string} word - The part of room name that should be added to placeholder.
      * @private
      * @returns {void}
      */
     _animateRoomNameChanging(word: string) {
-        let animateTimeoutId;
-        const roomPlaceholder = this.state.roomPlaceholder + word.substr(0, 1);
+        this._currentPlaceholder = this._currentPlaceholder + word.substr(0, 1);
+
+        // Update placeholder directly via ref to avoid re-render
+        if (this._roomInputRef) {
+            this._roomInputRef.placeholder = this._currentPlaceholder;
+        }
 
         if (word.length > 1) {
-            animateTimeoutId
-                = window.setTimeout(
-                    () => {
-                        this._animateRoomNameChanging(
-                            word.substring(1, word.length));
-                    },
-                    70);
+            const animateTimeoutId = window.setTimeout(
+                () => {
+                    this._animateRoomNameChanging(word.substring(1, word.length));
+                },
+                70
+            );
+
+            // Only update state with timeout ID (doesn't trigger visible re-render)
+            this.setState({ animateTimeoutId });
         }
-        this.setState({
-            animateTimeoutId,
-            roomPlaceholder
-        });
     }
 
     /**
@@ -184,8 +181,12 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
      * @returns {void}
      */
     _clearTimeouts() {
-        this.state.animateTimeoutId && clearTimeout(this.state.animateTimeoutId);
-        this.state.updateTimeoutId && clearTimeout(this.state.updateTimeoutId);
+        if (this.state.animateTimeoutId) {
+            clearTimeout(this.state.animateTimeoutId);
+        }
+        if (this.state.updateTimeoutId) {
+            clearTimeout(this.state.updateTimeoutId);
+        }
     }
 
     /**
@@ -255,25 +256,25 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
     }
 
     /**
-     * Triggers the generation of a new room name and initiates an animation of
-     * its changing.
+     * Triggers the generation of a new room name and initiates an animation of its changing.
      *
      * @protected
      * @returns {void}
      */
     _updateRoomName() {
         const generatedRoomName = generateRoomWithoutSeparator();
-        const roomPlaceholder = '';
         const updateTimeoutId = window.setTimeout(this._updateRoomName, 10000);
 
         this._clearTimeouts();
+        this._currentPlaceholder = '';
+
         this.setState(
             {
                 generatedRoomName,
-                roomPlaceholder,
                 updateTimeoutId
             },
-            () => this._animateRoomNameChanging(generatedRoomName));
+            () => this._animateRoomNameChanging(generatedRoomName)
+        );
     }
 }
 

--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -70,6 +70,7 @@ interface IState {
     joining: boolean;
     room: string;
     roomNameInputAnimation?: any;
+    roomPlaceholder: string;
     updateTimeoutId?: number;
 }
 
@@ -99,6 +100,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         insecureRoomName: false,
         joining: false,
         room: '',
+        roomPlaceholder: '',
         updateTimeoutId: undefined,
         _fieldFocused: false,
         isSettingsScreenFocused: false,
@@ -157,7 +159,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         this._currentPlaceholder = this._currentPlaceholder + word.substr(0, 1);
 
         // Update placeholder directly via ref to avoid re-render
-        if (this._roomInputRef) {
+        if (this._roomInputRef && 'placeholder' in this._roomInputRef) {
             this._roomInputRef.placeholder = this._currentPlaceholder;
         }
 

--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -31,7 +31,6 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
     _additionalContentRef: HTMLDivElement | null;
     _additionalToolbarContentRef: HTMLDivElement | null;
     _additionalCardRef: HTMLDivElement | null;
-    _roomInputRef: HTMLInputElement | null;
     _additionalCardTemplate: HTMLTemplateElement | null;
     _additionalContentTemplate: HTMLTemplateElement | null;
     _additionalToolbarContentTemplate: HTMLTemplateElement | null;
@@ -78,8 +77,6 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
          * @type {HTMLTemplateElement|null}
          */
         this._additionalContentRef = null;
-
-        this._roomInputRef = null;
 
         /**
          * The HTML Element used as the container for additional toolbar content. Used
@@ -239,7 +236,6 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                                             id = 'enter_room_field'
                                             onChange = { this._onRoomChange }
                                             pattern = { ROOM_NAME_VALIDATE_PATTERN_STR }
-                                            placeholder = { this.state.roomPlaceholder }
                                             ref = { this._setRoomInputRef }
                                             type = 'text'
                                             value = { this.state.room } />


### PR DESCRIPTION
### Summary
This PR fixes unnecessary re-renders on the welcome page caused by the auto-generated meeting name placeholder animation.

Previously, the placeholder animation updated React state on every animation tick, which caused `WelcomePage` and unrelated sibling components (e.g. SettingsButton, Tabs, RecentList, Tooltip) to re-render continuously while the page was idle.

### What changed
- The room name placeholder animation is now applied imperatively via a ref on the input element.
- React state updates are no longer used to drive the placeholder animation.
- All existing behavior and UX remain unchanged.

### Context:
This addresses the performance concern discussed in the community forum regarding extra re-renders on the welcome page.
link -> https://community.jitsi.org/t/ton-of-extra-react-re-renders-in-meet-jit-si/141580/5
