### PR TITLE
fix(breakout-rooms): close participant move menu on outside click

### DIFF
--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
@@ -108,6 +108,7 @@ export const RoomParticipantContextMenu = ({
 
     return isLocalModerator ? (
         <ContextMenu
+            activateFocusTrap = { true }
             entity = { entity }
             isDrawerOpen = { Boolean(entity) }
             offsetTarget = { offsetTarget }


### PR DESCRIPTION
### Summary
When opening the participant move menu in breakout rooms, the menu did not close when clicking outside and appeared above other components, requiring manual toggling to close.

This PR fixes the breakout room participant "More" (three-dot) menu so it closes automatically when clicking outside.

### Root Cause
The breakout participant context menu was missing the click-away focus trap behavior that is used by other click-driven menus.

### Changes
- Updated `react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx`
- Enabled click-away handling by adding:
  - `activateFocusTrap = { true }` to `ContextMenu`

### Behavior After Fix
- Click three-dot menu: opens 
- Click outside: closes.

### Before Fix:

https://github.com/user-attachments/assets/c5310fa6-bf75-4b12-bc8d-61042d675411

### After fix:

https://github.com/user-attachments/assets/e3bdb7f3-1974-410b-b311-07ca6fbcf40f