### PR TITLE
fix(settings): Fixes rendering a tab when props change.

### DIFF
--- a/react/features/base/ui/components/web/DialogWithTabs.tsx
+++ b/react/features/base/ui/components/web/DialogWithTabs.tsx
@@ -301,7 +301,7 @@ const DialogWithTabs = ({
         }
 
         return null;
-    }, [ selectedTabIndex, tabStates ]);
+    }, [ selectedTabIndex, tabStates, tabs ]);
 
     const closeIcon = useMemo(() => (
         <ClickableIcon


### PR DESCRIPTION
The Profile tab can display logged in state and auth id used for it. It does not re-render when this changes in the background.
