### PR TITLE
fix(participants): prevent duplicate participantLeft dispatch on conf…

### DIFF
--- a/react/features/base/participants/middleware.ts
+++ b/react/features/base/participants/middleware.ts
@@ -434,6 +434,7 @@ StateListenerRegistry.register(
         batch(() => {
             for (const [ id, p ] of getRemoteParticipants(getState())) {
                 (!conference || p.conference !== conference)
+                    && !conference
                     && dispatch(participantLeft(id, p.conference, {
                         isReplaced: p.isReplaced
                     }));


### PR DESCRIPTION
Fixes #17069

### Problem
The `participantLeft` IFrame API event was firing twice when a participant left the conference.

### Cause
The event was being dispatched from two places:
1. `conference.js` via `commonUserLeftHandling()` when the participant leaves.
2. `StateListenerRegistry` in `participants/middleware.ts` during conference cleanup.

Both dispatches triggered `notifyUserLeft()` in `external-api/middleware.ts`.

### Fix
Added `&& !conference` guard in the `StateListenerRegistry` listener inside
`react/features/base/participants/middleware.ts`. This ensures the cleanup
listener only dispatches `participantLeft` when the conference becomes `null`,
preventing a duplicate dispatch since `commonUserLeftHandling()` in
`conference.js` already handles the normal participant leave case.

### Files Changed
- `react/features/base/participants/middleware.ts`

### Testing Done
- Verified `participantLeft` fires only once when a participant leaves.
- `npx eslint react/features/base/participants/middleware.ts` passed with zero errors.

### Desired Reviewers
@saghul @jallamsetty1 @damencho