### PR TITLE
fix: whiteboard reopening when toggling lobby after hiding whiteboard

### DIFF
--- a/react/features/whiteboard/middleware.any.ts
+++ b/react/features/whiteboard/middleware.any.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'lodash-es';
+
 import { createOpenWhiteboardEvent } from '../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../analytics/functions';
 import { IStore } from '../app/types';
@@ -5,6 +7,7 @@ import { UPDATE_CONFERENCE_METADATA } from '../base/conference/actionTypes';
 import { getCurrentConference } from '../base/conference/functions';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../base/redux/StateListenerRegistry';
+import { _RESET_BREAKOUT_ROOMS } from '../breakout-rooms/actionTypes';
 
 import { SET_WHITEBOARD_OPEN } from './actionTypes';
 import {
@@ -17,10 +20,13 @@ import {
 import { WHITEBOARD_ID } from './constants';
 import {
     generateCollabServerUrl,
+    getCollabDetails,
     isWhiteboardOpen,
     shouldEnforceUserLimit,
     shouldNotifyUserLimit
 } from './functions';
+
+let ignoreNextWhiteboardMetadataAutoOpen = false;
 
 MiddlewareRegistry.register((store: IStore) => next => action => {
     const state = store.getState();
@@ -43,15 +49,31 @@ MiddlewareRegistry.register((store: IStore) => next => action => {
         const { metadata } = action;
 
         if (metadata?.[WHITEBOARD_ID]) {
+            const existingCollabDetails = getCollabDetails(state);
+            const { collabDetails } = metadata[WHITEBOARD_ID];
+            const hasNewCollabDetails = !isEqual(existingCollabDetails, collabDetails);
+
             store.dispatch(setupWhiteboard({
-                collabDetails: metadata[WHITEBOARD_ID].collabDetails,
+                collabDetails,
                 collabServerUrl: generateCollabServerUrl(store.getState())
             }));
-            store.dispatch(setWhiteboardOpen(true));
+
+            if (hasNewCollabDetails && !ignoreNextWhiteboardMetadataAutoOpen) {
+                store.dispatch(setWhiteboardOpen(true));
+            }
+
+            if (ignoreNextWhiteboardMetadataAutoOpen) {
+                ignoreNextWhiteboardMetadataAutoOpen = false;
+            }
         }
 
         break;
     }
+
+    case _RESET_BREAKOUT_ROOMS:
+        ignoreNextWhiteboardMetadataAutoOpen = true;
+        store.dispatch(resetWhiteboard());
+        break;
     }
 
     return next(action);


### PR DESCRIPTION
### Summary
This PR fixes an issue where the whiteboard could reopen in the background after being hidden, when the moderator later toggled Lobby from Security options.

### Problem
After the sequence:
1. Open Security and toggle Lobby (works),
2. Show Whiteboard, then hide Whiteboard (works),
3. Reopen Security and toggle Lobby,

the whiteboard reopened unexpectedly, even though the lobby action is unrelated.

### Root Cause
Whiteboard middleware was reopening whiteboard on conference metadata updates whenever whiteboard metadata existed, even when that metadata was not new.
Lobby toggling can trigger metadata updates, which unintentionally retriggered whiteboard open.

### Changed 
Updated `react/features/whiteboard/middleware.any.ts` so whiteboard auto-open runs only when whiteboard collaboration details are new/changed (roomId/roomKey changed), instead of on every metadata refresh.

### Before fix

https://github.com/user-attachments/assets/a2a42c5f-42f9-4ed5-81c7-6f97d6f3e8a6


### After fix

https://github.com/user-attachments/assets/ee2ddd1d-d694-4bc5-93cb-7e5aad4ee9b9

### Note:
This issue is reproducible on meet.jit.si