### PR TITLE
chore: add @deprecated JSDoc annotations to legacy config options

### DIFF
--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -61,10 +61,10 @@ type NotifyClickButtonKey = string |
     ParticipantMenuButtonsWithNotifyClick;
 
 export type NotifyClickButton = NotifyClickButtonKey |
-    {
-        key: NotifyClickButtonKey;
-        preventExecution: boolean;
-    };
+{
+    key: NotifyClickButtonKey;
+    preventExecution: boolean;
+};
 
 export type Sounds = 'ASKED_TO_UNMUTE_SOUND' |
     'E2EE_OFF_SOUND' |
@@ -196,7 +196,14 @@ export interface IConfig {
         opusMaxAverageBitrate?: number | null;
         stereo?: boolean;
     };
+    /**
+     * @deprecated Use `transcription.autoTranscribeOnRecord` instead.
+     */
     autoCaptionOnRecord?: boolean;
+
+    /**
+     * @deprecated Use `lobby.autoKnock` instead.
+     */
     autoKnockLobby?: boolean;
     backgroundAlpha?: number;
     bosh?: string;
@@ -287,13 +294,22 @@ export interface IConfig {
     disableCameraTintForeground?: boolean;
     disableChat?: boolean;
     disableChatSmileys?: boolean;
+    /**
+     * @deprecated Use `deeplinking.disabled` instead.
+     */
     disableDeepLinking?: boolean;
     disableFilmstripAutohiding?: boolean;
     disableFocus?: boolean;
     disableIframeAPI?: boolean;
+    /**
+     * @deprecated Use `disabledSounds` instead.
+     */
     disableIncomingMessageSound?: boolean;
     disableInitialGUM?: boolean;
     disableInviteFunctions?: boolean;
+    /**
+     * @deprecated Use `disabledSounds` instead.
+     */
     disableJoinLeaveSounds?: boolean;
     disableLocalVideoFlip?: boolean;
     disableModeratorIndicator?: boolean;
@@ -303,9 +319,15 @@ export interface IConfig {
     disableReactions?: boolean;
     disableReactionsInChat?: boolean;
     disableReactionsModeration?: boolean;
+    /**
+     * @deprecated Use `disabledSounds` instead.
+     */
     disableRecordAudioNotification?: boolean;
     disableRemoteControl?: boolean;
     disableRemoteMute?: boolean;
+    /**
+     * @deprecated Use `raisedHands.disableRemoveRaisedHandOnFocus` instead.
+     */
     disableRemoveRaisedHandOnFocus?: boolean;
     disableResponsiveTiles?: boolean;
     disableRtx?: boolean;
@@ -315,6 +337,9 @@ export interface IConfig {
     disableShortcuts?: boolean;
     disableShowMoreStats?: boolean;
     disableSimulcast?: boolean;
+    /**
+     * @deprecated Use `speakerStats.disableSearch` instead.
+     */
     disableSpeakerStatsSearch?: boolean;
     disableThirdPartyRequests?: boolean;
     disableTileEnlargement?: boolean;
@@ -359,6 +384,9 @@ export interface IConfig {
     enableEncodedTransformSupport?: boolean;
     enableForcedReload?: boolean;
     enableInsecureRoomNameWarning?: boolean;
+    /**
+     * @deprecated Use `lobby.enableChat` instead.
+     */
     enableLobbyChat?: boolean;
     enableNoAudioDetection?: boolean;
     enableNoisyMicDetection?: boolean;
@@ -368,6 +396,9 @@ export interface IConfig {
     enableTalkWhileMuted?: boolean;
     enableTcc?: boolean;
     enableWebHIDFeature?: boolean;
+    /**
+     * @deprecated Use `welcomePage.disabled` instead.
+     */
     enableWelcomePage?: boolean;
     etherpad_base?: string;
     faceLandmarks?: {
@@ -379,7 +410,14 @@ export interface IConfig {
         faceCenteringThreshold?: number;
     };
     feedbackPercentage?: number;
+    /**
+     * @deprecated Use `recordingService.enabled` instead.
+     */
     fileRecordingsServiceEnabled?: boolean;
+
+    /**
+     * @deprecated Use `recordingService.sharingEnabled` instead.
+     */
     fileRecordingsServiceSharingEnabled?: boolean;
     fileSharing?: {
         apiUrl?: string;
@@ -414,18 +452,27 @@ export interface IConfig {
         baseUrl?: string;
         disabled?: boolean;
     };
+    /**
+     * @deprecated Use `gravatar.baseUrl` instead.
+     */
     gravatarBaseURL?: string;
     guestDialOutStatusUrl?: string;
     guestDialOutUrl?: string;
     helpCentreURL?: string;
     hiddenDomain?: string;
     hiddenPremeetingButtons?: Array<'microphone' | 'camera' | 'select-background' | 'invite' | 'settings'>;
+    /**
+     * @deprecated Use `breakoutRooms.hideAddRoomButton` instead.
+     */
     hideAddRoomButton?: boolean;
     hideConferenceSubject?: boolean;
     hideConferenceTimer?: boolean;
     hideDisplayName?: boolean;
     hideDominantSpeakerBadge?: boolean;
     hideEmailInSettings?: boolean;
+    /**
+     * @deprecated Use `securityUi.hideLobbyButton` instead.
+     */
     hideLobbyButton?: boolean;
     hideLoginButton?: boolean;
     hideParticipantsStats?: boolean;
@@ -462,6 +509,9 @@ export interface IConfig {
         termsLink?: string;
         validatorRegExpString?: string;
     };
+    /**
+     * @deprecated Use `liveStreaming.enabled` instead.
+     */
     liveStreamingEnabled?: boolean;
     lobby?: {
         autoKnock?: boolean;
@@ -523,6 +573,9 @@ export interface IConfig {
     };
     preferBosh?: boolean;
     preferVisitor?: boolean;
+    /**
+     * @deprecated Use `transcription.preferredLanguage` instead.
+     */
     preferredTranscribeLanguage?: string;
     prejoinConfig?: {
         enabled?: boolean;
@@ -590,6 +643,9 @@ export interface IConfig {
         disabled?: boolean;
         order?: Array<'role' | 'name' | 'hasLeft'>;
     };
+    /**
+     * @deprecated Use `speakerStats.order` instead.
+     */
     speakerStatsOrder?: Array<'role' | 'name' | 'hasLeft'>;
     startAudioMuted?: number;
     startAudioOnly?: boolean;
@@ -632,7 +688,14 @@ export interface IConfig {
         initialTimeout?: number;
         timeout?: number;
     };
+    /**
+     * @deprecated Use `transcription.useAppLanguage` instead.
+     */
     transcribeWithAppLanguage?: boolean;
+
+    /**
+     * @deprecated Use `transcription.enabled` instead.
+     */
     transcribingEnabled?: boolean;
     transcription?: {
         autoCaptionOnTranscribe?: boolean;


### PR DESCRIPTION
Added @deprecated JSDoc annotations to 20 deprecated configuration options in configType.ts to improve developer experience and IDE tooling support. Each annotation references the recommended replacement option.


Fixes #16911

