### PR TITLE
fix(invite): decode dial-in room name consistently

### DIFF
--- a/react/features/invite/functions.ts
+++ b/react/features/invite/functions.ts
@@ -17,6 +17,7 @@ import { parseURLParams } from '../base/util/parseURLParams';
 import {
     StatusCode,
     appendURLParam,
+    getNormalizedRoomName,
     parseURIString
 } from '../base/util/uri';
 import { isVpaasMeeting } from '../jaas/functions';
@@ -729,13 +730,7 @@ export function getDialInfoPageURL(state: IReduxState, roomName?: string) {
     const conferenceName = roomName ?? getRoomName(state);
     const { locationURL } = state['features/base/connection'];
     const { href = '' } = locationURL ?? {};
-    let room = _decodeRoomURI(conferenceName ?? '');
-
-    try {
-        room = decodeURIComponent(room);
-    } catch {
-        // ignore malformed encoding
-    }
+    const room = getNormalizedRoomName(conferenceName) ?? '';
 
     const url = didPageUrl || `${href.substring(0, href.lastIndexOf('/'))}/${DIAL_IN_INFO_PAGE_PATH_NAME}`;
 


### PR DESCRIPTION
### What
Ensure the dial-in info page displays a human-readable room name when the
`room` query parameter is URL-encoded multiple times.

### Why
When opening the dial-in page from desktop/Electron clients, the room name can
arrive double-encoded (e.g. `%2520`). The page previously decoded only once,
causing `%20` to appear in the UI.

### How
- Added a small defensive helper to decode the room name repeatedly
- Replaced the single `decodeURIComponent` call with the helper

This keeps the display consistent across web and desktop entry points.