### PR TITLE
ci: optimize Android SDK build by caching Gradle dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,13 @@ jobs:
         node -v
         npm -v
     - run: npm install
+    - name: Cache Gradle dependencies
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: /root/.gradle
+        key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle.properties', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - run: |
         cd android
         ./gradlew :sdk:clean


### PR DESCRIPTION
### Summary

This PR optimizes the `Simple CI` workflow by caching Gradle dependencies for the `android-sdk-build` job.

### Changes
- Add Gradle dependency cache (`/root/.gradle`)
- Restore the cache before running the Gradle build

Previously the Android SDK job was downloading Gradle dependencies on every run, which added several minutes to the build time. With caching enabled, dependencies can be reused across runs, helping reduce CI time and cost while keeping the build behavior unchanged.

Prev CI Job:
https://github.com/jitsi/jitsi-meet/actions/runs/22581652827/job/65415106130?pr=17065

Now CI job: 
https://github.com/vishal2005025/jitsi-meet/actions/runs/22759308199/job/66014374404