### PR TITLE
fix(authentication): Shows notification if popup is blocked.

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -385,6 +385,7 @@
         "login": "Login",
         "loginFailed": "Login failed.",
         "loginOnResume": "Your authentication session has expired. You need to login again to continue the meeting.",
+        "loginPopupBlocked": "Login popup was blocked by your browser.",
         "loginQuestion": "Are you sure you want to login and leave the conference?",
         "logoutQuestion": "Are you sure you want to logout and leave the conference?",
         "logoutTitle": "Logout",

--- a/react/features/authentication/actions.web.ts
+++ b/react/features/authentication/actions.web.ts
@@ -4,7 +4,8 @@ import { connect } from '../base/connection/actions';
 import { openDialog } from '../base/dialog/actions';
 import { setJWT } from '../base/jwt/actions';
 import { browser } from '../base/lib-jitsi-meet';
-import { showErrorNotification } from '../notifications/actions';
+import { hideNotification, showErrorNotification, showNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE } from '../notifications/constants';
 
 import { CANCEL_LOGIN } from './actionTypes';
 import LoginQuestionDialog from './components/web/LoginQuestionDialog';
@@ -12,6 +13,22 @@ import { isTokenAuthInline } from './functions.any';
 import logger from './logger';
 
 export * from './actions.any';
+
+const PROMPT_POPUP_NOTIFICATION_ID = 'PROMPT_POPUP_NOTIFICATION_ID';
+
+/**
+ * Custom error that includes a recovery callback.
+ */
+class PopupBlockedError extends Error {
+    constructor(
+            message: string = 'Popup was blocked by browser',
+            public readonly retry?: () => Window | null
+    ) {
+        super(message);
+        this.name = 'PopupBlockedError';
+        Error.captureStackTrace(this, PopupBlockedError);
+    }
+}
 
 /**
  * Cancels {@ink LoginDialog}.
@@ -68,17 +85,12 @@ function generateNonce(): string {
  * Performs login with a popup window.
  *
  * @param {string} tokenAuthServiceUrl - Authentication service URL.
+ * @param {Window|undefined} popup - Authentication service URL.
  * @returns {Promise<any>} A promise that resolves with the authentication
  * result or rejects with an error.
  */
-export function loginWithPopup(tokenAuthServiceUrl: string): Promise<any> {
+export function loginWithPopup(tokenAuthServiceUrl: string, popup?: Window | null): Promise<any> {
     return new Promise<any>((resolve, reject) => {
-        // Open popup
-        const width = 500;
-        const height = 600;
-        const left = window.screen.width / 2 - width / 2;
-        const top = window.screen.height / 2 - height / 2;
-
         let nonceParam = '';
 
         try {
@@ -97,14 +109,30 @@ export function loginWithPopup(tokenAuthServiceUrl: string): Promise<any> {
             }
         }
 
-        const popup = window.open(
-            `${tokenAuthServiceUrl}${nonceParam}`,
-            `Auth-${Date.now()}`,
-            `width=${width},height=${height},left=${left},top=${top}`
-        );
+        const openPopup = () => {
+            // Open popup
+            const width = 500;
+            const height = 600;
+            const left = window.screen.width / 2 - width / 2;
+            const top = window.screen.height / 2 - height / 2;
+
+            return window.open(
+                `${tokenAuthServiceUrl}${nonceParam}`,
+                `Auth-${Date.now()}`,
+                `width=${width},height=${height},left=${left},top=${top}`
+            );
+        };
 
         if (!popup) {
-            reject(new Error('Popup blocked'));
+            popup = openPopup();
+        }
+
+        if (!popup) {
+            // adds a callback to the error that can be used to directly retry where window.open will be executed
+            // on the user click without any promises(dispatches) incoved
+            reject(new PopupBlockedError('Popup blocked', () => {
+                return openPopup();
+            }));
 
             return;
         }
@@ -113,7 +141,7 @@ export function loginWithPopup(tokenAuthServiceUrl: string): Promise<any> {
         const cleanup = (handler: (event: MessageEvent) => void) => {
             window.removeEventListener('message', handler);
             clearInterval(closedPollInterval);
-            popup.close();
+            popup?.close();
 
             try {
                 sessionStorage.removeItem('oauth_nonce');
@@ -153,7 +181,7 @@ export function loginWithPopup(tokenAuthServiceUrl: string): Promise<any> {
 
         // Detect manual popup close before authentication completes
         closedPollInterval = setInterval(() => {
-            if (popup.closed) {
+            if (popup?.closed) {
                 cleanup(handler);
                 reject(new Error('Login cancelled'));
             }
@@ -210,41 +238,62 @@ export function openTokenAuthUrl(tokenAuthServiceUrl: string): any {
         };
 
         if (!browser.isElectron() && isTokenAuthInline(getState()['features/base/config'])) {
-            loginWithPopup(tokenAuthServiceUrl)
-                .then((result: { accessToken: string; idToken: string; refreshToken?: string; }) => {
-                    // @ts-ignore
-                    const token: string = result.accessToken;
-                    const idToken: string = result.idToken;
-                    const refreshToken: string | undefined = result.refreshToken;
+            const login = (popup?: Window | null) => {
+                return loginWithPopup(tokenAuthServiceUrl, popup)
+                    .then((result: { accessToken: string; idToken: string; refreshToken?: string; }) => {
+                        // @ts-ignore
+                        const token: string = result.accessToken;
+                        const idToken: string = result.idToken;
+                        const refreshToken: string | undefined = result.refreshToken;
 
-                    // @ts-ignore
-                    dispatch(setJWT(token, idToken, refreshToken));
+                        // @ts-ignore
+                        dispatch(setJWT(token, idToken, refreshToken));
 
-                    logger.info('Reconnecting to conference with new token.');
+                        logger.info('Reconnecting to conference with new token.');
 
-                    const { connection } = getState()['features/base/connection'];
+                        const { connection } = getState()['features/base/connection'];
 
-                    if (connection) {
-                        connection.refreshToken(token).then(
-                            () => {
-                                const { membersOnly } = getState()['features/base/conference'];
+                        if (connection) {
+                            connection.refreshToken(token).then(
+                                () => {
+                                    const { membersOnly } = getState()['features/base/conference'];
 
-                                membersOnly?.join();
-                            })
-                            .catch((err: any) => {
-                                dispatch(setJWT());
-                                logger.error(err);
-                            });
-                    } else {
-                        dispatch(connect());
-                    }
-                })
-                .catch(err => {
+                                    membersOnly?.join();
+                                })
+                                .catch((err: any) => {
+                                    dispatch(setJWT());
+                                    logger.error(err);
+                                });
+                        } else {
+                            dispatch(connect());
+                        }
+                    });
+            };
+
+            login().catch(err => {
+                if (err instanceof PopupBlockedError) {
+                    dispatch(showNotification({
+                        titleKey: 'dialog.loginPopupBlocked',
+                        uid: PROMPT_POPUP_NOTIFICATION_ID,
+                        customActionNameKey: [ 'dialog.retry' ],
+                        customActionHandler: [ () => {
+                            dispatch(hideNotification(PROMPT_POPUP_NOTIFICATION_ID));
+
+                            // the window.open will be executed directly from the onClick handler of the notification action button
+                            login(err.retry ? err.retry() : undefined)
+                                .catch(logger.error);
+                        } ],
+                        appearance: NOTIFICATION_TYPE.ERROR
+                    }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
+
+                } else {
+                    // let's add expand that will show the error message in the notification
                     dispatch(showErrorNotification({
                         titleKey: 'dialog.loginFailed'
                     }));
-                    logger.error(err);
-                });
+                }
+                logger.error(err);
+            });
 
             return;
         }


### PR DESCRIPTION
Adds a retry logic with a button. The problem is that some browsers (Safari) when window.open is not executed directly in the onClick handler, but on some underlying Promise will block the popup.

<img width="410" height="166" alt="Screenshot 2026-03-06 at 2 42 59 PM" src="https://github.com/user-attachments/assets/b4bf7e8e-ca38-4b11-9c4c-2d58ea1a3d8f" />
