### PR TITLE
fix: Mirror Virtual Background preview to match other local video previews

### DIFF
--- a/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
+++ b/react/features/virtual-background/components/VirtualBackgroundPreview.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '@mui/material';
+import cx from 'classnames';
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -16,7 +17,6 @@ import { NOTIFICATION_TIMEOUT_TYPE } from '../../notifications/constants';
 import { toggleBackgroundEffect } from '../actions';
 import logger from '../logger';
 import { IVirtualBackground } from '../reducer';
-import cx from 'classnames';
 /**
  * The type of the React {@code PureComponent} props of {@link VirtualBackgroundPreview}.
  */
@@ -243,7 +243,7 @@ class VirtualBackgroundPreview extends PureComponent<IProps, IState> {
 
         return (
             <Video
-                className={cx(classes.previewVideo, 'flipVideoX')}
+                className = { cx(classes.previewVideo, 'flipVideoX') }
                 id = 'virtual_background_preview'
                 playsinline = { true }
                 videoTrack = {{ jitsiTrack: data }} />


### PR DESCRIPTION
## Summary

This PR fixes a UX inconsistency where the **Virtual Background preview is not mirrored**, while **Video Settings** and **local video tiles are mirrored**. This caused confusion for users who expected consistent mirror behavior across all local video previews.

---

#### Before
*Right* side appears on the *left* side of the preview:
<img width="1083" height="585" alt="Virtual Background Preview - Before (Non-mirrored)" src="https://github.com/user-attachments/assets/8543f6b1-3b3a-48e0-bb06-5c44a4611e98" />

#### After (Mirrored)
*Right* side appears on the *right* side of the preview:
<img width="1459" height="895" alt="Screenshot 2026-03-05 at 3 17 37 PM" src="https://github.com/user-attachments/assets/e6b23934-07b4-4d8e-9a76-a36c0495d985" />

---

### Solution:

#### 1. Added `flipVideoX` CSS class to Virtual Background preview
**File:** `react/features/virtual-background/components/VirtualBackgroundPreview.tsx`
```diff
+ import cx from 'classnames';
```
```diff
- className = { classes.previewVideo }
+ className = { cx(classes.previewVideo, 'flipVideoX') }
```
Fixes #17089