### PR TITLE
 GSoC: fix (video-permission) : video tab not updating UI on camera permission change 

### DIFF
--- a/react/features/device-selection/components/VideoDeviceSelection.web.tsx
+++ b/react/features/device-selection/components/VideoDeviceSelection.web.tsx
@@ -194,6 +194,13 @@ class VideoDeviceSelection extends AbstractDialogTab<IProps, IState> {
             !== this.props.selectedVideoInputId) {
             this._createVideoInputTrack(this.props.selectedVideoInputId);
         }
+
+        if (!prevProps.hasVideoPermission && this.props.hasVideoPermission) {
+            this._createVideoInputTrack(this.props.selectedVideoInputId)
+                ?.then(() => {
+                    this.props.dispatch(getAvailableDevices());
+                });
+        }
     }
 
     /**


### PR DESCRIPTION
The Video tab in the Settings dialog was not updating its UI when camera permissions changed. After granting permission, the video preview appeared but the “Permission not granted” message remained visible. Similarly, when camera permission was revoked, the video stream stopped, but the warning message "Permission Not Granted" did not appear until the tab was reopened. This PR ensures the Video tabs refresh immediately on permission grant or revoke, keeping the UI in sync with the current permission state. I am attaching the before and after screenshot for your review.


## Before(Live permission not updated)
https://github.com/user-attachments/assets/213dcf16-ac62-41f2-a060-b321a15bb6e8

## After (Live permission reflects in UI immediately)
https://github.com/user-attachments/assets/468a9a90-6a30-408a-bcd3-32c4550f0ee1

