### PR TITLE
fix: outside-click closing behaviour for participant pane menus in breakout and main rooms

### DIFF
--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
@@ -108,6 +108,7 @@ export const RoomParticipantContextMenu = ({
 
     return isLocalModerator ? (
         <ContextMenu
+            activateFocusTrap = { true }
             entity = { entity }
             isDrawerOpen = { Boolean(entity) }
             offsetTarget = { offsetTarget }

--- a/react/features/participants-pane/components/web/MeetingParticipants.tsx
+++ b/react/features/participants-pane/components/web/MeetingParticipants.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
@@ -95,6 +95,32 @@ function MeetingParticipants({
     const _isCurrentRoomRenamable = useSelector(isCurrentRoomRenamable);
 
     const { classes: styles } = useStyles();
+
+    useEffect(() => {
+        if (!raiseContext?.entity) {
+            return;
+        }
+
+        const onDocumentMouseDown = (event: MouseEvent) => {
+            const target = event.target as HTMLElement | null;
+
+            if (!target) {
+                return;
+            }
+
+            if (target.closest('[class*="contextMenu"]') || target.closest('[data-testid^="participant-more-options-"]')) {
+                return;
+            }
+
+            lowerMenu(true);
+        };
+
+        document.addEventListener('mousedown', onDocumentMouseDown);
+
+        return () => {
+            document.removeEventListener('mousedown', onDocumentMouseDown);
+        };
+    }, [ lowerMenu, raiseContext?.entity ]);
 
     return (
         <>


### PR DESCRIPTION
## Summary
Fixes participant context menu closing behavior so menus close on outside click in both:
- Breakout room participant menu
- Main room participants pane menu

This improves UI consistency and prevents the menu from remaining visible over other components.

## Changes
- Breakout room: enabled outside-click close behavior in participant context menu.
- Main room: added participants-pane-level outside-click handling to close the active participant menu while preserving existing toggle/hover behavior.

## Why
Participant menus were not consistently closing on outside click in these two flows, causing UI inconsistency and menus remaining visible over other components.

### Before fix:

https://github.com/user-attachments/assets/633701a7-2098-4956-9670-9686ba4ec53f

### After fix:

https://github.com/user-attachments/assets/fdfb9b50-6b2f-47ca-8535-94f785f2df01
