### PR TITLE
fix(i18n): fix locale detection for regional variants on React Native

### DIFF
--- a/react/features/base/i18n/languageDetector.native.ts
+++ b/react/features/base/i18n/languageDetector.native.ts
@@ -23,9 +23,11 @@ export default {
         let locale;
 
         if (parts.length >= 3) {
-            locale = `${lang}${region}`;
+            // e.g. zh-Hans-CN (iOS) -> zh-CN
+            locale = `${lang}-${region}`;
         } else if (parts.length === 2) {
-            locale = `${lang}${regionOrScript}`;
+            // e.g. zh-CN (Android) -> zh-CN
+            locale = `${lang}-${regionOrScript}`;
         } else {
             locale = lang;
         }


### PR DESCRIPTION
## Summary

Fix locale detection for regional language variants on React Native (Android & iOS).

## Problem

The `detect()` function in `languageDetector.native.ts` was building locale strings by directly concatenating language and region codes without a separator. This produced invalid keys like `zhCN` instead of `zh-CN`, which never matched any entry in `languages.json`, causing the app to fall back to English — even when the system language was correctly set.

Affected locales: `zh-CN`, `zh-TW`, `fr-CA`, `pt-BR`, `es-US`, and any other regional variants.

Root cause introduced in commit 9be78c60 and carried over in 35c7f156.

## Fix

Insert `-` separator when constructing the locale string:

| System locale | Before | After |
|---|---|---|
| `zh-CN` (Android) | `zhCN` ❌ | `zh-CN` ✅ |
| `zh-Hans-CN` (iOS) | `zhCN` ❌ | `zh-CN` ✅ |
| `pt-BR` | `ptBR` ❌ | `pt-BR` ✅ |
| `fr-CA` | `frCA` ❌ | `fr-CA` ✅ |

## Testing

Verified on Android emulator (API 36, locale `zh-Hans-CN`):
- **Before fix**: Settings showed `Language: zh` (invalid fallback), UI displayed in English
- **After fix**: Settings showed `Language: 中文（简体）`, UI displayed in Simplified Chinese

Also verified on physical Android device with Simplified Chinese system language.