### PR TITLE
issue no: 15066 keyboard shortcuts not working on Firefox Ubuntu

### DIFF
--- a/config.js
+++ b/config.js
@@ -1696,6 +1696,12 @@ var config = {
      */
     mouseMoveCallbackInterval: 1000,
 
+    // Allows remapping of Alt-based keyboard shortcuts.
+    // Useful for Firefox on Ubuntu where Alt+T, Alt+B, Alt+S are intercepted by the browser menu bar.
+    // Example: keyboardShortcutsMappings: { 'T': 'Y', 'B': 'G', 'S': 'J' }
+    // keyboardShortcutsMappings: {},
+
+
     /**
         Use this array to configure which notifications will be shown to the user
         The items correspond to the title or description key of that notification

--- a/react/features/keyboard-shortcuts/utils.ts
+++ b/react/features/keyboard-shortcuts/utils.ts
@@ -41,8 +41,11 @@ export const getKeyboardKey = (e: KeyboardEvent): string => {
 
     const replacedKey = code.replace('Key', '');
 
-    if (altKey) {
-        return `:${replacedKey}`;
+        if (altKey) {
+        const mappings = (window as any).config?.keyboardShortcutsMappings ?? {};
+        const mappedKey = mappings[replacedKey] ?? replacedKey;
+
+        return `:${mappedKey}`;
     }
 
     // If e.key is a string, then it is assumed it already plainly states


### PR DESCRIPTION

Hey team

this is janani here,
Fixed the issue where Alt+T, Alt+B, Alt+S were not working on 
Firefox + Ubuntu. Added a config option `keyboardShortcutsMappings` 
so users can remap those shortcuts to keys that Firefox doesn't steal.

Tested on Mac + Firefox and the actual behaviour is not changed at all.

Fixes #15066