### PR TITLE
fix(input): correct invalid vendor-prefixed inline styles

### DIFF
--- a/react/features/base/ui/components/web/Input.tsx
+++ b/react/features/base/ui/components/web/Input.tsx
@@ -107,12 +107,12 @@ const useStyles = makeStyles()(theme => {
         },
 
         'input::-webkit-outer-spin-button, input::-webkit-inner-spin-button': {
-            '-webkit-appearance': 'none',
+            'WebkitAppearance': 'none',
             margin: 0
         },
 
         'input[type=number]': {
-            '-moz-appearance': 'textfield'
+            'MozAppearance': 'textfield'
         },
 
         icon: {


### PR DESCRIPTION
### What does this PR do?

Fixes React console warnings caused by using kebab-case
vendor-prefixed CSS properties in an inline style object
in the Input component.

### Why is this needed?

React does not support kebab-case CSS property names
in JavaScript style objects. These keys are ignored
and trigger warnings in development mode.

### How was this tested?

- Ran the app locally
- Verified the Input component renders correctly
- Confirmed the related React warnings are no longer shown
