### PR TITLE
fix(android): support String[] config overrides in mergeProps

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -30,6 +30,9 @@ import com.facebook.react.ReactRootView;
 
 import org.jitsi.meet.sdk.log.JitsiMeetLogger;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 
 public class JitsiMeetView extends FrameLayout {
 
@@ -84,6 +87,10 @@ public class JitsiMeetView extends FrameLayout {
                 result.putInt(key, (int)bValue);
             } else if (valueType.contentEquals("Bundle")) {
                 result.putBundle(key, mergeProps((Bundle)aValue, (Bundle)bValue));
+            } else if (valueType.contentEquals("String[]")) {
+                // Convert String[] to ArrayList<String> for React Native bridge compatibility
+                String[] stringArray = (String[]) bValue;
+                result.putStringArrayList(key, new ArrayList<>(Arrays.asList(stringArray)));
             } else {
                 throw new RuntimeException("Unsupported type: " + valueType);
             }


### PR DESCRIPTION
### Fixes: #16825 

### Summary

Fixes a crash in the Android SDK when passing array-based config overrides (e.g. `config.toolbarButtons`) from Kotlin.

The crash occurred with `RuntimeException: Unsupported type: String[]` during props merging.

---

### Root Cause

`JitsiMeetConferenceOptions.Builder.setConfigOverride()` accepts `String[]` values and stores them in a `Bundle`.

When these props are merged in `JitsiMeetView.mergeProps()`, the method did not support `String[]` types and would throw a `RuntimeException`.

---

### Changes

- Extend `mergeProps()` to explicitly handle `String[]` values
- Convert `String[]` to `ArrayList<String>` and store via `Bundle.putStringArrayList`
- Preserve existing behavior for all other supported types and error cases



