### PR TITLE
fix(long-chats): message and notification display for long chats in react native

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -109,6 +109,8 @@
         }
     },
     "chat": {
+        "seeMore": "see more",
+        "seeLess": "see less",
         "disabled": "Sending chat messages is disabled.",
         "enter": "Enter room",
         "error": "Error: your message was not sent. Reason: {{error}}",

--- a/react/features/chat/components/native/ChatMessage.tsx
+++ b/react/features/chat/components/native/ChatMessage.tsx
@@ -17,6 +17,15 @@ import {
     replaceNonUnicodeEmojis
 } from '../../functions';
 import { IChatMessageProps } from '../../types';
+import i18next from '../../../base/i18n/i18next';
+
+interface IState {
+
+    /**
+     * Whether the message is expanded to show full text.
+     */
+    expanded: boolean;
+}
 
 import GifMessage from './GifMessage';
 import PrivateMessageButton from './PrivateMessageButton';
@@ -26,7 +35,11 @@ import styles from './styles';
 /**
  * Renders a single chat message.
  */
-class ChatMessage extends Component<IChatMessageProps> {
+class ChatMessage extends Component<IChatMessageProps, IState> {
+    state = {
+        expanded: false
+    };
+
     /**
      * Implements {@code Component#render}.
      *
@@ -145,13 +158,30 @@ class ChatMessage extends Component<IChatMessageProps> {
      * @returns {React.ReactElement<*>}
      */
     _renderMessageTextComponent(messageText: string) {
+        const { expanded } = this.state;
 
         if (messageText.length >= CHAR_LIMIT) {
+            if (expanded) {
+                return (
+                    <Text selectable = { true } style = { styles.chatMessage }>
+                        { messageText }
+                        <Text
+                            onPress = { this._toggleExpanded }
+                            style = { styles.seeMoreClickableText }>
+                            {' '}{i18next.t('chat.seeLess')}
+                        </Text>
+                    </Text>
+                );
+            }
+
             return (
-                <Text
-                    selectable = { true }
-                    style = { styles.chatMessage }>
-                    { messageText }
+                <Text selectable = { true } style = { styles.chatMessage }>
+                    { messageText.slice(0, (CHAR_LIMIT - 10)) }
+                    <Text
+                        onPress = { this._toggleExpanded }
+                        style = { styles.seeMoreClickableText }>
+                        {' '}...{i18next.t('chat.seeMore')}
+                    </Text>
                 </Text>
             );
         }
@@ -164,6 +194,15 @@ class ChatMessage extends Component<IChatMessageProps> {
             </Linkify>
         );
     }
+
+    /**
+     * Toggles the expanded state of the message.
+     *
+     * @returns {void}
+     */
+    _toggleExpanded = () => {
+        this.setState(prevState => ({ expanded: !prevState.expanded }));
+    };
 
     /**
      * Renders the message privacy notice, if necessary.

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -267,6 +267,12 @@ export default {
         ...BaseTheme.typography.bodyShortRegular,
         color: BaseTheme.palette.text01,
         flex: 1
+    },
+
+    seeMoreClickableText: {
+        ...BaseTheme.typography.bodyShortRegular,
+        color: BaseTheme.palette.link01,
+        fontWeight: 'bold'
     }
 };
 

--- a/react/features/notifications/components/native/Notification.tsx
+++ b/react/features/notifications/components/native/Notification.tsx
@@ -14,6 +14,7 @@ import Button from '../../../base/ui/components/native/Button';
 import IconButton from '../../../base/ui/components/native/IconButton';
 import { BUTTON_MODES, BUTTON_TYPES } from '../../../base/ui/constants.native';
 import { CHAR_LIMIT } from '../../../chat/constants';
+import { NOTIFICATION_CHAR_LIMIT } from '../../constants';
 import { replaceNonUnicodeEmojis } from '../../../chat/functions';
 import { NOTIFICATION_ICON, NOTIFICATION_TYPE } from '../../constants';
 import { INotificationProps } from '../../types';
@@ -133,15 +134,30 @@ const Notification = ({
         return src;
     };
 
-    const _getDescription = () => {
-        const descriptionArray = [];
+    const _getDescription = (): string[] => {
+        const descriptionArray: string[] = [];
 
         descriptionKey
             && descriptionArray.push(t(descriptionKey, descriptionArguments));
 
-        description && descriptionArray.push(description);
+        if (description && typeof description === 'string') {
+            descriptionArray.push(description);
+        }
 
         return descriptionArray;
+    };
+
+    /**
+     * Truncates message for notification display.
+     *
+     * @param {string} line - The message line to process.
+     * @returns {string} The processed message.
+     */
+    const _processMessage = (line: string): string => {
+        if (line.length > NOTIFICATION_CHAR_LIMIT) {
+            return `${line.slice(0, NOTIFICATION_CHAR_LIMIT)}...`;
+        }
+        return replaceNonUnicodeEmojis(line);
     };
 
     // eslint-disable-next-line react/no-multi-comp
@@ -162,7 +178,7 @@ const Notification = ({
                             <Text
                                 key = { index }
                                 style = { styles.contentText }>
-                                { line.length >= CHAR_LIMIT ? line : replaceNonUnicodeEmojis(line) }
+                                { _processMessage(line) }
                             </Text>
                         ))
                     }
@@ -176,7 +192,7 @@ const Notification = ({
                             <Text
                                 key = { index }
                                 style = { styles.contentTextDescription }>
-                                { line.length >= CHAR_LIMIT ? line : replaceNonUnicodeEmojis(line) }
+                                { _processMessage(line) }
                             </Text>
                         ))
                     }

--- a/react/features/notifications/constants.ts
+++ b/react/features/notifications/constants.ts
@@ -135,3 +135,8 @@ export const SILENT_JOIN_THRESHOLD = 30;
  * Amount of participants beyond which no left notification will be emitted.
  */
 export const SILENT_LEFT_THRESHOLD = 30;
+
+/**
+ * Maximum character limit for notification message description.
+ */
+export const NOTIFICATION_CHAR_LIMIT = 150;


### PR DESCRIPTION
fixes: #17032

### what does it do?

It fixes issues with long messages visibility in chats and notifications.

for notifications, it shows only 150 characters now by making sure it does not cover up all the screen to show a single message

for chats, it shows see more and see less buttons which shows full text only when user clicks on see more and hides once user clicks see less

### visual demos:

#### Images

<img width="440" height="800" alt="image" src="https://github.com/user-attachments/assets/2f839d5c-a7b9-4c43-b19a-37729b77089a" />

<img width="506" height="919" alt="image" src="https://github.com/user-attachments/assets/0f64512d-2889-40c5-b718-34e787f5406e" />

<img width="440" height="800" alt="image" src="https://github.com/user-attachments/assets/293ff7dc-eae2-4fa6-b5d1-284ef7c0be86" />

#### Video

https://github.com/user-attachments/assets/f53a2ed9-3aea-4eac-a80c-1c696ffcfc31

