### PR TITLE
fix(welcome): stop meeting name animation when typing

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -235,6 +235,14 @@ export class AbstractWelcomePage<P extends IProps> extends Component<P, IState> 
      * @returns {void}
      */
     _onRoomChange(value: string) {
+        // v2: Better handling - stop animation when typing,
+        // but only restart it if the feature is actually enabled in config.
+        if (value.length > 0) {
+            this._clearTimeouts();
+        } else if (this.state.generateRoomNames) {
+            this._updateRoomName();
+        }
+
         this.setState({
             room: value,
             insecureRoomName: Boolean(this.props._enableInsecureRoomNameWarning && value && isInsecureRoomName(value))


### PR DESCRIPTION
Fixes #16809

### Description
This PR addresses issue #16809 ("Animated meeting name placeholder continues after user input").

**The Problem:**
Previously, the meeting name generator would continue its animation loop (calculating a new random name every 70ms) even after the user started typing. This caused unnecessary CPU usage and potential input lag.

**The Fix:**
- Immediately stops the animation timeout when the user types into the input field.
- Ensures the animation only restarts if the input is cleared AND the `GENERATE_ROOMNAMES_ON_WELCOME_PAGE` config is enabled.

**Why This Solution is Better:**
- **Immediate Response**: Stops the animation instantly (0ms delay) rather than waiting for the next timer tick (up to 10s delay).
- **Config Awareness**: Correctly checks `generateRoomNames` state before restarting, preventing unwanted restarts if the feature is disabled.
- **Performance**: Eliminates unnecessary background processing while user is typing, improving battery life and responsiveness.

### Testing
Verified locally that:
1. Animation stops immediately when user types
2. Animation restarts when input is cleared (if feature is enabled)
3. No background processing occurs while typing