### PR TITLE
fix(room join): multiple button click disabled while submitting room join form

### DIFF
--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -67,6 +67,7 @@ interface IState {
     hintBoxAnimation?: any;
     insecureRoomName: boolean;
     isSettingsScreenFocused?: boolean;
+    isSubmitted?: boolean;
     joining: boolean;
     room: string;
     roomNameInputAnimation?: any;

--- a/react/features/welcome/components/WelcomePage.web.tsx
+++ b/react/features/welcome/components/WelcomePage.web.tsx
@@ -59,7 +59,8 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
             ...this.state,
 
             generateRoomNames:
-                interfaceConfig.GENERATE_ROOMNAMES_ON_WELCOME_PAGE
+                interfaceConfig.GENERATE_ROOMNAMES_ON_WELCOME_PAGE,
+            isSubmitted: false
         };
 
         /**
@@ -251,6 +252,7 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
                                     aria-label = 'Start meeting'
                                     className = 'welcome-page-button'
                                     id = 'enter_room_button'
+                                    disabled={this.state.isSubmitted}
                                     onClick = { this._onFormSubmit }
                                     tabIndex = { 0 }
                                     type = 'button'>
@@ -329,6 +331,7 @@ class WelcomePage extends AbstractWelcomePage<IProps> {
      */
     _onFormSubmit(event: React.FormEvent) {
         event.preventDefault();
+        this.setState({ isSubmitted: true }); // prevent multiple submissions
 
         if (!this._roomInputRef || this._roomInputRef.reportValidity()) {
             this._onJoin();


### PR DESCRIPTION
What does it do?

Fixes multiple submission of a form while joining a single room. It adds a state to determine whether the _onFormSubmit has already been called or not, if yes, it disables the joining button so that we can prevent multiple calls

Please look at the loading status on tab for both the before/after fixed video attached below;

Before fix:

https://github.com/user-attachments/assets/e1ef6481-016a-4b29-93fc-5a42eba119f9

After fix:

https://github.com/user-attachments/assets/ce62fba5-b8f6-40a9-87e3-8bfdc182ca02
