### PR TITLE
fix(local-recording): close AudioContext on recording stop

### DIFF
--- a/react/features/recording/components/Recording/LocalRecordingManager.web.ts
+++ b/react/features/recording/components/Recording/LocalRecordingManager.web.ts
@@ -279,6 +279,7 @@ const LocalRecordingManager: ILocalRecordingManager = {
             // The stop event is emitted when the recorder is done, and _after_ the last buffered
             // data has been handed over to the dataavailable event.
             this.recorder = undefined;
+            this.audioContext?.close();
             this.audioContext = undefined;
             this.audioDestination = undefined;
             this.startTime = undefined;


### PR DESCRIPTION
## Problem
AudioContext is created in initializeAudioMixer() but never closed in the stop handler, only dereferenced.
This causes a resource leak on every recording session.

## Evidence
**Heap Snapshot — AudioContext grew ×3 → ×10 across sessions**

![preview](https://github.com/user-attachments/assets/809a2249-4ae9-4613-9f78-1cc35f015eed)
![preview1](https://github.com/user-attachments/assets/bc4848f0-2f4d-422a-a9d7-df9f8dd253d0)

## Fix
```typescript
this.audioContext?.close();
```

## Forum Discussion
https://community.jitsi.org/t/local-recording-leaks-audiocontext-on-every-recording-stop/141856?u=yash_rastogi