### PR TITLE
feat(external-api): add getRecordingStatus() to query recording and transcribing state

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -124,6 +124,7 @@ import { SETTINGS_TABS } from '../../react/features/settings/constants';
 import { playSharedVideo, stopSharedVideo } from '../../react/features/shared-video/actions';
 import { extractYoutubeIdOrURL } from '../../react/features/shared-video/functions';
 import { setRequestingSubtitles, toggleRequestingSubtitles } from '../../react/features/subtitles/actions';
+import { isTranscribing } from '../../react/features/transcribing/functions';
 import { isAudioMuteButtonDisabled } from '../../react/features/toolbox/functions';
 import { setTileView, toggleTileView } from '../../react/features/video-layout/actions.any';
 import { muteAllParticipants, muteRemote } from '../../react/features/video-menu/actions';
@@ -1082,6 +1083,31 @@ function initCommands() {
             }
             callback({
                 livestreamUrl
+            });
+            break;
+        }
+        case 'get-recording-status': {
+            const state = APP.store.getState();
+            const conference = getCurrentConference(state);
+            const { FILE, STREAM } = JitsiRecordingConstants.mode;
+            let fileRecording = null;
+            let streamRecording = null;
+            let transcribing = false;
+
+            if (conference) {
+                const fileSession = getActiveSession(state, FILE);
+                const streamSession = getActiveSession(state, STREAM);
+
+                fileRecording = fileSession?.status ?? null;
+                streamRecording = streamSession?.status ?? null;
+                transcribing = isTranscribing(state);
+            } else {
+                logger.error('Conference is not defined');
+            }
+            callback({
+                fileRecording,
+                streamRecording,
+                transcribing
             });
             break;
         }

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1059,6 +1059,21 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns the current recording and transcribing status.
+     *
+     * @returns {Promise<{fileRecording: string|null, streamRecording: string|null, transcribing: boolean}>}
+     * - Resolves with an object containing:
+     *   - fileRecording: recording status for file mode ('on', 'off', 'pending') or null if no session exists.
+     *   - streamRecording: recording status for stream mode ('on', 'off', 'pending') or null if no session exists.
+     *   - transcribing: true if a transcriber is currently active in the conference.
+     */
+    getRecordingStatus() {
+        return this._transport.sendRequest({
+            name: 'get-recording-status'
+        });
+    }
+
+    /**
      * Returns the conference participants information.
      *
      * @returns {Array<Object>} - Returns an array containing participants


### PR DESCRIPTION
## Summary

Adds a new `getRecordingStatus()` method to the External API that allows embedding applications to synchronously query the current recording and transcribing state immediately after joining a conference.

### Problem

The existing `recordingStatusChanged` event is unreliable for determining initial recording state at join time:
- It fires multiple times, initially with `false` values
- Error notifications for previous sessions also trigger the event with `false`
- Jicofo and Jibri each send separate `ON` status updates
- The authoritative `file` recording status can arrive after `videoConferenceJoined`

### Solution

A request/response getter — consistent with the existing `getLivestreamUrl()` pattern — that reads directly from Redux state at call time.

### Usage

```js
api.addEventListener('videoConferenceJoined', async () => {
    const { fileRecording, streamRecording, transcribing } = await api.getRecordingStatus();
    // fileRecording / streamRecording: 'on' | 'off' | 'pending' | null
    // transcribing: boolean
});