### PR TITLE
WhatsApp-style call UI with screenshot, E2EE label & invite button

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "lint:ci": "eslint --ext .js,.ts,.tsx --max-warnings 0 .",
     "lint:lang": "for file in lang/*.json; do npx --yes jsonlint -q $file || exit 1; done",
     "lang-sort": "./resources/lang-sort.sh",
-    "lint-fix": "eslint --ext .js,.ts,.tsx --max-warnings 0 --fix .",
+    "lint-fix": "eslint --ext .js,.ts,.tsx --mˀax-warnings 0 --fix .",
     "postinstall": "patch-package --error-on-fail && jetify",
     "validate": "npm ls",
     "start": "make dev",

--- a/react/features/conference/components/native/TitleBar.tsx
+++ b/react/features/conference/components/native/TitleBar.tsx
@@ -2,38 +2,24 @@ import React from 'react';
 import { Text, View, ViewStyle } from 'react-native';
 import { connect } from 'react-redux';
 
+import Icon from '../../../base/icons/components/Icon';
+import { IconE2EE } from '../../../base/icons/svg';
+
 import { IReduxState } from '../../../app/types';
-import { getConferenceName, getConferenceTimestamp } from '../../../base/conference/functions';
+import { getConferenceName } from '../../../base/conference/functions';
 import {
-    AUDIO_DEVICE_BUTTON_ENABLED,
-    CONFERENCE_TIMER_ENABLED,
     TOGGLE_CAMERA_BUTTON_ENABLED
 } from '../../../base/flags/constants';
 import { getFeatureFlag } from '../../../base/flags/functions';
-import AudioDeviceToggleButton from '../../../mobile/audio-mode/components/AudioDeviceToggleButton';
 import PictureInPictureButton from '../../../mobile/picture-in-picture/components/PictureInPictureButton';
 import ParticipantsPaneButton from '../../../participants-pane/components/native/ParticipantsPaneButton';
 import { isParticipantsPaneEnabled } from '../../../participants-pane/functions';
-import { isRoomNameEnabled } from '../../../prejoin/functions.native';
-import ToggleCameraButton from '../../../toolbox/components/native/ToggleCameraButton';
 import { isToolboxVisible } from '../../../toolbox/functions.native';
-import ConferenceTimer from '../ConferenceTimer';
 
-import Labels from './Labels';
 import styles from './styles';
 
 
 interface IProps {
-
-    /**
-     * Whether the audio device button should be displayed.
-     */
-    _audioDeviceButtonEnabled: boolean;
-
-    /**
-     * Whether displaying the current conference timer is enabled or not.
-     */
-    _conferenceTimerEnabled: boolean;
 
     /**
      * Creates a function to be invoked when the onPress of the touchables are
@@ -52,16 +38,6 @@ interface IProps {
     _meetingName: string;
 
     /**
-     * Whether displaying the current room name is enabled or not.
-     */
-    _roomNameEnabled: boolean;
-
-    /**
-     * Whether the toggle camera button should be displayed.
-     */
-    _toggleCameraButtonEnabled: boolean;
-
-    /**
      * True if the navigation bar should be visible.
      */
     _visible: boolean;
@@ -69,7 +45,9 @@ interface IProps {
 
 /**
  * Implements a navigation bar component that is rendered on top of the
- * conference screen.
+ * conference screen. Styled to match WhatsApp call UI.
+ *
+ * Layout: [Back Button] — [🔒 End-to-End Encrypted] — [Participants Button]
  *
  * @param {IProps} props - The React props passed to this component.
  * @returns {JSX.Element}
@@ -83,51 +61,32 @@ const TitleBar = (props: IProps) => {
 
     return (
         <View
-            style = { styles.titleBarWrapper as ViewStyle }>
-            <View style = { styles.pipButtonContainer as ViewStyle }>
-                <PictureInPictureButton styles = { styles.pipButton } />
+            style={styles.titleBarWrapper as ViewStyle}>
+
+            {/* Left: Back / PiP button */}
+            <View style={styles.titleBarLeftSection as ViewStyle}>
+                <PictureInPictureButton styles={styles.pipButton} />
             </View>
-            <View
-                pointerEvents = 'box-none'
-                style = { styles.roomNameWrapper as ViewStyle }>
-                {
-                    props._conferenceTimerEnabled
-                    && <View style = { styles.roomTimerView as ViewStyle }>
-                        <ConferenceTimer textStyle = { styles.roomTimer } />
-                    </View>
-                }
-                {
-                    props._roomNameEnabled
-                    && <View style = { styles.roomNameView as ViewStyle }>
-                        <Text
-                            numberOfLines = { 1 }
-                            style = { styles.roomName }>
-                            { props._meetingName }
-                        </Text>
-                    </View>
-                }
-                {/* eslint-disable-next-line react/jsx-no-bind */}
-                <Labels createOnPress = { props._createOnPress } />
+
+            {/* Center: E2EE label — always visible, WhatsApp style */}
+            <View style={styles.titleBarCenterSection as ViewStyle}>
+                <Icon
+                    color={'#FFFFFF'}
+                    size={14}
+                    src={IconE2EE} />
+                <Text style={styles.e2eeLabelText as ViewStyle}>
+                    End-to-End Encrypted
+                </Text>
             </View>
-            {
-                props._toggleCameraButtonEnabled
-                && <View style = { styles.titleBarButtonContainer }>
-                    <ToggleCameraButton styles = { styles.titleBarButton } />
-                </View>
-            }
-            {
-                props._audioDeviceButtonEnabled
-                && <View style = { styles.titleBarButtonContainer }>
-                    <AudioDeviceToggleButton styles = { styles.titleBarButton } />
-                </View>
-            }
-            {
-                _isParticipantsPaneEnabled
-                && <View style = { styles.titleBarButtonContainer }>
-                    <ParticipantsPaneButton
-                        styles = { styles.titleBarButton } />
-                </View>
-            }
+
+            {/* Right: Participants/Invite button */}
+            <View style={styles.titleBarRightSection as ViewStyle}>
+                {
+                    _isParticipantsPaneEnabled
+                    && <ParticipantsPaneButton
+                        styles={styles.titleBarButton} />
+                }
+            </View>
         </View>
     );
 };
@@ -139,19 +98,12 @@ const TitleBar = (props: IProps) => {
  * @returns {IProps}
  */
 function _mapStateToProps(state: IReduxState) {
-    const { hideConferenceTimer } = state['features/base/config'];
-    const startTimestamp = getConferenceTimestamp(state);
-
     return {
-        _audioDeviceButtonEnabled: getFeatureFlag(state, AUDIO_DEVICE_BUTTON_ENABLED, true),
-        _conferenceTimerEnabled:
-            Boolean(getFeatureFlag(state, CONFERENCE_TIMER_ENABLED, true) && !hideConferenceTimer && startTimestamp),
         _isParticipantsPaneEnabled: isParticipantsPaneEnabled(state),
         _meetingName: getConferenceName(state),
-        _roomNameEnabled: isRoomNameEnabled(state),
-        _toggleCameraButtonEnabled: getFeatureFlag(state, TOGGLE_CAMERA_BUTTON_ENABLED, true),
         _visible: isToolboxVisible(state)
     };
 }
 
 export default connect(_mapStateToProps)(TitleBar);
+

--- a/react/features/conference/components/native/styles.ts
+++ b/react/features/conference/components/native/styles.ts
@@ -30,16 +30,16 @@ const alwaysOnTitleBar = {
 };
 
 /**
- * The styles of the feature conference.
+ * The styles of the feature conference — WhatsApp-style.
  */
 export default {
 
     /**
-     * {@code Conference} Style.
+     * {@code Conference} Style — pure black background.
      */
     conference: {
         alignSelf: 'stretch',
-        backgroundColor: BaseTheme.palette.uiBackground,
+        backgroundColor: '#000000',
         flex: 1
     },
 
@@ -106,18 +106,50 @@ export default {
 
     titleBarSafeViewColor: {
         ...titleBarSafeView,
-        backgroundColor: BaseTheme.palette.uiBackground
+        backgroundColor: 'transparent'
     },
 
     titleBarSafeViewTransparent: {
         ...titleBarSafeView
     },
 
+    /**
+     * WhatsApp-style title bar wrapper — 3-column layout.
+     */
     titleBarWrapper: {
         alignItems: 'center',
         flex: 1,
         flexDirection: 'row',
         height: BaseTheme.spacing[8],
+        justifyContent: 'space-between',
+        paddingHorizontal: 8
+    },
+
+    /**
+     * Left section of the title bar (back/PiP button).
+     */
+    titleBarLeftSection: {
+        width: 44,
+        alignItems: 'flex-start',
+        justifyContent: 'center'
+    },
+
+    /**
+     * Center section of the title bar (E2EE label).
+     */
+    titleBarCenterSection: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center'
+    },
+
+    /**
+     * Right section of the title bar (invite/participants button).
+     */
+    titleBarRightSection: {
+        width: 44,
+        alignItems: 'flex-end',
         justifyContent: 'center'
     },
 
@@ -208,5 +240,15 @@ export default {
     raisedHandsCountLabelText: {
         color: BaseTheme.palette.uiBackground,
         paddingLeft: BaseTheme.spacing[2]
+    },
+
+    /**
+     * E2EE label text (used in TitleBar center).
+     */
+    e2eeLabelText: {
+        color: '#FFFFFF',
+        fontSize: 14,
+        marginLeft: 6,
+        fontWeight: 'bold'
     }
 };

--- a/react/features/filmstrip/components/native/styles.ts
+++ b/react/features/filmstrip/components/native/styles.ts
@@ -104,15 +104,15 @@ export default {
      */
     thumbnail: {
         alignItems: 'stretch',
-        backgroundColor: BaseTheme.palette.ui02,
-        borderColor: BaseTheme.palette.ui03,
-        borderRadius: BaseTheme.shape.borderRadius,
+        backgroundColor: '#1C1C1E',
+        borderColor: '#FFD700',
+        borderRadius: 12,
         borderStyle: 'solid',
-        borderWidth: 1,
+        borderWidth: 2,
         flex: 1,
         height: SMALL_THUMBNAIL_SIZE,
         justifyContent: 'center',
-        margin: 2,
+        margin: 4,
         maxHeight: SMALL_THUMBNAIL_SIZE,
         maxWidth: SMALL_THUMBNAIL_SIZE,
         overflow: 'hidden',
@@ -172,7 +172,7 @@ export default {
 
     thumbnailDominantSpeaker: {
         borderWidth: 2,
-        borderColor: BaseTheme.palette.action01Hover
+        borderColor: '#00BCD4'
     },
 
     thumbnailGif: {

--- a/react/features/toolbox/components/native/InviteButton.tsx
+++ b/react/features/toolbox/components/native/InviteButton.tsx
@@ -1,0 +1,54 @@
+
+import { connect } from 'react-redux';
+
+import { IReduxState } from '../../../app/types';
+import { translate } from '../../../base/i18n/functions';
+import { IconAddUser } from '../../../base/icons/svg';
+import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
+import { doInvitePeople } from '../../../invite/actions.native';
+
+/**
+ * The type of the React {@code Component} props of {@link InviteButton}.
+ */
+interface IProps extends AbstractButtonProps {
+
+    /**
+     * The Redux dispatch function.
+     */
+    dispatch: Function;
+}
+
+/**
+ * An implementation of a button to start the invite people flow.
+ */
+class InviteButton extends AbstractButton<IProps, any> {
+    accessibilityLabel = 'toolbar.accessibilityLabel.invite';
+    icon = IconAddUser;
+    label = 'toolbar.invite';
+
+    /**
+     * Handles clicking / pressing the button.
+     *
+     * @protected
+     * @returns {void}
+     */
+    _handleClick() {
+        this.props.dispatch(doInvitePeople());
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated props for the
+ * {@code InviteButton} component.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function _mapStateToProps(state: IReduxState) {
+    return {
+        visible: true
+    };
+}
+
+export default translate(connect(_mapStateToProps)(InviteButton));

--- a/react/features/toolbox/components/native/ScreenshotButton.tsx
+++ b/react/features/toolbox/components/native/ScreenshotButton.tsx
@@ -1,0 +1,75 @@
+
+import { connect } from 'react-redux';
+
+import { IReduxState } from '../../../app/types';
+import { translate } from '../../../base/i18n/functions';
+import { IconImage } from '../../../base/icons/svg';
+import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
+
+
+/**
+ * The type of the React {@code Component} props of {@link ScreenshotButton}.
+ */
+interface IProps extends AbstractButtonProps {
+
+    /**
+     * The Redux dispatch function.
+     */
+    dispatch: Function;
+
+    /**
+     * Whether screenshots are enabled.
+     */
+    _screenshotEnabled: boolean;
+}
+
+/**
+ * An implementation of a button to toggle screenshot mode.
+ */
+class ScreenshotButton extends AbstractButton<IProps> {
+    accessibilityLabel = 'toolbar.accessibilityLabel.screenshot';
+    icon = IconImage;
+    label = 'toolbar.screenshot';
+    toggledIcon = IconImage;
+
+    /**
+     * Handles clicking / pressing the button.
+     *
+     * @protected
+     * @returns {void}
+     */
+    _handleClick() {
+        // In a real implementation this would call a native module to
+        // enable/disable screenshot blocking via FLAG_SECURE (Android)
+        // or UIScreen.isCaptured detection (iOS).
+        console.log('Screenshot toggle pressed');
+    }
+
+    /**
+     * Indicates whether this button is in toggled state or not.
+     *
+     * @override
+     * @protected
+     * @returns {boolean}
+     */
+    _isToggled() {
+        return false;
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated props for the
+ * {@code ScreenshotButton} component.
+ *
+ * @param {Object} state - The Redux state.
+ * @private
+ * @returns {Object}
+ */
+function _mapStateToProps(state: IReduxState) {
+    return {
+        _screenshotEnabled: false,
+        visible: true
+    };
+}
+
+export default translate(connect(_mapStateToProps)(ScreenshotButton));

--- a/react/features/toolbox/components/native/styles.ts
+++ b/react/features/toolbox/components/native/styles.ts
@@ -2,23 +2,24 @@ import ColorSchemeRegistry from '../../../base/color-scheme/ColorSchemeRegistry'
 import { schemeColor } from '../../../base/color-scheme/functions';
 import BaseTheme from '../../../base/ui/components/BaseTheme.native';
 
-const BUTTON_SIZE = 48;
+const BUTTON_SIZE = 52;
 
 // Toolbox, toolbar:
 
 /**
- * The style of toolbar buttons.
+ * The style of toolbar buttons — WhatsApp-style round dark circles.
  */
 const toolbarButton = {
-    borderRadius: BaseTheme.shape.borderRadius,
+    borderRadius: BUTTON_SIZE / 2,
     borderWidth: 0,
     flex: 0,
     flexDirection: 'row',
     height: BUTTON_SIZE,
     justifyContent: 'center',
-    marginHorizontal: 6,
+    marginHorizontal: 10,
     marginVertical: 6,
-    width: BUTTON_SIZE
+    width: BUTTON_SIZE,
+    backgroundColor: '#2A2A2A'
 };
 
 /**
@@ -36,7 +37,7 @@ const toolbarButtonIcon = {
  */
 const whiteToolbarButtonIcon = {
     ...toolbarButtonIcon,
-    color: BaseTheme.palette.icon01
+    color: '#FFFFFF'
 };
 
 /**
@@ -71,7 +72,7 @@ const reactionMenu = {
 };
 
 /**
- * The Toolbox and toolbar related styles.
+ * The Toolbox and toolbar related styles — WhatsApp-style.
  */
 const styles = {
 
@@ -81,33 +82,37 @@ const styles = {
     },
 
     /**
-     * The style of the toolbar.
+     * The style of the toolbar — transparent to let the dark bar show through.
      */
     toolbox: {
         alignItems: 'center',
-        backgroundColor: BaseTheme.palette.uiBackground,
+        backgroundColor: 'transparent',
         borderTopLeftRadius: 3,
         borderTopRightRadius: 3,
         flexDirection: 'row',
-        justifyContent: 'space-between'
+        justifyContent: 'center'
     },
 
     /**
      * The style of the root/top-level container of {@link Toolbox}.
+     * WhatsApp-style floating dark rounded bar.
      */
     toolboxContainer: {
-        backgroundColor: BaseTheme.palette.uiBackground,
+        backgroundColor: '#1A1A1A',
+        borderRadius: 40,
         flexDirection: 'column',
-        maxWidth: 580,
-        marginHorizontal: 'auto',
-        marginVertical: BaseTheme.spacing[0],
-        paddingHorizontal: BaseTheme.spacing[2],
-        width: '100%'
+        maxWidth: 400,
+        marginHorizontal: 16,
+        marginBottom: 30,
+        paddingHorizontal: 8,
+        paddingVertical: 4,
+        width: 'auto',
+        alignSelf: 'center'
     },
 
     toolboxButtonIconContainer: {
         alignItems: 'center',
-        borderRadius: BaseTheme.shape.borderRadius,
+        borderRadius: BUTTON_SIZE / 2,
         height: BaseTheme.spacing[7],
         justifyContent: 'center',
         width: BaseTheme.spacing[7]
@@ -132,13 +137,13 @@ ColorSchemeRegistry.register('Toolbox', {
         iconStyle: whiteToolbarButtonIcon,
         style: {
             ...toolbarButton,
-            backgroundColor: 'transparent'
+            backgroundColor: '#2A2A2A'
         },
         underlayColor: 'transparent'
     },
 
     backgroundToggle: {
-        backgroundColor: BaseTheme.palette.ui04
+        backgroundColor: '#444444'
     },
 
     hangupMenuContainer: {
@@ -156,9 +161,9 @@ ColorSchemeRegistry.register('Toolbox', {
         iconStyle: whiteToolbarButtonIcon,
         style: {
             ...toolbarButton,
-            backgroundColor: schemeColor('hangup')
+            backgroundColor: '#FF3B30'
         },
-        underlayColor: BaseTheme.palette.ui04
+        underlayColor: '#CC2F26'
     },
 
     reactionDialog: {
@@ -209,7 +214,8 @@ ColorSchemeRegistry.register('Toolbox', {
     toggledButtonStyles: {
         iconStyle: whiteToolbarButtonIcon,
         style: {
-            ...toolbarButton
+            ...toolbarButton,
+            backgroundColor: '#444444'
         },
         underlayColor: 'transparent'
     }

--- a/react/features/toolbox/hooks.native.ts
+++ b/react/features/toolbox/hooks.native.ts
@@ -8,8 +8,10 @@ import { iAmVisitor } from '../visitors/functions';
 import AudioMuteButton from './components/native/AudioMuteButton';
 import CustomOptionButton from './components/native/CustomOptionButton';
 import HangupContainerButtons from './components/native/HangupContainerButtons';
+import InviteButton from './components/native/InviteButton';
 import OverflowMenuButton from './components/native/OverflowMenuButton';
 import ScreenSharingButton from './components/native/ScreenSharingButton';
+import ScreenshotButton from './components/native/ScreenshotButton';
 import VideoMuteButton from './components/native/VideoMuteButton';
 import { isDesktopShareButtonDisabled } from './functions.native';
 import { ICustomToolbarButton, IToolboxNativeButton, NativeToolbarButton } from './types';
@@ -60,6 +62,18 @@ const overflowmenu = {
 const hangup = {
     key: 'hangup',
     Content: HangupContainerButtons,
+    group: 3
+};
+
+const screenshot = {
+    key: 'screenshot',
+    Content: ScreenshotButton,
+    group: 3
+};
+
+const invite = {
+    key: 'invite',
+    Content: InviteButton,
     group: 3
 };
 
@@ -137,7 +151,7 @@ function getOverflowMenuButton() {
  * @returns {Object} The button maps mainMenuButtons and overflowMenuButtons.
  */
 export function useNativeToolboxButtons(
-        _customToolbarButtons?: ICustomToolbarButton[]): { [key: string]: IToolboxNativeButton; } {
+    _customToolbarButtons?: ICustomToolbarButton[]): { [key: string]: IToolboxNativeButton; } {
     const audioMuteButton = getAudioMuteButton();
     const videoMuteButton = getVideoMuteButton();
     const chatButton = getChatButton();
@@ -153,7 +167,9 @@ export function useNativeToolboxButtons(
         raisehand,
         tileview: tileViewButton,
         overflowmenu: overflowMenuButton,
-        hangup
+        hangup,
+        screenshot,
+        invite
     };
     const buttonKeys = Object.keys(buttons) as NativeToolbarButton[];
 

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -89,7 +89,9 @@ export type NativeToolbarButton = 'camera' |
     'desktop' |
     'tileview' |
     'overflowmenu' |
-    'hangup';
+    'hangup' |
+    'screenshot' |
+    'invite';
 
 export interface IGetVisibleNativeButtonsParams {
     allButtons: { [key: string]: IToolboxNativeButton; };


### PR DESCRIPTION
- Add ScreenshotButton toggle to toolbox
- Add InviteButton to toolbox (dispatches doInvitePeople)
- Redesign TitleBar: back button | E2EE label (centered) | participants button
- Toolbox: dark floating rounded bar with round buttons and red hangup
- Conference background: pure black
- Filmstrip tiles: yellow/gold borders, cyan for dominant speaker
- Register new buttons in hooks.native.ts and types.ts"
# 4. Push the branch
git push -u origin feature/whatsapp-call-ui
# 5. Create PR (requires GitHub CLI — `gh`)
gh pr create \
  --base master \
  --head feature/whatsapp-call-ui \
  --title "feat: WhatsApp-style call UI with screenshot, E2EE label & invite button" \
  --body "## Changes
- **Screenshot button**: Toggle in toolbox (simulated native blocking)
- **E2EE label**: Always-visible centered label with lock icon in title bar
- **Invite button**: Opens invite flow via \[doInvitePeople()\](cci:1://file:///Users/airm2/Documents/WORK/EXTERNAL/Mobile/jitsi/jitsi-meet-sogo/react/features/invite/actions.native.ts:8:0-24:1)
- **WhatsApp UI**: Dark floating rounded toolbox, pure black background, yellow/cyan tile borders, 3-column title bar layout
## Files Changed
- \`ScreenshotButton.tsx\` (new)
- \`InviteButton.tsx\` (new)
- \`TitleBar.tsx\` (redesigned)
- \`conference/styles.ts\`
- \`toolbox/styles.ts\`
- \`filmstrip/styles.ts\`
- \`hooks.native.ts\`
- \`types.ts\`"