### PR TITLE
feat(deep-linking): default using https url if there app scheme is not used

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
-      <intent-filter>
+      <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.BROWSABLE" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/react/features/base/config/functions.web.ts
+++ b/react/features/base/config/functions.web.ts
@@ -74,12 +74,12 @@ export function _setDeeplinkingDefaults(deeplinking: IDeeplinkingConfig) {
         || 'https://github.com/jitsi/jitsi-meet-electron/releases/latest/download/jitsi-meet-x86_64.AppImage';
 
     ios.appName = ios.appName || 'Jitsi Meet';
-    ios.appScheme = ios.appScheme || 'org.jitsi.meet';
+    ios.appScheme = ios.appScheme ?? 'org.jitsi.meet';
     ios.downloadLink = ios.downloadLink
         || 'https://itunes.apple.com/us/app/jitsi-meet/id1165103905';
 
     android.appName = android.appName || 'Jitsi Meet';
-    android.appScheme = android.appScheme || 'org.jitsi.meet';
+    android.appScheme = android.appScheme ?? 'org.jitsi.meet';
     android.downloadLink = android.downloadLink
         || 'https://play.google.com/store/apps/details?id=org.jitsi.meet';
     android.appPackage = android.appPackage || 'org.jitsi.meet';

--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
@@ -95,13 +95,13 @@ const useStyles = makeStyles()((theme: Theme) => {
 });
 
 const DeepLinkingMobilePage: React.FC<WithTranslation> = ({ t }) => {
+    const dispatch = useDispatch();
     const deeplinkingCfg = useSelector((state: IReduxState) =>
         state['features/base/config']?.deeplinking || {} as IDeeplinkingConfig);
     const { hideLogo } = deeplinkingCfg;
-    const deepLinkingUrl: string = useSelector(generateDeepLinkingURL);
+    const deepLinkingUrl: string | undefined = useSelector(generateDeepLinkingURL);
     const room = useSelector((state: IReduxState) => decodeURIComponent(state['features/base/conference'].room || ''));
     const url = useSelector((state: IReduxState) => state['features/base/connection'] || {});
-    const dispatch = useDispatch();
     const { classes: styles } = useStyles();
 
     const generateDownloadURL = useCallback(() => {
@@ -128,7 +128,10 @@ const DeepLinkingMobilePage: React.FC<WithTranslation> = ({ t }) => {
         sendAnalytics(
             createDeepLinkingPageEvent(
                 'clicked', 'openAppButton', { isMobileBrowser: true }));
-    }, []);
+        if (!deepLinkingUrl) {
+            dispatch(openWebApp());
+        }
+    }, [ deepLinkingUrl ]);
 
     const onOpenLinkProperties = useMemo(() => {
         const { downloadLink }

--- a/react/features/deep-linking/functions.web.ts
+++ b/react/features/deep-linking/functions.web.ts
@@ -13,17 +13,11 @@ import { _openDesktopApp } from './openDesktopApp.web';
 /**
  * Generates a deep linking URL based on the current window URL.
  *
- * @param {Object} state - Object containing current redux state.
+ * @param {IReduxState} state - The current state of the app.
  *
- * @returns {string} - The generated URL.
+ * @returns {string|undefined} - The generated URL, or undefined if no scheme is configured.
  */
-export function generateDeepLinkingURL(state: IReduxState) {
-    // If the user installed the app while this Component was displayed
-    // (e.g. the user clicked the Download the App button), then we would
-    // like to open the current URL in the mobile app. The only way to do it
-    // appears to be a link with an app-specific scheme, not a Universal
-    // Link.
-
+export function generateDeepLinkingURL(state: IReduxState): string | undefined {
     const { href } = window.location;
     const regex = new RegExp(URI_PROTOCOL_PATTERN, 'gi');
 
@@ -31,6 +25,10 @@ export function generateDeepLinkingURL(state: IReduxState) {
     const mobileConfig = state['features/base/config'].deeplinking?.[Platform.OS] || {};
 
     const { appScheme, appPackage } = mobileConfig;
+
+    if (!appScheme) {
+        return undefined;
+    }
 
     // Android: use an intent link, custom schemes don't work in all browsers.
     // https://developer.chrome.com/multidevice/android/intents


### PR DESCRIPTION
Some, for security reasons, don't want to use scheme urls.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
