### PR TITLE
 GSoC: Fix audio settings tab not updating UI on microphone permission change    

### DIFF
--- a/react/features/device-selection/components/AudioDevicesSelection.web.tsx
+++ b/react/features/device-selection/components/AudioDevicesSelection.web.tsx
@@ -235,6 +235,13 @@ class AudioDevicesSelection extends AbstractDialogTab<IProps, {}> {
             !== this.props.selectedAudioInputId) {
             this._createAudioInputTrack(this.props.selectedAudioInputId);
         }
+
+        if (!prevProps.hasAudioPermission && this.props.hasAudioPermission) {
+            this._createAudioInputTrack(this.props.selectedAudioInputId)
+                ?.then(() => {
+                    this.props.dispatch(getAvailableDevices());
+                });
+        }
     }
 
     /**


### PR DESCRIPTION
The Audio tab in the Settings dialog was not updating its UI when microphone permissions changed. After granting permission, the “Permission not granted” message remained visible until switching tabs, and after revoking permission, the message did not appear until re-entering the Audio tab. This PR ensures the Audio tab refreshes immediately on permission grant or revoke, keeping the UI in sync with the current permission state. Screenshots before and after the fix are attached.
 
## Before : 
https://github.com/user-attachments/assets/57c5e88d-0003-43d9-a229-b700b8d68ba3

## After : 
https://github.com/user-attachments/assets/0cb73c0a-fca2-4f27-b8bd-d01d4e4581c6


