### PR TITLE
 GSoC: fix(settings): don't activate all mics when audio levels are disabled

### DIFF
--- a/react/features/settings/components/web/audio/AudioSettingsContent.tsx
+++ b/react/features/settings/components/web/audio/AudioSettingsContent.tsx
@@ -244,11 +244,11 @@ const AudioSettingsContent = ({
      * @returns {void}
      */
     const _setTracks = async () => {
-        if (browser.isWebKitBased()) {
-
+        if (!measureAudioLevels || browser.isWebKitBased()) {
             // It appears that at the time of this writing, creating audio tracks blocks the browser's main thread for
             // long time on safari. Wasn't able to confirm which part of track creation does the blocking exactly, but
             // not creating the tracks seems to help and makes the UI much more responsive.
+            // Also skip when audio levels are disabled to avoid activating all microphones unnecessarily.
             return;
         }
 


### PR DESCRIPTION
fix #16964

# Description : 
Opening the mic picker popup calls `getUserMedia` for every microphone to show audio level meters. When disableAudioLevels=true, the meters are hidden but all mics are still activated. This causes Bluetooth headphones to switch to HFP mode and degrades audio quality.

## Changes:
  - Skip audio track creation in` AudioSettingsContent._setTracks` when measureAudioLevels is false
  - Set` disableAudioLevels: true` in default config
 
##   Testing:
The dev server loads config from the proxy server, so local config.js changes don't take effect. Used `APP.store.dispatch({ type: 'SET_CONFIG', config: { disableAudioLevels: true } })`  in dev console to set the config instead. Verified in chrome://webrtc-internals that no extra getUserMedia calls happen when opening the mic picker , which previously gets called equals to number of mics  when clicking on AudioSettingPopup. If you need I can attach Screenshots.
If the dev server should be loading local config instead, happy to look into that too.

 