### PR TITLE
add lower sorbian language to transcription and translation

### DIFF
--- a/lang/translation-languages.json
+++ b/lang/translation-languages.json
@@ -14,6 +14,7 @@
     "cy": "Welsh",
     "da": "Danish",
     "de": "German",
+    "dsb": "Lower Sorbian",
     "el": "Greek",
     "en": "English",
     "eo": "Esperanto",

--- a/react/features/transcribing/jitsi-bcp47-map.json
+++ b/react/features/transcribing/jitsi-bcp47-map.json
@@ -7,6 +7,7 @@
     "cs": "cs-CZ",
     "da": "da-DK",
     "de": "de-DE",
+    "dsb": "dsb-DE",
     "el": "el-GR",
     "enGB": "en-GB",
     "es": "es-ES",

--- a/react/features/transcribing/transcriber-langs.json
+++ b/react/features/transcribing/transcriber-langs.json
@@ -6,6 +6,7 @@
     "cs-CZ": "Czech (Czech Republic)",
     "da-DK": "Danish (Denmark)",
     "de-DE": "German (Germany)",
+    "dsb-DE": "Lower Sorbian (Germany)",
     "en-AU": "English (Australia)",
     "en-CA": "English (Canada)",
     "en-GB": "English (United Kingdom)",


### PR DESCRIPTION
Please add "Lower Sorbian" (ISO 639 code "dsb") to the list of languages for transcription and translation.

CLA has been signed already a while ago.