### PR TITLE
fix(react-native-sdk): Export JitsiMeeting component

### DIFF
--- a/react-native-sdk/.npmignore
+++ b/react-native-sdk/.npmignore
@@ -1,1 +1,6 @@
 *.tgz
+tsconfig.json
+.npmrc
+.git
+.gitignore
+node_modules

--- a/react-native-sdk/package.json
+++ b/react-native-sdk/package.json
@@ -2,7 +2,8 @@
     "name": "@jitsi/react-native-sdk",
     "version": "0.0.0",
     "description": "React Native SDK for Jitsi Meet.",
-    "main": "index.tsx",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "license": "Apache-2.0",
     "author": "",
     "homepage": "https://jitsi.org",
@@ -92,9 +93,27 @@
         "@babel/plugin-proposal-optional-chaining": "0.0.0"
     },
     "scripts": {
+        "build": "tsc -p tsconfig.json",
         "postinstall": "node sdk_instructions.js",
-        "prepare": "node prepare_sdk.js"
+        "prepare": "node prepare_sdk.js && npm run build"
     },
+    "files": [
+        "dist",
+        "android",
+        "ios",
+        "index.tsx",
+        "jitsi-meet-rnsdk.podspec",
+        "prepare_sdk.js",
+        "sdk_instructions.js",
+        "update_dependencies.js",
+        "update_sdk_dependencies.js",
+        "README.md",
+        "images",
+        "sounds",
+        "lang",
+        "modules",
+        "react"
+    ],
     "bugs": {
         "url": "https://github.com/jitsi/jitsi-meet/issues"
     },

--- a/react-native-sdk/tsconfig.json
+++ b/react-native-sdk/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "../tsconfig.native.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "emitDeclarationOnly": false
+    },
+    "include": [
+        "index.tsx"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}


### PR DESCRIPTION
- Change main entry point from index.tsx to dist/index.js
- Add types field pointing to dist/index.d.ts
- Create tsconfig.json for TypeScript compilation
- Add build script: tsc -p tsconfig.json
- Update prepare hook to auto-compile on npm publish
- Add files array to control npm package contents
- Add .npmignore to exclude build artifacts

Resolves #16443 where JitsiMeeting could not be imported from @jitsi/react-native-sdk

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
