### PR TITLE
feat(chat): add emoji reaction support for chat message

### DIFF
--- a/react/features/chat/actionTypes.ts
+++ b/react/features/chat/actionTypes.ts
@@ -26,6 +26,18 @@ export const ADD_MESSAGE = 'ADD_MESSAGE';
 export const ADD_MESSAGE_REACTION = 'ADD_MESSAGE_REACTION';
 
 /**
+ * The type of the action that removes a reaction from a chat message.
+ *
+ * {
+ *     type: REMOVE_MESSAGE_REACTION,
+ *     reaction: string,
+ *     messageId: string,
+ *     participantId: string,
+ * }
+ */
+export const REMOVE_MESSAGE_REACTION = 'REMOVE_MESSAGE_REACTION';
+
+/**
  * The type of the action which signals to clear Redux.
  *
  * {

--- a/react/features/chat/actions.any.ts
+++ b/react/features/chat/actions.any.ts
@@ -13,6 +13,7 @@ import {
     NOTIFY_PRIVATE_RECIPIENTS_CHANGED,
     OPEN_CHAT,
     REMOVE_LOBBY_CHAT_PARTICIPANT,
+    REMOVE_MESSAGE_REACTION,
     SEND_MESSAGE,
     SEND_REACTION,
     SET_FOCUSED_TAB,
@@ -71,6 +72,27 @@ export function addMessage(messageDetails: Object) {
 export function addMessageReaction(reactionDetails: Object) {
     return {
         type: ADD_MESSAGE_REACTION,
+        ...reactionDetails
+    };
+}
+
+/**
+ * Removes a reaction from a chat message.
+ *
+ * @param {Object} reactionDetails - The reaction to remove.
+ * @param {string} reactionDetails.participantId - The ID of the participant removing the reaction.
+ * @param {string} reactionDetails.reaction - The reaction emoji to remove.
+ * @param {string} reactionDetails.messageId - The message ID.
+ * @returns {{
+ *     type: REMOVE_MESSAGE_REACTION,
+ *     participantId: string,
+ *     reaction: string,
+ *     messageId: string
+ * }}
+ */
+export function removeMessageReaction(reactionDetails: Object) {
+    return {
+        type: REMOVE_MESSAGE_REACTION,
         ...reactionDetails
     };
 }

--- a/react/features/chat/components/web/EmojiSelector.tsx
+++ b/react/features/chat/components/web/EmojiSelector.tsx
@@ -6,19 +6,28 @@ interface IProps {
     onSelect: (emoji: string) => void;
 }
 
+const EMOJIS = [ '👍', '👎', '❤️', '😂', '😮', '👋' ];
+
 const useStyles = makeStyles()((theme: Theme) => {
     return {
-        emojiGrid: {
+        container: {
             display: 'flex',
-            flexDirection: 'row',
-            borderRadius: '4px',
-            backgroundColor: theme.palette.chatInputBackground
+            alignItems: 'center',
+            gap: '2px'
         },
 
         emojiButton: {
+            background: 'none',
+            border: 'none',
             cursor: 'pointer',
-            padding: '5px',
-            fontSize: '1.5em'
+            fontSize: '1.2em',
+            padding: '3px',
+            borderRadius: '4px',
+
+            '&:hover': {
+                backgroundColor: theme.palette.action03,
+                transform: 'scale(1.2)'
+            }
         }
     };
 });
@@ -26,32 +35,22 @@ const useStyles = makeStyles()((theme: Theme) => {
 const EmojiSelector: React.FC<IProps> = ({ onSelect }) => {
     const { classes } = useStyles();
 
-    const emojiMap: Record<string, string> = {
-        thumbsUp: '👍',
-        redHeart: '❤️',
-        faceWithTearsOfJoy: '😂',
-        faceWithOpenMouth: '😮',
-        fire: '🔥'
-    };
-    const emojiNames = Object.keys(emojiMap);
-
     const handleSelect = useCallback(
-        (emoji: string) => (event: React.MouseEvent<HTMLSpanElement>) => {
-            event.preventDefault();
+        (emoji: string) => () => {
             onSelect(emoji);
         },
         [ onSelect ]
     );
 
     return (
-        <div className = { classes.emojiGrid }>
-            {emojiNames.map(name => (
-                <span
+        <div className = { classes.container }>
+            {EMOJIS.map(emoji => (
+                <button
                     className = { classes.emojiButton }
-                    key = { name }
-                    onClick = { handleSelect(emojiMap[name]) }>
-                    {emojiMap[name]}
-                </span>
+                    key = { emoji }
+                    onClick = { handleSelect(emoji) }>
+                    {emoji}
+                </button>
             ))}
         </div>
     );

--- a/react/features/chat/components/web/ReactButton.tsx
+++ b/react/features/chat/components/web/ReactButton.tsx
@@ -1,13 +1,7 @@
-import { Theme } from '@mui/material';
-import React, { useCallback, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
-import { IconFaceSmile } from '../../../base/icons/svg';
-import Popover from '../../../base/popover/components/Popover.web';
-import Button from '../../../base/ui/components/web/Button';
-import { BUTTON_TYPES } from '../../../base/ui/constants.any';
 import { sendReaction } from '../../actions.any';
 
 import EmojiSelector from './EmojiSelector';
@@ -17,20 +11,11 @@ interface IProps {
     receiverId: string;
 }
 
-const useStyles = makeStyles()((theme: Theme) => {
+const useStyles = makeStyles()(() => {
     return {
-        reactButton: {
-            padding: '2px'
-        },
-        reactionPanelContainer: {
-            position: 'relative',
-            display: 'inline-block'
-        },
-        popoverContent: {
-            backgroundColor: theme.palette.background.paper,
-            borderRadius: theme.shape.borderRadius,
-            boxShadow: theme.shadows[3],
-            overflow: 'hidden'
+        reactContainer: {
+            display: 'inline-flex',
+            alignItems: 'center'
         }
     };
 });
@@ -38,49 +23,15 @@ const useStyles = makeStyles()((theme: Theme) => {
 const ReactButton = ({ messageId, receiverId }: IProps) => {
     const { classes } = useStyles();
     const dispatch = useDispatch();
-    const { t } = useTranslation();
 
-    const onSendReaction = useCallback(emoji => {
+    const handleEmojiSelect = useCallback((emoji: string) => {
         dispatch(sendReaction(emoji, messageId, receiverId));
     }, [ dispatch, messageId, receiverId ]);
 
-    const [ isPopoverOpen, setIsPopoverOpen ] = useState(false);
-
-    const handleReactClick = useCallback(() => {
-        setIsPopoverOpen(true);
-    }, []);
-
-    const handleClose = useCallback(() => {
-        setIsPopoverOpen(false);
-    }, []);
-
-    const handleEmojiSelect = useCallback((emoji: string) => {
-        onSendReaction(emoji);
-        handleClose();
-    }, [ onSendReaction, handleClose ]);
-
-    const popoverContent = (
-        <div className = { classes.popoverContent }>
+    return (
+        <div className = { classes.reactContainer }>
             <EmojiSelector onSelect = { handleEmojiSelect } />
         </div>
-    );
-
-    return (
-        <Popover
-            content = { popoverContent }
-            onPopoverClose = { handleClose }
-            position = 'top'
-            trigger = 'click'
-            visible = { isPopoverOpen }>
-            <div className = { classes.reactionPanelContainer }>
-                <Button
-                    accessibilityLabel = { t('toolbar.accessibilityLabel.react') }
-                    className = { classes.reactButton }
-                    icon = { IconFaceSmile }
-                    onClick = { handleReactClick }
-                    type = { BUTTON_TYPES.TERTIARY } />
-            </div>
-        </Popover>
     );
 };
 

--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -13,6 +13,7 @@ import {
     NOTIFY_PRIVATE_RECIPIENTS_CHANGED,
     OPEN_CHAT,
     REMOVE_LOBBY_CHAT_PARTICIPANT,
+    REMOVE_MESSAGE_REACTION,
     SET_CHAT_IS_RESIZING,
     SET_CHAT_WIDTH,
     SET_FOCUSED_TAB,
@@ -124,6 +125,41 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
 
                     participants.add(participantId);
                 });
+
+                return {
+                    ...message,
+                    reactions: newReactions
+                };
+            }
+
+            return message;
+        });
+
+        return {
+            ...state,
+            messages
+        };
+    }
+
+    case REMOVE_MESSAGE_REACTION: {
+        const { participantId, reaction, messageId } = action;
+
+        const messages = state.messages.map(message => {
+            if (messageId === message.messageId) {
+                const newReactions = new Map(message.reactions);
+                const participants = newReactions.get(reaction);
+
+                if (participants) {
+                    const newParticipants = new Set(participants);
+
+                    newParticipants.delete(participantId);
+
+                    if (newParticipants.size === 0) {
+                        newReactions.delete(reaction);
+                    } else {
+                        newReactions.set(reaction, newParticipants);
+                    }
+                }
 
                 return {
                     ...message,


### PR DESCRIPTION
 ## Description 

This PR enables support for reacting to chat messages using emojis.

## What it does

 - Emoji reaction bar appears on message hover
 - Quick reactions (👍👎❤️😂😮👋);
 - Reactions are displayed below messages with counts
 - Clicking your own reaction again removes it

## How to test

 - Open a meeting link in Chrome
 - Open the same link in Incognito (second participant)
- Send a chat message from one participant
- Hover over the message and add a reaction
 - Verify the reaction appears for both participants

## Screenshot 

https://github.com/user-attachments/assets/1ad4f93f-8469-454b-a7d4-ec44fe37fcc0

