### PR TITLE
feat: add user feedback for copy failures and fix setTimeout memory leak

### DIFF
--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -71,6 +71,7 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
     const [ popupPosition, setPopupPosition ] = useState({ top: 0,
         left: 0 });
     const buttonRef = useRef<HTMLDivElement>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const participant = useSelector((state: IReduxState) => getParticipantById(state, participantId));
 
@@ -122,7 +123,14 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                         });
                     }
                     setShowCopiedMessage(true);
-                    setTimeout(() => {
+                    
+                    // Clear any existing timeout
+                    if (timeoutRef.current) {
+                        clearTimeout(timeoutRef.current);
+                    }
+                    
+                    // Set new timeout and store reference
+                    timeoutRef.current = setTimeout(() => {
                         setShowCopiedMessage(false);
                     }, 2000);
                 } else {
@@ -133,7 +141,16 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                 logger.error('Error copying text', error);
             });
         handleClose();
-    }, [ message ]);
+    }, [ message, handleClose ]);
+
+    // Cleanup timeout on component unmount
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, []);
 
     const popoverContent = (
         <div className = { classes.menuPanel }>

--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -68,6 +68,7 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
     const { t } = useTranslation();
     const [ isPopoverOpen, setIsPopoverOpen ] = useState(false);
     const [ showCopiedMessage, setShowCopiedMessage ] = useState(false);
+    const [ copyFailed, setCopyFailed ] = useState(false);
     const [ popupPosition, setPopupPosition ] = useState({ top: 0,
         left: 0 });
     const buttonRef = useRef<HTMLDivElement>(null);
@@ -135,6 +136,15 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                     }, 2000);
                 } else {
                     logger.error('Failed to copy text');
+                    setCopyFailed(true);
+                    
+                    // Clear any existing timeout and set new one for error message
+                    if (timeoutRef.current) {
+                        clearTimeout(timeoutRef.current);
+                    }
+                    timeoutRef.current = setTimeout(() => {
+                        setCopyFailed(false);
+                    }, 2000);
                 }
             })
             .catch((error: Error) => {
@@ -195,6 +205,15 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                     style = {{ top: `${popupPosition.top}px`,
                         left: `${popupPosition.left}px` }}>
                     {t('Message Copied')}
+                </div>,
+                document.body
+            )}
+            {copyFailed && ReactDOM.createPortal(
+                <div
+                    className = { cx(classes.copiedMessage, { [classes.showCopiedMessage]: copyFailed }) }
+                    style = {{ top: `${popupPosition.top}px`,
+                        left: `${popupPosition.left}px` }}>
+                    {t('Failed to copy text')}
                 </div>,
                 document.body
             )}


### PR DESCRIPTION
## Problem
Currently, when a copy fails in `MessageMenu`, users get no feedback. Failures are only logged in the console, so users don’t know if their action worked.  

## Solution
- Added `copyFailed` state to track failures.  
- Show a "**Failed to copy text**" toast for 2 seconds, similar to the success message.  
- Manage timeouts to handle rapid clicks and prevent memory leaks.  
- Use existing translation key for the error message.  

## Impact
- Users now get clear feedback on copy failures.  
- Behavior is consistent with the success toast.  
- No changes to existing functionality.  
- Timeout cleanup prevents memory leaks.  

## Testing
- Success and failure toasts display correctly for 2 seconds.  
- Rapid clicks are handled gracefully.  
- Component unmounts cleanly.  
- No TypeScript errors.  
