### PR TITLE
fix(recording) Restores track mute state to original state after consent is provided.

### DIFF
--- a/react/features/recording/components/Recording/native/RecordingConsentDialog.tsx
+++ b/react/features/recording/components/Recording/native/RecordingConsentDialog.tsx
@@ -8,19 +8,20 @@ import ConfirmDialog from '../../../../base/dialog/components/native/ConfirmDial
 import { setAudioMuted, setAudioUnmutePermissions, setVideoMuted, setVideoUnmutePermissions } from '../../../../base/media/actions';
 import { VIDEO_MUTISM_AUTHORITY } from '../../../../base/media/constants';
 import Link from '../../../../base/react/components/native/Link';
+import { IRecordingConsentDialogProps } from '../../../reducer';
 import styles from '../styles.native';
 
 /**
  * Component that renders the dialog for explicit consent for recordings.
  *
+ * @param {IRecordingConsentDialogProps} props - The component props.
  * @returns {JSX.Element}
  */
-export default function RecordingConsentDialog() {
+export default function RecordingConsentDialog({ audioWasMuted = false, videoWasMuted = false }: IRecordingConsentDialogProps) {
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const { recordings } = useSelector((state: IReduxState) => state['features/base/config']);
     const { consentLearnMoreLink } = recordings ?? {};
-
 
     const consent = useCallback(() => {
         dispatch(setAudioUnmutePermissions(false, true));
@@ -32,11 +33,13 @@ export default function RecordingConsentDialog() {
     const consentAndUnmute = useCallback(() => {
         dispatch(setAudioUnmutePermissions(false, true));
         dispatch(setVideoUnmutePermissions(false, true));
-        dispatch(setAudioMuted(false, true));
-        dispatch(setVideoMuted(false, VIDEO_MUTISM_AUTHORITY.USER, true));
+
+        // Restore to the mute state before consent was requested.
+        dispatch(setAudioMuted(audioWasMuted, false));
+        dispatch(setVideoMuted(videoWasMuted, VIDEO_MUTISM_AUTHORITY.USER, false));
 
         return true;
-    }, []);
+    }, [ audioWasMuted, videoWasMuted ]);
 
     return (
         <ConfirmDialog

--- a/react/features/recording/components/Recording/web/RecordingConsentDialog.tsx
+++ b/react/features/recording/components/Recording/web/RecordingConsentDialog.tsx
@@ -10,6 +10,7 @@ import { grantRecordingConsent, grantRecordingConsentAndUnmute } from '../../../
 
 /**
  * Component that renders the dialog for explicit consent for recordings.
+ * The prejoin mute state is read from Redux by the action creator.
  *
  * @returns {JSX.Element}
  */

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -421,12 +421,21 @@ function _showExplicitConsentDialog(recorderSession: any, dispatch: IStore['disp
         return;
     }
 
+    // Capture the current mute state BEFORE forcing mute for consent
+    // This preserves the user's intentional mute choices from prejoin or initial settings
+    const state = getState();
+    const audioWasMuted = state['features/base/media'].audio.muted;
+    const videoWasMuted = state['features/base/media'].video.muted;
+
     batch(() => {
         dispatch(markConsentRequested(recorderSession.getID()));
         dispatch(setAudioUnmutePermissions(true, true));
         dispatch(setVideoUnmutePermissions(true, true));
         dispatch(setAudioMuted(true));
         dispatch(setVideoMuted(true));
-        dispatch(openDialog('RecordingConsentDialog', RecordingConsentDialog));
+        dispatch(openDialog('RecordingConsentDialog', RecordingConsentDialog, {
+            audioWasMuted,
+            videoWasMuted
+        }));
     });
 }

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -43,6 +43,14 @@ export interface IRecordingState {
 }
 
 /**
+ * Props for the RecordingConsentDialog component.
+ */
+export interface IRecordingConsentDialogProps {
+    audioWasMuted?: boolean;
+    videoWasMuted?: boolean;
+}
+
+/**
  * The name of the Redux store this feature stores its state in.
  */
 const STORE_NAME = 'features/recording';


### PR DESCRIPTION

Do not forcefully unmute audio and video if the user consents to being recorded and wants to stay unmuted but was muted before hitting join.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
