### PR TITLE
fix(prejoin): improve disabled join button contrast

### DIFF
--- a/react/features/base/premeeting/components/web/ActionButton.tsx
+++ b/react/features/base/premeeting/components/web/ActionButton.tsx
@@ -122,12 +122,12 @@ const useStyles = makeStyles()(theme => {
             '&.disabled': {
                 background: theme.palette.prejoinActionButtonDisabled,
                 border: '1px solid #5E6D7A',
-                color: '#AFB6BC',
+                color: theme.palette.prejoinActionButtonDisabledText,
                 cursor: 'initial',
 
                 '.icon': {
                     '& > svg': {
-                        fill: '#AFB6BC'
+                        fill: theme.palette.prejoinActionButtonDisabledText
                     }
                 }
             },

--- a/react/features/base/ui/Tokens.ts
+++ b/react/features/base/ui/Tokens.ts
@@ -171,6 +171,7 @@ export const colorMap = {
     prejoinActionButtonSecondaryText: 'text04', // Secondary button text
     prejoinActionButtonDanger: 'actionDanger', // Danger button (leave)
     prejoinActionButtonDisabled: 'disabled01', // Disabled button
+    prejoinActionButtonDisabledText: 'textColor01', // Disabled button text
     prejoinCountryPickerBackground: 'ui01', // Country picker background
     prejoinCountryPickerBorder: 'ui03', // Country picker border
     prejoinCountryPickerText: 'text01', // Country picker text

--- a/react/features/base/ui/types.ts
+++ b/react/features/base/ui/types.ts
@@ -137,6 +137,7 @@ export interface IPalette {
     preMeetingPreview: string;
     prejoinActionButtonDanger: string;
     prejoinActionButtonDisabled: string;
+    prejoinActionButtonDisabledText: string;
     prejoinActionButtonPrimary: string;
     prejoinActionButtonPrimaryHover: string;
     prejoinActionButtonPrimaryText: string;


### PR DESCRIPTION
## Summary
Improves the contrast of the disabled `Join meeting` button when the insecure room warning is shown on the prejoin screen.

This change is styling-only and does not modify existing behavior.


## How to test
1. Open the prejoin screen.
2. Enter an insecure room name to trigger the warning.
3. Leave the confirmation checkbox unchecked.
4. Verify that the disabled `Join meeting` button text and icon remain clearly readable.

new 
<img width="395" height="677" alt="Screenshot 2026-03-18 at 4 21 54 PM" src="https://github.com/user-attachments/assets/dea74712-b076-406c-99fa-86c096854d92" />

old
<img width="436" height="747" alt="563171839-258b5ab0-0d83-4707-a8a4-b2279087086c" src="https://github.com/user-attachments/assets/5009a073-35e2-49ee-8953-44d0a1dff9a7" />


## Issue
Closes #17140