### PR TITLE
feat(polls): add CSV export with email-based voter verification

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1005,6 +1005,7 @@
         "results": {
             "changeVote": "Change vote",
             "empty": "There are no polls in the meeting yet.",
+            "exportResults": "Export results",
             "hideDetailedResults": "Hide details",
             "showDetailedResults": "Show details",
             "vote": "Vote"

--- a/react/features/polls/components/AbstractPollResults.tsx
+++ b/react/features/polls/components/AbstractPollResults.tsx
@@ -76,10 +76,13 @@ const AbstractPollResults = (Component: ComponentType<AbstractProps>) => (props:
             const percentage = allVoters.size > 0 ? Math.round(nrOfVotersPerAnswer / allVoters.size * 100) : 0;
 
             const voters = answer.voters?.reduce((acc, v) => {
+                const participant = getParticipantById(reduxState, v.id);
+
                 acc.push({
                     id: v.id,
-                    name: getParticipantById(reduxState, v.id)
-                        ? getParticipantDisplayName(reduxState, v.id) : v.name
+                    name: participant
+                        ? getParticipantDisplayName(reduxState, v.id) : v.name,
+                    email: participant?.email
                 });
 
                 return acc;

--- a/react/features/polls/components/web/PollResults.tsx
+++ b/react/features/polls/components/web/PollResults.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
-import AbstractPollResults, { AbstractProps } from '../AbstractPollResults';
+import { isLocalParticipantModerator } from '../../../base/participants/functions';
+import AbstractPollResults, { AbstractProps, AnswerInfo } from '../AbstractPollResults';
 
 const useStyles = makeStyles()(theme => {
     return {
@@ -120,6 +122,54 @@ const PollResults = ({
     toggleIsDetailed
 }: AbstractProps) => {
     const { classes } = useStyles();
+    const exportResults = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const csvRows: string[] = [];
+
+        csvRows.push(`"Question:","${question}"`);
+        csvRows.push(`"Created By:","${creatorName}"`);
+        csvRows.push('');
+
+        const headers: string[] = [ 'Option', 'Voter Count', 'Valid Voters (with email)', 'Other Voters' ];
+
+        csvRows.push(headers.map(h => `"${h}"`).join(','));
+
+        answers.forEach((answer: AnswerInfo) => {
+            const validVoters = answer.voters
+                ?.filter(voter => voter.email)
+                .map(voter => `${voter.name} (${voter.email})`)
+                .join('; ') || '';
+
+            const otherVoters = answer.voters
+                ?.filter(voter => !voter.email)
+                .map(voter => voter.name)
+                .join('; ') || '';
+
+            const row = [
+                `"${answer.name}"`,
+                answer.voterCount.toString(),
+                `"${validVoters}"`,
+                `"${otherVoters}"`
+            ];
+
+            csvRows.push(row.join(','));
+        });
+
+        const csvContent = csvRows.join('\n');
+        const blob = new Blob([ csvContent ], { type: 'text/csv;charset=utf-8;' });
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+
+
+        link.href = url;
+        link.setAttribute('download', `poll-results-${pollId}.csv`);
+        link.click();
+        window.URL.revokeObjectURL(url);
+    }, [ answers, question, creatorName, pollId ]);
+
+    const isModerator = useSelector(isLocalParticipantModerator);
 
     return (
         <div
@@ -153,22 +203,33 @@ const PollResults = ({
                         </div>
                         {showDetails && voters && voterCount > 0
                         && <ul className = { classes.voters }>
-                            { voters.map(voter =>
-                                <li key = { voter.id }>{ voter.name }</li>
+                            {voters.map(voter =>
+                                <li key = { voter.id }>{voter.name}</li>
                             )}
                         </ul>}
                     </li>)
                 )}
             </ul>
             <div className = { classes.buttonsContainer }>
-                <button
-                    onClick = { toggleIsDetailed }>
-                    {showDetails ? t('polls.results.hideDetailedResults') : t('polls.results.showDetailedResults')}
+                <button onClick = { toggleIsDetailed }>
+                    {showDetails
+                        ? t('polls.results.hideDetailedResults')
+                        : t('polls.results.showDetailedResults')}
                 </button>
-                <button
-                    onClick = { changeVote }>
-                    {haveVoted ? t('polls.results.changeVote') : t('polls.results.vote')}
+
+                <button onClick = { changeVote }>
+                    {haveVoted
+                        ? t('polls.results.changeVote')
+                        : t('polls.results.vote')}
                 </button>
+
+                {isModerator && (
+                    <button
+                        onClick = { exportResults }
+                        type = 'button'>
+                        {t('polls.results.exportResults')}
+                    </button>
+                )}
             </div>
         </div>
     );

--- a/react/features/polls/types.ts
+++ b/react/features/polls/types.ts
@@ -92,6 +92,11 @@ export interface IPollData extends IPoll {
  */
 export interface IVoterData {
     /**
+     * The email of the voter.
+     */
+    email?: string;
+
+    /**
      * The id of the voter.
      */
     id: string;
@@ -100,6 +105,7 @@ export interface IVoterData {
      * Voter name if voter is not in the meeting.
      */
     name: string;
+
 }
 
 /**


### PR DESCRIPTION
## Description
Adds a CSV export button to the poll results view for moderators. This allows educators and meeting hosts to save poll data for grading, participation tracking, or post-session review.

Closes #17124



