### PR TITLE
fix: align setting logo as per jitsi logo

### DIFF
--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -86,6 +86,7 @@ $welcomePageButtonFocusOutline: #00225A;
 $welcomePageHeaderContainerMarginTop: 104px;
 $welcomePageHeaderContainerDisplay: flex;
 $welcomePageHeaderContainerMargin: $welcomePageHeaderContainerMarginTop auto 0;
+$welcomePageHeaderTopOffset: calc(20px - #{$welcomePageHeaderContainerMarginTop});
 
 $welcomePageHeaderTextTitleMarginBottom: 0;
 $welcomePageHeaderTextTitleFontSize: 2.625rem;

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -240,7 +240,7 @@ body.welcome-page {
         color: $welcomePageDescriptionColor;
         padding: 4px;
         position: absolute;
-        top: calc(35px - #{$welcomePageHeaderContainerMarginTop});
+        top: calc(20px - #{$welcomePageHeaderContainerMarginTop});
         right: 0;
         z-index: $zindex2;
 

--- a/css/_welcome_page.scss
+++ b/css/_welcome_page.scss
@@ -37,7 +37,7 @@ body.welcome-page {
             position: absolute;
             width: 100%;
             height: 100%;
-            margin-top: calc(20px - #{$welcomePageHeaderContainerMarginTop});
+            margin-top: $welcomePageHeaderTopOffset;
         }
 
         .header-text-title {
@@ -240,7 +240,7 @@ body.welcome-page {
         color: $welcomePageDescriptionColor;
         padding: 4px;
         position: absolute;
-        top: calc(20px - #{$welcomePageHeaderContainerMarginTop});
+        top: $welcomePageHeaderTopOffset;
         right: 0;
         z-index: $zindex2;
 


### PR DESCRIPTION
FIxes: #17048 

I have aligned the settings logo with the jitsi logo 

## Before
<img width="1032" height="408" alt="Screenshot from 2026-02-28 22-06-28" src="https://github.com/user-attachments/assets/6ce75019-cc58-4b31-a901-92c9d96c9437" />

## After
<img width="1032" height="408" alt="image" src="https://github.com/user-attachments/assets/b7d4087d-381a-4bad-9e55-eed91bdfb273" />
