### PR TITLE
fix(custom-panel): Button group

### DIFF
--- a/react/features/custom-panel/hooks.web.ts
+++ b/react/features/custom-panel/hooks.web.ts
@@ -9,7 +9,7 @@ import { isCustomPanelEnabled } from './functions';
 const customPanel = {
     key: 'custom-panel',
     Content: CustomPanelButton,
-    group: 2
+    group: 5
 };
 
 /**


### PR DESCRIPTION
Since we render the button last when it has group 2 out of 4 React prints console.error.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
