### PR TITLE
feat(chat): Add light/dark theme toggle for chat panel

### DIFF
--- a/css/_chat_theme.scss
+++ b/css/_chat_theme.scss
@@ -1,0 +1,132 @@
+/**
+ * Light theme overrides for the chat panel.
+ * Applied when [data-chat-theme="light"] is set on the chat container.
+ *
+ * Uses high-specificity selectors to override MUI makeStyles generated classes.
+ * NOTE: Icon component sets fill as inline attribute on <svg>, so we must
+ * target child elements (path, rect, circle, polygon) to override it.
+ */
+
+#sideToolbarContainer[data-chat-theme="light"] {
+    background-color: #F5F5F5 !important;
+    color: #1C2025 !important;
+
+    /* Override CSS variable for jitsi-icon-default */
+    --icon-svg-fill: #1C2025;
+
+    /* ---- Header ---- */
+    & .chat-header {
+        background-color: #E8E8E8 !important;
+        color: #1C2025 !important;
+    }
+
+    /*
+     * Target SVG child elements — this overrides the inline fill attribute
+     * that Icon component sets directly on the <svg> tag.
+     */
+    & svg path,
+    & svg rect,
+    & svg circle,
+    & svg polygon,
+    & svg polyline,
+    & svg ellipse,
+    & svg line {
+        fill: #1C2025 !important;
+    }
+
+    /* ---- Tabs (Chat / Polls / CC / Files) ---- */
+    /* The tab container row */
+    & [role="tablist"] {
+        background-color: #E0E0E0 !important;
+        border-bottom-color: #CCCCCC !important;
+    }
+
+    /* Each tab button — unselected */
+    & [role="tab"] {
+        color: #555555 !important;
+        border-bottom-color: #BBBBBB !important;
+        background: none !important;
+
+        & svg path,
+        & svg rect,
+        & svg circle,
+        & svg polygon {
+            fill: #555555 !important;
+        }
+    }
+
+    /* Selected tab */
+    & [role="tab"].selected,
+    & [role="tab"][aria-selected="true"] {
+        color: #1C2025 !important;
+        border-bottom-color: #1C2025 !important;
+        background-color: #F5F5F5 !important;
+
+        & svg path,
+        & svg rect,
+        & svg circle,
+        & svg polygon {
+            fill: #1C2025 !important;
+        }
+    }
+
+    /* ---- Message bubbles ---- */
+    & .chatmessage {
+        &.localuser {
+            background-color: #DCF8C6 !important;
+            color: #1C2025 !important;
+        }
+        &.remoteuser {
+            background-color: #FFFFFF !important;
+            color: #1C2025 !important;
+        }
+    }
+
+    & .display-name {
+        color: #555555 !important;
+    }
+
+    & .timestamp {
+        color: #888888 !important;
+    }
+
+    /* ---- Chat input area ---- */
+    & .chat-input-container {
+        background-color: #F5F5F5 !important;
+    }
+
+    & .chat-input {
+        background-color: #FFFFFF !important;
+        color: #1C2025 !important;
+        border-color: #CCCCCC !important;
+
+        & textarea,
+        & input {
+            color: #1C2025 !important;
+            background-color: #FFFFFF !important;
+        }
+    }
+
+    & .chat-message-group {
+        color: #1C2025 !important;
+    }
+
+    & a {
+        color: #1A73E8 !important;
+    }
+
+    & .chat-recipient {
+        background-color: #E0E0E0 !important;
+        color: #1C2025 !important;
+    }
+
+    /* ---- Smiley / emoji panel ---- */
+    & #smileysContainer {
+        background-color: #FFFFFF !important;
+        border-top-color: #CCCCCC !important;
+    }
+
+    & .new-messages-button {
+        background-color: #1A73E8 !important;
+    }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -43,6 +43,7 @@ $flagsImagePath: "../images/";
 @import 'recording';
 @import 'login_menu';
 @import 'chat';
+@import 'chat_theme';
 @import 'ringing/ringing';
 @import 'welcome_page';
 @import 'welcome_page_content';

--- a/lang/main.json
+++ b/lang/main.json
@@ -157,6 +157,7 @@
         "titleWithFeatures": "Chat and",
         "titleWithFileSharing": "Files",
         "titleWithPolls": "Polls",
+        "toggleTheme": "Toggle light/dark theme",
         "you": "you"
     },
     "chromeExtensionBanner": {

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -36,6 +36,7 @@ const DEFAULT_STATE: ISettingsState = {
     soundsParticipantLeft: true,
     soundsTalkWhileMuted: true,
     soundsReactions: true,
+    chatTheme: 'dark' as 'dark' | 'light',
     startAudioOnly: false,
     startCarMode: false,
     startWithAudioMuted: false,
@@ -82,6 +83,7 @@ export interface ISettingsState {
     soundsParticipantLeft?: boolean;
     soundsReactions?: boolean;
     soundsTalkWhileMuted?: boolean;
+    chatTheme?: 'dark' | 'light';
     startAudioOnly?: boolean;
     startCarMode?: boolean;
     startWithAudioMuted?: boolean;

--- a/react/features/base/ui/components/web/Tabs.tsx
+++ b/react/features/base/ui/components/web/Tabs.tsx
@@ -7,6 +7,7 @@ import Icon from '../../../icons/components/Icon';
 interface ITabProps {
     accessibilityLabel: string;
     className?: string;
+    iconColor?: string;
     onChange: (id: string) => void;
     selected: string;
     tabs: Array<{
@@ -93,6 +94,7 @@ const useStyles = makeStyles()(theme => {
 const Tabs = ({
     accessibilityLabel,
     className,
+    iconColor,
     onChange,
     selected,
     tabs
@@ -150,6 +152,7 @@ const Tabs = ({
                         {
                             tab.icon && <Icon
                                 className = { classes.icon }
+                                color = { iconColor }
                                 src = { tab.icon } />
                         }
                         { tab.label }

--- a/react/features/chat/chatTheme.ts
+++ b/react/features/chat/chatTheme.ts
@@ -1,0 +1,44 @@
+/**
+ * Light theme color overrides for the chat panel.
+ * These are applied as inline style overrides when the user selects light mode.
+ */
+export const CHAT_LIGHT_THEME = {
+    background: '#F5F5F5',
+    headerBackground: '#E8E8E8',
+    headerText: '#1C2025',
+    messageLocalBackground: '#DCF8C6',
+    messageRemoteBackground: '#FFFFFF',
+    messageText: '#1C2025',
+    senderName: '#555555',
+    timestamp: '#888888',
+    inputBackground: '#FFFFFF',
+    inputBorder: '#CCCCCC',
+    inputText: '#1C2025',
+    link: '#1A73E8',
+    tabBackground: '#E0E0E0',
+    tabActiveBackground: '#FFFFFF',
+    tabText: '#1C2025'
+};
+
+/**
+ * Dark theme color overrides for the chat panel.
+ * These match the default Jitsi dark theme.
+ */
+export const CHAT_DARK_THEME = {
+    background: '',
+    headerBackground: '',
+    headerText: '',
+    messageLocalBackground: '',
+    messageRemoteBackground: '',
+    messageText: '',
+    senderName: '',
+    timestamp: '',
+    inputBackground: '',
+    inputBorder: '',
+    inputText: '',
+    link: '',
+    tabBackground: '',
+    tabActiveBackground: '',
+    tabText: ''
+};
+

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
+import { CHAT_LIGHT_THEME } from '../../chatTheme';
 import { IReduxState } from '../../../app/types';
 import { isTouchDevice, shouldEnableResize } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
@@ -47,6 +48,11 @@ import MessageRecipient from './MessageRecipient';
 
 
 interface IProps extends AbstractProps {
+
+    /**
+     * The current chat panel theme ('dark' or 'light').
+     */
+    _chatTheme: 'dark' | 'light';
 
     /**
      * The currently focused tab.
@@ -254,6 +260,7 @@ const useStyles = makeStyles<{
 });
 
 const Chat = ({
+    _chatTheme,
     _isModal,
     _isOpen,
     _isPollsEnabled,
@@ -608,6 +615,7 @@ const Chat = ({
                     })
                     : t('chat.title')
                 }
+                iconColor = { _chatTheme === 'light' ? '#1C2025' : undefined }
                 onChange = { onChangeTab }
                 selected = { _focusedTab }
                 tabs = { tabs } />
@@ -618,11 +626,19 @@ const Chat = ({
         return null;
     }
 
+    const isLightTheme = _chatTheme === 'light';
+    const lightThemeStyle = isLightTheme ? {
+        backgroundColor: CHAT_LIGHT_THEME.background,
+        color: CHAT_LIGHT_THEME.messageText
+    } : undefined;
+
     return (
         _isOpen ? <div
             className = { classes.container }
+            data-chat-theme = { _chatTheme }
             id = 'sideToolbarContainer'
-            onKeyDown = { onEscClick } >
+            onKeyDown = { onEscClick }
+            style = { lightThemeStyle } >
             <ChatHeader
                 className = { cx('chat-header', classes.chatHeader) }
                 isCCTabEnabled = { _isCCTabEnabled }
@@ -677,6 +693,7 @@ function _mapStateToProps(state: IReduxState, _ownProps: any) {
     const { reducedUI } = state['features/base/responsive-ui'];
 
     return {
+        _chatTheme: (state['features/base/settings'].chatTheme ?? 'dark') as 'dark' | 'light',
         _isModal: window.innerWidth <= SMALL_WIDTH_THRESHOLD,
         _isOpen: isOpen,
         _isPollsEnabled: !arePollsDisabled(state),

--- a/react/features/chat/components/web/ChatHeader.tsx
+++ b/react/features/chat/components/web/ChatHeader.tsx
@@ -2,8 +2,10 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { IReduxState } from '../../../app/types';
 import Icon from '../../../base/icons/components/Icon';
 import { IconCloseLarge } from '../../../base/icons/svg';
+import { updateSettings } from '../../../base/settings/actions';
 import { isFileSharingEnabled } from '../../../file-sharing/functions.any';
 import { toggleChat } from '../../actions.web';
 import { ChatTabs } from '../../constants';
@@ -43,10 +45,15 @@ function ChatHeader({ className, isCCTabEnabled, isPollsEnabled }: IProps) {
     const _isChatDisabled = useSelector(isChatDisabled);
     const focusedTab = useSelector(getFocusedTab);
     const fileSharingTabEnabled = useSelector(isFileSharingEnabled);
+    const chatTheme = useSelector((state: IReduxState) => state['features/base/settings'].chatTheme ?? 'dark');
 
     const onCancel = useCallback(() => {
         dispatch(toggleChat());
     }, []);
+
+    const onToggleTheme = useCallback(() => {
+        dispatch(updateSettings({ chatTheme: chatTheme === 'dark' ? 'light' : 'dark' }));
+    }, [ chatTheme ]);
 
     const onKeyPressHandler = useCallback(e => {
         if (onCancel && (e.key === ' ' || e.key === 'Enter')) {
@@ -72,21 +79,45 @@ function ChatHeader({ className, isCCTabEnabled, isPollsEnabled }: IProps) {
         return null;
     }
 
+    const isLight = chatTheme === 'light';
+    const iconColor = isLight ? '#1C2025' : undefined;
+
     return (
         <div
-            className = { className || 'chat-dialog-header' }>
+            className = { className || 'chat-dialog-header' }
+            style = { isLight ? { backgroundColor: '#E8E8E8', color: '#1C2025' } : undefined }>
             <span
                 aria-level = { 1 }
-                role = 'heading'>
+                role = 'heading'
+                style = { isLight ? { color: '#1C2025' } : undefined }>
                 { t(title) }
             </span>
-            <Icon
-                ariaLabel = { t('toolbar.closeChat') }
-                onClick = { onCancel }
-                onKeyPress = { onKeyPressHandler }
-                role = 'button'
-                src = { IconCloseLarge }
-                tabIndex = { 0 } />
+            <div style = {{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <button
+                    aria-label = { t('chat.toggleTheme') }
+                    onClick = { onToggleTheme }
+                    style = {{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        fontSize: '18px',
+                        padding: '4px',
+                        borderRadius: '4px',
+                        display: 'flex',
+                        alignItems: 'center'
+                    }}
+                    title = { t('chat.toggleTheme') }>
+                    { isLight ? '🌙' : '☀️' }
+                </button>
+                <Icon
+                    ariaLabel = { t('toolbar.closeChat') }
+                    color = { iconColor }
+                    onClick = { onCancel }
+                    onKeyPress = { onKeyPressHandler }
+                    role = 'button'
+                    src = { IconCloseLarge }
+                    tabIndex = { 0 } />
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
 ## Description
 
 Adds a theme toggle button (☀️/🌙) in the chat header that lets users switch between dark and light mode for the chat panel.

## Screenshot

https://github.com/user-attachments/assets/12d4192a-1af8-49b0-93bc-cd084095fc77

