### PR TITLE
fix: Advanced Options label toggles wrong switch

### DIFF
--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -103,13 +103,13 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                         <div className = 'recording-header space-top'>
                             <label
                                 className = 'recording-title'
-                                htmlFor = 'recording-switch-transcription'>
+                                htmlFor = 'recording-switch-audio-video'>
                                 { t('recording.recordAudioAndVideo') }
                             </label>
                             <Switch
                                 checked = { shouldRecordAudioAndVideo }
                                 className = 'recording-switch'
-                                id = 'recording-switch-transcription'
+                                id = 'recording-switch-audio-video'
                                 onChange = { this._onRecordAudioAndVideoSwitchChange } />
                         </div>
                     </>


### PR DESCRIPTION
Fixes #16985

## Summary

In the Start Recording dialog → Advanced Options, clicking the
"Record Audio and Video" label toggled the "Record Transcription"
switch instead.

This happened because both switches were using the same `id`
("recording-switch-transcription"), causing both labels to reference
the same input element.

## Changes

- Assigned the correct id to Audio and Video switch
- Updated the corresponding `htmlFor` attribute
- Ensured each label toggles the correct switch

https://github.com/user-attachments/assets/b216720e-edbb-44e1-9d3d-034763e91247


## Testing

- Verified clicking each label toggles the correct switch
- Verified direct toggle interaction works correctly
