### PR TITLE
add lower sorbian

### DIFF
--- a/react/features/transcribing/jitsi-bcp47-map.json
+++ b/react/features/transcribing/jitsi-bcp47-map.json
@@ -7,6 +7,7 @@
     "cs": "cs-CZ",
     "da": "da-DK",
     "de": "de-DE",
+    "dsb": "dsb-DE",
     "el": "el-GR",
     "enGB": "en-GB",
     "es": "es-ES",


### PR DESCRIPTION
This is a one-liner to add the lower sorbian language to jitsi meet's internal mapping of primary language codes to BCP47 codes. This shall make it possible to properly support lower sorbian translation (and transcription) functionality in Jitsi with custom implementations of speech recognizers and text translators, in combination with "custom branding" even with a proper UI.