### PR TITLE
lang: Small change of wording

### DIFF
--- a/lang/main-sv.json
+++ b/lang/main-sv.json
@@ -817,7 +817,7 @@
         "focusFail": "{{component}} inte tillgänglig – försöker igen om {{ms}} sek",
         "gifsMenu": "GIPHY",
         "groupTitle": "Notifieringar",
-        "hostAskedUnmute": "Värden vill att du ska stänga av ljudet",
+        "hostAskedUnmute": "Värden vill att du ska starta din mikrofon",
         "invalidTenant": "Ogiltig tenant",
         "invalidTenantHyphenDescription": "Tenant du använder har ogiltiga tecken (startar eller slutar med '-').",
         "invalidTenantLengthDescription": "Tenant du använder är för lång",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
The old wording suggested the user to mute the output sound and not unmute mikrofone. Some users got confused by that. Now it translates to Host whants you to unmute microphone, instead of Host whants you to mute sound output. 