### PR TITLE
fix: add keyboard accessibility to message menu items

### DIFF
--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -68,8 +68,10 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
     const { t } = useTranslation();
     const [ isPopoverOpen, setIsPopoverOpen ] = useState(false);
     const [ showCopiedMessage, setShowCopiedMessage ] = useState(false);
-    const [ popupPosition, setPopupPosition ] = useState({ top: 0,
-        left: 0 });
+    const [ popupPosition, setPopupPosition ] = useState({
+        top: 0,
+        left: 0
+    });
     const buttonRef = useRef<HTMLDivElement>(null);
 
     const participant = useSelector((state: IReduxState) => getParticipantById(state, participantId));
@@ -135,19 +137,39 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
         handleClose();
     }, [ message ]);
 
+    const handlePrivateKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handlePrivateClick();
+        }
+    }, [ handlePrivateClick ]);
+
+    const handleCopyKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handleCopyClick();
+        }
+    }, [ handleCopyClick ]);
+
     const popoverContent = (
         <div className = { classes.menuPanel }>
             {enablePrivateChat && (
                 <div
+                    aria-label = { t('toolbar.accessibilityLabel.privateMessage') }
                     className = { classes.menuItem }
-                    onClick = { handlePrivateClick }>
+                    onClick = { handlePrivateClick }
+                    onKeyDown = { handlePrivateKeyDown }
+                    role = 'menuitem'
+                    tabIndex = { 0 }>
                     {t('Private Message')}
                 </div>
             )}
             {!isFileMessage && (
                 <div
+                    aria-label = { t('dialog.copy') }
                     className = { classes.menuItem }
-                    onClick = { handleCopyClick }>
+                    onClick = { handleCopyClick }
+                    onKeyDown = { handleCopyKeyDown }
+                    role = 'menuitem'
+                    tabIndex = { 0 }>
                     {t('Copy')}
                 </div>
             )}
@@ -175,8 +197,10 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
             {showCopiedMessage && ReactDOM.createPortal(
                 <div
                     className = { cx(classes.copiedMessage, { [classes.showCopiedMessage]: showCopiedMessage }) }
-                    style = {{ top: `${popupPosition.top}px`,
-                        left: `${popupPosition.left}px` }}>
+                    style = {{
+                        top: `${popupPosition.top}px`,
+                        left: `${popupPosition.left}px`
+                    }}>
                     {t('Message Copied')}
                 </div>,
                 document.body


### PR DESCRIPTION
## Summary

This PR improves keyboard accessibility for the chat message context menu by enabling keyboard and screen reader users to interact with the **"Private Message"** and **"Copy"** options.

Previously, these actions were primarily accessible through mouse interaction. With this change, users can now navigate to and activate these options using the keyboard, improving accessibility and usability.

---

## Changes

### `react/features/chat/components/web/MessageMenu.tsx`

- Added `role="menuitem"` to clearly identify the elements as menu items for assistive technologies.
- Added `tabIndex={0}` to allow the items to receive focus during keyboard navigation.
- Added `aria-label` attributes for both **Private Message** and **Copy** actions to provide descriptive labels for screen readers.
- Implemented `onKeyDown` handlers so that pressing the **Enter** key triggers the same behavior as clicking.
- Moved keyboard event handlers into `useCallback` hooks (`handlePrivateKeyDown`, `handleCopyKeyDown`) to comply with the ESLint rule `react/jsx-no-bind`.
- Reused existing i18n translation keys (`toolbar.accessibilityLabel.privateMessage`, `dialog.copy`) to ensure proper localization across all supported languages.
- Sorted props alphabetically to follow the project's ESLint style guidelines.

---

## Accessibility Improvements

| Attribute | Purpose |
|-----------|--------|
| `role="menuitem"` | Indicates that the element is part of a menu for assistive technologies |
| `tabIndex={0}` | Makes the element focusable via keyboard navigation |
| `aria-label` | Provides clear descriptions for screen readers |
| `onKeyDown` (Enter) | Enables keyboard activation equivalent to mouse click |

---

## Testing

- **ESLint** — no errors
- **TypeScript** (`tsc --noEmit`) — passes successfully