### PR TITLE
fix :  prevent memory leak in MessageMenu setTimeout cleanup

### DIFF
--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -71,6 +71,7 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
     const [ popupPosition, setPopupPosition ] = useState({ top: 0,
         left: 0 });
     const buttonRef = useRef<HTMLDivElement>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const participant = useSelector((state: IReduxState) => getParticipantById(state, participantId));
 
@@ -122,7 +123,14 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                         });
                     }
                     setShowCopiedMessage(true);
-                    setTimeout(() => {
+                    
+                    // Clear any existing timeout
+                    if (timeoutRef.current) {
+                        clearTimeout(timeoutRef.current);
+                    }
+                    
+                    // Set new timeout and store reference
+                    timeoutRef.current = setTimeout(() => {
                         setShowCopiedMessage(false);
                     }, 2000);
                 } else {
@@ -133,7 +141,16 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                 logger.error('Error copying text', error);
             });
         handleClose();
-    }, [ message ]);
+    }, [ message, handleClose ]);
+
+    // Cleanup timeout on component unmount
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, []);
 
     const popoverContent = (
         <div className = { classes.menuPanel }>


### PR DESCRIPTION
## Problem
The `MessageMenu` component currently has a memory leak. When a user clicks "Copy" and the 2-second "Message Copied" notification is active, if the component unmounts before the timeout completes, the state update tries to run on an unmounted component. This can lead to memory leaks and runtime errors.  

## Solution
To fix this, we made a few improvements:  
- **Store the timeout reference:** We use `useRef` to keep track of the `setTimeout`.  
- **Prevent overlapping timeouts:** Clearing any existing timeout ensures rapid clicks don’t cause issues.  
- **Cleanup on unmount:** `useEffect` clears the timeout when the component unmounts.  
- **Fix dependencies:** Added the missing `handleClose` to the `useCallback` dependency array.  

## Benefits
- Eliminates memory leaks when the component unmounts.  
- Handles multiple rapid copy clicks smoothly.  
- Follows React best practices for side-effect cleanup.  
- No changes to the UI or breaking functionality.  
- TypeScript still compiles without errors.  

## Testing
- Component unmounts cleanly even during the timeout.  
- Rapid consecutive clicks work as expected.  
- Copy functionality behaves correctly.  
- No TypeScript or runtime errors.  

## Learnings
This update highlights proper React patterns for managing side effects:  
- Using `useRef` to store mutable values like timeout IDs.  
- Cleaning up side effects with `useEffect`.  
- Ensuring correct dependencies in `useCallback` to avoid stale closures.