### PR TITLE
refactor(large-video): migrate LargeVideo.native.tsx to function component

### DIFF
--- a/react/features/base/tracks/types.ts
+++ b/react/features/base/tracks/types.ts
@@ -58,6 +58,7 @@ export interface ITrack {
         uid?: string;
     };
     participantId: string;
+    stream?: any;
     streamingStatus?: string;
     videoStarted: boolean;
     videoType?: string | null;

--- a/react/features/large-video/components/LargeVideo.native.tsx
+++ b/react/features/large-video/components/LargeVideo.native.tsx
@@ -1,8 +1,7 @@
-import React, { PureComponent } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../app/types';
-import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
 import ParticipantView from '../../base/participants/components/ParticipantView.native';
 import { getParticipantById, isLocalScreenshareParticipant } from '../../base/participants/functions';
 import { trackStreamingStatusChanged } from '../../base/tracks/actions.native';
@@ -10,7 +9,7 @@ import { getVideoTrackByParticipant, isLocalVideoTrackDesktop } from '../../base
 import { ITrack } from '../../base/tracks/types';
 
 import { AVATAR_SIZE } from './styles';
-
+import { useLocalTrackStreamingStatus } from './useLocalTrackStreamingStatus';
 /**
  * The type of the React {@link Component} props of {@link LargeVideo}.
  */
@@ -51,187 +50,60 @@ interface IProps {
     /**
      * Callback to invoke when the {@code LargeVideo} is clicked/pressed.
      */
-    onClick?: Function;
+    onClick?: () => void;
 }
 
-/**
- * The type of the React {@link Component} state of {@link LargeVideo}.
- */
-interface IState {
+function LargeVideo(props: IProps) {
+    const {
+        _videoTrack,
+        dispatch,
+        _disableVideo,
+        _participantId,
+        _height,
+        _width,
+        onClick
+    } = props;
 
-    /**
-     * Size for the Avatar. It will be dynamically adjusted based on the
-     * available size.
-     */
-    avatarSize: number;
-
-    /**
-     * Whether the connectivity indicator will be shown or not. It will be true
-     * by default, but it may be turned off if there is not enough space.
-     */
-    useConnectivityInfoLabel: boolean;
-}
-
-const DEFAULT_STATE = {
-    avatarSize: AVATAR_SIZE,
-    useConnectivityInfoLabel: true
-};
-
-/** .
- * Implements a React {@link Component} which represents the large video (a.k.a.
- * The conference participant who is on the local stage) on mobile/React Native.
- *
- * @augments Component
- */
-class LargeVideo extends PureComponent<IProps, IState> {
-    /**
-     * Creates new LargeVideo component.
-     *
-     * @param {IProps} props - The props of the component.
-     * @returns {LargeVideo}
-     */
-    constructor(props: IProps) {
-        super(props);
-
-        this.handleTrackStreamingStatusChanged = this.handleTrackStreamingStatusChanged.bind(this);
-    }
-
-    state = {
-        ...DEFAULT_STATE
-    };
-
-    /**
-     * Handles dimension changes. In case we deem it's too
-     * small, the connectivity indicator won't be rendered and the avatar
-     * will occupy the entirety of the available screen state.
-     *
-     * @inheritdoc
-     */
-    static getDerivedStateFromProps(props: IProps) {
-        const { _height, _width } = props;
-
-        // Get the size, rounded to the nearest even number.
+    const { avatarSize, useConnectivityInfoLabel } = useMemo(() => {
         const size = 2 * Math.round(Math.min(_height, _width) / 2);
 
         if (size < AVATAR_SIZE * 1.5) {
             return {
-                avatarSize: size - 15, // Leave some margin.
+                avatarSize: size - 15,
                 useConnectivityInfoLabel: false
             };
         }
 
-        return DEFAULT_STATE;
+        return {
+            avatarSize: AVATAR_SIZE,
+            useConnectivityInfoLabel: true
+        };
+    }, [ _height, _width ]);
 
-    }
+    const handleTrackStreamingStatusChanged = useCallback(
+        (jitsiTrack: any, streamingStatus: string) => {
+            dispatch(trackStreamingStatusChanged(jitsiTrack, streamingStatus));
+        },
+        [ dispatch ]
+    );
 
-    /**
-     * Starts listening for track streaming status updates after the initial render.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentDidMount() {
-        // Listen to track streaming status changed event to keep it updated.
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
+    useLocalTrackStreamingStatus(
+        _videoTrack,
+        dispatch,
+        handleTrackStreamingStatusChanged
+    );
 
-        if (_videoTrack && !_videoTrack.local) {
-            _videoTrack.jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                this.handleTrackStreamingStatusChanged);
-            dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-        }
-    }
-
-    /**
-     * Stops listening for track streaming status updates on the old track and starts listening instead on the new
-     * track.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentDidUpdate(prevProps: IProps) {
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
-
-        if (prevProps._videoTrack?.jitsiTrack?.getSourceName() !== _videoTrack?.jitsiTrack?.getSourceName()) {
-            if (prevProps._videoTrack && !prevProps._videoTrack.local) {
-                prevProps._videoTrack.jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                    this.handleTrackStreamingStatusChanged);
-                dispatch(trackStreamingStatusChanged(prevProps._videoTrack.jitsiTrack,
-                    prevProps._videoTrack.jitsiTrack.getTrackStreamingStatus()));
-            }
-            if (_videoTrack && !_videoTrack.local) {
-                _videoTrack.jitsiTrack.on(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                    this.handleTrackStreamingStatusChanged);
-                dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                    _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-            }
-        }
-    }
-
-    /**
-     * Remove listeners for track streaming status update.
-     *
-     * @inheritdoc
-     * @returns {void}
-     */
-    override componentWillUnmount() {
-        // TODO: after converting this component to a react function component,
-        // use a custom hook to update local track streaming status.
-        const { _videoTrack, dispatch } = this.props;
-
-        if (_videoTrack && !_videoTrack.local) {
-            _videoTrack.jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
-                this.handleTrackStreamingStatusChanged);
-            dispatch(trackStreamingStatusChanged(_videoTrack.jitsiTrack,
-                _videoTrack.jitsiTrack.getTrackStreamingStatus()));
-        }
-    }
-
-    /**
-     * Handle track streaming status change event by by dispatching an action to update track streaming status for the
-     * given track in app state.
-     *
-     * @param {JitsiTrack} jitsiTrack - The track with streaming status updated.
-     * @param {JitsiTrackStreamingStatus} streamingStatus - The updated track streaming status.
-     * @returns {void}
-     */
-    handleTrackStreamingStatusChanged(jitsiTrack: any, streamingStatus: string) {
-        this.props.dispatch(trackStreamingStatusChanged(jitsiTrack, streamingStatus));
-    }
-
-    /**
-     * Implements React's {@link Component#render()}.
-     *
-     * @inheritdoc
-     * @returns {ReactElement}
-     */
-    override render() {
-        const {
-            avatarSize,
-            useConnectivityInfoLabel
-        } = this.state;
-        const {
-            _disableVideo,
-            _participantId,
-            onClick
-        } = this.props;
-
-        return (
-            <ParticipantView
-                avatarSize = { avatarSize }
-                disableVideo = { _disableVideo }
-                onPress = { onClick }
-                participantId = { _participantId }
-                testHintId = 'org.jitsi.meet.LargeVideo'
-                useConnectivityInfoLabel = { useConnectivityInfoLabel }
-                zOrder = { 0 }
-                zoomEnabled = { true } />
-        );
-    }
+    return (
+        <ParticipantView
+            avatarSize = { avatarSize }
+            disableVideo = { _disableVideo }
+            onPress = { onClick }
+            participantId = { _participantId }
+            testHintId = 'org.jitsi.meet.LargeVideo'
+            useConnectivityInfoLabel = { useConnectivityInfoLabel }
+            zOrder = { 0 }
+            zoomEnabled = { true } />
+    );
 }
 
 /**

--- a/react/features/large-video/components/useLocalTrackStreamingStatus.ts
+++ b/react/features/large-video/components/useLocalTrackStreamingStatus.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+
+import { IStore } from '../../app/types';
+import { JitsiTrackEvents } from '../../base/lib-jitsi-meet';
+import { trackStreamingStatusChanged } from '../../base/tracks/actions.native';
+import { ITrack } from '../../base/tracks/types';
+
+export function useLocalTrackStreamingStatus(
+        videoTrack: ITrack | undefined,
+        dispatch: IStore['dispatch'],
+        handleTrackStreamingStatusChanged: (jitsiTrack: any, streamingStatus: string) => void
+) {
+    useEffect(() => {
+        if (!videoTrack || videoTrack.local) {
+            return;
+        }
+
+        const jitsiTrack = videoTrack.jitsiTrack;
+
+        jitsiTrack.on(
+                        JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
+                        handleTrackStreamingStatusChanged
+        );
+
+        dispatch(trackStreamingStatusChanged(
+                        jitsiTrack,
+                        jitsiTrack.getTrackStreamingStatus()
+        ));
+
+        return () => {
+            jitsiTrack.off(
+                                JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED,
+                                handleTrackStreamingStatusChanged
+            );
+
+            dispatch(trackStreamingStatusChanged(
+                                jitsiTrack,
+                                jitsiTrack.getTrackStreamingStatus()
+            ));
+        };
+    }, [ videoTrack, dispatch, handleTrackStreamingStatusChanged ]);
+}


### PR DESCRIPTION
### What this PR does
- Converts `LargeVideo.native.tsx` from a class component to a function component.
- Extracts track streaming status logic into a dedicated hook (`useLocalTrackStreamingStatus`).
- Preserves existing streaming-status behavior and lifecycle semantics.

### Why
- Aligns the component with modern React hooks patterns.
- Addresses existing TODOs in the file regarding hook-based implementation.
- Improves maintainability without changing feature ownership or behavior scope.

### Notes on testing
- Local E2E tests related to audio/video moderation depend on broader Redux updates
  not owned by `LargeVideo`. This refactor intentionally keeps the hook scoped only
  to track streaming status, as per the original TODO and component responsibility.