### PR TITLE
ci: optimize ios-rn-bundle-build by caching CocoaPods dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,18 @@ jobs:
         ruby-version: '3.4'
         bundler-cache: true
     - run: npx react-native info
+    - name: Cache CocoaPods
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+      with:
+        path: |
+          ios/Pods
+          ~/Library/Caches/CocoaPods
+        key: ${{ runner.os }}-cocoapods-${{ hashFiles('ios/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cocoapods-
     - name: Install Pods
       working-directory: ./ios
-      run: bundle exec pod install --repo-update --deployment
+      run: bundle exec pod install --deployment
     - run: npx react-native bundle --entry-file react/index.native.js --platform ios --bundle-output /tmp/ios.bundle --reset-cache
   android-sdk-build:
     name: Build mobile SDK (Android)


### PR DESCRIPTION
### Summary

This PR optimizes the `ios-rn-bundle-build` job in the `Simple CI` workflow. Like the iOS SDK build, this optimizes the CocoaPods dependency installation.

### Changes
- Add CocoaPods cache (`ios/Pods` and `~/Library/Caches/CocoaPods`)
- Remove the unnecessary `--repo-update` during `pod install`
- Restore the cache before running the CocoaPods installation

Previously the job was downloading CocoaPods dependencies on every run. With caching enabled, dependencies can be reused across runs which helps reduce CI time and cost while keeping the build behavior unchanged.

Prev CI job:
https://github.com/jitsi/jitsi-meet/actions/runs/22633498340/job/65589907687

Now CI job:
https://github.com/vishal2005025/jitsi-meet/actions/runs/22762302702/job/66022471318