### PR TITLE
fix(conference): suppress redundant reason dialog on host-terminated session

### DIFF
--- a/react/features/base/conference/middleware.native.ts
+++ b/react/features/base/conference/middleware.native.ts
@@ -35,11 +35,15 @@ MiddlewareRegistry.register(store => next => action => {
 
         const [ reason ] = error.params;
 
-        const reasonKey = Object.keys(TRIGGER_READY_TO_CLOSE_REASONS)[
+        let localizedReason = Object.keys(TRIGGER_READY_TO_CLOSE_REASONS)[
             Object.values(TRIGGER_READY_TO_CLOSE_REASONS).indexOf(reason)
         ];
 
-        dispatch(notifyConferenceFailed(reasonKey, () => {
+        if (reason === TRIGGER_READY_TO_CLOSE_REASONS['dialog.sessTerminatedReason']) {
+            localizedReason = '';
+        }
+
+        dispatch(notifyConferenceFailed(localizedReason, () => {
             dispatch(conferenceLeft(action.conference));
             dispatch(appNavigate(undefined));
         }));

--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -136,7 +136,13 @@ MiddlewareRegistry.register(store => next => action => {
                 Object.values(TRIGGER_READY_TO_CLOSE_REASONS).indexOf(reason)
             ];
 
-            dispatch(hangup(true, i18next.t(titlekey) || reason, notifyOnConferenceDestruction));
+            let localizedReason: string = i18next.t(titlekey) || reason;
+
+            if (reason === TRIGGER_READY_TO_CLOSE_REASONS['dialog.sessTerminatedReason']) {
+                localizedReason = '';
+            }
+
+            dispatch(hangup(true, localizedReason, notifyOnConferenceDestruction));
         }
 
         releaseScreenLock();


### PR DESCRIPTION
## Problem

When a moderator ends the conference for all participants via "End meeting for all",
the server sends `CONFERENCE_DESTROYED` with reason `"The meeting has been terminated"`.
This reason string gets passed to `hangup()` / `notifyConferenceFailed()` and shows up
as an error dialog to participants — even though it is not an error, but a normal
intentional termination by the host.

## Solution

Check the destroy reason against `TRIGGER_READY_TO_CLOSE_REASONS['dialog.sessTerminatedReason']`
(the single source of truth already defined in `constants.ts`) and pass an empty
`localizedReason` in that case, suppressing the redundant error notification.

## Changes

- `middleware.web.ts` — extract `localizedReason`, clear it for `sessTerminatedReason`
- `middleware.native.ts` — same fix for React Native path

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Host ends meeting for all | Error dialog shown to participants | Clean disconnect, no dialog |
| Server crash / unexpected destroy | Error reason shown correctly | Unchanged |
