### PR TITLE
feat(subtitles): rework how isAsyncTranscriptionEnabled is being used

### DIFF
--- a/react/features/chat/components/AbstractClosedCaptions.tsx
+++ b/react/features/chat/components/AbstractClosedCaptions.tsx
@@ -15,7 +15,6 @@ export type AbstractProps = {
     canStartSubtitles: boolean;
     filteredSubtitles: ISubtitle[];
     groupedSubtitles: IMessageGroup<ISubtitle>[];
-    isAsyncTranscriptionEnabled: boolean | undefined;
     isButtonPressed: boolean;
     isTranscribing: boolean;
     startClosedCaptions: () => void;
@@ -102,7 +101,6 @@ const AbstractClosedCaptions = (Component: ComponentType<AbstractProps>) => () =
             canStartSubtitles = { _canStartSubtitles }
             filteredSubtitles = { filteredSubtitles }
             groupedSubtitles = { groupedSubtitles }
-            isAsyncTranscriptionEnabled = { isAsyncTranscriptionEnabled }
             isButtonPressed = { isButtonPressed }
             isTranscribing = { _isTranscribing }
             startClosedCaptions = { startClosedCaptions } />

--- a/react/features/chat/components/native/ClosedCaptions.tsx
+++ b/react/features/chat/components/native/ClosedCaptions.tsx
@@ -31,7 +31,6 @@ const ClosedCaptions = ({
     canStartSubtitles,
     filteredSubtitles,
     groupedSubtitles,
-    isAsyncTranscriptionEnabled,
     isButtonPressed,
     isTranscribing,
     startClosedCaptions
@@ -43,6 +42,8 @@ const ClosedCaptions = ({
     const navigateToLanguageSelect = useCallback(() => {
         navigate(screen.conference.subtitles);
     }, [ navigation, screen ]);
+    const isAsyncTranscriptionEnabled = useSelector((state: IReduxState) =>
+        state['features/base/conference'].conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
 
     useEffect(() => {
         navigation?.setOptions({

--- a/react/features/chat/components/web/ClosedCaptionsTab.tsx
+++ b/react/features/chat/components/web/ClosedCaptionsTab.tsx
@@ -76,7 +76,6 @@ const ClosedCaptionsTab = ({
     canStartSubtitles,
     filteredSubtitles,
     groupedSubtitles,
-    isAsyncTranscriptionEnabled,
     isButtonPressed,
     isTranscribing,
     startClosedCaptions
@@ -115,7 +114,7 @@ const ClosedCaptionsTab = ({
 
     return (
         <div className = { classes.container }>
-            <LanguageSelector isAsyncTranscriptionEnabled = { isAsyncTranscriptionEnabled } />
+            <LanguageSelector />
             <div className = { classes.messagesContainer }>
                 <SubtitlesMessagesContainer
                     groups = { groupedSubtitles }

--- a/react/features/subtitles/components/web/LanguageSelector.tsx
+++ b/react/features/subtitles/components/web/LanguageSelector.tsx
@@ -8,10 +8,6 @@ import Select from '../../../base/ui/components/web/Select';
 import { setRequestingSubtitles } from '../../actions.any';
 import { getAvailableSubtitlesLanguages } from '../../functions.any';
 
-interface IProps {
-    isAsyncTranscriptionEnabled: boolean | undefined;
-}
-
 /**
  * The styles for the LanguageSelector component.
  *
@@ -43,10 +39,9 @@ const useStyles = makeStyles()(theme => {
  * Uses the same language options as LanguageSelectorDialog and
  * updates the subtitles language preference in Redux.
  *
- * @param {IProps} props - The component props.
  * @returns {JSX.Element} - The rendered component.
  */
-function LanguageSelector({ isAsyncTranscriptionEnabled }: IProps) {
+function LanguageSelector() {
     const { t } = useTranslation();
     const { classes } = useStyles();
     const dispatch = useDispatch();
@@ -55,6 +50,8 @@ function LanguageSelector({ isAsyncTranscriptionEnabled }: IProps) {
         state,
         selectedLanguage?.replace('translation-languages:', '')
     ));
+    const isAsyncTranscriptionEnabled = useSelector((state: IReduxState) =>
+        state['features/base/conference'].conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
 
     // Hide the "Translate to" option when asyncTranscription is enabled
     if (isAsyncTranscriptionEnabled) {


### PR DESCRIPTION
The previous approach was inconsistent because of prop drilling between AbstractClosedCaptions and LanguageSelector components.
