### PR TITLE
Fix(external-api): replay dataChannelOpened for late listeners

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -341,6 +341,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this._onStageParticipant = undefined;
         this._iAmvisitor = undefined;
         this._pipConfig = configOverwrite?.pip;
+        this._dataChannelOpened = false;
         this._setupListeners();
         id++;
     }
@@ -641,6 +642,12 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             const eventName = events[name];
 
             if (eventName) {
+                // Cache dataChannelOpened so late-registering listeners still fire.
+                // Must be set before emit so addListener replay works synchronously.
+                if (eventName === 'dataChannelOpened') {
+                    this._dataChannelOpened = true;
+                }
+
                 this.emit(eventName, data);
 
                 return true;
@@ -662,6 +669,25 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         });
 
         this._setupIntersectionObserver();
+    }
+
+    /**
+     * Overrides EventEmitter.addListener to fix a race condition where
+     * dataChannelOpened fires before the parent page can register a listener.
+     * If the event already fired, the callback is invoked on the next tick.
+     *
+     * @param {string} event - The event name.
+     * @param {Function} listener - The callback function.
+     * @returns {JitsiMeetExternalAPI} This.
+     */
+    addListener(event, listener) {
+        super.addListener(event, listener);
+
+        if (event === 'dataChannelOpened' && this._dataChannelOpened) {
+            setTimeout(() => listener({}), 0);
+        }
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
## Synopsis

`addListener('dataChannelOpened', cb)` silently never fires when the
listener is registered after the event has already been emitted.

## Details

`data-channel-opened` is emitted by lib-jitsi-meet's BridgeChannel during
ICE connection setup, typically 2-3 seconds after page load. By that point
the parent page has not yet had a chance to call `addListener()` via
JitsiMeetExternalAPI, so the event is permanently missed with no way to
recover it.

## Changes

`modules/API/external/external_api.js`
- Add `_dataChannelOpened` boolean flag in constructor
- Set flag to `true` inside `_setupListeners` when `eventName === 'dataChannelOpened'`
  fires, placed before `this.emit()` so it is available immediately
- Add `addListener()` override — invokes callback via `setTimeout(0)` if
  the event already fired when a new listener is registered

## Testing
```js
const api = new JitsiMeetExternalAPI('meet.jit.si', { roomName: 'test' });

// registered before event fires — works as before
api.addListener('dataChannelOpened', () => console.log('early'));

// registered after event fires — previously silent, now replays
setTimeout(() => {
    api.addListener('dataChannelOpened', () => console.log('late'));
}, 8000);
```

I have signed the CLA.

 #11186