### PR TITLE
feat(pip): add debug logging for better PiP flow observability

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2325,6 +2325,7 @@ class API {
      * @returns {void}
      */
     notifyPictureInPictureRequested() {
+        logger.debug('Sending _pip-requested event to External API');
         this._sendEvent({
             name: '_pip-requested'
         });
@@ -2336,6 +2337,7 @@ class API {
      * @returns {void}
      */
     notifyPictureInPictureEntered() {
+        logger.debug('Sending pip-entered event to External API');
         this._sendEvent({
             name: 'pip-entered'
         });
@@ -2347,6 +2349,7 @@ class API {
      * @returns {void}
      */
     notifyPictureInPictureLeft() {
+        logger.debug('Sending pip-left event to External API');
         this._sendEvent({
             name: 'pip-left'
         });

--- a/react/features/pip/actions.ts
+++ b/react/features/pip/actions.ts
@@ -68,6 +68,8 @@ export function toggleVideoFromPiP() {
  */
 export function exitPiP() {
     return (dispatch: IStore['dispatch']) => {
+        logger.debug('exitPiP called');
+
         if (document.pictureInPictureElement) {
             document.exitPictureInPicture()
             .then(() => {
@@ -95,6 +97,8 @@ export function handleWindowBlur(videoElement: HTMLVideoElement) {
         const state = getState();
         const isPiPActive = state['features/pip']?.isPiPActive;
 
+        logger.debug(`Window blur detected, isPiPActive=${isPiPActive}`);
+
         if (!isPiPActive) {
             enterPiP(videoElement);
         }
@@ -111,6 +115,8 @@ export function handleWindowFocus() {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const isPiPActive = state['features/pip']?.isPiPActive;
+
+        logger.debug(`Window focus detected, isPiPActive=${isPiPActive}`);
 
         if (isPiPActive) {
             dispatch(exitPiP());
@@ -160,17 +166,24 @@ export function showPiP() {
     return (_dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const isPiPActive = state['features/pip']?.isPiPActive;
+        const _shouldShowPip = shouldShowPiP(state);
 
-        if (!shouldShowPiP(state)) {
+        logger.debug(`showPiP called, shouldShow=${_shouldShowPip}, isPiPActive=${isPiPActive}`);
+
+        if (!_shouldShowPip) {
             return;
         }
 
         if (!isPiPActive) {
             const videoElement = document.getElementById('pipVideo') as HTMLVideoElement;
 
-            if (videoElement) {
-                enterPiP(videoElement);
+            if (!videoElement) {
+                logger.warn('showPiP: pipVideo element not found');
+
+                return;
             }
+
+            enterPiP(videoElement);
         }
     };
 }
@@ -185,6 +198,8 @@ export function hidePiP() {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const isPiPActive = state['features/pip']?.isPiPActive;
+
+        logger.debug(`hidePiP called, isPiPActive=${isPiPActive}`);
 
         if (isPiPActive) {
             dispatch(exitPiP());

--- a/react/features/pip/functions.ts
+++ b/react/features/pip/functions.ts
@@ -311,8 +311,12 @@ export function requestPictureInPicture() {
 
         // Wait for metadata to load before requesting PiP.
         video.addEventListener('loadedmetadata', () => {
+            logger.debug(`Calling video.requestPictureInPicture(), readyState=${video.readyState}`);
+
             // @ts-ignore - requestPictureInPicture is not yet in all TypeScript definitions.
-            video.requestPictureInPicture().catch((err: Error) => {
+            video.requestPictureInPicture().then(() => {
+                logger.debug('video.requestPictureInPicture() succeeded');
+            }).catch((err: Error) => {
                 logger.error(`Error while requesting PiP after metadata loaded: ${err.message}`);
             }).finally(() => {
                 // Currently Electron will only pass the requests and execute requestPictureInPicture but
@@ -326,8 +330,12 @@ export function requestPictureInPicture() {
         return;
     }
 
+    logger.debug(`Calling video.requestPictureInPicture(), readyState=${video.readyState}`);
+
     // @ts-ignore - requestPictureInPicture is not yet in all TypeScript definitions.
-    video.requestPictureInPicture().catch((err: Error) => {
+    video.requestPictureInPicture().then(() => {
+        logger.debug('video.requestPictureInPicture() succeeded');
+    }).catch((err: Error) => {
         logger.error(`Error while requesting PiP: ${err.message}`);
     }).finally(() => {
         // Currently Electron will only pass the requests and execute requestPictureInPicture but

--- a/react/features/pip/subscriber.ts
+++ b/react/features/pip/subscriber.ts
@@ -5,6 +5,7 @@ import { isLocalTrackMuted } from '../base/tracks/functions.any';
 import { getElectronGlobalNS } from '../base/util/helpers';
 
 import { requestPictureInPicture, shouldShowPiP, updateMediaSessionState } from './functions';
+import logger from './logger';
 
 /**
  * Listens to audio and video mute state changes when PiP is active
@@ -51,9 +52,11 @@ StateListenerRegistry.register(
         if (_shouldShowPiP) {
             // Expose requestPictureInPicture for Electron main process.
             if (!electronNS.requestPictureInPicture) {
+                logger.debug('Exposing requestPictureInPicture to Electron namespace');
                 electronNS.requestPictureInPicture = requestPictureInPicture;
             }
         } else if (typeof electronNS.requestPictureInPicture === 'function') {
+            logger.debug('Removing requestPictureInPicture from Electron namespace (PiP disabled)');
             delete electronNS.requestPictureInPicture;
         }
     }


### PR DESCRIPTION
## Summary

- Add `logger.debug` calls in `modules/API/API.js` when dispatching `_pip-requested`, `pip-entered`, and `pip-left` events to the External API
- Add state-aware debug logs in `react/features/pip/actions.ts` for `showPiP`, `hidePiP`, `exitPiP`, `handleWindowBlur`, and `handleWindowFocus` — each log includes the relevant PiP state snapshot
- Add `logger.debug` (and a `.then()` success branch) to `requestPictureInPicture()` in `react/features/pip/functions.ts` to capture both success and failure of the native API call
- Add logger import and debug logs in `react/features/pip/subscriber.ts` when the Electron namespace is mutated to expose/remove `requestPictureInPicture`

## Motivation

Debugging PiP behaviour in production and staging environments required attaching a debugger or adding temporary print statements. These structured debug logs make the full PiP lifecycle visible through the existing logging infrastructure without changing any functional behaviour.

## Test plan

- [ ] Join a meeting and trigger PiP (e.g. switch away from the window in Electron or call `showPiP`)
- [ ] Verify debug-level log messages appear for each PiP event in the browser/Electron console
- [ ] Confirm no regressions in PiP enter/exit flow in both browser and Electron contexts