### PR TITLE
fix(react/features/tabs): cast element to HTMLElement for focus support

### DIFF
--- a/react/features/welcome/components/Tabs.tsx
+++ b/react/features/welcome/components/Tabs.tsx
@@ -55,8 +55,7 @@ const Tabs = ({ accessibilityLabel, tabs }: IProps) => {
     useEffect(() => {
         // this test is needed to make sure the effect is triggered because of user actually changing tab
         if (document.activeElement?.getAttribute('role') === 'tab') {
-            // @ts-ignore
-            document.querySelector(`#${`${tabs[current].id}-tab`}`)?.focus();
+            document.querySelector<HTMLElement>(`#${`${tabs[current].id}-tab`}`)?.focus();
         }
 
     }, [ current, tabs ]);


### PR DESCRIPTION
### Description
Resolved TypeScript error: "Property 'focus' does not exist on type 'Element'".

### Changes
- Cast the querySelector result to `<HTMLElement>` to satisfy the compiler.
- Used optional chaining to ensure runtime safety.

### Testing
- Confirmed the project builds without TypeScript errors.
