### PR TITLE
fix(file-sharing): Add missing error handling for download and file removal

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -593,6 +593,8 @@
         "fileUploadedSuccessfully": "File uploaded successfully",
         "newFileNotification": "{{ participantName }} shared '{{ fileName }}'",
         "removeFile": "Remove",
+        "removeFileFailedDescription": "The file metadata was removed but the file data may still exist on the server. Please try again.",
+        "removeFileFailedTitle": "Failed to remove file from server",
         "removeFileSuccess": "File removed successfully",
         "uploadDisabled": "Not allowed to upload files. Ask a moderator for permission rights for that operation.",
         "uploadFailedDescription": "Please try again.",

--- a/react/features/file-sharing/middleware.web.ts
+++ b/react/features/file-sharing/middleware.web.ts
@@ -212,6 +212,12 @@ MiddlewareRegistry.register(store => next => action => {
         })
         .catch((error: any) => {
             logger.warn('Could not delete file:', error);
+
+            store.dispatch(showErrorNotification({
+                titleKey: 'fileSharing.removeFileFailedTitle',
+                descriptionKey: 'fileSharing.removeFileFailedDescription',
+                appearance: NOTIFICATION_TYPE.ERROR
+            }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
         });
 
         return next(action);
@@ -230,7 +236,13 @@ MiddlewareRegistry.register(store => next => action => {
                 'Authorization': `Bearer ${token}`
             }
         }))
-        .then((response: any) => response.json())
+        .then((response: any) => {
+            if (!response.ok) {
+                throw new Error(`Failed to fetch file metadata: ${response.status} ${response.statusText}`);
+            }
+
+            return response.json();
+        })
         .then((data: { fileName: string; presignedUrl: string; }) => {
             const { presignedUrl, fileName } = data;
 

--- a/react/features/file-sharing/utils.ts
+++ b/react/features/file-sharing/utils.ts
@@ -1,5 +1,10 @@
 const generateDownloadUrl = async (url: string) => {
     const resp = await fetch(url);
+
+    if (!resp.ok) {
+        throw new Error(`Failed to download file: ${resp.status} ${resp.statusText}`);
+    }
+
     const respBlob = await resp.blob();
 
     const blob = new Blob([ respBlob ]);
@@ -8,13 +13,13 @@ const generateDownloadUrl = async (url: string) => {
 };
 
 export const downloadFile = async (url: string, fileName: string) => {
-    const dowloadUrl = await generateDownloadUrl(url);
+    const downloadUrl = await generateDownloadUrl(url);
     const link = document.createElement('a');
 
     if (fileName) {
         link.download = fileName;
     }
-    link.href = dowloadUrl;
+    link.href = downloadUrl;
 
     document.body.appendChild(link);
     link.click();
@@ -22,6 +27,6 @@ export const downloadFile = async (url: string, fileName: string) => {
 
     // fix for certain browsers
     setTimeout(() => {
-        URL.revokeObjectURL(dowloadUrl);
+        URL.revokeObjectURL(downloadUrl);
     }, 0);
 };


### PR DESCRIPTION
### Description

Fixes missing error handling in the file-sharing feature that causes silent failures and misleading UX when server-side operations fail.

### Problems Fixed

1. **Download: No HTTP status check** — `DOWNLOAD_FILE` handler calls `response.json()` without checking `response.ok`. A 4xx/5xx response causes confusing failures instead of showing the existing error notification.

2. **Download: Presigned URL not validated** — [generateDownloadUrl()](cci:1://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-12:2) in [utils.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-0:0) calls `resp.blob()` without checking `resp.ok`. An expired/invalid presigned URL (403/404) causes the user to silently download garbage data.

3. **Remove: Silent server-side failure** — `REMOVE_FILE` handler removes file metadata locally and shows "File removed successfully" before confirming the server DELETE succeeded. When the delete fails, the user is never informed and the file data remains orphaned on the server.

4. **Typo** — `dowloadUrl` → `downloadUrl` in [utils.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-0:0).

### Changes

| File | Change |
|------|--------|
| [react/features/file-sharing/middleware.web.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/middleware.web.ts:0:0-0:0) | Add `response.ok` check before `.json()` in `DOWNLOAD_FILE` handler |
| [react/features/file-sharing/middleware.web.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/middleware.web.ts:0:0-0:0) | Show error notification when server-side file deletion fails in `REMOVE_FILE` |
| [react/features/file-sharing/utils.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-0:0) | Add `resp.ok` check in [generateDownloadUrl()](cci:1://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-12:2) before `.blob()` |
| [react/features/file-sharing/utils.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/react/features/file-sharing/utils.ts:0:0-0:0) | Fix typo: `dowloadUrl` → `downloadUrl` |
| [lang/main.json](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/lang/main.json:0:0-0:0) | Add `removeFileFailedTitle` and `removeFileFailedDescription` translation keys |

### How was it tested?

- ✅ TypeScript compilation (`tsc -p tsconfig.web.json --noEmit`) — passes clean
- ✅ ESLint on both changed [.ts](cci:7://file:///c:/Users/Abhishek/OneDrive/Desktop/Projects/Opensource/jitsi-meet/custom.d.ts:0:0-0:0) files — passes clean
- ✅ Code review: happy-path logic is completely untouched; only defensive error guards added

### Risk

Very low — changes only add `if (!response.ok)` guards and a notification dispatch in the existing `.catch()` block. The success path is untouched.

Closes #17054 