### PR TITLE
ci: optimize mobile iOS SDK build and switch CI installs to npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,19 @@ jobs:
       with:
         ruby-version: '3.4'
         bundler-cache: true
+    - name: Cache CocoaPods
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
+      with:
+        path: |
+          ios/Pods
+          ~/Library/Caches/CocoaPods
+        key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock', 'Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
     - run: npx react-native info
     - name: Install Pods
       working-directory: ./ios
-      run: bundle exec pod install --repo-update --deployment
+      run: bundle exec pod install --deployment
     - run: |
         xcodebuild -downloadPlatform iOS -buildVersion 18.2
         xcodebuild archive \


### PR DESCRIPTION
### Summary

This PR optimizes the `Simple CI` workflow to reduce dependency installation time, particularly for the `ios-sdk-build` job which was taking around ~20–30 minutes.

prev CI job:
https://github.com/jitsi/jitsi-meet/actions/runs/22633498340/job/65589907719?pr=17071

### Changes
- Switch all CI jobs from `npm install` to `npm ci` 
- Cache CocoaPods dependencies in the `ios-sdk-build` job
- Remove the unnecessary `--repo-update` during `pod install`

Previously the iOS SDK job was spending significant time reinstalling dependencies.  
With these changes, dependency installation is reused across runs while keeping the build behavior unchanged.

now CI job :
https://github.com/vishal2005025/jitsi-meet/actions/runs/22707235544/job/65841454081