### PR TITLE
fix(wepback-dep-proxy): Fixes header errors.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -271,6 +271,9 @@ function getDevServerConfig() {
             }
         ],
         server: process.env.CODESPACES ? 'http' : 'https',
+        setupMiddlewares: (middlewares, _devServer) => middlewares.filter(
+            m => m.name !== 'cross-origin-header-check'
+        ),
         static: {
             directory: process.cwd(),
             watch: {


### PR DESCRIPTION
webpack-dev-server v5 added a cross-origin-header-check security middleware that unconditionally returns 403 Cross-Origin request blocked for any request with sec-fetch-mode: no-cors + sec-fetch-site: cross-site.
