### PR TITLE
feat(chat-message-copy): chat message long press action copy

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -109,6 +109,7 @@
         }
     },
     "chat": {
+        "copyMessage": "Copy message",
         "disabled": "Sending chat messages is disabled.",
         "enter": "Enter room",
         "error": "Error: your message was not sent. Reason: {{error}}",

--- a/react/features/base/react/components/native/Linkify.tsx
+++ b/react/features/base/react/components/native/Linkify.tsx
@@ -23,6 +23,12 @@ interface IProps {
      * The extra styles to be applied to text.
      */
     style?: StyleType;
+
+
+    /**
+     * Long press handler for text messages.
+     */
+    onLongPress?: (event: any) => void;
 }
 
 /**
@@ -51,6 +57,7 @@ export default class Linkify extends Component<IProps> {
                 componentDecorator = { this._componentDecorator }>
                 <Text
                     selectable = { true }
+                    onLongPress={ this.props.onLongPress }
                     style = { this.props.style }>
                     { this.props.children }
                 </Text>

--- a/react/features/chat/components/native/ChatMessage.tsx
+++ b/react/features/chat/components/native/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
 import Avatar from '../../../base/avatar/components/Avatar';
+import { openSheet } from '../../../base/dialog/actions';
 import { translate } from '../../../base/i18n/functions';
 import Linkify from '../../../base/react/components/native/Linkify';
 import { isGifEnabled, isGifMessage } from '../../../gifs/functions.native';
@@ -18,6 +19,7 @@ import {
 } from '../../functions';
 import { IChatMessageProps } from '../../types';
 
+import ChatMessageMenu from './ChatMessageMenu.native';
 import GifMessage from './GifMessage';
 import PrivateMessageButton from './PrivateMessageButton';
 import styles from './styles';
@@ -150,6 +152,7 @@ class ChatMessage extends Component<IChatMessageProps> {
             return (
                 <Text
                     selectable = { true }
+                    onLongPress={ this._onLongPress }
                     style = { styles.chatMessage }>
                     { messageText }
                 </Text>
@@ -159,11 +162,24 @@ class ChatMessage extends Component<IChatMessageProps> {
         return (
             <Linkify
                 linkStyle = { styles.chatLink }
+                onLongPress = { this._onLongPress }
                 style = { styles.chatMessage }>
                 { replaceNonUnicodeEmojis(messageText) }
             </Linkify>
         );
     }
+
+    /**
+     * Handles the list's navigate action.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onLongPress = () => {
+        const { dispatch, message } = this.props;
+
+        dispatch?.(openSheet(ChatMessageMenu, { message }));
+    };
 
     /**
      * Renders the message privacy notice, if necessary.

--- a/react/features/chat/components/native/ChatMessageMenu.native.tsx
+++ b/react/features/chat/components/native/ChatMessageMenu.native.tsx
@@ -1,0 +1,97 @@
+import React, { PureComponent } from 'react';
+import { Text, TextStyle, View, ViewStyle } from 'react-native';
+import { connect } from 'react-redux';
+
+import { IStore } from '../../../app/types';
+import { hideSheet } from '../../../base/dialog/actions';
+import BottomSheet from '../../../base/dialog/components/native/BottomSheet';
+import { bottomSheetStyles } from '../../../base/dialog/components/native/styles';
+import { IMessage } from '../../types';
+
+import CopyMessageButton from './CopyMessageButton.native';
+import styles from './styles';
+
+interface IProps {
+
+    /**
+     * The Redux dispatch function.
+     */
+    dispatch: IStore['dispatch'];
+
+    /**
+     * The message being rendered in this menu.
+     */
+    message: IMessage;
+}
+
+class ChatMessageMenu extends PureComponent<IProps> {
+    /**
+     * Constructor of the component.
+     *
+     * @inheritdoc
+     */
+    constructor(props: IProps) {
+        super(props);
+
+        this._onCancel = this._onCancel.bind(this);
+        this._renderMenuHeader = this._renderMenuHeader.bind(this);
+    }
+
+    /**
+     * Implements {@code Component#render}.
+     *
+     * @inheritdoc
+     */
+    override render() {
+        const { message } = this.props;
+        const buttonProps = {
+            afterClick: this._onCancel,
+            message,
+            showLabel: true,
+            styles: bottomSheetStyles.buttons
+        };
+
+        return (
+            <BottomSheet
+                renderHeader = { this._renderMenuHeader }>
+                <CopyMessageButton { ...buttonProps } />
+            </BottomSheet>
+        );
+    }
+
+    /**
+     * Callback to hide this menu.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _onCancel() {
+        this.props.dispatch(hideSheet());
+    }
+
+    /**
+     * Function to render the menu's header.
+     *
+     * @returns {React$Element}
+     */
+    _renderMenuHeader() {
+        const { message } = this.props;
+
+        return (
+            <View
+                style = { [
+                    bottomSheetStyles.sheet,
+                    styles.messageMenuHeader as ViewStyle
+                ] }>
+                <Text
+                    ellipsizeMode = { 'middle' }
+                    numberOfLines = { 1 }
+                    style = { styles.messageMenuHeaderText as TextStyle }>
+                    { message.message }
+                </Text>
+            </View>
+        );
+    }
+}
+
+export default connect()(ChatMessageMenu);

--- a/react/features/chat/components/native/CopyMessageButton.native.tsx
+++ b/react/features/chat/components/native/CopyMessageButton.native.tsx
@@ -1,0 +1,36 @@
+import { Share } from 'react-native';
+import { connect } from 'react-redux';
+
+import { translate } from '../../../base/i18n/functions';
+import { IconCopy } from '../../../base/icons/svg';
+import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
+import { IMessage } from '../../types';
+import Clipboard from '@react-native-clipboard/clipboard';
+
+export interface IProps extends AbstractButtonProps {
+
+    /**
+     * The message to be copied.
+     */
+    message: IMessage;
+}
+
+class CopyMessageButton extends AbstractButton<IProps> {
+    override accessibilityLabel = 'chat.copyMessage';
+    override icon = IconCopy;
+    override label = 'chat.copyMessage';
+
+    /**
+     * Handles clicking / pressing the button.
+     *
+     * @private
+     * @returns {void}
+     */
+    override _handleClick() {
+        const { message } = this.props;
+
+        Clipboard.setString(message.message)
+    }
+}
+
+export default translate(connect()(CopyMessageButton));

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -267,6 +267,17 @@ export default {
         ...BaseTheme.typography.bodyShortRegular,
         color: BaseTheme.palette.text01,
         flex: 1
+    },
+
+    messageMenuHeader: {
+        alignItems: 'center',
+        padding: BaseTheme.spacing[3]
+    },
+
+    messageMenuHeaderText: {
+        ...BaseTheme.typography.bodyShortRegular,
+        color: BaseTheme.palette.text01,
+        textAlign: 'center'
     }
 };
 

--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -51,6 +51,11 @@ export interface IChatMessageProps extends WithTranslation {
     canReply?: boolean;
 
     /**
+     * The Redux dispatch function.
+     */
+    dispatch?: IStore['dispatch'];
+
+    /**
      * Whether gifs are enabled or not.
      */
     gifEnabled?: boolean;


### PR DESCRIPTION
fixes: #17008

what does it do?

Introduces long press handlers with copy action for native applications. This will be needed eventually for more actions like delete, edit etc. Currently only copy is implemented

visual demo:

https://github.com/user-attachments/assets/10482eb5-280f-417c-a0ba-710f87227575

more:
https://community.jitsi.org/t/chat-message-long-press-actions-in-native/141863