### PR TITLE
feat(chat): add message search with highlight

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -143,6 +143,7 @@
         },
         "noMessagesMessage": "There are no messages in the meeting yet. Start a conversation here!",
         "privateNotice": "Private message to {{recipient}}",
+        "searchPlaceholder": "Search in chat…",
         "sendButton": "Send",
         "smileysPanel": "Emoji panel",
         "systemDisplayName": "System",

--- a/react/features/base/ui/Tokens.ts
+++ b/react/features/base/ui/Tokens.ts
@@ -92,6 +92,7 @@ export const colorMap = {
     chatRecipientContainer: 'support05',      // Recipient container background
     chatRecipientText: 'textColor01',         // Recipient text color
     chatReplyIcon: 'icon01',                  // Reply icon color
+    chatSearchHighlightText: 'surface01',     // Search match highlight text
     chatSenderName: 'textColor02',            // Sender display name color
     chatTimestamp: 'ui03',                    // Chat timestamp text
 

--- a/react/features/base/ui/types.ts
+++ b/react/features/base/ui/types.ts
@@ -83,6 +83,7 @@ export interface IPalette {
     chatRecipientContainer: string;
     chatRecipientText: string;
     chatReplyIcon: string;
+    chatSearchHighlightText: string;
     chatSenderName: string;
     chatTimestamp: string;
     dialogBackground: string;

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -284,6 +284,10 @@ const Chat = ({
     const [ isMouseDown, setIsMouseDown ] = useState(false);
     const [ mousePosition, setMousePosition ] = useState<number | null>(null);
     const [ dragChatWidth, setDragChatWidth ] = useState<number | null>(null);
+
+    // Search state
+    const [ isSearchOpen, setIsSearchOpen ] = useState(false);
+    const [ searchTerm, setSearchTerm ] = useState('');
     const maxChatWidth = useSelector(getChatMaxSize);
     const notifyTimestamp = useSelector((state: IReduxState) =>
         state['features/chat'].notifyPrivateRecipientsChangedTimestamp
@@ -314,6 +318,30 @@ const Chat = ({
 
         return o;
     }, [ participants, defaultRemoteDisplayName, t, notifyTimestamp ]);
+
+    const filteredMessages = useMemo(() => {
+        const trimmed = searchTerm.trim().toLowerCase();
+
+        if (!trimmed) {
+            return _messages;
+        }
+
+        return _messages.filter(m => m.message?.toLowerCase().includes(trimmed));
+    }, [ _messages, searchTerm ]);
+
+    const onSearchToggle = useCallback(() => {
+        setIsSearchOpen(open => {
+            if (open) {
+                setSearchTerm('');
+            }
+
+            return !open;
+        });
+    }, []);
+
+    const onSearch = useCallback((value: string) => {
+        setSearchTerm(value);
+    }, []);
 
     /**
      * Handles pointer down on the drag handle.
@@ -484,7 +512,8 @@ const Chat = ({
                     tabIndex = { 0 }>
                     <MessageContainer
                         isVisible = { _focusedTab === ChatTabs.CHAT }
-                        messages = { _messages } />
+                        messages = { filteredMessages }
+                        searchTerm = { searchTerm.trim() } />
                     <MessageRecipient />
                     {isPrivateChatAllowed && (
                         <Select
@@ -628,7 +657,11 @@ const Chat = ({
                 className = { cx('chat-header', classes.chatHeader) }
                 isCCTabEnabled = { _isCCTabEnabled }
                 isPollsEnabled = { _isPollsEnabled }
-                onCancel = { onToggleChat } />
+                isSearchOpen = { isSearchOpen }
+                onCancel = { onToggleChat }
+                onSearch = { onSearch }
+                onSearchToggle = { onSearchToggle }
+                searchTerm = { searchTerm } />
             {_showNamePrompt
                 ? <DisplayNameForm
                     isCCTabEnabled = { _isCCTabEnabled }

--- a/react/features/chat/components/web/ChatHeader.tsx
+++ b/react/features/chat/components/web/ChatHeader.tsx
@@ -1,13 +1,16 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
 
 import Icon from '../../../base/icons/components/Icon';
-import { IconCloseLarge } from '../../../base/icons/svg';
+import { IconCloseLarge, IconSearch } from '../../../base/icons/svg';
 import { isFileSharingEnabled } from '../../../file-sharing/functions.any';
 import { toggleChat } from '../../actions.web';
 import { ChatTabs } from '../../constants';
 import { getFocusedTab, isChatDisabled } from '../../functions';
+
+import ChatSearch from './ChatSearch';
 
 interface IProps {
 
@@ -27,19 +30,80 @@ interface IProps {
     isPollsEnabled: boolean;
 
     /**
+     * Whether search mode is currently active.
+     */
+    isSearchOpen: boolean;
+
+    /**
      * Function to be called when pressing the close button.
      */
     onCancel: Function;
+
+    /**
+     * Callback to update the search term from the parent.
+     */
+    onSearch: (value: string) => void;
+
+    /**
+     * Callback to toggle the search bar.
+     */
+    onSearchToggle: () => void;
+
+    /**
+     * The current search term.
+     */
+    searchTerm: string;
 }
+
+const useStyles = makeStyles()(theme => {
+    return {
+        headerActions: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing(2),
+            flexShrink: 0
+        },
+
+        iconButton: {
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            color: theme.palette.icon01,
+
+            '&:hover': {
+                color: theme.palette.icon02
+            }
+        },
+
+        headerRow: {
+            display: 'flex',
+            alignItems: 'center',
+            width: '100%'
+        },
+
+        headerTitle: {
+            flex: 1
+        }
+    };
+});
 
 /**
  * Custom header of the {@code ChatDialog}.
  *
  * @returns {React$Element<any>}
  */
-function ChatHeader({ className, isCCTabEnabled, isPollsEnabled }: IProps) {
+function ChatHeader({
+    className,
+    isCCTabEnabled,
+    isPollsEnabled,
+    isSearchOpen,
+    onSearch,
+    onSearchToggle,
+    searchTerm
+}: IProps) {
     const dispatch = useDispatch();
     const { t } = useTranslation();
+    const { classes } = useStyles();
     const _isChatDisabled = useSelector(isChatDisabled);
     const focusedTab = useSelector(getFocusedTab);
     const fileSharingTabEnabled = useSelector(isFileSharingEnabled);
@@ -48,12 +112,19 @@ function ChatHeader({ className, isCCTabEnabled, isPollsEnabled }: IProps) {
         dispatch(toggleChat());
     }, []);
 
-    const onKeyPressHandler = useCallback(e => {
-        if (onCancel && (e.key === ' ' || e.key === 'Enter')) {
+    const onKeyPressHandler = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
             e.preventDefault();
             onCancel();
         }
     }, []);
+
+    const onSearchToggleKeyPress = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            onSearchToggle();
+        }
+    }, [ onSearchToggle ]);
 
     let title = 'chat.title';
 
@@ -66,27 +137,52 @@ function ChatHeader({ className, isCCTabEnabled, isPollsEnabled }: IProps) {
     } else if (fileSharingTabEnabled && focusedTab === ChatTabs.FILE_SHARING) {
         title = 'chat.tabs.fileSharing';
     } else {
-        // If the focused tab is not enabled, don't render the header.
-        // This should not happen in normal circumstances since Chat.tsx already checks
-        // if any tabs are available before rendering.
         return null;
     }
 
+    const isChatTab = !_isChatDisabled && focusedTab === ChatTabs.CHAT;
+    const showSearchBar = isChatTab && isSearchOpen;
+
     return (
-        <div
-            className = { className || 'chat-dialog-header' }>
-            <span
-                aria-level = { 1 }
-                role = 'heading'>
-                { t(title) }
-            </span>
-            <Icon
-                ariaLabel = { t('toolbar.closeChat') }
-                onClick = { onCancel }
-                onKeyPress = { onKeyPressHandler }
-                role = 'button'
-                src = { IconCloseLarge }
-                tabIndex = { 0 } />
+        <div className = { className || 'chat-dialog-header' }>
+            <div className = { classes.headerRow }>
+                {showSearchBar
+                    ? (
+                        <ChatSearch
+                            onSearch = { onSearch }
+                            searchTerm = { searchTerm } />
+                    )
+                    : (
+                        <span
+                            aria-level = { 1 }
+                            className = { classes.headerTitle }
+                            role = 'heading'>
+                            {t(title)}
+                        </span>
+                    )
+                }
+                <div className = { classes.headerActions }>
+                    {isChatTab && !isSearchOpen && (
+                        <span
+                            className = { classes.iconButton }
+                            onClick = { onSearchToggle }
+                            onKeyPress = { onSearchToggleKeyPress }
+                            role = 'button'
+                            tabIndex = { 0 }>
+                            <Icon
+                                size = { 20 }
+                                src = { IconSearch } />
+                        </span>
+                    )}
+                    <Icon
+                        ariaLabel = { t('toolbar.closeChat') }
+                        onClick = { onCancel }
+                        onKeyPress = { onKeyPressHandler }
+                        role = 'button'
+                        src = { IconCloseLarge }
+                        tabIndex = { 0 } />
+                </div>
+            </div>
         </div>
     );
 }

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -8,6 +8,7 @@ import { translate } from '../../../base/i18n/functions';
 import { getParticipantById, getParticipantDisplayName, isPrivateChatEnabled } from '../../../base/participants/functions';
 import Popover from '../../../base/popover/components/Popover.web';
 import Message from '../../../base/react/components/web/Message';
+import { escapeRegexp } from '../../../base/util/helpers';
 import { MESSAGE_TYPE_LOCAL } from '../../constants';
 import { getDisplayNameSuffix, getFormattedTimestamp, getMessageText, getPrivateNoticeMessage, isFileMessage } from '../../functions';
 import { IChatMessageProps } from '../../types';
@@ -19,6 +20,7 @@ import ReactButton from './ReactButton';
 interface IProps extends IChatMessageProps {
     className?: string;
     enablePrivateChat?: boolean;
+    searchTerm?: string;
     shouldDisplayMenuOnRight?: boolean;
     state?: IReduxState;
 }
@@ -202,6 +204,11 @@ const useStyles = makeStyles()((theme: Theme) => {
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap'
+        },
+        highlight: {
+            color: theme.palette.chatSearchHighlightText,
+            borderRadius: '2px',
+            padding: '0 1px'
         }
     };
 });
@@ -209,6 +216,7 @@ const useStyles = makeStyles()((theme: Theme) => {
 const ChatMessage = ({
     className = '',
     message,
+    searchTerm,
     state,
     showDisplayName,
     shouldDisplayMenuOnRight,
@@ -219,6 +227,31 @@ const ChatMessage = ({
     const { classes, cx } = useStyles();
     const [ isHovered, setIsHovered ] = useState(false);
     const [ isReactionsOpen, setIsReactionsOpen ] = useState(false);
+
+    /**
+     * Splits a plain-text string by the search term and returns an array of
+     * React nodes with matching portions wrapped in a highlighted <mark>.
+     *
+     * @param {string} text - The message text to highlight.
+     * @returns {Array<React.ReactNode>}
+     */
+
+    function _renderHighlightedText(text: string): React.ReactNode {
+        if (!searchTerm) {
+            return text;
+        }
+
+        const regex = new RegExp(`(${escapeRegexp(searchTerm)})`, 'gi');
+        const parts = text.split(regex);
+
+        return parts.map((part, i) =>
+            regex.test(part)
+                ? <mark
+                    className = { classes.highlight }
+                    key = { i }>{part}</mark>
+                : part
+        );
+    }
 
     const handleMouseEnter = useCallback(() => {
         setIsHovered(true);
@@ -389,6 +422,16 @@ const ChatMessage = ({
                                                 user: message.displayName
                                             })
                                         } />
+                                ) : searchTerm ? (
+                                    <p>
+                                        <span className = 'sr-only'>
+                                            {message.messageType === MESSAGE_TYPE_LOCAL
+                                                ? t('chat.messageAccessibleTitleMe')
+                                                : t('chat.messageAccessibleTitle', { user: message.displayName })
+                                            }
+                                        </span>
+                                        {_renderHighlightedText(getMessageText(message))}
+                                    </p>
                                 ) : (
                                     <Message
                                         screenReaderHelpText = { message.messageType === MESSAGE_TYPE_LOCAL

--- a/react/features/chat/components/web/ChatMessageGroup.tsx
+++ b/react/features/chat/components/web/ChatMessageGroup.tsx
@@ -18,6 +18,11 @@ interface IProps {
      * The messages to display as a group.
      */
     messages: Array<IMessage>;
+    
+    /**
+     * The active search term used to highlight matching text in messages.
+     */
+    searchTerm?: string;
 }
 
 const useStyles = makeStyles()(theme => {
@@ -54,7 +59,7 @@ const useStyles = makeStyles()(theme => {
 });
 
 
-const ChatMessageGroup = ({ className = '', messages }: IProps) => {
+const ChatMessageGroup = ({ className = '', messages, searchTerm }: IProps) => {
     const { classes } = useStyles();
     const messagesLength = messages.length;
 
@@ -74,6 +79,7 @@ const ChatMessageGroup = ({ className = '', messages }: IProps) => {
                         className = { className }
                         key = { i }
                         message = { message }
+                        searchTerm = { searchTerm }
                         showDisplayName = { i === 0 }
                         showTimestamp = { i === messages.length - 1 } />
                 ))}

--- a/react/features/chat/components/web/ChatSearch.tsx
+++ b/react/features/chat/components/web/ChatSearch.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from 'tss-react/mui';
+
+import Icon from '../../../base/icons/components/Icon';
+import { IconCloseCircle } from '../../../base/icons/svg';
+
+interface IProps {
+
+    /**
+     * Callback invoked when the search input value changes.
+     */
+    onSearch: (value: string) => void;
+
+    /**
+     * The current search term value (controlled).
+     */
+    searchTerm: string;
+}
+
+const useStyles = makeStyles()(theme => {
+    return {
+        chatSearch: {
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing(2),
+            padding: `0 ${theme.spacing(3)}`,
+            height: '36px',
+            backgroundColor: theme.palette.inputFieldBackground,
+            borderRadius: theme.shape.borderRadius,
+            flex: 1
+        },
+
+        input: {
+            flex: 1,
+            background: 'transparent',
+            border: 'none',
+            outline: 'none',
+            color: theme.palette.inputFieldText,
+            ...theme.typography.bodyShortRegular,
+
+            '&::placeholder': {
+                color: theme.palette.inputFieldPlaceholder
+            }
+        },
+
+        clearButton: {
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            flexShrink: 0,
+            color: theme.palette.icon02,
+
+            '&:hover': {
+                color: theme.palette.icon01
+            }
+        }
+    };
+});
+
+/**
+ * A search input bar for filtering chat messages.
+ *
+ * @returns {JSX.Element}
+ */
+function ChatSearch({ onSearch, searchTerm }: IProps) {
+    const { classes } = useStyles();
+    const { t } = useTranslation();
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        inputRef.current?.focus();
+    }, []);
+
+    const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        onSearch(e.target.value);
+    }, [ onSearch ]);
+
+    const onClear = useCallback(() => {
+        onSearch('');
+        inputRef.current?.focus();
+    }, [ onSearch ]);
+
+    const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            onSearch('');
+        }
+    }, [ onSearch ]);
+
+    const onClearKeyPress = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+            e.preventDefault();
+            onClear();
+        }
+    }, [ onClear ]);
+
+    return (
+        <div className = { classes.chatSearch }>
+            <input
+                autoComplete = 'off'
+                className = { classes.input }
+                onChange = { onChange }
+                onKeyDown = { onKeyDown }
+                placeholder = { t('chat.searchPlaceholder') }
+                ref = { inputRef }
+                type = 'text'
+                value = { searchTerm } />
+            {searchTerm.length > 0 && (
+                <span
+                    className = { classes.clearButton }
+                    onClick = { onClear }
+                    onKeyPress = { onClearKeyPress }
+                    role = 'button'
+                    tabIndex = { 0 }>
+                    <Icon
+                        size = { 16 }
+                        src = { IconCloseCircle } />
+                </span>
+            )}
+        </div>
+    );
+}
+
+export default ChatSearch;

--- a/react/features/chat/components/web/MessageContainer.tsx
+++ b/react/features/chat/components/web/MessageContainer.tsx
@@ -18,6 +18,7 @@ interface IProps {
      */
     isVisible?: boolean;
     messages: IMessage[];
+    searchTerm?: string;
 }
 
 interface IState {
@@ -109,6 +110,7 @@ export default class MessageContainer extends Component<IProps, IState> {
      * @inheritdoc
      */
     override render() {
+        const { searchTerm } = this.props;
         const groupedMessages = this._getMessagesGroupedBySender();
         const content = groupedMessages.map((group, index) => {
             const { messages } = group;
@@ -118,7 +120,8 @@ export default class MessageContainer extends Component<IProps, IState> {
                 <ChatMessageGroup
                     className = { messageType || MESSAGE_TYPE_REMOTE }
                     key = { index }
-                    messages = { messages } />
+                    messages = { messages } 
+                    searchTerm = { searchTerm } />
             );
         });
 


### PR DESCRIPTION
## Summary
Adds a chat search feature to help users quickly find older messages during a meeting.

Clicking the 🔍 icon in the chat header opens a search bar. As the user types, messages are filtered and matching words are highlighted. Clearing the search or closing it shows the fulll chat again.

Changes: new ChatSearch component, search toggle in ChatHeader, message filtering in Chat, highlighted matches in ChatMessage, and the related theme and translation updates.

## Recording

https://github.com/user-attachments/assets/4435f333-cd41-42ae-8b1f-81e2400829d5


Note: closing the search bar is not yet implemented — open to suggestions on the best approach.
