### PR TITLE
GSOC : types(chat) - narrow IMessage.messageType using literal union types

### DIFF
--- a/react/features/chat/actionTypes.ts
+++ b/react/features/chat/actionTypes.ts
@@ -6,7 +6,7 @@
  *     displayName: string
  *     hasRead: boolean,
  *     id: string,
- *     messageType: string,
+ *     messageType: ChatMessageType,
  *     message: string,
  *     timestamp: string,
  * }

--- a/react/features/chat/actions.any.ts
+++ b/react/features/chat/actions.any.ts
@@ -42,7 +42,7 @@ import { ChatTabs } from './constants';
  *     displayName: string,
  *     hasRead: boolean,
  *     message: string,
- *     messageType: string,
+ *     messageType: ChatMessageType,
  *     timestamp: string,
  *     isReaction: boolean
  * }}

--- a/react/features/chat/constants.ts
+++ b/react/features/chat/constants.ts
@@ -19,17 +19,17 @@ export const INCOMING_MSG_SOUND_ID = 'INCOMING_MSG_SOUND';
 /**
  * The {@code messageType} of error (system) messages.
  */
-export const MESSAGE_TYPE_ERROR = 'error';
+export const MESSAGE_TYPE_ERROR = 'error' as const;
 
 /**
  * The {@code messageType} of local messages.
  */
-export const MESSAGE_TYPE_LOCAL = 'local';
+export const MESSAGE_TYPE_LOCAL = 'local' as const;
 
 /**
  * The {@code messageType} of remote messages.
  */
-export const MESSAGE_TYPE_REMOTE = 'remote';
+export const MESSAGE_TYPE_REMOTE = 'remote' as const;
 
 export const SMALL_WIDTH_THRESHOLD = 580;
 

--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -3,9 +3,20 @@ import { WithTranslation } from 'react-i18next';
 import { IStore } from '../app/types';
 import { IFileMetadata } from '../file-sharing/types';
 
+import {
+    MESSAGE_TYPE_ERROR,
+    MESSAGE_TYPE_LOCAL,
+    MESSAGE_TYPE_REMOTE
+} from './constants';
+
+export type ChatMessageType =
+    | typeof MESSAGE_TYPE_LOCAL
+    | typeof MESSAGE_TYPE_ERROR
+    | typeof MESSAGE_TYPE_REMOTE;
+
 export interface IMessage {
     displayName: string;
-    error?: Object;
+    error?: unknown;
     fileMetadata?: IFileMetadata;
     isFromGuest?: boolean;
     isFromVisitor?: boolean;
@@ -13,7 +24,7 @@ export interface IMessage {
     lobbyChat: boolean;
     message: string;
     messageId: string;
-    messageType: string;
+    messageType: ChatMessageType;
     participantId: string;
     privateMessage: boolean;
     reactions: Map<string, Set<string>>;


### PR DESCRIPTION
This PR improves type safety in the chat feature by narrowing
`IMessage.messageType` to a literal union of the defined message types.

Changes:
- Marked MESSAGE_TYPE_* constants with `as const`
- Introduced a `ChatMessageType` union type
- Updated `IMessage.messageType` to use the union
- Aligned action typings to use the new type

Tested locally:
- Chat messages render correctly
- Sending local, remote and error messages works as before
- No type errors or lint warnings

No runtime behavior changes were introduced.

This prevents accidental use of invalid messageType values,
strengthens the chat data model, and improves maintainability.