### PR TITLE
issue N0: #16750  Enabled  camera and microphone by default in all supporting browsers (WebOS not tested)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:installLocation="auto">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
   <application
       android:allowBackup="true"
       android:extractNativeLibs="true"

--- a/config.js
+++ b/config.js
@@ -364,7 +364,30 @@ var config = {
 
     // Start calls with video muted. Unlike the option above, this one is only
     // applied locally. FIXME: having these 2 options is confusing.
-    // startWithVideoMuted: false,
+    // var config = {
+
+    //  startWithVideoMuted: false,
+    //  startWithAudioMuted: false,
+    // }
+
+
+// config: {
+//     startWithAudioMuted: false,
+//     startWithVideoMuted: false,
+// }
+
+
+      
+            hosts: {
+                domain: 'localhost',
+                muc: 'conference.localhost'
+            },
+
+            startWithAudioMuted: false,
+            startWithVideoMuted: false,
+
+        };
+
 
     // Desktop sharing
 

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -1,5 +1,9 @@
 import i18n from 'i18next';
 import { AnyAction } from 'redux';
+import {
+    getLocalAudioTrack,
+    getLocalVideoTrack
+} from '../tracks/functions.web';
 
 // @ts-ignore
 import { MIN_ASSUMED_BANDWIDTH_BPS } from '../../../../modules/API/constants';
@@ -97,7 +101,24 @@ MiddlewareRegistry.register(store => next => action => {
         return _conferenceFailed(store, next, action);
 
     case CONFERENCE_JOINED:
-        return _conferenceJoined(store, next, action);
+          const state = store.getState();
+
+    const videoTrack =
+        getLocalVideoTrack(state['features/base/tracks']);
+
+    if (videoTrack && videoTrack.jitsiTrack?.isMuted()) {
+        videoTrack.jitsiTrack.unmute();
+    }
+
+    const audioTrack =
+        getLocalAudioTrack(state['features/base/tracks']);
+
+    if (audioTrack && audioTrack.jitsiTrack?.isMuted()) {
+        audioTrack.jitsiTrack.unmute();
+    }
+
+    break;
+        // return _conferenceJoined(store, next, action);
 
     case CONNECTION_ESTABLISHED:
         return _connectionEstablished(store, next, action);

--- a/react/features/prejoin/actions.web.ts
+++ b/react/features/prejoin/actions.web.ts
@@ -206,7 +206,15 @@ export function joinConference(options?: Object, ignoreJoiningInProgress = false
             dispatch(setJoiningInProgress(true));
         }
 
+        // FORCE camera & mic ON
+       options = {
+            ...(options || {}),
+            startWithAudioMuted: false,
+            startWithVideoMuted: false
+    };
+
         options && dispatch(updateConfig(options));
+        
 
         logger.info('Dispatching connect from joinConference.');
         dispatch(connect(jid, password))
@@ -258,10 +266,29 @@ export function joinConferenceWithoutAudio() {
         }
 
         logger.info('Dispatching joinConference action with startSilent=true from joinConferenceWithoutAudio.');
+        
+        const isWebOS =
+        navigator.userAgent.toLowerCase().includes('webos');
+
+        if (isWebOS && navigator.mediaDevices?.getUserMedia) {
+            navigator.mediaDevices.getUserMedia({
+            video: true,
+            audio: true
+        }).catch(error => {
+            console.warn('WebOS permission request failed', error);
+        });
+    }
 
         dispatch(joinConference({
-            startSilent: true
+            // startSilent: true
+             startWithAudioMuted: false,
+            startWithVideoMuted: false
         }, true));
+
+
+
+
+        
     };
 }
 


### PR DESCRIPTION
This PR enables camera and microphone by default on all supported browsers when joining a meeting. 

WebOS functionality has not been tested due to lack of access to the platform, so maintainers please  verify behavior there. 

Fixes issue #16750.
