### PR TITLE
GSOC : Feat/chat permission selectors

### DIFF
--- a/react/features/chat/functions.ts
+++ b/react/features/chat/functions.ts
@@ -9,7 +9,7 @@ import { getLocalizedDateFormatter } from '../base/i18n/dateUtil';
 import i18next from '../base/i18n/i18next';
 import { MEET_FEATURES } from '../base/jwt/constants';
 import { isJwtFeatureEnabled } from '../base/jwt/functions';
-import { getParticipantById, isPrivateChatEnabled, getLocalParticipant, isLocalParticipantModerator} from '../base/participants/functions';
+import { getLocalParticipant, getParticipantById, isLocalParticipantModerator, isPrivateChatEnabled } from '../base/participants/functions';
 import { IParticipant } from '../base/participants/types';
 import { escapeRegexp } from '../base/util/helpers';
 import { arePollsDisabled } from '../conference/functions.any';


### PR DESCRIPTION
This PR introduces two selector utilities to support future
message editing and moderation features:

- canEditMessage
- canDeleteMessage

These selectors centralize permission logic based on message ownership and participant role.

No runtime behaviour changes were introduced.
This lays groundwork for implementing moderation and editing features in a structured manner.
