### PR TITLE
docs(external-api) fix typo 'comatability' -> 'compatibility'

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -775,7 +775,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {void}
      *
      * @deprecated
-     * NOTE: This method is not removed for backward comatability purposes.
+     * NOTE: This method is not removed for backward compatibility purposes.
      */
     addEventListener(event, listener) {
         this.on(event, listener);
@@ -862,7 +862,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {void}
      *
      * @deprecated
-     * NOTE: This method is not removed for backward comatability purposes.
+     * NOTE: This method is not removed for backward compatibility purposes.
      */
     addEventListeners(listeners) {
         for (const event in listeners) { // eslint-disable-line guard-for-in
@@ -1413,7 +1413,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {void}
      *
      * @deprecated
-     * NOTE: This method is not removed for backward comatability purposes.
+     * NOTE: This method is not removed for backward compatibility purposes.
      */
     removeEventListener(event) {
         this.removeAllListeners(event);
@@ -1426,7 +1426,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @returns {void}
      *
      * @deprecated
-     * NOTE: This method is not removed for backward comatability purposes.
+     * NOTE: This method is not removed for backward compatibility purposes.
      */
     removeEventListeners(eventList) {
         eventList.forEach(event => this.removeEventListener(event));


### PR DESCRIPTION
### Description
Fixed a recurring typo "comatability" (should be "compatibility") in `external_api.js`.

### Why
This is a non-functional documentation/comment fix to improve code readability and maintainability. 

### Scope
- **File:** `external_api.js`
- **Lines:** 778, 865

### Impact
- **Risk:** Zero. The changes are confined to comments/documentation strings.
- **Breaking Changes:** None. No logic, variable names, or API exports were modified.

