### PR TITLE
 GSoC: docs: fix Contributing Guidelines link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,4 +264,4 @@ react/features/sample/
 - [Jitsi Handbook](https://jitsi.github.io/handbook/) - Comprehensive documentation
 - [Community Forum](https://community.jitsi.org/) - Ask questions and get support
 - [Architecture Guide](https://jitsi.github.io/handbook/docs/architecture) - System overview
-- [Contributing Guidelines](https://jitsi.github.io/handbook/docs/dev-guide/contributing) - Detailed contribution process
+- [Contributing Guidelines](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-contributing/) - Detailed contribution process


### PR DESCRIPTION
Fixes a broken External Resources link that was leading to a Page Not Found error.
