### PR TITLE
refactor(chat): clarify and harden EDIT_MESSAGE semantics

### DIFF
--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -148,19 +148,27 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
         };
 
     case EDIT_MESSAGE: {
+        const editedMessage = action.message;
         let found = false;
-        const newMessage = action.message;
-        const messages = state.messages.map(m => {
-            if (m.messageId === newMessage.messageId) {
-                found = true;
 
-                return newMessage;
+        const messages = state.messages.map(m => {
+            if (m.messageId !== editedMessage.messageId) {
+                return m;
             }
 
-            return m;
+            found = true;
+
+            return {
+                ...m,
+                message: editedMessage.message,
+                participantId: m.participantId,
+                timestamp: m.timestamp,
+
+                isEdited: true,
+                editedTimestamp: editedMessage.editedTimestamp ?? Date.now()
+            };
         });
 
-        // no change
         if (!found) {
             return state;
         }


### PR DESCRIPTION
### Summary
This PR refines the `EDIT_MESSAGE` handling in the chat reducer to make message editing semantics explicit and safe.

### What changed
- Treats message edits as semantic updates instead of full replacements
- Preserves immutable metadata (author and original send timestamp)
- Explicitly marks edited messages with an edit timestamp

### Why
The previous implementation replaced the entire message object, which could unintentionally overwrite immutable fields and complicate future moderation and edit-history features. This change strengthens reducer invariants without altering any UI or backend behavior.

### Scope
- Chat reducer only
- No UI changes
- No backend / Prosody changes

### Testing
- Verified locally by running Jitsi Meet in development mode
- Manually validated state updates via reducer behavior
