### PR TITLE
 GSoC: fix(participants-pane): fix breakout room participant ellipsis tooltip

### DIFF
--- a/react/features/participants-pane/components/breakout-rooms/components/web/CollapsibleRoom.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/CollapsibleRoom.tsx
@@ -204,7 +204,7 @@ export const CollapsibleRoom = ({
                         participantID = { p.jid }>
                         {!overflowDrawer && moderator && (
                             <ParticipantActionEllipsis
-                                accessibilityLabel = { t('breakoutRoom.more') }
+                                accessibilityLabel = { t('breakoutRooms.actions.more') }
                                 onClick = { getEllipsisClickHandler(p.jid, p.displayName) } />
                         )}
                     </ParticipantItem>


### PR DESCRIPTION
## Description 

The ellipsis (⋯) button for participants inside breakout rooms was using an incorrect translation key `breakoutRoom.more`. Since this key does not exist, the tooltip displayed the raw key instead of the translated text.

This PR updates it to the correct key `breakoutRooms.actions.more`.

## Screenshots 

 * Before
<img width="235" height="484" alt="BreakoutRoom1 Screenshot " src="https://github.com/user-attachments/assets/b72e0a92-8028-414e-85fa-40c0ec1e1d9f" />

 * After
<img width="233" height="481" alt="BreakoutRoom2 Screenshot " src="https://github.com/user-attachments/assets/6fac87f4-7dfd-44b5-a725-c0591322fc9f" />


