### PR TITLE
Remove duplicate nested CSS in ChatMessage.tsx

### DIFF
--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -71,25 +71,17 @@ const useStyles = makeStyles()((theme: Theme) => {
             '&.local': {
                 backgroundColor: theme.palette.chatMessageLocal,
                 borderRadius: '12px 4px 12px 12px',
-
+            
                 '&.privatemessage': {
                     backgroundColor: theme.palette.chatMessagePrivate
                 },
-                '&.local': {
-                    backgroundColor: theme.palette.chatMessageLocal,
-                    borderRadius: '12px 4px 12px 12px',
-
-                    '&.privatemessage': {
-                        backgroundColor: theme.palette.chatMessagePrivate
-                    }
-                },
-
+            
                 '&.error': {
                     backgroundColor: theme.palette.actionDanger,
                     borderRadius: 0,
                     fontWeight: 100
                 },
-
+            
                 '&.lobbymessage': {
                     backgroundColor: theme.palette.chatMessagePrivate
                 }


### PR DESCRIPTION
This PR removes a duplicate nested `&.local` CSS block in ChatMessage.tsx (lines 78–85).

Impact:
- No functional change
- Removes dead/duplicate CSS
- Improves maintainability

Tested locally:
- Verified chat message styling
- Verified private message styling
- No UI regression observed
