### PR TITLE
ci: fix android SDK build by removing unused preinstalled tools from github runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,16 @@ jobs:
     container: 
       image: reactnativecommunity/react-native-android:v15.0
       volumes:
-        - /usr/local:/host/usr/local
+        - /usr:/host/usr
     steps:
     - name: Make space in image by removing preinstalled, but unused SDKs
       run: |
+        df -h /
         rm -rf /host/usr/local/lib/android
         rm -rf /host/usr/local/.ghcup
+        rm -rf /host/usr/share/dotnet
+        rm -rf /host/usr/share/swift
+        df -h /
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:


### PR DESCRIPTION
The android SDK build anyway uses a docker image with react native and an android SDK inside, so remove android, haskell, dotnet and swift from the host runner, freeing up 26GB, so increasing available space from 14GB to 40GB free space.
