### PR TITLE
refactor(webhid-manager): use COMMANDS.OFF_HOLD constant instead of hardcoded string

### DIFF
--- a/react/features/web-hid/webhid-manager.ts
+++ b/react/features/web-hid/webhid-manager.ts
@@ -881,7 +881,7 @@ export default class WebHidManager extends EventTarget {
         case COMMANDS.ON_HOLD:
             this.deviceInfo.hold = true;
             break;
-        case 'offHold':
+        case COMMANDS.OFF_HOLD:
             this.deviceInfo.hold = false;
             break;
         default:


### PR DESCRIPTION
## Problem
case 'offHold' uses a hardcoded string instead of COMMANDS.OFF_HOLD constant. If the constant value ever changes, this case will silently break.

## Fix
Replace hardcoded string with COMMANDS.OFF_HOLD constant.