### PR TITLE
fix(security): resolve E2EE toggle getting stuck after enable

### DIFF
--- a/react/features/base/ui/components/web/Switch.tsx
+++ b/react/features/base/ui/components/web/Switch.tsx
@@ -116,7 +116,7 @@ const Switch = ({ className, id, checked, disabled, onChange }: IProps) => {
 
     const change = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         onChange(e.target.checked);
-    }, []);
+    }, [ onChange ]);
 
     return (
         <span


### PR DESCRIPTION
### Summary
This PR fixes an issue where the End-to-End Encryption toggle button in the Security options could be turned on, but would not reliably turn back off on the next click.

### Root cause
The shared web `Switch` component memoized its internal `onChange` handler with an empty dependency array. In some flows, that caused the switch to keep calling an outdated callback reference, which made the E2EE toggle behavior inconsistent.

### What changed
- Updated the `Switch` component to keep the `onChange` callback current:
  - Changed `useCallback(..., [])` to `useCallback(..., [onChange])`
- No feature-specific logic was changed in E2EE, Lobby, or Security dialog code.

Before:

https://github.com/user-attachments/assets/ad465867-25b4-4403-bae7-c28c9b6723ed

After:

https://github.com/user-attachments/assets/93700a6f-775d-4067-9fc9-fb587bb81730


### Note:
This is also reproducible on the meet.jit.si