### PR TITLE
GSOC : feat(chat)- extend IMessage model to support edit and moderation metadata

### DIFF
--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -4,7 +4,16 @@ import { IStore } from '../app/types';
 import { IFileMetadata } from '../file-sharing/types';
 
 export interface IMessage {
+    deleted?: boolean;
+    deletedBy?: string;
+    deletedTimestamp?: number;
     displayName: string;
+    editHistory?: Array<{
+        editedAt: number;
+        message?: string;
+    }>;
+    editTimestamp?: number;
+    edited?: boolean;
     error?: Object;
     fileMetadata?: IFileMetadata;
     isFromGuest?: boolean;
@@ -14,6 +23,14 @@ export interface IMessage {
     message: string;
     messageId: string;
     messageType: string;
+    moderation?: {
+        flagged?: boolean;
+        flaggedAt?: number;
+        flaggedBy?: string;
+        redacted?: boolean;
+        redactedAt?: number;
+        redactedBy?: string;
+    };
     participantId: string;
     privateMessage: boolean;
     reactions: Map<string, Set<string>>;


### PR DESCRIPTION
## Summary

Extend the `IMessage` data model to support future editing and moderation features.

## Changes

- Added optional `edited`, `editTimestamp`, and `editHistory` fields
- Introduced soft deletion metadata (`deleted`, `deletedBy`, `deletedTimestamp`)
- Added extensible `moderation` metadata container

## Motivation

The current message model does not support structured editing or moderation.
This change lays the architectural groundwork required for implementing:

- Message editing with history
- Soft deletion
- Moderator redaction
- Reporting and flagging

All additions are backward-compatible and introduce no behavioral changes.