### PR TITLE
feat(keyboard-shortcuts): add alternativeShortcutKeys config for layout-independent shortcuts

### DIFF
--- a/config.js
+++ b/config.js
@@ -735,6 +735,10 @@ var config = {
     // Disable app shortcuts that are registered upon joining a conference
     // disableShortcuts: false,
 
+    // An array with alternative key codes for hot keys.
+    // type:  Array<{ key: string; alt: string; }>
+    // alternativeShortcutKeys: [],
+
     // Disable initial browser getUserMedia requests.
     // This is useful for scenarios where users might want to start a conference for screensharing only
     // disableInitialGUM: false,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -171,6 +171,10 @@ export interface IConfig {
     _desktopSharingSourceDevice?: string;
     _immediateReloadThreshold?: string;
     _screenshotHistoryRegionUrl?: number;
+    alternativeShortcutKeys?: Array<{
+        alt: string;
+        key: string;
+    }>;
     analytics?: {
         amplitudeAPPKey?: string;
         blackListedEvents?: string[];

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -16,6 +16,7 @@ export default [
     '_desktopSharingSourceDevice',
     '_peerConnStatusOutOfLastNTimeout',
     '_peerConnStatusRtcMuteTimeout',
+    'alternativeShortcutKeys', 
     'analytics.disabled',
     'analytics.rtcstatsEnabled',
     'analytics.watchRTCEnabled',

--- a/react/features/keyboard-shortcuts/actions.ts
+++ b/react/features/keyboard-shortcuts/actions.ts
@@ -15,7 +15,7 @@ import {
     REGISTER_KEYBOARD_SHORTCUT,
     UNREGISTER_KEYBOARD_SHORTCUT
 } from './actionTypes';
-import { areKeyboardShortcutsEnabled, getKeyboardShortcuts } from './functions';
+import { areKeyboardShortcutsEnabled, getKeyboardShortcuts, getPrimaryShortcutKey } from './functions';
 import logger from './logger';
 import { IKeyboardShortcut } from './types';
 import { getKeyboardKey, getPriorityFocusedElement } from './utils';
@@ -193,6 +193,13 @@ export function initKeyboardShortcuts() {
 
             if (shortcuts.has(key)) {
                 shortcuts.get(key)?.handler(e);
+            }
+            else {
+                const pKey = getPrimaryShortcutKey(state, key);
+
+                if (shortcuts.has(pKey)) {
+                    shortcuts.get(pKey)?.handler(e);
+                }
             }
         };
 

--- a/react/features/keyboard-shortcuts/actions.ts
+++ b/react/features/keyboard-shortcuts/actions.ts
@@ -197,7 +197,7 @@ export function initKeyboardShortcuts() {
             else {
                 const pKey = getPrimaryShortcutKey(state, key);
 
-                if (shortcuts.has(pKey)) {
+                if (pKey && shortcuts.has(pKey)) {
                     shortcuts.get(pKey)?.handler(e);
                 }
             }

--- a/react/features/keyboard-shortcuts/functions.ts
+++ b/react/features/keyboard-shortcuts/functions.ts
@@ -29,3 +29,19 @@ export function getKeyboardShortcuts(state: IReduxState) {
 export function getKeyboardShortcutsHelpDescriptions(state: IReduxState) {
     return state['features/keyboard-shortcuts'].shortcutsHelp;
 }
+
+/**
+ * Returns the primary shortcut key for alternative key.
+ *
+ * @param {Object} state - The redux state.
+ * @param {string} key - Alternative shortcut key.
+ * @returns {string?} - Primary shortcut key if exists.
+ */
+export function getPrimaryShortcutKey(state: IReduxState, key: string): string | null {
+
+    const { alternativeShortcutKeys } = state['features/base/config'];
+
+    const dict = Object.fromEntries((alternativeShortcutKeys || []).map(x => [ x.alt, x.key ]));
+
+    return dict[key];
+}


### PR DESCRIPTION
## Problem

On non-QWERTY keyboard layouts (e.g. AZERTY, QWERTZ, Cyrillic) the physical keys produce different characters, so existing single-key shortcuts (like `A`, `V`, `C`) stop working correctly — the keypress event delivers the layout-specific character rather than the intended one.

## Solution

Add an `alternativeShortcutKeys` config option that maps alternative key codes to their primary shortcut equivalents. When a keydown event doesn't match any registered shortcut directly, the handler looks up whether the pressed key has a primary mapping and dispatches that shortcut instead.

## Changes

- **`config.js`** — documents new `alternativeShortcutKeys` option: `Array<{ key: string; alt: string }>`
- **`configType.ts`** — adds TypeScript type for `alternativeShortcutKeys`
- **`configWhitelist.ts`** — allows `alternativeShortcutKeys` to be overridden via `configOverwrite`
- **`keyboard-shortcuts/functions.ts`** — adds `getPrimaryShortcutKey(state, altKey)` selector
- **`keyboard-shortcuts/actions.ts`** — extends `keyDownHandler` to resolve alternative keys before shortcut lookup

## Usage

```js
// config.js or configOverwrite
alternativeShortcutKeys: [
    { key: 'A', alt: 'Q' },  // AZERTY: Q physical key → A shortcut
    { key: 'M', alt: 'µ' },  // macOS option key variant
]
