### PR TITLE
Fix black empty space on tablet screens -> Fix of issue no #16867: Potential UI issue on Android Tablets — Settings screen layout not optimized 

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetActivity.java
@@ -27,14 +27,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.Window;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.facebook.react.modules.core.PermissionListener;
@@ -103,46 +101,13 @@ public class JitsiMeetActivity extends AppCompatActivity
         w.setStatusBarColor(android.graphics.Color.TRANSPARENT);
         w.setNavigationBarColor(android.graphics.Color.TRANSPARENT);
 
-        View decorView = w.getDecorView();
-
-        // Get display metrics for calculating density-independent caps
-        final android.util.DisplayMetrics metrics = v.getContext().getResources().getDisplayMetrics();
-        final int screenHeight = metrics.heightPixels;
-        final float density = metrics.density;
-
-        // Listen for window inset changes 
-        // when system bars visibility is toggled or when the device rotates
-        ViewCompat.setOnApplyWindowInsetsListener(decorView, (view, windowInsets) -> {
-
-            // Get the actual inset values reported by the system
-            int statusBarInset = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
-            int navBarInset = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
-
-            // Calculate maximum allowed inset values to prevent device-specific bugs
-            final int maxTopInset = Math.min((int)(60 * density), (int)(screenHeight * 0.10));
-            final int maxBottomInset = Math.min((int)(120 * density), (int)(screenHeight * 0.10));
-
-            int topInset = Math.min(statusBarInset, maxTopInset);
-            int bottomInset = Math.min(navBarInset, maxBottomInset);
-
-            // Apply calculated insets
-            ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
-
-            // Update margins only if they've changed
-            if (params.topMargin != topInset || params.bottomMargin != bottomInset) {
-                params.topMargin = topInset;
-                params.bottomMargin = bottomInset;
-                v.setLayoutParams(params);
-            }
-
-            view.setBackgroundColor(JitsiMeetView.BACKGROUND_COLOR);
-
-            // Return CONSUMED to prevent double-application of margins
-            return WindowInsetsCompat.CONSUMED;
+        // Keep the root content full-height and forward insets to children.
+        // Mutating the root margins can create large empty bars on tablets.
+        ViewCompat.setOnApplyWindowInsetsListener(v, (view, windowInsets) -> {
+            return windowInsets;
         });
 
-        // Manually trigger the inset listener to apply margins immediately
-        ViewCompat.requestApplyInsets(decorView);
+        ViewCompat.requestApplyInsets(v);
     }
 
     // Overrides


### PR DESCRIPTION
 **Problem**
On Android tablet devices (tested on Samsung Galaxy Tab A9, SM-X115), 
the bottom portion of all screens (Home, Recent, Calendar, Settings) 
appears as a large black empty space. The content does not fill the 
full screen height on larger tablet displays.

**Solution**
Fixed the layout in JitsiMeetActivity to properly fill the entire 
screen height on tablet devices.

**Testing**
Tested on Samsung Galaxy Tab A9 (SM-X115) - all screens now fill 
the complete screen height with no black empty space.

Relevant screenshots have been attached showing the issue before 
and after the fix.
**Before:** 
![photo_2026-02-20_10-21-22 (2)](https://github.com/user-attachments/assets/70025226-368e-4cf1-b447-32021465f854)
![photo_2026-02-20_10-21-22](https://github.com/user-attachments/assets/5ca74ed5-c56e-4e85-9194-31c08cec50c9)

**After**
![photo_2026-02-20_09-55-29 (2)](https://github.com/user-attachments/assets/82ea4320-a3f9-4a46-b3a7-3a51a5725fc4)
![photo_2026-02-20_09-55-29](https://github.com/user-attachments/assets/069884f8-9de7-4fba-9f06-eedab5e5d92e)

Fixes #16867
@saghul @damencho I had previously reported this issue in #16867, and since it still persisted on Android tablets (tested on Samsung Galaxy Tab A9), I investigated further and proposed this fix.

Please let me know if any adjustments are needed.