### PR TITLE
security: update fastlane and json gem to remediate CVE-2025-27788

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby ">= 3.4.0"
 gem "cocoapods", "~> 1.16"
 
 # (Optional) Fastlane for automation
-gem "fastlane"
+gem "fastlane", "~> 2.232"
 gem "abbrev"
 gem "logger"
 gem "mutex_m"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.226.0)
+    fastlane (2.232.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -232,7 +232,7 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    json (2.10.1)
+    json (2.11.3)
     jwt (2.10.1)
       base64
     logger (1.6.6)


### PR DESCRIPTION
Summary
This PR updates the fastlane and json Ruby dependencies to remediate a High-severity vulnerability (CVE-2025-27788) affecting the json gem.

Vulnerability Details
CVE ID: [CVE-2025-27788](https://nvd.nist.gov/vuln/detail/CVE-2025-27788)

Severity: High (CVSS 7.5)

Issue: An out-of-bounds read vulnerability in the json gem (versions 2.10.0 and 2.10.1) that can lead to application crashes or denial of service when parsing malformed JSON input.

Impact on Jitsi: Affects the development/automation toolchain (fastlane) used for mobile deployments.

Changes
Gemfile: Updated fastlane from gem "fastlane" to gem "fastlane", "~> 2.232".

Gemfile.lock:

Upgraded fastlane from 2.226.0 to 2.232.1.

Upgraded json from vulnerable version 2.10.1 to patched version 2.11.3.

Why this approach?
Instead of forcing a version pin on the transitive json dependency, I have updated the parent fastlane gem to its latest stable version. This ensures that the dependency tree remains healthy and compatible with the official fastlane requirements while resolving the security risk.

AI Disclosure & Verification
AI Tooling: This vulnerability was identified and analyzed with the assistance of AI(OpsMx-AI- Guardian)

Human Verification: The vulnerability was manually verified against the Ruby Advisory Database. The resulting Gemfile.lock changes were audited to ensure no breaking major-version jumps were introduced to other dependencies.
