### PR TITLE
fix(gifs): prevent GIF popover from closing on internal clicks

### DIFF
--- a/react/features/gifs/components/web/GifsMenu.tsx
+++ b/react/features/gifs/components/web/GifsMenu.tsx
@@ -191,12 +191,20 @@ function GifsMenu({ columns = 2, parent }: IProps) {
         e.stopPropagation();
     }, []);
 
+    // Prevent clicks inside the GIFs menu content (including the search input)
+    // from bubbling to the global window click handler used by Popover for
+    // outside-click dismissal.
+    const stopClickPropagation = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation();
+    }, []);
+
     const gifMenu = (
         <div
             className = { cx(styles.gifsMenu,
                 parent === IReactionsMenuParent.OverflowDrawer && styles.overflowDrawerMenu,
                 parent === IReactionsMenuParent.OverflowMenu && styles.overflowMenu
-            ) }>
+            ) }
+            onClick = { stopClickPropagation }>
             <Input
                 autoFocus = { true }
                 className = { cx(styles.searchField, 'gif-input') }


### PR DESCRIPTION
### Description

This PR fixes an issue where the GIF menu inside the reactions popover would close immediately when clicking inside it (e.g. focusing the search input).

This happened because the GIF menu content is rendered in a portal, causing internal clicks to be treated as outside clicks by the popover’s global click handler.

The fix ensures that clicks originating from within the GIF menu do not bubble to the window-level outside-click listener, while preserving the existing behavior for true outside clicks.

### Root Cause

- The reactions popover registers a global `window.click` listener to handle outside-click dismissal.
- The GIF menu content is rendered via a portal, outside the popover trigger’s DOM subtree.
- As a result, clicks inside the GIF search input were interpreted as outside clicks and closed the popover.
- Other interactive elements (e.g. GIF tiles) already stopped click propagation, but the menu container did not.

### Solution

- Stop click propagation at the root container of the GIF menu.
- This prevents internal interactions (search input, scrolling, GIF selection) from reaching the popover’s outside-click handler.
- No changes were made to shared popover infrastructure to avoid unintended regressions.

### References

- Jitsi Community Forum discussion where this issue was originally reported:  [Link](https://community.jitsi.org/t/gif-popover-closes-when-clicking-inside-it/141634)