### PR TITLE
added beforeunload confirmation during active meeting

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1198,6 +1198,7 @@
         "desktopShareFramerate": "Desktop sharing frame rate",
         "desktopShareHighFpsWarning": "A higher frame rate for desktop sharing might affect your bandwidth. You need to restart the screen share for the new settings to take effect.",
         "desktopShareWarning": "You need to restart the screen share for the new settings to take effect.",
+        "enableBeforeUnloadConfirmation": "Warn before leaving a meeting",
         "devices": "Devices",
         "followMe": "Everyone follows me",
         "followMeRecorder": "Recorder follows me",

--- a/react/features/always-on-top/index.tsx
+++ b/react/features/always-on-top/index.tsx
@@ -8,6 +8,6 @@ import AlwaysOnTop from './AlwaysOnTop';
 ReactDOM.render(<AlwaysOnTop />, document.getElementById('react'));
 
 window.addEventListener(
-    'beforeunload',
+    'unload',
     /* eslint-disable-next-line react/no-deprecated */
     () => ReactDOM.unmountComponentAtNode(document.getElementById('react') ?? document.body));

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -41,6 +41,7 @@ import {
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import StateListenerRegistry from '../redux/StateListenerRegistry';
 import { TRACK_ADDED, TRACK_REMOVED } from '../tracks/actionTypes';
+import { getPropertyValue } from '../settings/functions.any';
 import { parseURIString } from '../util/uri';
 
 import {
@@ -386,11 +387,8 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
         dispatch(overwriteConfig({ disableFocus: false }));
     }
 
-    const { enableBeforeUnloadConfirmation: configEnabled } = getState()['features/base/config'];
-    const { enableBeforeUnloadConfirmation: settingEnabled } = getState()['features/base/settings'];
-
     if (typeof window !== 'undefined') {
-        if (configEnabled || settingEnabled) {
+        if (getPropertyValue(getState, 'enableBeforeUnloadConfirmation')) {
             window.addEventListener('beforeunload', beforeUnloadHandler);
         }
         window.addEventListener('unload', unloadHandler);

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -386,8 +386,13 @@ function _conferenceJoined({ dispatch, getState }: IStore, next: Function, actio
         dispatch(overwriteConfig({ disableFocus: false }));
     }
 
+    const { enableBeforeUnloadConfirmation: configEnabled } = getState()['features/base/config'];
+    const { enableBeforeUnloadConfirmation: settingEnabled } = getState()['features/base/settings'];
+
     if (typeof window !== 'undefined') {
-        window.addEventListener('beforeunload', beforeUnloadHandler);
+        if (configEnabled || settingEnabled) {
+            window.addEventListener('beforeunload', beforeUnloadHandler);
+        }
         window.addEventListener('unload', unloadHandler);
     }
 

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -352,6 +352,7 @@ export interface IConfig {
         maxMessagesPerSecond?: number;
         numRequests?: number;
     };
+    enableBeforeUnloadConfirmation?: boolean;
     enableCalendarIntegration?: boolean;
     enableClosePage?: boolean;
     enableDisplayNameInStats?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -138,6 +138,7 @@ export default [
     'e2eeLabels',
     'e2ee',
     'e2eping',
+    'enableBeforeUnloadConfirmation',
     'enableCalendarIntegration',
     'enableDisplayNameInStats',
     'enableEmailInStats',

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -48,7 +48,7 @@ const DEFAULT_STATE: ISettingsState = {
     userSelectedNotifications: {
         'notify.chatMessages': true
     },
-    enableBeforeUnloadConfirmation: false,
+    enableBeforeUnloadConfirmation: undefined,
     userSelectedMicDeviceLabel: undefined
 };
 

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -48,6 +48,7 @@ const DEFAULT_STATE: ISettingsState = {
     userSelectedNotifications: {
         'notify.chatMessages': true
     },
+    enableBeforeUnloadConfirmation: false,
     userSelectedMicDeviceLabel: undefined
 };
 
@@ -69,6 +70,7 @@ export interface ISettingsState {
     disableSelfView?: boolean;
     displayName?: string;
     email?: string;
+    enableBeforeUnloadConfirmation?: boolean;
     hideShareAudioHelper?: boolean;
     localFlipX?: boolean;
     maxStageParticipants?: number;

--- a/react/features/external-api/middleware.ts
+++ b/react/features/external-api/middleware.ts
@@ -238,13 +238,10 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case SET_CONFIG: {
-        const state = store.getState();
-        const { disableBeforeUnloadHandlers = false } = state['features/base/config'];
-
         /**
          * Disposing the API when the user closes the page.
          */
-        window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', () => {
+        window.addEventListener('unload', () => {
             APP.API.notifyConferenceLeft(APP.conference.roomName);
             APP.API.dispose();
             getJitsiMeetTransport().dispose();

--- a/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
+++ b/react/features/invite/components/dial-in-info-page/DialInInfoApp.web.tsx
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
     );
 });
 
-window.addEventListener('beforeunload', () => {
+window.addEventListener('unload', () => {
     /* eslint-disable-next-line react/no-deprecated */
     ReactDOM.unmountComponentAtNode(document.getElementById('react')!);
 });

--- a/react/features/settings/actions.web.ts
+++ b/react/features/settings/actions.web.ts
@@ -152,6 +152,10 @@ export function submitMoreTab(newState: any) {
         if (newState.showSubtitlesOnStage !== currentState.showSubtitlesOnStage) {
             dispatch(updateSettings({ showSubtitlesOnStage: newState.showSubtitlesOnStage }));
         }
+
+        if (newState.enableBeforeUnloadConfirmation !== currentState.enableBeforeUnloadConfirmation) {
+            dispatch(updateSettings({ enableBeforeUnloadConfirmation: newState.enableBeforeUnloadConfirmation }));
+        }
     };
 }
 

--- a/react/features/settings/components/web/MoreTab.tsx
+++ b/react/features/settings/components/web/MoreTab.tsx
@@ -39,6 +39,11 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     disableHideSelfView: boolean;
 
     /**
+     * Whether or not the beforeunload confirmation is enabled.
+     */
+    enableBeforeUnloadConfirmation: boolean;
+
+    /**
      * Whether or not follow me is currently active (enabled by some other participant).
      */
     followMeActive: boolean;
@@ -126,6 +131,7 @@ class MoreTab extends AbstractDialogTab<IProps, any> {
         this._onMaxStageParticipantsSelect = this._onMaxStageParticipantsSelect.bind(this);
         this._onHideSelfViewChanged = this._onHideSelfViewChanged.bind(this);
         this._onShowSubtitlesOnStageChanged = this._onShowSubtitlesOnStageChanged.bind(this);
+        this._onEnableBeforeUnloadConfirmationChanged = this._onEnableBeforeUnloadConfirmationChanged.bind(this);
         this._onLanguageItemSelect = this._onLanguageItemSelect.bind(this);
     }
 
@@ -141,6 +147,7 @@ class MoreTab extends AbstractDialogTab<IProps, any> {
             disableHideSelfView,
             iAmVisitor,
             hideSelfView,
+            enableBeforeUnloadConfirmation,
             showLanguageSettings,
             showSubtitlesOnStage,
             t
@@ -166,6 +173,12 @@ class MoreTab extends AbstractDialogTab<IProps, any> {
                     label = { t('settings.showSubtitlesOnStage') }
                     name = 'show-subtitles-button'
                     onChange = { this._onShowSubtitlesOnStageChanged } /> }
+                <Checkbox
+                    checked = { enableBeforeUnloadConfirmation }
+                    className = { classes.checkbox }
+                    label = { t('settings.enableBeforeUnloadConfirmation') }
+                    name = 'enable-before-unload-confirmation'
+                    onChange = { this._onEnableBeforeUnloadConfirmationChanged } />
                 {showLanguageSettings && this._renderLanguageSelect()}
             </div>
         );
@@ -204,6 +217,17 @@ class MoreTab extends AbstractDialogTab<IProps, any> {
      */
     _onShowSubtitlesOnStageChanged({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) {
         super._onChange({ showSubtitlesOnStage: checked });
+    }
+
+    /**
+     * Callback invoked to select if beforeunload confirmation should be enabled.
+     *
+     * @param {Object} e - The key event to handle.
+     *
+     * @returns {void}
+     */
+    _onEnableBeforeUnloadConfirmationChanged({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) {
+        super._onChange({ enableBeforeUnloadConfirmation: checked });
     }
 
     /**

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -316,6 +316,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
                     ...newProps,
                     currentLanguage: tabState?.currentLanguage,
                     hideSelfView: tabState?.hideSelfView,
+                    enableBeforeUnloadConfirmation: tabState?.enableBeforeUnloadConfirmation,
                     showSubtitlesOnStage: tabState?.showSubtitlesOnStage,
                     maxStageParticipants: tabState?.maxStageParticipants
                 };

--- a/react/features/settings/functions.any.ts
+++ b/react/features/settings/functions.any.ts
@@ -134,6 +134,7 @@ export function getMoreTabProps(stateful: IStateful) {
         areClosedCaptionsEnabled: areClosedCaptionsEnabled(state),
         currentLanguage: language,
         disableHideSelfView: disableSelfViewSettings || disableSelfView,
+        enableBeforeUnloadConfirmation: state['features/base/settings'].enableBeforeUnloadConfirmation,
         hideSelfView: getHideSelfView(state),
         iAmVisitor: iAmVisitor(state),
         languages: LANGUAGES,

--- a/react/features/visitors/middleware.ts
+++ b/react/features/visitors/middleware.ts
@@ -178,9 +178,8 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
         // let's subscribe for visitor waiting queue
         const { room } = getState()['features/base/conference'];
-        const { disableBeforeUnloadHandlers = false } = getState()['features/base/config'];
         const conferenceJid = `${room}@${hosts?.muc}`;
-        const beforeUnloadHandler = () => {
+        const unloadHandler = () => {
             WebsocketClient.getInstance().disconnect();
         };
 
@@ -194,9 +193,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
                         WebsocketClient.getInstance().disconnect()
                             .then(() => {
-                                window.removeEventListener(
-                                    disableBeforeUnloadHandlers ? 'unload' : 'beforeunload',
-                                    beforeUnloadHandler);
+                                window.removeEventListener('unload', unloadHandler);
                                 let delay = 0;
 
                                 // now let's connect to meeting
@@ -226,7 +223,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         /**
          * Disconnecting the WebSocket client when the user closes the page.
          */
-        window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', beforeUnloadHandler);
+        window.addEventListener('unload', unloadHandler);
 
 
         break;


### PR DESCRIPTION
This PR adds a beforeunload handler when a conference is active to prevent accidental tab closure or refresh disconnects.

Implementation:
- Attached beforeunload listener when joining a conference
- Removed listener when leaving the conference
- Uses the browser’s standard confirmation popup

Testing:
- Reload/tab close shows confirmation during active call
- No popup after leaving the meeting
- Verified navigation away behavior

Fixes #16928
