### PR TITLE
fix(base/tracks): prevent crash when starting screenshare with audio and null local audio

### DIFF
--- a/react/features/base/tracks/actions.any.ts
+++ b/react/features/base/tracks/actions.any.ts
@@ -319,7 +319,13 @@ export function replaceLocalTrack(oldTrack: any, newTrack: any, conference?: IJi
             || (conference = getState()['features/base/conference'].conference);
 
         if (conference) {
-            await conference.replaceTrack(oldTrack, newTrack);
+            if (oldTrack) {
+                await conference.replaceTrack(oldTrack, newTrack);
+            } else if (newTrack) {
+                // No existing transceiver for old track, add new track directly
+                // to avoid "no transceiver for old: null" error.
+                await conference.addTrack(newTrack);
+            }
         }
 
         return dispatch(replaceStoredTracks(oldTrack, newTrack));


### PR DESCRIPTION
### Fixes #16846

This pull request resolves a critical runtime error (`TypeError: Cannot read properties of null (reading 'setEffect')`) that occurs when a user initiates screen sharing with audio while their local microphone is blocked or disconnected.

Previously, the application would crash because it attempted to apply an audio mixer effect to a `null` local audio track. This change implements proper null safety and improves WebRTC track handling by falling back to `addTrack()` when no existing transceiver is found.

### Testing done
Manual verification was performed on a local development environment to ensure stability.

**Manual testing steps:**
* Launched Jitsi Meet locally.
* **Blocked microphone permissions** in the browser to force a `null` local audio state.
* Initiated **Screen Sharing** with the **"Share Tab Audio"** option enabled.
* Verified that the "Uncaught runtime errors" red screen no longer appears.
* Joined meeting with another participant.
* Started screen share with audio enabled.
* Changed microphone during screen share.
* Verified that "Replace track failed - no transceiver" error no longer appears.

**Verified:**
* The application correctly triggers `conference.addTrack()` instead of `replaceTrack(null, ...)`.
* Screen sharing starts successfully without crashing the session.

### Screenshots (UI changes only)

#### Before
<img width="1853" height="1002" alt="Screenshot from 2026-02-22 18-49-20" src="https://github.com/user-attachments/assets/0a4cbdbc-eca8-460f-a7f1-14ce983a78a2" />

#### After
<img width="1853" height="1002" alt="Screenshot from 2026-02-22 19-04-33" src="https://github.com/user-attachments/assets/64489f53-9077-4bfc-baac-2704ba433593" />


### Proposed changelog entries

- fix(base/tracks): prevent crash during screen sharing when microphone is disabled or changed.

### Files changed
* `actions.web.ts` - null guard on localAudio before calling setEffect()
* `actions.any.ts` - handle null oldTrack in replaceLocalTrack by using addTrack instead of replaceTrack

### Proposed changelog category

/label bug, base/tracks

### Submitter checklist

- [x] The issue #16846 is well-described and linked.
- [x] The commit follows the mandatory `fix(base/tracks)` scope.
- [x] The branch has been rebased onto the latest master (No merge commits).
- [x] Manual testing has been performed as described above.
- [x] `npm run lint` was executed and passed with no errors.

### Desired reviewers

@saghul @jallamsetty1 