### PR TITLE
feat(dynamic-branding): Adds more options for overriding translations.

### DIFF
--- a/react/features/base/i18n/functions.tsx
+++ b/react/features/base/i18n/functions.tsx
@@ -8,13 +8,14 @@ import i18next from './i18next';
  *
  * @param {string} language - The language e.g. 'en', 'fr'.
  * @param {string} url - The url of the translation bundle.
+ * @param {string} ns - The namespace of the translation bundle.
  * @returns {void}
  */
-export async function changeLanguageBundle(language: string, url: string) {
+export async function changeLanguageBundle(language: string, url: string, ns = 'main') {
     const res = await fetch(url);
     const bundle = await res.json();
 
-    i18next.addResourceBundle(language, 'main', bundle, true, true);
+    i18next.addResourceBundle(language, ns, bundle, true, true);
 }
 
 /**

--- a/react/features/base/i18n/i18next.ts
+++ b/react/features/base/i18n/i18next.ts
@@ -59,6 +59,14 @@ export const DEFAULT_LANGUAGE = 'en';
 export const TRANSLATION_LANGUAGES_HEAD: Array<string> = [ DEFAULT_LANGUAGE ];
 
 /**
+ * The available/supported i18n namespaces.
+ *
+ * @public
+ * @type {Array<string>}
+ */
+export const SUPPORTED_NS = [ 'main', 'languages', 'countries', 'translation-languages' ];
+
+/**
  * The options to initialize i18next with.
  *
  * @type {i18next.InitOptions}
@@ -81,7 +89,7 @@ const options: i18next.InitOptions = {
         escapeValue: false // not needed for react as it escapes by default
     },
     load: 'all',
-    ns: [ 'main', 'languages', 'countries', 'translation-languages' ],
+    ns: SUPPORTED_NS,
     react: {
         // re-render when a new resource bundle is added
         // @ts-expect-error. Fixed in i18next 19.6.1.


### PR DESCRIPTION
In branding you can add now
"labels-translation-languages": {
        "en": "/static/translation-overwritten-en.json"
    }

This allows overwriting strings from the translation-languages namespace, till now it was possible only for the main one.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
