### PR TITLE
fix(video-layout) Fixes auto-pinning of SS in large calls.

### DIFF
--- a/react/features/video-layout/functions.any.ts
+++ b/react/features/video-layout/functions.any.ts
@@ -4,7 +4,7 @@ import { getFeatureFlag } from '../base/flags/functions';
 import { pinParticipant } from '../base/participants/actions';
 import { getParticipantCount, getPinnedParticipant } from '../base/participants/functions';
 import { FakeParticipant } from '../base/participants/types';
-import { isStageFilmstripAvailable, isTopPanelEnabled, isTileViewModeDisabled } from '../filmstrip/functions';
+import { isStageFilmstripAvailable, isTileViewModeDisabled, isTopPanelEnabled } from '../filmstrip/functions';
 import { isFollowMeActive } from '../follow-me/functions';
 import { isVideoPlaying } from '../shared-video/functions';
 import { VIDEO_QUALITY_LEVELS } from '../video-quality/constants';


### PR DESCRIPTION
In calls with 50+ participants, isTopPanelEnabled returns true. This causes isStageFilmstripAvailable(state) (called with no minimum participant count from getPinnedParticipant) to return true even when activeParticipants is empty. When getPinnedParticipant takes that stage filmstrip path, it reads from activeParticipants.find(p => p.pinned) — which is always
  empty for an auto-pinned screenshare.
Added an explicit check in shouldDisplayTileView's auto-mode logic: when there are active screenshares AND the top panel is enabled AND auto-pin is active AND Follow Me isn't controlling the layout, exit tile view. The guards on getAutoPinSetting() and !isFollowMeActive(state) mirror the same conditions checked everywhere else before auto-pinning fires, ensuring
  consistent behavior.

