### PR TITLE
fix(chat): correct invalid vendor-prefixed inline style

### DIFF
--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -132,7 +132,7 @@ const useStyles = makeStyles<{ _isResizing: boolean; width: number; }>()((theme,
 
             '*': {
                 userSelect: 'text',
-                '-webkit-user-select': 'text'
+                WebkitUserSelect: 'text'
             }
         },
 


### PR DESCRIPTION
### What does this PR do?

Fixes a React console warning caused by using a kebab-case
vendor-prefixed CSS property in an inline style object in the Chat
component.

### Why is this needed?

React does not support kebab-case CSS property names in inline style
objects. The existing key was ignored by React and triggered a runtime
warning.

### How was this tested?

- Ran the app locally
- Verified the Chat component renders correctly
- Confirmed the related React console warning is no longer shown
