### PR TITLE
fix(chat): scroll to latest messages when opening chat or CC tabs

### DIFF
--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -483,6 +483,7 @@ const Chat = ({
                     role = 'tabpanel'
                     tabIndex = { 0 }>
                     <MessageContainer
+                        isVisible = { _focusedTab === ChatTabs.CHAT }
                         messages = { _messages } />
                     <MessageRecipient />
                     {isPrivateChatAllowed && (

--- a/react/features/chat/components/web/ClosedCaptionsTab.tsx
+++ b/react/features/chat/components/web/ClosedCaptionsTab.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import Icon from '../../../base/icons/components/Icon';
 import { IconSubtitles } from '../../../base/icons/svg';
 import Button from '../../../base/ui/components/web/Button';
 import LanguageSelector from '../../../subtitles/components/web/LanguageSelector';
+import { ChatTabs } from '../../constants';
+import { getFocusedTab } from '../../functions';
 // @ts-ignore
 import AbstractClosedCaptions, { AbstractProps } from '../AbstractClosedCaptions';
 
@@ -82,6 +85,7 @@ const ClosedCaptionsTab = ({
 }: AbstractProps): JSX.Element => {
     const { classes, theme } = useStyles();
     const { t } = useTranslation();
+    const isVisible = useSelector(getFocusedTab) === ChatTabs.CLOSED_CAPTIONS;
 
     if (!isTranscribing) {
         if (canStartSubtitles) {
@@ -118,6 +122,7 @@ const ClosedCaptionsTab = ({
             <div className = { classes.messagesContainer }>
                 <SubtitlesMessagesContainer
                     groups = { groupedSubtitles }
+                    isVisible = { isVisible }
                     messages = { filteredSubtitles } />
             </div>
         </div>

--- a/react/features/chat/components/web/MessageContainer.tsx
+++ b/react/features/chat/components/web/MessageContainer.tsx
@@ -11,6 +11,12 @@ import ChatMessageGroup from './ChatMessageGroup';
 import NewMessagesButton from './NewMessagesButton';
 
 interface IProps {
+
+    /**
+     * Whether the message container is currently visible to the user.
+     * Defaults to true when not provided.
+     */
+    isVisible?: boolean;
     messages: IMessage[];
 }
 
@@ -65,7 +71,14 @@ export default class MessageContainer extends Component<IProps, IState> {
      */
     _bottomListObserver: IntersectionObserver;
 
+    /**
+     * Whether the component has performed its initial scroll to the bottom.
+     * Used to ensure we scroll on first visibility but preserve scroll position on subsequent tab switches.
+     */
+    _hasInitiallyScrolled: boolean;
+
     static defaultProps = {
+        isVisible: true,
         messages: [] as IMessage[]
     };
 
@@ -80,6 +93,7 @@ export default class MessageContainer extends Component<IProps, IState> {
 
         this._messageListRef = React.createRef<HTMLDivElement>();
         this._messagesListEndRef = React.createRef<HTMLDivElement>();
+        this._hasInitiallyScrolled = false;
 
         // Bind event handlers so they are only bound once for every instance.
         this._handleIntersectBottomList = this._handleIntersectBottomList.bind(this);
@@ -139,7 +153,16 @@ export default class MessageContainer extends Component<IProps, IState> {
      * @inheritdoc
      */
     override componentDidMount() {
-        this.scrollToElement(false, null);
+        // Only scroll on mount if the component is visible, since scrollIntoView
+        // silently does nothing on hidden (display: none) elements. If hidden,
+        // componentDidUpdate will handle scrolling when the component first becomes visible.
+        if (this.props.isVisible) {
+            this._hasInitiallyScrolled = true;
+            requestAnimationFrame(() => {
+                this.scrollToElement(false, null);
+            });
+        }
+
         this._createBottomListObserver();
     }
 
@@ -163,6 +186,15 @@ export default class MessageContainer extends Component<IProps, IState> {
                 // eslint-disable-next-line react/no-did-update-set-state
                 this.setState({ hasNewMessages: true });
             }
+        }
+
+        // If the component was mounted while hidden, scrollIntoView was skipped.
+        // Scroll to the bottom the first time it becomes visible to show the latest messages.
+        if (this.props.isVisible && !prevProps.isVisible && !this._hasInitiallyScrolled) {
+            this._hasInitiallyScrolled = true;
+            requestAnimationFrame(() => {
+                this.scrollToElement(false, null);
+            });
         }
     }
 

--- a/react/features/chat/components/web/SubtitlesMessagesContainer.tsx
+++ b/react/features/chat/components/web/SubtitlesMessagesContainer.tsx
@@ -12,6 +12,11 @@ interface IProps {
         messages: ISubtitle[];
         senderId: string;
     }>;
+
+    /**
+     * Whether the subtitles container is currently visible to the user.
+     */
+    isVisible: boolean;
     messages: ISubtitle[];
 }
 
@@ -46,12 +51,13 @@ const useStyles = makeStyles()(() => {
  *
  * @returns {JSX.Element} - A React component displaying subtitles messages with scroll functionality.
  */
-export function SubtitlesMessagesContainer({ messages, groups }: IProps) {
+export function SubtitlesMessagesContainer({ messages, groups, isVisible }: IProps) {
     const { classes } = useStyles();
     const [ hasNewMessages, setHasNewMessages ] = useState(false);
     const [ isScrolledToBottom, setIsScrolledToBottom ] = useState(true);
     const [ observer, setObserver ] = useState<IntersectionObserver | null>(null);
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const hasInitiallyScrolled = useRef(false);
 
     const scrollToElement = useCallback((withAnimation: boolean, element: Element | null) => {
         const scrollTo = element ? element : messagesEndRef.current;
@@ -97,7 +103,16 @@ export function SubtitlesMessagesContainer({ messages, groups }: IProps) {
     };
 
     useEffect(() => {
-        scrollToElement(false, null);
+        // Only scroll on mount if the component is visible, since scrollIntoView
+        // silently does nothing on hidden (display: none) elements. If hidden,
+        // the isVisible useEffect below will handle scrolling when it first becomes visible.
+        if (isVisible) {
+            hasInitiallyScrolled.current = true;
+            requestAnimationFrame(() => {
+                scrollToElement(false, null);
+            });
+        }
+
         createBottomListObserver();
 
         return () => {
@@ -107,6 +122,15 @@ export function SubtitlesMessagesContainer({ messages, groups }: IProps) {
             }
         };
     }, []);
+
+    useEffect(() => {
+        if (isVisible && !hasInitiallyScrolled.current) {
+            hasInitiallyScrolled.current = true;
+            requestAnimationFrame(() => {
+                scrollToElement(false, null);
+            });
+        }
+    }, [ isVisible, scrollToElement ]);
 
     const previousMessages = useRef(messages);
 


### PR DESCRIPTION
## Summary
- Chat and CC panels showed oldest messages at the top when opened because `scrollIntoView` was called on hidden (`display: none`) elements where it silently does nothing
- Now we skip scrolling on mount for hidden tabs and defer it to when each tab first becomes visible
- User's scroll position is preserved on subsequent tab switches (only the first visibility triggers auto-scroll)

## Test plan
- [x] Open chat panel with many messages (Chat tab focused) — should show newest at bottom
- [x] Switch to CC tab with many subtitles — should show newest at bottom (first-time scroll)
- [x] Scroll up in CC, switch to Chat, switch back to CC — scroll position preserved (no re-scroll)
- [x] Close panel, reopen — both tabs should scroll to bottom again on first view (components remounted)
- [x] Verify "New Messages" button still works when user scrolls up and new messages arrive