### PR TITLE
fix(participants-pane): virtualize participant list for improved performance (#17011)

### DIFF
--- a/react/features/participants-pane/components/web/MeetingParticipantItems.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipantItems.tsx
@@ -1,6 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { FixedSizeList, ListChildComponentProps } from 'react-window';
 
 import MeetingParticipantItem from './MeetingParticipantItem';
+
+/**
+ * Height of a single participant item in pixels.
+ * This must match the actual rendered height of MeetingParticipantItem for proper virtualization.
+ */
+const PARTICIPANT_ITEM_HEIGHT = 56;
 
 interface IProps {
 
@@ -66,7 +74,10 @@ interface IProps {
 }
 
 /**
- * Component used to display a list of meeting participants.
+ * Component used to display a virtualized list of meeting participants.
+ * Uses react-window for efficient rendering of large participant lists,
+ * solving the performance issue where unmounting 500+ components with
+ * useTranslation hook was taking 10+ seconds.
  *
  * @returns {ReactNode}
  */
@@ -82,24 +93,86 @@ function MeetingParticipantItems({
     searchString,
     youText
 }: IProps) {
-    const renderParticipant = (id: string) => (
-        <MeetingParticipantItem
-            isHighlighted = { raiseContextId === id }
-            isInBreakoutRoom = { isInBreakoutRoom }
-            key = { id }
-            onContextMenu = { toggleMenu(id) }
-            onLeave = { lowerMenu }
-            openDrawerForParticipant = { openDrawerForParticipant }
-            overflowDrawer = { overflowDrawer }
-            participantActionEllipsisLabel = { participantActionEllipsisLabel }
-            participantID = { id }
-            searchString = { searchString }
-            youText = { youText } />
-    );
+    /**
+     * Renders a single participant row for the virtualized list.
+     */
+    const Row = useCallback(({ index, style }: ListChildComponentProps) => {
+        const id = participantIds[index];
 
-    return (<>
-        {participantIds.map(renderParticipant)}
-    </>);
+        return (
+            <div style = { style }>
+                <MeetingParticipantItem
+                    isHighlighted = { raiseContextId === id }
+                    isInBreakoutRoom = { isInBreakoutRoom }
+                    key = { id }
+                    onContextMenu = { toggleMenu(id) }
+                    onLeave = { lowerMenu }
+                    openDrawerForParticipant = { openDrawerForParticipant }
+                    overflowDrawer = { overflowDrawer }
+                    participantActionEllipsisLabel = { participantActionEllipsisLabel }
+                    participantID = { id }
+                    searchString = { searchString }
+                    youText = { youText } />
+            </div>
+        );
+    }, [
+        participantIds,
+        raiseContextId,
+        isInBreakoutRoom,
+        toggleMenu,
+        lowerMenu,
+        openDrawerForParticipant,
+        overflowDrawer,
+        participantActionEllipsisLabel,
+        searchString,
+        youText
+    ]);
+
+    // Style to prevent horizontal scrollbar and enable vertical scrolling
+    const listStyle = {
+        overflowX: 'hidden' as const,
+        overflowY: 'auto' as const
+    };
+
+    // For small lists (< 20 items), render without virtualization for simplicity
+    if (participantIds.length < 20) {
+        return (
+            <>
+                {participantIds.map(id => (
+                    <MeetingParticipantItem
+                        isHighlighted = { raiseContextId === id }
+                        isInBreakoutRoom = { isInBreakoutRoom }
+                        key = { id }
+                        onContextMenu = { toggleMenu(id) }
+                        onLeave = { lowerMenu }
+                        openDrawerForParticipant = { openDrawerForParticipant }
+                        overflowDrawer = { overflowDrawer }
+                        participantActionEllipsisLabel = { participantActionEllipsisLabel }
+                        participantID = { id }
+                        searchString = { searchString }
+                        youText = { youText } />
+                ))}
+            </>
+        );
+    }
+
+    // For larger lists, use virtualization to improve performance
+    return (
+        <div style = {{ height: '100%', minHeight: '200px' }}>
+            <AutoSizer>
+                {({ height, width }) => (
+                    <FixedSizeList
+                        height = { Math.max(height, 200) }
+                        itemCount = { participantIds.length }
+                        itemSize = { PARTICIPANT_ITEM_HEIGHT }
+                        style = { listStyle }
+                        width = { width }>
+                        { Row }
+                    </FixedSizeList>
+                )}
+            </AutoSizer>
+        </div>
+    );
 }
 
 // Memoize the component in order to avoid rerender on drawer open/close.

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -42,6 +42,12 @@ const useStyles = makeStyles()(theme => {
                 textAlign: 'center',
                 paddingRight: '16px'
             }
+        },
+
+        listContainer: {
+            flex: 1,
+            minHeight: '200px',
+            maxHeight: '100%'
         }
     };
 });
@@ -83,12 +89,9 @@ function MeetingParticipants({
     const [ lowerMenu, , toggleMenu, menuEnter, menuLeave, raiseContext ] = useContextMenu<string>();
     const [ drawerParticipant, closeDrawer, openDrawerForParticipant ] = useParticipantDrawer();
 
-    // FIXME:
-    // It seems that useTranslation is not very scalable. Unmount 500 components that have the useTranslation hook is
-    // taking more than 10s. To workaround the issue we need to pass the texts as props. This is temporary and dirty
-    // solution!!!
-    // One potential proper fix would be to use react-window component in order to lower the number of components
-    // mounted.
+    // Translation strings are passed as props to avoid useTranslation in each child component.
+    // This, combined with virtualization in MeetingParticipantItems, ensures good performance
+    // even with 500+ participants.
     const participantActionEllipsisLabel = t('participantsPane.actions.moreParticipantOptions');
     const youText = t('chat.you');
     const isBreakoutRoom = useSelector(isInBreakoutRoom);
@@ -123,7 +126,7 @@ function MeetingParticipants({
                 onChange = { setSearchString }
                 placeholder = { t('participantsPane.search') }
                 value = { searchString } />
-            <div>
+            <div className = { styles.listContainer }>
                 <MeetingParticipantItems
                     isInBreakoutRoom = { isBreakoutRoom }
                     lowerMenu = { lowerMenu }

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -89,9 +89,9 @@ function MeetingParticipants({
     const [ lowerMenu, , toggleMenu, menuEnter, menuLeave, raiseContext ] = useContextMenu<string>();
     const [ drawerParticipant, closeDrawer, openDrawerForParticipant ] = useParticipantDrawer();
 
-    // Translation strings are passed as props to avoid useTranslation in each child component.
-    // This, combined with virtualization in MeetingParticipantItems, ensures good performance
-    // even with 500+ participants.
+    // Where possible, translation strings are passed as props to reduce per-row useTranslation calls
+    // in child components. This, combined with virtualization in MeetingParticipantItems, helps ensure
+    // good performance even with 500+ participants.
     const participantActionEllipsisLabel = t('participantsPane.actions.moreParticipantOptions');
     const youText = t('chat.you');
     const isBreakoutRoom = useSelector(isInBreakoutRoom);


### PR DESCRIPTION
## Summary

Fixes #17011

This PR implements list virtualization using `react-window` to solve the performance issue where unmounting 500+ components with `useTranslation` hook was causing **10+ second UI freezes**.

## Problem

As documented in the FIXME comment in the codebase:
> It seems that useTranslation is not very scalable. Unmount 500 components that have the useTranslation hook is taking more than 10s. To workaround the issue we need to pass the texts as props. This is temporary and dirty solution!!!
> One potential proper fix would be to use react-window component in order to lower the number of components mounted.

## Solution

- Implement `FixedSizeList` from `react-window` with `AutoSizer` for dynamic sizing
- Only virtualize lists with 20+ participants (small lists render normally for simplicity)
- Reduces mounted components from 500+ to ~20-30 visible items at any time
- Eliminates the unmount performance issue entirely

## Changes

| File | Changes |
|------|---------|
| `MeetingParticipantItems.tsx` | Added virtualized list rendering using `react-window` |
| `MeetingParticipants.tsx` | Added `listContainer` style for proper AutoSizer height; updated comments |

## Testing

- [x] Small participant lists (<20) render without virtualization
- [x] Large participant lists use virtualized rendering
- [x] Context menu interactions work correctly
- [x] Search filtering works with virtualized list

## Notes

- `react-window` and `react-virtualized-auto-sizer` are already project dependencies
- Implementation follows the same pattern as `CurrentVisitorsList.tsx` which already uses virtualization
- Item height (56px) matches existing participant item styling