### PR TITLE
Fix: Remove duplicate nested CSS in ChatMessage.tsx (#16920)

### DIFF
--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -75,14 +75,7 @@ const useStyles = makeStyles()((theme: Theme) => {
                 '&.privatemessage': {
                     backgroundColor: theme.palette.chatMessagePrivate
                 },
-                '&.local': {
-                    backgroundColor: theme.palette.chatMessageLocal,
-                    borderRadius: '12px 4px 12px 12px',
 
-                    '&.privatemessage': {
-                        backgroundColor: theme.palette.chatMessagePrivate
-                    }
-                },
 
                 '&.error': {
                     backgroundColor: theme.palette.actionDanger,


### PR DESCRIPTION
##Summary
Removed duplicate nested &.local CSS block in ChatMessage.tsx.

##Changes
Deleted redundant nested &.local definition 
No functional impact
Improves code quality

#16920