### PR TITLE
feat(external-api): add toggleInvite command to open invite screen

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -73,7 +73,7 @@ import {
     setPrivateMessageRecipient,
     toggleChat
 } from '../../react/features/chat/actions';
-import { openChat } from '../../react/features/chat/actions.web';
+import { openChat, showInviteScreen } from '../../react/features/chat/actions.web';
 import { showDesktopPicker } from '../../react/features/desktop-picker/actions';
 import {
     processExternalDeviceRequest
@@ -460,6 +460,10 @@ function initCommands() {
         'toggle-chat': () => {
             sendAnalytics(createApiEvent('chat.toggled'));
             APP.store.dispatch(toggleChat());
+        },
+        'toggle-invite': () => {
+            sendAnalytics(createApiEvent('invite.opened'));
+            APP.store.dispatch(showInviteScreen());
         },
         'toggle-moderation': (enabled, mediaType) => {
             const state = APP.store.getState();

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -86,6 +86,7 @@ const commands = {
     toggleChat: 'toggle-chat',
     toggleE2EE: 'toggle-e2ee',
     toggleFilmStrip: 'toggle-film-strip',
+    toggleInvite: 'toggle-invite',
     toggleLobby: 'toggle-lobby',
     toggleModeration: 'toggle-moderation',
     toggleNoiseSuppression: 'toggle-noise-suppression',

--- a/react/features/chat/actions.web.ts
+++ b/react/features/chat/actions.web.ts
@@ -10,6 +10,7 @@ import {
 } from './actionTypes';
 import { closeChat, setFocusedTab } from './actions.any';
 import { ChatTabs } from './constants';
+import { beginAddPeople } from '../invite/actions.any';
 
 export * from './actions.any';
 
@@ -50,6 +51,17 @@ export function toggleChat() {
 
         // Recompute the large video size whenever we toggle the chat, as it takes chat state into account.
         VideoLayout.onResize();
+    };
+}
+
+/**
+ * Show invite screen
+ *
+ * @returns {Function}
+ */
+export function showInviteScreen() {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        dispatch(beginAddPeople());
     };
 }
 


### PR DESCRIPTION
### Summary

Adds a `toggleInvite` command to the External API that allows embedding applications to programmatically open the invite people screen.

### Changes

- `modules/API/API.js` — adds `toggle-invite` command handler dispatching `showInviteScreen()`
- `modules/API/external/external_api.js` — registers `toggleInvite` in the commands map
- `react/features/chat/actions.web.ts` — adds `showInviteScreen()` action that dispatches `beginAddPeople()`

### Usage

```js
api.executeCommand('toggleInvite');