### PR TITLE
 GSoC: feat(command-palette): Add searchable command palette (Ctrl+Shift+P)

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -80,6 +80,27 @@
         "showParticipantList": "Show participant list",
         "title": "Breakout Rooms"
     },
+    "commandPalette": {
+        "closeChat": "Close Chat",
+        "closeParticipantsPane": "Close Participants Pane",
+        "disableNoiseSuppression": "Disable Noise Suppression",
+        "enableNoiseSuppression": "Enable Noise Suppression",
+        "invitePeople": "Invite People",
+        "lowerHand": "Lower Hand",
+        "mute": "Mute Microphone",
+        "noResults": "No matching commands",
+        "openChat": "Open Chat",
+        "openPalette": "Open command palette",
+        "openParticipantsPane": "Open Participants Pane",
+        "placeholder": "Type a command...",
+        "raiseHand": "Raise Hand",
+        "startCamera": "Start Camera",
+        "startScreenShare": "Start Screen Sharing",
+        "stopCamera": "Stop Camera",
+        "stopScreenShare": "Stop Screen Sharing",
+        "title": "Actions",
+        "unmute": "Unmute Microphone"
+    },
     "calendarSync": {
         "addMeetingURL": "Add a meeting link",
         "confirmAddLink": "Do you want to add a Jitsi link to this event?",

--- a/lang/main.json
+++ b/lang/main.json
@@ -80,27 +80,6 @@
         "showParticipantList": "Show participant list",
         "title": "Breakout Rooms"
     },
-    "commandPalette": {
-        "closeChat": "Close Chat",
-        "closeParticipantsPane": "Close Participants Pane",
-        "disableNoiseSuppression": "Disable Noise Suppression",
-        "enableNoiseSuppression": "Enable Noise Suppression",
-        "invitePeople": "Invite People",
-        "lowerHand": "Lower Hand",
-        "mute": "Mute Microphone",
-        "noResults": "No matching commands",
-        "openChat": "Open Chat",
-        "openPalette": "Open command palette",
-        "openParticipantsPane": "Open Participants Pane",
-        "placeholder": "Type a command...",
-        "raiseHand": "Raise Hand",
-        "startCamera": "Start Camera",
-        "startScreenShare": "Start Screen Sharing",
-        "stopCamera": "Stop Camera",
-        "stopScreenShare": "Stop Screen Sharing",
-        "title": "Actions",
-        "unmute": "Unmute Microphone"
-    },
     "calendarSync": {
         "addMeetingURL": "Add a meeting link",
         "confirmAddLink": "Do you want to add a Jitsi link to this event?",
@@ -190,6 +169,27 @@
     "closedCaptionsTab": {
         "emptyState": "The closed captions content will be available once a moderator starts it",
         "startClosedCaptionsButton": "Start closed captions"
+    },
+    "commandPalette": {
+        "closeChat": "Close Chat",
+        "closeParticipantsPane": "Close Participants Pane",
+        "disableNoiseSuppression": "Disable Noise Suppression",
+        "enableNoiseSuppression": "Enable Noise Suppression",
+        "invitePeople": "Invite People",
+        "lowerHand": "Lower Hand",
+        "mute": "Mute Microphone",
+        "noResults": "No matching commands",
+        "openChat": "Open Chat",
+        "openPalette": "Open command palette",
+        "openParticipantsPane": "Open Participants Pane",
+        "placeholder": "Type a command...",
+        "raiseHand": "Raise Hand",
+        "startCamera": "Start Camera",
+        "startScreenShare": "Start Screen Sharing",
+        "stopCamera": "Stop Camera",
+        "stopScreenShare": "Stop Screen Sharing",
+        "title": "Actions",
+        "unmute": "Unmute Microphone"
     },
     "connectingOverlay": {
         "joiningRoom": "Connecting you to your meeting…"

--- a/react/features/command-palette/commands.ts
+++ b/react/features/command-palette/commands.ts
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { IReduxState, IStore } from '../app/types';
+import JitsiMeetJS from '../base/lib-jitsi-meet';
+import { MEDIA_TYPE } from '../base/media/constants';
+import { isAudioMuted, isVideoMuted } from '../base/media/functions';
+import { raiseHand } from '../base/participants/actions';
+import { getLocalParticipant, hasRaisedHand } from '../base/participants/functions';
+import { toggleChat } from '../chat/actions.web';
+import { isChatDisabled } from '../chat/functions';
+import { beginAddPeople } from '../invite/actions.any';
+import { toggleNoiseSuppression } from '../noise-suppression/actions';
+import { isNoiseSuppressionEnabled } from '../noise-suppression/functions';
+import {
+    close as closeParticipantsPane,
+    open as openParticipantsPane
+} from '../participants-pane/actions.web';
+import {
+    getParticipantsPaneOpen,
+    isParticipantsPaneEnabled
+} from '../participants-pane/functions';
+import { startScreenShareFlow } from '../screen-share/actions.web';
+import { isScreenVideoShared } from '../screen-share/functions';
+import { isButtonEnabled } from '../toolbox/functions.web';
+import { muteLocal } from '../video-menu/actions.any';
+
+import { ICommand } from './types';
+
+/**
+ * Custom hook that returns the list of available commands
+ * for the command palette. Labels update dynamically based
+ * on the current application state.
+ *
+ * @returns {ICommand[]}
+ */
+export function useCommands(): ICommand[] {
+    const dispatch: IStore['dispatch'] = useDispatch();
+    const toolbarButtons = useSelector(
+        (state: IReduxState) => state['features/toolbox'].toolbarButtons || []);
+    const audioMuted = useSelector(isAudioMuted);
+    const videoMuted = useSelector(isVideoMuted);
+    const screenSharing = useSelector(isScreenVideoShared);
+    const chatOpen = useSelector((state: IReduxState) => state['features/chat'].isOpen);
+    const raisedHand = useSelector(
+        (state: IReduxState) => hasRaisedHand(getLocalParticipant(state)));
+    const participantsPaneOpen = useSelector(getParticipantsPaneOpen);
+    const noiseSuppressionOn = useSelector(isNoiseSuppressionEnabled);
+    const _isChatDisabled = useSelector(isChatDisabled);
+    const _isParticipantsPaneEnabled = useSelector(isParticipantsPaneEnabled);
+    const desktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled();
+
+    return useMemo(() => {
+            const commands: ICommand[] = [];
+
+            commands.push({
+                id: 'toggle-audio',
+                label: audioMuted ? 'commandPalette.unmute' : 'commandPalette.mute',
+                execute: () => dispatch(muteLocal(!audioMuted, MEDIA_TYPE.AUDIO))
+            });
+
+            commands.push({
+                id: 'toggle-video',
+                label: videoMuted ? 'commandPalette.startCamera' : 'commandPalette.stopCamera',
+                execute: () => dispatch(muteLocal(!videoMuted, MEDIA_TYPE.VIDEO))
+            });
+
+            if (desktopSharingEnabled && isButtonEnabled('desktop', toolbarButtons)) {
+                commands.push({
+                    id: 'toggle-screen-share',
+                    label: screenSharing ? 'commandPalette.stopScreenShare' : 'commandPalette.startScreenShare',
+                    execute: () => dispatch(startScreenShareFlow(!screenSharing))
+                });
+            }
+
+            if (!_isChatDisabled && isButtonEnabled('chat', toolbarButtons)) {
+                commands.push({
+                    id: 'toggle-chat',
+                    label: chatOpen ? 'commandPalette.closeChat' : 'commandPalette.openChat',
+                    execute: () => dispatch(toggleChat())
+                });
+            }
+
+            if (isButtonEnabled('raisehand', toolbarButtons)) {
+                commands.push({
+                    id: 'toggle-raise-hand',
+                    label: raisedHand ? 'commandPalette.lowerHand' : 'commandPalette.raiseHand',
+                    execute: () => dispatch(raiseHand(!raisedHand))
+                });
+            }
+
+            if (_isParticipantsPaneEnabled
+                && isButtonEnabled('participants-pane', toolbarButtons)) {
+                commands.push({
+                    id: 'toggle-participants-pane',
+                    label: participantsPaneOpen ? 'commandPalette.closeParticipantsPane' : 'commandPalette.openParticipantsPane',
+                    execute: () => {
+                        if (participantsPaneOpen) {
+                            dispatch(closeParticipantsPane());
+                        } else {
+                            dispatch(openParticipantsPane());
+                        }
+                    }
+                });
+            }
+
+            if (isButtonEnabled('noisesuppression', toolbarButtons)) {
+                commands.push({
+                    id: 'toggle-noise-suppression',
+                    label: noiseSuppressionOn ? 'commandPalette.disableNoiseSuppression' : 'commandPalette.enableNoiseSuppression',
+                    execute: () => dispatch(toggleNoiseSuppression())
+                });
+            }
+
+            if (isButtonEnabled('invite', toolbarButtons)) {
+                commands.push({
+                    id: 'invite-people',
+                    label: 'commandPalette.invitePeople',
+                    execute: () => dispatch(beginAddPeople())
+                });
+            }
+
+            return commands;
+        }, [ audioMuted, chatOpen, desktopSharingEnabled, dispatch, _isChatDisabled, _isParticipantsPaneEnabled, noiseSuppressionOn, participantsPaneOpen, raisedHand, screenSharing, toolbarButtons, videoMuted ]
+    );
+}

--- a/react/features/command-palette/commands.ts
+++ b/react/features/command-palette/commands.ts
@@ -51,76 +51,76 @@ export function useCommands(): ICommand[] {
     const desktopSharingEnabled = JitsiMeetJS.isDesktopSharingEnabled();
 
     return useMemo(() => {
-            const commands: ICommand[] = [];
+        const commands: ICommand[] = [];
 
+        commands.push({
+            id: 'toggle-audio',
+            label: audioMuted ? 'commandPalette.unmute' : 'commandPalette.mute',
+            execute: () => dispatch(muteLocal(!audioMuted, MEDIA_TYPE.AUDIO))
+        });
+
+        commands.push({
+            id: 'toggle-video',
+            label: videoMuted ? 'commandPalette.startCamera' : 'commandPalette.stopCamera',
+            execute: () => dispatch(muteLocal(!videoMuted, MEDIA_TYPE.VIDEO))
+        });
+
+        if (desktopSharingEnabled && isButtonEnabled('desktop', toolbarButtons)) {
             commands.push({
-                id: 'toggle-audio',
-                label: audioMuted ? 'commandPalette.unmute' : 'commandPalette.mute',
-                execute: () => dispatch(muteLocal(!audioMuted, MEDIA_TYPE.AUDIO))
+                id: 'toggle-screen-share',
+                label: screenSharing ? 'commandPalette.stopScreenShare' : 'commandPalette.startScreenShare',
+                execute: () => dispatch(startScreenShareFlow(!screenSharing))
             });
+        }
 
+        if (!_isChatDisabled && isButtonEnabled('chat', toolbarButtons)) {
             commands.push({
-                id: 'toggle-video',
-                label: videoMuted ? 'commandPalette.startCamera' : 'commandPalette.stopCamera',
-                execute: () => dispatch(muteLocal(!videoMuted, MEDIA_TYPE.VIDEO))
+                id: 'toggle-chat',
+                label: chatOpen ? 'commandPalette.closeChat' : 'commandPalette.openChat',
+                execute: () => dispatch(toggleChat())
             });
+        }
 
-            if (desktopSharingEnabled && isButtonEnabled('desktop', toolbarButtons)) {
-                commands.push({
-                    id: 'toggle-screen-share',
-                    label: screenSharing ? 'commandPalette.stopScreenShare' : 'commandPalette.startScreenShare',
-                    execute: () => dispatch(startScreenShareFlow(!screenSharing))
-                });
-            }
+        if (isButtonEnabled('raisehand', toolbarButtons)) {
+            commands.push({
+                id: 'toggle-raise-hand',
+                label: raisedHand ? 'commandPalette.lowerHand' : 'commandPalette.raiseHand',
+                execute: () => dispatch(raiseHand(!raisedHand))
+            });
+        }
 
-            if (!_isChatDisabled && isButtonEnabled('chat', toolbarButtons)) {
-                commands.push({
-                    id: 'toggle-chat',
-                    label: chatOpen ? 'commandPalette.closeChat' : 'commandPalette.openChat',
-                    execute: () => dispatch(toggleChat())
-                });
-            }
-
-            if (isButtonEnabled('raisehand', toolbarButtons)) {
-                commands.push({
-                    id: 'toggle-raise-hand',
-                    label: raisedHand ? 'commandPalette.lowerHand' : 'commandPalette.raiseHand',
-                    execute: () => dispatch(raiseHand(!raisedHand))
-                });
-            }
-
-            if (_isParticipantsPaneEnabled
+        if (_isParticipantsPaneEnabled
                 && isButtonEnabled('participants-pane', toolbarButtons)) {
-                commands.push({
-                    id: 'toggle-participants-pane',
-                    label: participantsPaneOpen ? 'commandPalette.closeParticipantsPane' : 'commandPalette.openParticipantsPane',
-                    execute: () => {
-                        if (participantsPaneOpen) {
-                            dispatch(closeParticipantsPane());
-                        } else {
-                            dispatch(openParticipantsPane());
-                        }
+            commands.push({
+                id: 'toggle-participants-pane',
+                label: participantsPaneOpen ? 'commandPalette.closeParticipantsPane' : 'commandPalette.openParticipantsPane',
+                execute: () => {
+                    if (participantsPaneOpen) {
+                        dispatch(closeParticipantsPane());
+                    } else {
+                        dispatch(openParticipantsPane());
                     }
-                });
-            }
+                }
+            });
+        }
 
-            if (isButtonEnabled('noisesuppression', toolbarButtons)) {
-                commands.push({
-                    id: 'toggle-noise-suppression',
-                    label: noiseSuppressionOn ? 'commandPalette.disableNoiseSuppression' : 'commandPalette.enableNoiseSuppression',
-                    execute: () => dispatch(toggleNoiseSuppression())
-                });
-            }
+        if (isButtonEnabled('noisesuppression', toolbarButtons)) {
+            commands.push({
+                id: 'toggle-noise-suppression',
+                label: noiseSuppressionOn ? 'commandPalette.disableNoiseSuppression' : 'commandPalette.enableNoiseSuppression',
+                execute: () => dispatch(toggleNoiseSuppression())
+            });
+        }
 
-            if (isButtonEnabled('invite', toolbarButtons)) {
-                commands.push({
-                    id: 'invite-people',
-                    label: 'commandPalette.invitePeople',
-                    execute: () => dispatch(beginAddPeople())
-                });
-            }
+        if (isButtonEnabled('invite', toolbarButtons)) {
+            commands.push({
+                id: 'invite-people',
+                label: 'commandPalette.invitePeople',
+                execute: () => dispatch(beginAddPeople())
+            });
+        }
 
-            return commands;
-        }, [ audioMuted, chatOpen, desktopSharingEnabled, dispatch, _isChatDisabled, _isParticipantsPaneEnabled, noiseSuppressionOn, participantsPaneOpen, raisedHand, screenSharing, toolbarButtons, videoMuted ]
+        return commands;
+    }, [ audioMuted, chatOpen, desktopSharingEnabled, dispatch, _isChatDisabled, _isParticipantsPaneEnabled, noiseSuppressionOn, participantsPaneOpen, raisedHand, screenSharing, toolbarButtons, videoMuted ]
     );
 }

--- a/react/features/command-palette/components/web/CommandPalette.tsx
+++ b/react/features/command-palette/components/web/CommandPalette.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
@@ -70,14 +70,22 @@ const CommandPalette = () => {
      * @param {number} index - Index in the filtered list.
      * @returns {void}
      */
-    function run(index: number): void {
+    const run = useCallback((index: number) => {
         if (index >= 0 && index < filtered.length) {
             dispatch(hideDialog());
             filtered[index].execute();
         }
-    }
+    }, [ dispatch, filtered ]);
 
-    function onKeyDown(e: React.KeyboardEvent): void {
+    const onQueryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        setQuery(e.target.value);
+    }, []);
+
+    const onCommandClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        run(Number(e.currentTarget.dataset.index));
+    }, [ run ]);
+
+    const onKeyDown = useCallback((e: React.KeyboardEvent) => {
         if (e.key === 'ArrowDown') {
             e.preventDefault();
             setSelected(s => Math.min(s + 1, filtered.length - 1));
@@ -89,7 +97,7 @@ const CommandPalette = () => {
             e.stopPropagation();
             run(selected);
         }
-    }
+    }, [ filtered.length, run, selected ]);
 
     return (
         <Dialog
@@ -103,7 +111,7 @@ const CommandPalette = () => {
                     autoComplete = 'off'
                     autoFocus = { true }
                     className = { classes.search }
-                    onChange = { e => setQuery(e.target.value) }
+                    onChange = { onQueryChange }
                     placeholder = { t('commandPalette.placeholder') }
                     type = 'text'
                     value = { query } />
@@ -111,8 +119,9 @@ const CommandPalette = () => {
                     {filtered.map((cmd, i) => (
                         <div
                             className = { cx(classes.commandItem, i === selected && 'selected') }
+                            data-index = { i }
                             key = { cmd.id }
-                            onClick = { () => run(i) }>
+                            onClick = { onCommandClick }>
                             {t(cmd.label)}
                         </div>
                     ))}

--- a/react/features/command-palette/components/web/CommandPalette.tsx
+++ b/react/features/command-palette/components/web/CommandPalette.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable react/jsx-no-bind */
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+
+import { hideDialog } from '../../../base/dialog/actions';
+import Dialog from '../../../base/ui/components/web/Dialog';
+import { useCommands } from '../../commands';
+
+const useStyles = makeStyles()(theme => {
+    return {
+        search: {
+            backgroundColor: theme.palette.ui03,
+            color: theme.palette.text01,
+            ...theme.typography.bodyShortRegular,
+            padding: '10px 16px',
+            borderRadius: theme.shape.borderRadius,
+            border: 0,
+            height: '40px',
+            boxSizing: 'border-box' as const,
+            width: '100%',
+            marginBottom: '8px',
+
+            '&::placeholder': {
+                color: theme.palette.text02
+            },
+
+            '&:focus': {
+                outline: 0,
+                boxShadow: `0px 0px 0px 2px ${theme.palette.focus01}`
+            }
+        },
+
+        commandItem: {
+            padding: '8px 16px',
+            cursor: 'pointer',
+            borderRadius: `${theme.shape.borderRadius}px`,
+
+            '&:hover, &.selected': {
+                backgroundColor: theme.palette.ui03
+            }
+        }
+    };
+});
+
+/**
+ * A searchable command palette dialog that lets users quickly
+ * find and execute meeting actions.
+ *
+ * @returns {React.ReactElement}
+ */
+const CommandPalette = () => {
+    const { t } = useTranslation();
+    const { classes, cx } = useStyles();
+    const dispatch = useDispatch();
+    const commands = useCommands();
+
+    const [ query, setQuery ] = useState('');
+    const [ selected, setSelected ] = useState(0);
+
+    const filtered = query
+        ? commands.filter(c => t(c.label).toLowerCase().includes(query.toLowerCase()))
+        : commands;
+
+    /**
+     * Run a command and close the palette.
+     *
+     * @param {number} index - Index in the filtered list.
+     * @returns {void}
+     */
+    function run(index: number): void {
+        if (index >= 0 && index < filtered.length) {
+            dispatch(hideDialog());
+            filtered[index].execute();
+        }
+    }
+
+    function onKeyDown(e: React.KeyboardEvent): void {
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setSelected(s => Math.min(s + 1, filtered.length - 1));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setSelected(s => Math.max(s - 1, 0));
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            e.stopPropagation();
+            run(selected);
+        }
+    }
+
+    return (
+        <Dialog
+            cancel = {{ hidden: true }}
+            disableEnter = { true }
+            hideCloseButton = { true }
+            ok = {{ hidden: true }}
+            titleKey = 'commandPalette.title'>
+            <div onKeyDown = { onKeyDown }>
+                <input
+                    autoComplete = 'off'
+                    autoFocus = { true }
+                    className = { classes.search }
+                    onChange = { e => setQuery(e.target.value) }
+                    placeholder = { t('commandPalette.placeholder') }
+                    type = 'text'
+                    value = { query } />
+                <div>
+                    {filtered.map((cmd, i) => (
+                        <div
+                            className = { cx(classes.commandItem, i === selected && 'selected') }
+                            key = { cmd.id }
+                            onClick = { () => run(i) }>
+                            {t(cmd.label)}
+                        </div>
+                    ))}
+                    {filtered.length === 0 && (
+                        <div>{t('commandPalette.noResults')}</div>
+                    )}
+                </div>
+            </div>
+        </Dialog>
+    );
+};
+
+export default CommandPalette;

--- a/react/features/command-palette/hooks.web.ts
+++ b/react/features/command-palette/hooks.web.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { toggleDialog } from '../base/dialog/actions';
+import { registerShortcut, unregisterShortcut } from '../keyboard-shortcuts/actions';
+import CommandPalette from './components/web/CommandPalette';
+
+const SHORTCUT_KEY = '-P';
+
+/**
+ * Hook that registers the Ctrl+Shift+P keyboard shortcut to open the
+ * command palette.
+ * @returns {void}
+ */
+export function useCommandPaletteShortcut(): void {
+    const dispatch = useDispatch();
+
+    useEffect(() => {
+        dispatch(registerShortcut({
+            character: SHORTCUT_KEY,
+            helpCharacter: 'Ctrl+Shift+P',
+            helpDescription: 'commandPalette.openPalette',
+            handler: () => {
+                // No-op: actual handling is done by the keydown listener below
+                // because the shortcut system uses keyup and cannot prevent
+                // browser default behavior or distinguish Shift modifier.
+            }
+        }));
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.code === 'KeyP') {
+                e.preventDefault();
+                dispatch(toggleDialog('CommandPalette', CommandPalette));
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            dispatch(unregisterShortcut(SHORTCUT_KEY));
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []);
+}

--- a/react/features/command-palette/hooks.web.ts
+++ b/react/features/command-palette/hooks.web.ts
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+
 import { toggleDialog } from '../base/dialog/actions';
 import { registerShortcut, unregisterShortcut } from '../keyboard-shortcuts/actions';
+
 import CommandPalette from './components/web/CommandPalette';
 
 const SHORTCUT_KEY = '-P';
@@ -9,6 +11,7 @@ const SHORTCUT_KEY = '-P';
 /**
  * Hook that registers the Ctrl+Shift+P keyboard shortcut to open the
  * command palette.
+ *
  * @returns {void}
  */
 export function useCommandPaletteShortcut(): void {
@@ -19,7 +22,9 @@ export function useCommandPaletteShortcut(): void {
             character: SHORTCUT_KEY,
             helpCharacter: 'Ctrl+Shift+P',
             helpDescription: 'commandPalette.openPalette',
-            handler: () => {}
+            handler: () => { // eslint-disable-line @typescript-eslint/no-empty-function
+                // Handled via keydown listener to support Ctrl+Shift
+            }
         }));
 
         const handleKeyDown = (e: KeyboardEvent) => {

--- a/react/features/command-palette/hooks.web.ts
+++ b/react/features/command-palette/hooks.web.ts
@@ -19,11 +19,7 @@ export function useCommandPaletteShortcut(): void {
             character: SHORTCUT_KEY,
             helpCharacter: 'Ctrl+Shift+P',
             helpDescription: 'commandPalette.openPalette',
-            handler: () => {
-                // No-op: actual handling is done by the keydown listener below
-                // because the shortcut system uses keyup and cannot prevent
-                // browser default behavior or distinguish Shift modifier.
-            }
+            handler: () => {}
         }));
 
         const handleKeyDown = (e: KeyboardEvent) => {

--- a/react/features/command-palette/types.ts
+++ b/react/features/command-palette/types.ts
@@ -1,0 +1,5 @@
+export interface ICommand {
+    execute: () => void;
+    id: string;
+    label: string;
+}

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -16,6 +16,7 @@ import { isInBreakoutRoom } from '../breakout-rooms/functions';
 import { toggleChat } from '../chat/actions.web';
 import { isChatDisabled } from '../chat/functions';
 import { useChatButton } from '../chat/hooks.web';
+import { useCommandPaletteShortcut } from '../command-palette/hooks.web';
 import { useCustomPanelButton } from '../custom-panel/hooks.web';
 import { useEmbedButton } from '../embed-meeting/hooks';
 import { useEtherpadButton } from '../etherpad/hooks';
@@ -373,6 +374,7 @@ export function useToolboxButtons(
 
 
 export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
+    useCommandPaletteShortcut();
     const dispatch = useDispatch();
     const _isSpeakerStatsDisabled = useSelector(isSpeakerStatsDisabled);
     const _isParticipantsPaneEnabled = useSelector(isParticipantsPaneEnabled);


### PR DESCRIPTION
## Description
Added a command palette that shows actions when the user presses Ctrl+Shift+P. Since this is an initial implementation, I have used a subset of commands and reused the `Dialog` component with styles.

Once this concept looks good to you, I can continue improving it by adding more commands and by creating a dedicated component instead of reusing Dialog and some other improvements 

## Screenshot 
https://github.com/user-attachments/assets/be1b815e-7629-4253-af17-83dd7e2a2694

