### PR TITLE
feat(responsive-ui): make reduced UI threshold configurable

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -61,10 +61,10 @@ type NotifyClickButtonKey = string |
     ParticipantMenuButtonsWithNotifyClick;
 
 export type NotifyClickButton = NotifyClickButtonKey |
-    {
-        key: NotifyClickButtonKey;
-        preventExecution: boolean;
-    };
+{
+    key: NotifyClickButtonKey;
+    preventExecution: boolean;
+};
 
 export type Sounds = 'ASKED_TO_UNMUTE_SOUND' |
     'E2EE_OFF_SOUND' |
@@ -560,6 +560,7 @@ export interface IConfig {
         suggestRecording?: boolean;
     };
     reducedUIEnabled?: boolean;
+    reducedUIThreshold?: number;
     reducedUImainToolbarButtons?: Array<string>;
     remoteVideoMenu?: {
         disableDemote?: boolean;

--- a/react/features/base/responsive-ui/actions.ts
+++ b/react/features/base/responsive-ui/actions.ts
@@ -87,7 +87,7 @@ export function setAspectRatio(width: number, height: number) {
                 = width < height ? ASPECT_RATIO_NARROW : ASPECT_RATIO_WIDE;
 
             if (aspectRatio
-                    !== getState()['features/base/responsive-ui'].aspectRatio) {
+                !== getState()['features/base/responsive-ui'].aspectRatio) {
                 return dispatch({
                     type: SET_ASPECT_RATIO,
                     aspectRatio
@@ -110,9 +110,18 @@ export function setAspectRatio(width: number, height: number) {
  */
 export function setReducedUI(width: number, height: number) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
-        const threshold = navigator.product === 'ReactNative'
+        let threshold = navigator.product === 'ReactNative'
             ? REDUCED_UI_THRESHOLD
             : WEB_REDUCED_UI_THRESHOLD;
+
+        if (navigator.product !== 'ReactNative') {
+            const { reducedUIThreshold } = getState()['features/base/config'];
+
+            if (typeof reducedUIThreshold === 'number') {
+                threshold = reducedUIThreshold;
+            }
+        }
+
         const reducedUI = Math.max(width, height) < threshold;
 
         if (reducedUI !== getState()['features/base/responsive-ui'].reducedUI) {


### PR DESCRIPTION
This PR addresses the flexibility limitations discussed in #16854.

## Motivation
Currently, "Reduced UI" mode is hardcoded to trigger at `320px`. While recent changes allow disabling it, there are use cases (e.g., narrow sidebars, embedded views) where a custom threshold (e.g., 250px) is preferred over completely disabling the feature.

## Changes
- **New Config Option:** Adds `reducedUIThreshold` to `config.js` options.
- **Logic:** Updates `setReducedUI` to respect this configuration, falling back to the default 320px if undefined.

This gives deployments granular control over when the UI simplifies.