### PR TITLE
refactor(chat): Improve chat input UI with integrated recipient selector

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -26,7 +26,7 @@
         outline: 0;
         margin: 4px;
         border-radius: 0 0 variables.$borderRadius variables.$borderRadius;
-        box-shadow: 0px 0px 0px 2px #4687ed; // focus01/primary07
+        box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.3);
     }
 
     & > :first-child {
@@ -54,19 +54,134 @@
     }
 }
 
-.chat-input-container {
-    padding: 0 16px 24px;
-}
-
 #chat-input {
-    display: flex;
-    align-items: flex-end;
     position: relative;
 }
 
 .chat-input {
     flex: 1;
     margin-right: 8px;
+}
+
+.chat-input-container {
+    padding: 0 16px 24px;
+}
+
+.chat-input-wrapper {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    position: relative;
+}
+
+.chat-floating-panel {
+    position: absolute;
+    bottom: 100%;
+    margin-bottom: 8px;
+    z-index: variables.$zindex3;
+    background-color: #131519;
+    border: 1px solid #A4B8D1;
+    border-radius: variables.$borderRadius;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    overflow: hidden;
+}
+
+.chat-floating-panel-left {
+    left: 0;
+}
+
+.chat-floating-panel-right {
+    right: 0;
+}
+
+.chat-recipient-menu {
+    min-width: 200px;
+    max-height: 250px;
+    overflow-y: auto;
+}
+
+.chat-menu-item {
+    padding: 10px 16px;
+    cursor: pointer;
+    color: #fff;
+    font-size: 0.875rem;
+    transition: background 0.2s;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.15);
+    }
+
+    &.selected {
+        color: #fff;
+        font-weight: bold;
+        background-color: rgba(255, 255, 255, 0.25);
+    }
+}
+
+.chat-input-field-container {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.chat-recipient-trigger {
+    position: absolute;
+    top: 8px;
+    left: 12px;
+    z-index: variables.$zindex3;
+    cursor: pointer;
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: bold;
+    padding: 4px 8px;
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: variables.$borderRadius;
+    white-space: nowrap;
+
+    &:hover {
+        background-color: rgba(255, 255, 255, 0.15);
+    }
+}
+
+.chat-emoji-trigger {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    z-index: variables.$zindex3;
+    cursor: pointer;
+    display: flex;
+    opacity: 0.8;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
+.chat-send-button-container {
+    position: absolute;
+    bottom: 8px;
+    right: 12px;
+    z-index: variables.$zindex3;
+    display: flex;
+}
+
+.chat-smileys-popup {
+    width: 240px;
+    max-height: 330px;
+}
+
+.chat-input-override {
+    width: 100%;
+
+    & textarea {
+        padding-top: 40px;
+        padding-right: 50px;
+        padding-bottom: 40px;
+        min-height: 40px;
+        line-height: 1.25rem;
+        font-family: variables.$baseFontFamily;
+    }
 }
 
 #nickname {
@@ -93,7 +208,7 @@
 .mobile-browser {
     #nickname {
         input {
-            height: 48px;
+            height: variables.$newToolbarSizeMobile;
         }
     }
 
@@ -139,6 +254,7 @@
     position: absolute;
     top: 0;
     left: 0;
+    z-index: variables.$zindex2;
 }
 
 #smileysContainer .smiley {
@@ -154,7 +270,7 @@
 
 .smileyContainer:hover {
     background-color: rgba(255, 255, 255, 0.15);
-    border-radius: 5px;
+    border-radius: variables.$borderRadius;
     cursor: pointer;
 }
 
@@ -182,7 +298,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    margin-top: -5px; // Margin set by atlaskit.
+    margin-top: -5px;
 
     &-header {
         display: flex;
@@ -206,15 +322,27 @@
     }
 }
 
-
-/**
- * Make header close button more easily tappable on mobile.
- */
 .mobile-browser .chat-dialog-header .jitsi-icon {
     display: grid;
     place-items: center;
-    height: 48px;
-    width: 48px;
+    height: variables.$newToolbarSizeMobile;
+    width: variables.$newToolbarSizeMobile;
     background: #36383C;
-    border-radius: 3px;
+    border-radius: variables.$borderRadius;
+}
+
+@media (max-width: variables.$verySmallScreen) {
+    .chat-recipient-trigger {
+        font-size: 0.875rem;
+        padding: 6px 10px;
+    }
+
+    .chat-emoji-trigger {
+        right: 12px;
+    }
+
+    .chat-send-button-container {
+        bottom: 10px;
+        right: 14px;
+    }
 }

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -8,7 +8,6 @@ import { isTouchDevice, shouldEnableResize } from '../../../base/environment/uti
 import { translate } from '../../../base/i18n/functions';
 import { IconInfo, IconMessage, IconShareDoc, IconSubtitles } from '../../../base/icons/svg';
 import { getLocalParticipant, getRemoteParticipants, isPrivateChatEnabledSelf } from '../../../base/participants/functions';
-import Select from '../../../base/ui/components/web/Select';
 import Tabs from '../../../base/ui/components/web/Tabs';
 import { arePollsDisabled } from '../../../conference/functions.any';
 import FileSharing from '../../../file-sharing/components/web/FileSharing';
@@ -245,10 +244,6 @@ const useStyles = makeStyles<{
             ...(isTouch && resizeEnabled && {
                 backgroundColor: theme.palette.icon01
             })
-        },
-
-        privateMessageRecipientsList: {
-            padding: '0 16px 5px'
         }
     };
 });
@@ -295,7 +290,11 @@ const Chat = ({
     const participants = useSelector(getRemoteParticipants);
     const isPrivateChatAllowed = useSelector((state: IReduxState) => isPrivateChatEnabledSelf(state));
 
-    const options = useMemo(() => {
+    const recipientOptions = useMemo(() => {
+        if (!isPrivateChatAllowed) {
+            return [];
+        }
+
         const o = Array.from(participants?.values() || [])
                 .filter(p => !p.fakeParticipant)
                 .map(p => {
@@ -313,7 +312,7 @@ const Chat = ({
         });
 
         return o;
-    }, [ participants, defaultRemoteDisplayName, t, notifyTimestamp ]);
+    }, [ participants, defaultRemoteDisplayName, t, notifyTimestamp, isPrivateChatAllowed ]);
 
     /**
      * Handles pointer down on the drag handle.
@@ -486,16 +485,11 @@ const Chat = ({
                         isVisible = { _focusedTab === ChatTabs.CHAT }
                         messages = { _messages } />
                     <MessageRecipient />
-                    {isPrivateChatAllowed && (
-                        <Select
-                            containerClassName = { cx(classes.privateMessageRecipientsList) }
-                            id = 'select-chat-recipient'
-                            onChange = { onSelectedRecipientChange }
-                            options = { options }
-                            value = { privateMessageRecipient?.id || OPTION_GROUPCHAT } />
-                    )}
                     <ChatInput
-                        onSend = { onSendMessage } />
+                        onRecipientChange = { onSelectedRecipientChange }
+                        onSend = { onSendMessage }
+                        recipientOptions = { recipientOptions }
+                        selectedRecipient = { privateMessageRecipient?.id || OPTION_GROUPCHAT } />
                 </div>) }
                 { _isPollsEnabled && (
                     <>

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -7,10 +7,11 @@ import { withStyles } from 'tss-react/mui';
 import { IReduxState, IStore } from '../../../app/types';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { translate } from '../../../base/i18n/functions';
+import Icon from '../../../base/icons/components/Icon';
 import { IconFaceSmile, IconSend } from '../../../base/icons/svg';
 import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';
-import { CHAT_SIZE } from '../../constants';
+import { CHAT_SIZE, OPTION_GROUPCHAT } from '../../constants';
 import { areSmileysDisabled, isSendGroupChatDisabled } from '../../functions';
 
 import SmileysPanel from './SmileysPanel';
@@ -18,85 +19,68 @@ import SmileysPanel from './SmileysPanel';
 
 const styles = (_theme: Theme, { _chatWidth }: IProps) => {
     return {
-        smileysPanel: {
-            bottom: '100%',
-            boxSizing: 'border-box' as const,
-            backgroundColor: 'rgba(0, 0, 0, .6) !important',
-            height: 'auto',
-            display: 'flex' as const,
-            overflow: 'hidden',
-            position: 'absolute' as const,
-            width: `${_chatWidth - 32}px`,
-            marginBottom: '5px',
-            marginLeft: '-5px',
-            transition: 'max-height 0.3s',
+        // Only keep minimal JSS styles for dynamic values, use SCSS for static styles
+        floatingPanel: {
+            width: `${_chatWidth - 32}px`
+        },
 
-            '& #smileysContainer': {
-                backgroundColor: '#131519',
-                borderTop: '1px solid #A4B8D1'
+        smileysPopup: {
+            width: '240px',
+            maxHeight: '330px'
+        },
+
+        inputOverride: {
+            width: '100%',
+            '& textarea': {
+                fontSize: isMobileBrowser() ? '1rem' : '0.75rem',
+                lineHeight: '1.25rem',
+                paddingTop: '40px',
+                paddingRight: '70px', // Extra space for emoji + send button
+                paddingBottom: '40px',
+                minHeight: '40px'
             }
         },
+
         chatDisabled: {
             borderTop: `1px solid ${_theme.palette.chatInputBorder}`,
-            boxSizing: 'border-box' as const,
             padding: _theme.spacing(4),
             textAlign: 'center' as const,
+        },
+
+        // Mobile adjustments that need theme values
+        mobileRecipientTrigger: {
+            fontSize: '14px',
+            padding: '6px 10px'
+        },
+
+        mobileEmojiTrigger: {
+            right: '70px' // Adjusted for send button
+        },
+
+        mobileSendTrigger: {
+            bottom: '10px',
+            right: '14px'
         }
     };
 };
 
-/**
- * The type of the React {@code Component} props of {@link ChatInput}.
- */
 interface IProps extends WithTranslation {
-
-    /**
-     * Whether chat emoticons are disabled.
-     */
     _areSmileysDisabled: boolean;
-
-
     _chatWidth: number;
-
-    /**
-     * Whether sending group chat messages is disabled.
-     */
     _isSendGroupChatDisabled: boolean;
-
-    /**
-     * The id of the message recipient, if any.
-     */
     _privateMessageRecipientId?: string;
-
-    /**
-     * An object containing the CSS classes.
-     */
+    _privateMessageRecipientName?: string;
     classes?: Partial<Record<keyof ReturnType<typeof styles>, string>>;
-
-    /**
-     * Invoked to send chat messages.
-     */
     dispatch: IStore['dispatch'];
-
-    /**
-     * Callback to invoke on message send.
-     */
+    onRecipientChange?: (e: any) => void;
     onSend: Function;
+    recipientOptions?: Array<{ label: string; value: string; }>;
+    selectedRecipient?: string;
 }
 
-/**
- * The type of the React {@code Component} state of {@link ChatInput}.
- */
 interface IState {
-
-    /**
-     * User provided nickname when the input text is provided in the view.
-     */
     message: string;
-
-    /**
-     * Whether or not the smiley selector is visible.
-     */
+    showRecipientMenu: boolean;
     showSmileysPanel: boolean;
 }
 
@@ -107,10 +91,12 @@ interface IState {
  */
 class ChatInput extends Component<IProps, IState> {
     _textArea?: RefObject<HTMLTextAreaElement>;
+    _containerRef: RefObject<HTMLDivElement>;
 
     override state = {
         message: '',
-        showSmileysPanel: false
+        showSmileysPanel: false,
+        showRecipientMenu: false
     };
 
     /**
@@ -123,13 +109,18 @@ class ChatInput extends Component<IProps, IState> {
         super(props);
 
         this._textArea = React.createRef<HTMLTextAreaElement>();
+        this._containerRef = React.createRef<HTMLDivElement>();
 
         // Bind event handlers so they are only bound once for every instance.
         this._onDetectSubmit = this._onDetectSubmit.bind(this);
         this._onMessageChange = this._onMessageChange.bind(this);
         this._onSmileySelect = this._onSmileySelect.bind(this);
         this._onSubmitMessage = this._onSubmitMessage.bind(this);
-        this._toggleSmileysPanel = this._toggleSmileysPanel.bind(this);
+        this._onToggleSmileysPanel = this._onToggleSmileysPanel.bind(this);
+        this._onToggleRecipientMenu = this._onToggleRecipientMenu.bind(this);
+        this._handleClickOutside = this._handleClickOutside.bind(this);
+        this._onRecipientSelect = this._onRecipientSelect.bind(this);
+        this._createMenuItemClickHandler = this._createMenuItemClickHandler.bind(this);
     }
 
     /**
@@ -138,77 +129,35 @@ class ChatInput extends Component<IProps, IState> {
      * @inheritdoc
      */
     override componentDidMount() {
-        if (isMobileBrowser()) {
-            // Ensure textarea is not focused when opening chat on mobile browser.
-            this._textArea?.current && this._textArea.current.blur();
-        } else {
+        if (!isMobileBrowser()) {
             this._focus();
         }
+        document.addEventListener('mousedown', this._handleClickOutside);
     }
 
     /**
-     * Implements {@code Component#componentDidUpdate}.
+     * Implements React's {@link Component#componentWillUnmount()}.
      *
      * @inheritdoc
      */
-    override componentDidUpdate(prevProps: Readonly<IProps>) {
-        if (prevProps._privateMessageRecipientId !== this.props._privateMessageRecipientId) {
-            this._textArea?.current?.focus();
-        }
+    override componentWillUnmount() {
+        document.removeEventListener('mousedown', this._handleClickOutside);
     }
 
     /**
-     * Implements React's {@link Component#render()}.
+     * Handles clicks outside the component to close floating panels.
      *
-     * @inheritdoc
-     * @returns {ReactElement}
+     * @param {MouseEvent} event - The mouse event.
+     * @private
+     * @returns {void}
      */
-    override render() {
-        const classes = withStyles.getClasses(this.props);
-        const hideInput = this.props._isSendGroupChatDisabled && !this.props._privateMessageRecipientId;
-
-        if (hideInput) {
-            return (
-                <div className = { classes.chatDisabled }>
-                    {this.props.t('chat.disabled')}
-                </div>
-            );
+    _handleClickOutside(event: MouseEvent) {
+        if (this._containerRef.current && !this._containerRef.current.contains(event.target as Node)) {
+            this.setState({
+                showSmileysPanel: false,
+                showRecipientMenu: false
+            });
         }
-
-        return (
-            <div className = { `chat-input-container${this.state.message.trim().length ? ' populated' : ''}` }>
-                <div id = 'chat-input' >
-                    {!this.props._areSmileysDisabled && this.state.showSmileysPanel && (
-                        <div
-                            className = 'smiley-input'>
-                            <div
-                                className = { classes.smileysPanel } >
-                                <SmileysPanel
-                                    onSmileySelect = { this._onSmileySelect } />
-                            </div>
-                        </div>
-                    )}
-                    <Input
-                        className = 'chat-input'
-                        icon = { this.props._areSmileysDisabled ? undefined : IconFaceSmile }
-                        iconClick = { this._toggleSmileysPanel }
-                        id = 'chat-input-messagebox'
-                        maxRows = { 5 }
-                        onChange = { this._onMessageChange }
-                        onKeyPress = { this._onDetectSubmit }
-                        placeholder = { this.props.t('chat.messagebox') }
-                        ref = { this._textArea }
-                        textarea = { true }
-                        value = { this.state.message } />
-                    <Button
-                        accessibilityLabel = { this.props.t('chat.sendButton') }
-                        disabled = { !this.state.message.trim() }
-                        icon = { IconSend }
-                        onClick = { this._onSubmitMessage }
-                        size = { isMobileBrowser() ? 'large' : 'medium' } />
-                </div>
-            </div>
-        );
     }
 
     /**
@@ -222,35 +171,103 @@ class ChatInput extends Component<IProps, IState> {
     }
 
     /**
+     * Callback invoked to hide or show the recipient menu.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onToggleRecipientMenu() {
+        this.setState({
+            showRecipientMenu: !this.state.showRecipientMenu,
+            showSmileysPanel: false
+        });
+    }
+
+    /**
+     * Callback invoked to hide or show the smileys selector.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onToggleSmileysPanel() {
+        this.setState({
+            showSmileysPanel: !this.state.showSmileysPanel,
+            showRecipientMenu: false
+        });
+    }
+
+    /**
+     * Handles recipient selection from the menu.
+     *
+     * @param {string} value - The selected recipient value.
+     * @private
+     * @returns {void}
+     */
+    _onRecipientSelect(value: string) {
+        if (this.props.onRecipientChange) {
+            this.props.onRecipientChange({ target: { value } });
+        }
+        this.setState({ showRecipientMenu: false });
+        this._focus();
+    }
+
+    /**
+     * Creates a click handler for a menu item.
+     *
+     * @param {string} value - The recipient value.
+     * @returns {Function} - The click handler function.
+     * @private
+     */
+    _createMenuItemClickHandler(value: string) {
+        return (event: React.MouseEvent) => {
+            event.preventDefault();
+            this._onRecipientSelect(value);
+        };
+    }
+
+    /**
+     * Updates the known message the user is drafting.
+     *
+     * @param {string} value - Keyboard event.
+     * @private
+     * @returns {void}
+     */
+    _onMessageChange(value: string) {
+        this.setState({ message: value });
+    }
+
+    /**
+     * Appends a selected smileys to the chat message draft.
+     *
+     * @param {string} smileyText - The value of the smiley to append to the
+     * chat message.
+     * @private
+     * @returns {void}
+     */
+    _onSmileySelect(smileyText: string) {
+        this.setState({
+            message: smileyText ? `${this.state.message} ${smileyText}` : this.state.message,
+            showSmileysPanel: false
+        }, () => this._focus());
+    }
+
+    /**
      * Submits the message to the chat window.
      *
      * @returns {void}
      */
     _onSubmitMessage() {
-        const {
-            _isSendGroupChatDisabled,
-            _privateMessageRecipientId,
-            onSend
-        } = this.props;
+        const { _isSendGroupChatDisabled, _privateMessageRecipientId, onSend } = this.props;
 
-        if (_isSendGroupChatDisabled && !_privateMessageRecipientId) {
-            return;
-        }
+        if (_isSendGroupChatDisabled && !_privateMessageRecipientId) return;
 
         const trimmed = this.state.message.trim();
 
         if (trimmed) {
             onSend(trimmed);
-
-            this.setState({ message: '' });
-
-            // Keep the textarea in focus when sending messages via submit button.
+            this.setState({ message: '', showSmileysPanel: false });
             this._focus();
-
-            // Hide the Emojis box after submitting the message
-            this.setState({ showSmileysPanel: false });
         }
-
     }
 
     /**
@@ -285,50 +302,99 @@ class ChatInput extends Component<IProps, IState> {
     }
 
     /**
-     * Updates the known message the user is drafting.
+     * Implements React's {@link Component#render()}.
      *
-     * @param {string} value - Keyboard event.
-     * @private
-     * @returns {void}
+     * @inheritdoc
+     * @returns {ReactElement}
      */
-    _onMessageChange(value: string) {
-        this.setState({ message: value });
-    }
+    override render() {
+        const { classes, t, _privateMessageRecipientName, recipientOptions, _areSmileysDisabled, selectedRecipient } = this.props;
+        const hideInput = this.props._isSendGroupChatDisabled && !this.props._privateMessageRecipientId;
+        const isMobile = isMobileBrowser();
 
-    /**
-     * Appends a selected smileys to the chat message draft.
-     *
-     * @param {string} smileyText - The value of the smiley to append to the
-     * chat message.
-     * @private
-     * @returns {void}
-     */
-    _onSmileySelect(smileyText: string) {
-        if (smileyText) {
-            this.setState({
-                message: `${this.state.message} ${smileyText}`,
-                showSmileysPanel: false
-            });
-        } else {
-            this.setState({
-                showSmileysPanel: false
-            });
+        if (hideInput) {
+            return <div className = { classes?.chatDisabled }>{t('chat.disabled')}</div>;
         }
 
-        this._focus();
-    }
+        return (
+            <div
+                className = 'chat-input-container'
+                ref = { this._containerRef }>
+                <div id = 'chat-input'>
 
-    /**
-     * Callback invoked to hide or show the smileys selector.
-     *
-     * @private
-     * @returns {void}
-     */
-    _toggleSmileysPanel() {
-        if (this.state.showSmileysPanel) {
-            this._focus();
-        }
-        this.setState({ showSmileysPanel: !this.state.showSmileysPanel });
+                    {/* Floating Panels */}
+                    {!_areSmileysDisabled && this.state.showSmileysPanel && (
+                        <div className = { `chat-floating-panel chat-floating-panel-right chat-smileys-popup ${classes?.floatingPanel} ${classes?.smileysPopup}` }>
+                            <SmileysPanel onSmileySelect = { this._onSmileySelect } />
+                        </div>
+                    )}
+
+                    {this.state.showRecipientMenu && recipientOptions && (
+                        <div className = 'chat-floating-panel chat-floating-panel-left chat-recipient-menu'>
+                            {recipientOptions.map(option => {
+                                const isSelected = option.value === (selectedRecipient || OPTION_GROUPCHAT);
+                                const className = `chat-menu-item ${isSelected ? 'selected' : ''}`;
+                                const onClick = this._createMenuItemClickHandler(option.value);
+
+                                return (
+                                    <div
+                                        className = { className }
+                                        key = { option.value }
+                                        onClick = { onClick }>
+                                        {option.label}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+
+                    <div className = 'chat-input-wrapper'>
+                        <div className = 'chat-input-field-container'>
+
+                            {/* Left Adornment: Recipient */}
+                            <div
+                                className = { `chat-recipient-trigger ${isMobile ? classes?.mobileRecipientTrigger : ''}` }
+                                onClick = { this._onToggleRecipientMenu }>
+                                {t('to')}: {_privateMessageRecipientName || t('chat.everyone')}
+                            </div>
+
+                            {/* Main Input Component */}
+                            <Input
+                                className = { `chat-input-override ${classes?.inputOverride}` }
+                                id = 'chat-input-messagebox'
+                                maxRows = { 5 }
+                                onChange = { this._onMessageChange }
+                                onKeyPress = { this._onDetectSubmit }
+                                placeholder = { this.state.message ? '' : t('chat.messagebox') }
+                                ref = { this._textArea }
+                                textarea = { true }
+                                value = { this.state.message } />
+
+                            {/* Right Adornment: Emoji */}
+                            {!_areSmileysDisabled && (
+                                <div
+                                    className = { `chat-emoji-trigger ${isMobile ? classes?.mobileEmojiTrigger : ''}` }
+                                    onClick = { this._onToggleSmileysPanel }>
+                                    <Icon
+                                        size = { 20 }
+                                        src = { IconFaceSmile } />
+                                </div>
+                            )}
+
+                            {/* Send Button - Positioned absolutely inside input */}
+                            <div className = 'chat-send-button-container'>
+                                <Button
+                                    accessibilityLabel = { t('chat.sendButton') }
+                                    disabled = { !this.state.message.trim() }
+                                    icon = { IconSend }
+                                    onClick = { this._onSubmitMessage }
+                                    size = { isMobile ? 'large' : 'medium' } />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
     }
 }
 
@@ -338,7 +404,11 @@ class ChatInput extends Component<IProps, IState> {
  * @param {Object} state - Redux state.
  * @private
  * @returns {{
- *     _areSmileysDisabled: boolean
+ *     _areSmileysDisabled: boolean,
+ *     _privateMessageRecipientId: string,
+ *     _privateMessageRecipientName: string,
+ *     _isSendGroupChatDisabled: boolean,
+ *     _chatWidth: number
  * }}
  */
 const mapStateToProps = (state: IReduxState) => {
@@ -348,6 +418,7 @@ const mapStateToProps = (state: IReduxState) => {
     return {
         _areSmileysDisabled: areSmileysDisabled(state),
         _privateMessageRecipientId: privateMessageRecipient?.id,
+        _privateMessageRecipientName: privateMessageRecipient?.name,
         _isSendGroupChatDisabled: isGroupChatDisabled,
         _chatWidth: width.current ?? CHAT_SIZE,
     };


### PR DESCRIPTION
## Description

Refactors the chat input UI by moving the private message recipient selector from a separate dropdown into the input field itself. The recipient now appears as a clickable "To: Name" pill at the left side, with emoji button at top right and send button at bottom right inside the input.

## Changes

- Integrate recipient selector inside chat input as clickable pill
- Reposition emoji button to top right inside input
- Reposition send button to bottom right inside input
- Update SCSS styles for new layout
- Remove standalone recipient dropdown component
- Keep all existing private message functionality

## Why

- More efficient use of vertical space
- Cleaner, modern interface
- Better user experience
- Matches patterns in other meeting apps 

## Screenshots
| Before | After |
| ---------- | ------- |
|<img width="294" height="106" alt="image" src="https://github.com/user-attachments/assets/e2179272-ce19-4b5c-9478-511104e9c9c3" />|<img width="299" height="121" alt="image" src="https://github.com/user-attachments/assets/9c65ed2e-7d64-4bfd-b377-847bc894ae7a" />| 
|<img width="303" height="120" alt="image" src="https://github.com/user-attachments/assets/11d86f19-28fc-4297-9d4a-bcafb730b856" />|<img width="302" height="218" alt="image" src="https://github.com/user-attachments/assets/8d441580-5722-40ba-9c30-a616e1f69129" />|
|<img width="353" height="158" alt="image" src="https://github.com/user-attachments/assets/f5598701-9443-4d95-8abb-f7e4d5ee254e" />|<img width="390" height="166" alt="image" src="https://github.com/user-attachments/assets/6ff24e78-8ff7-476d-b0b5-e30757f2209c" />|
|<img width="300" height="199" alt="image" src="https://github.com/user-attachments/assets/63201929-cd29-47c3-aca0-c2855821321c" />|<img width="303" height="293" alt="image" src="https://github.com/user-attachments/assets/7d7e7767-2d79-4923-87d8-128bef4df8fb" />|

Fixes #17159