### PR TITLE
Fix infinite meeting name placeholder animation on Welcome screen

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -162,8 +162,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         const roomPlaceholder = this.state.roomPlaceholder + word.substr(0, 1);
 
         if (word.length > 1) {
-            animateTimeoutId
-                = window.setTimeout(
+            animateTimeoutId = window.setTimeout(
                     () => {
                         this._animateRoomNameChanging(
                             word.substring(1, word.length));
@@ -238,6 +237,8 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
             room: value,
             insecureRoomName: Boolean(this.props._enableInsecureRoomNameWarning && value && isInsecureRoomName(value))
         });
+
+        if(!value) this._updateRoomName();
     }
 
     /**
@@ -266,13 +267,17 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
         const updateTimeoutId = window.setTimeout(this._updateRoomName, 10000);
 
         this._clearTimeouts();
+
         this.setState(
             {
                 generatedRoomName,
                 roomPlaceholder,
                 updateTimeoutId
             },
-            () => this._animateRoomNameChanging(generatedRoomName));
+            () => {
+                if(this.state.room) this._clearTimeouts();
+                else this._animateRoomNameChanging(generatedRoomName)
+            });
     }
 }
 

--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -238,7 +238,7 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
             insecureRoomName: Boolean(this.props._enableInsecureRoomNameWarning && value && isInsecureRoomName(value))
         });
 
-        if(!value) this._updateRoomName();
+        if (!value) this._updateRoomName();
     }
 
     /**
@@ -275,8 +275,8 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
                 updateTimeoutId
             },
             () => {
-                if(this.state.room) this._clearTimeouts();
-                else this._animateRoomNameChanging(generatedRoomName)
+                if (this.state.room) this._clearTimeouts();
+                else this._animateRoomNameChanging(generatedRoomName);
             });
     }
 }


### PR DESCRIPTION
Stops the animated meeting name placeholder on the Welcome screen once the user enters a custom value.

The animation previously continued indefinitely after user input, triggering repeated state updates and unnecessary re-renders. This change scopes updates only to the input when a user-provided name is present.

Fixes  #16809
