### PR TITLE
fix(polls): avoid direct redux state mutation in RECEIVE_ANSWER

### DIFF
--- a/react/features/polls/reducer.ts
+++ b/react/features/polls/reducer.ts
@@ -81,45 +81,45 @@ ReducerRegistry.register<IPollsState>(STORE_NAME, (state = INITIAL_STATE, action
     // Reducer triggered when an answer is received
     // The answer is added  to an existing poll
     case RECEIVE_ANSWER: {
-
         const { answer }: { answer: IIncomingAnswerData; } = action;
         const pollId = answer.pollId;
-        const poll = state.polls[pollId];
 
-        // if the poll doesn't exist
         if (!(pollId in state.polls)) {
+            // @ts-ignore
             logger.warn('Requested poll does not exist', { pollId });
 
             return state;
         }
 
-        // if the poll exists, we update it with the incoming answer
-        for (let i = 0; i < poll.answers.length; i++) {
-            // if the answer was chosen, we add the senderId to the array of voters of this answer
-            let voters = poll.answers[i].voters || [];
+        const poll = state.polls[pollId];
+
+        const updatedAnswers = poll.answers.map((pollAnswer, i) => {
+            let voters = pollAnswer.voters ? [ ...pollAnswer.voters ] : [];
 
             if (voters.find(user => user.id === answer.senderId)) {
                 if (!answer.answers[i]) {
                     voters = voters.filter(user => user.id !== answer.senderId);
                 }
             } else if (answer.answers[i]) {
-                voters.push({
+                voters = [ ...voters, {
                     id: answer.senderId,
                     name: answer.voterName
-                });
+                } ];
             }
 
-            poll.answers[i].voters = voters?.length ? voters : undefined;
-        }
+            return {
+                ...pollAnswer,
+                voters: voters.length ? voters : undefined
+            };
+        });
 
-        // finally we update the state by returning the updated poll
         return {
             ...state,
             polls: {
                 ...state.polls,
                 [pollId]: {
                     ...poll,
-                    answers: [ ...poll.answers ]
+                    answers: updatedAnswers
                 }
             }
         };


### PR DESCRIPTION
Fixes #17074

### Problem
The Polls reducer was directly mutating the Redux state tree within the `RECEIVE_ANSWER` case. This resulted in in-place modifications of the `voters` array and the `poll.answers` object, rather than returning a new state reference.

### Cause
The existing implementation used a `for` loop with `.push()` directly on the `voters` array and assigned `poll.answers[i].voters` in-place, mutating the Redux state before returning it.

### Fix
Refactored `react/features/polls/reducer.ts` to implement standard functional immutability patterns:
- Replaced the `for` loop with `.map()` to generate a newly allocated `answers` array.
- Used object spreading (`...`) at every level to ensure fresh memory references.
- Replaced native `.push()` with spread-based array concatenation `[...voters, { ... }]`.

### Testing Done
- Verified polls UI updates correctly when receiving answers locally.
- Edge cases confirmed (empty voter lists set to `undefined`).
- `npx eslint react/features/polls/reducer.ts` passed with zero errors.

### Proposed Changelog Entry
fix(polls): avoid direct Redux state mutation in RECEIVE_ANSWER reducer.

### Submitter Checklist
- [x] Issue is well described
- [x] Functional immutability preserved
- [x] Manual testing performed
- [x] ESLint checks passed

### Desired Reviewers
@saghul @jallamsetty1 @mihhu