### PR TITLE
fix(base/util): prevent double URL encoding of non-ASCII room names

### DIFF
--- a/react/features/app/actions.native.ts
+++ b/react/features/app/actions.native.ts
@@ -18,7 +18,7 @@ import isInsecureRoomName from '../base/util/isInsecureRoomName';
 import { parseURLParams } from '../base/util/parseURLParams';
 import {
     appendURLParam,
-    getBackendSafeRoomName,
+    getNormalizedRoomName,
     parseURIString,
     toURLString
 } from '../base/util/uri';
@@ -110,7 +110,7 @@ export function appNavigate(uri?: string, options: IReloadNowOptions = {}) {
         let url = `${baseURL}config.js`;
 
         // XXX In order to support multiple shards, tell the room to the deployment.
-        room && (url = appendURLParam(url, 'room', getBackendSafeRoomName(room) ?? ''));
+        room && (url = appendURLParam(url, 'room', getNormalizedRoomName(room) ?? ''));
 
         const { release } = parseURLParams(location, true, 'search');
 

--- a/react/features/base/connection/actions.any.ts
+++ b/react/features/base/connection/actions.any.ts
@@ -9,7 +9,8 @@ import { isEmbedded } from '../util/embedUtils';
 import { parseURLParams } from '../util/parseURLParams';
 import {
     appendURLParam,
-    getBackendSafeRoomName
+    getBackendSafeRoomName,
+    getNormalizedRoomName
 } from '../util/uri';
 
 import {
@@ -142,7 +143,7 @@ export function constructOptions(state: IReduxState) {
     const { room } = state['features/base/conference'];
 
     if (serviceUrl && room) {
-        const roomName = getBackendSafeRoomName(room);
+        const roomName = getNormalizedRoomName(room);
 
         options.serviceUrl = appendURLParam(serviceUrl, 'room', roomName ?? '');
 

--- a/react/features/base/util/uri.ts
+++ b/react/features/base/util/uri.ts
@@ -134,12 +134,13 @@ export function getBackendSafePath(path?: string): string | undefined {
 }
 
 /**
- * Converts a room name to a backend-safe format. Properly lowercased and url encoded.
+ * Decodes, NFKC-normalizes, and lowercases a room name without percent-encoding the result.
+ * Use this when the result will be passed to an API (e.g. URLSearchParams) that encodes automatically.
  *
- * @param {string?} room - The room name to convert.
+ * @param {string?} room - The room name to normalize.
  * @returns {string?}
  */
-export function getBackendSafeRoomName(room?: string): string | undefined {
+export function getNormalizedRoomName(room?: string): string | undefined {
     if (!room) {
         return room;
     }
@@ -162,16 +163,27 @@ export function getBackendSafeRoomName(room?: string): string | undefined {
 
     // Only decoded and normalized strings can be lowercased properly.
     room = room?.toLowerCase();
-
-    // But we still need to (re)encode it.
-    room = encodeURIComponent(room ?? '');
     /* eslint-enable no-param-reassign */
 
-    // Unfortunately we still need to lowercase it, because encoding a string will
-    // add some uppercase characters, but some backend services
-    // expect it to be full lowercase. However lowercasing an encoded string
-    // doesn't change the string value.
-    return room.toLowerCase();
+    return room;
+}
+
+/**
+ * Converts a room name to a backend-safe format. Properly lowercased and url encoded.
+ *
+ * @param {string?} room - The room name to convert.
+ * @returns {string?}
+ */
+export function getBackendSafeRoomName(room?: string): string | undefined {
+    const normalized = getNormalizedRoomName(room);
+
+    if (!normalized) {
+        return normalized;
+    }
+
+    // Lowercase again after encoding because encodeURIComponent produces uppercase hex digits,
+    // but some backend services expect fully lowercase encoded strings.
+    return encodeURIComponent(normalized).toLowerCase();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Room names with non-ASCII characters (e.g. `testròom`) were being double URL-encoded when appended as query parameters to websocket, conference-request, and keepalive URLs. The `%` from the first encoding (e.g. `%c3%b2`) was re-encoded as `%25`, producing `%25c3%25b2`, which breaks room lookup on the backend.
- Extracted `getNormalizedRoomName()` that decodes, NFKC-normalizes, and lowercases without percent-encoding, for use in `appendURLParam()` call sites where `URLSearchParams.append()` handles encoding automatically.
- Refactored `getBackendSafeRoomName()` to call `getNormalizedRoomName()` internally, preserving identical behavior for all other callers (XMPP JIDs, `connection.connect()`, etc.).

## Test plan

- [ ] Join a room with non-ASCII characters (e.g. `testròom`), inspect network requests to confirm `?room=` param is single-encoded (`%c3%b2`, not `%25c3%25b2`)
- [ ] Verify XMPP JID still works correctly (uses `getBackendSafeRoomName`, unchanged)
- [ ] Verify plain ASCII room names still work (no-op change)
- [ ] Test with 2 participants (P2P) and 3+ participants (JVB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)