### PR TITLE
feat(mobile/external-api): add chat-custom-open.enabled flag to intercept chat button on native

### DIFF
--- a/react/features/base/flags/constants.ts
+++ b/react/features/base/flags/constants.ts
@@ -73,6 +73,12 @@ export const CONFERENCE_TIMER_ENABLED = 'conference-timer.enabled';
 export const CHAT_ENABLED = 'chat.enabled';
 
 /**
+ * Flag indicating if chat button should have a custom action.
+ * Default: disabled (false).
+ */
+export const CHAT_CUSTOM_OPEN_ENABLED = 'chat-custom-open.enabled';
+
+/**
  * Flag indicating if the filmstrip should be enabled.
  * Default: enabled (true).
  */

--- a/react/features/chat/actions.any.ts
+++ b/react/features/chat/actions.any.ts
@@ -106,6 +106,19 @@ export function clearChatState() {
 }
 
 /**
+ * Action to signal the opening of the chat dialog.
+ *
+ * @returns {{
+*     type: OPEN_CHAT
+* }}
+*/
+export function openChat() {
+    return {
+        type: OPEN_CHAT
+    };
+}
+
+/**
  * Action to signal the closing of the chat dialog.
  *
  * @returns {{

--- a/react/features/chat/components/native/ChatButton.ts
+++ b/react/features/chat/components/native/ChatButton.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import { CHAT_ENABLED } from '../../../base/flags/constants';
+import { CHAT_CUSTOM_OPEN_ENABLED, CHAT_ENABLED } from '../../../base/flags/constants';
 import { getFeatureFlag } from '../../../base/flags/functions';
 import { translate } from '../../../base/i18n/functions';
 import { IconChatUnread, IconMessage } from '../../../base/icons/svg';
@@ -10,9 +10,15 @@ import { arePollsDisabled } from '../../../conference/functions.any';
 import { navigate } from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../mobile/navigation/routes';
 import { getUnreadPollCount } from '../../../polls/functions';
+import { openChat } from '../../actions.any';
 import { getUnreadCount, getUnreadFilesCount, isChatDisabled } from '../../functions';
 
 interface IProps extends AbstractButtonProps {
+
+    /**
+     * True if one redefines chat opening.
+     */
+    _chatCustomActionEnabled: boolean;
 
     /**
      * True if the polls feature is disabled.
@@ -41,9 +47,14 @@ class ChatButton extends AbstractButton<IProps> {
      * @returns {void}
      */
     override _handleClick() {
-        this.props._isPollsDisabled
-            ? navigate(screen.conference.chat)
-            : navigate(screen.conference.chatTabs.main);
+        if (this.props._chatCustomActionEnabled) {
+            this.props.dispatch(openChat());
+        }
+        else {
+            this.props._isPollsDisabled
+                ? navigate(screen.conference.chat)
+                : navigate(screen.conference.chatTabs.main);
+        }
     }
 
     /**
@@ -68,8 +79,11 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
     const enabled = getFeatureFlag(state, CHAT_ENABLED, true) && !isChatDisabled(state);
     const { visible = enabled } = ownProps;
 
+    const chatCustomActionEnabled = Boolean(getFeatureFlag(state, CHAT_CUSTOM_OPEN_ENABLED, false));
+
     return {
         _isPollsDisabled: arePollsDisabled(state),
+        _chatCustomActionEnabled: chatCustomActionEnabled,
         _unreadMessageCount: getUnreadCount(state) || getUnreadPollCount(state) || getUnreadFilesCount(state),
         visible
     };

--- a/react/features/mobile/external-api/middleware.ts
+++ b/react/features/mobile/external-api/middleware.ts
@@ -451,7 +451,9 @@ function _registerForNativeEvents(store: IStore) {
     eventEmitter.addListener(ExternalAPI.OPEN_CHAT, ({ to }: any) => {
         const participant = getParticipantById(store, to);
 
-        dispatch(openChat(participant));
+        const { disablePolls } = getState()['features/base/config'];
+
+        dispatch(openChat(participant, disablePolls ?? false));
     });
 
     eventEmitter.addListener(ExternalAPI.CLOSE_CHAT, () => {


### PR DESCRIPTION
## Problem

In embedded/SDK scenarios on React Native it is not always desirable to open the
built-in chat screen when the user taps the chat button. There is currently no way
for the host app to intercept that action and substitute its own chat UI.

## Solution

Add a new feature flag `chat-custom-open.enabled`. When enabled, tapping the chat
button dispatches an `OPEN_CHAT` Redux action instead of navigating to the built-in
chat screen. The host app can listen for this action via the External API and respond
with its own UI.

## Changes

- **`base/flags/constants.ts`** — new flag constant `CHAT_CUSTOM_OPEN_ENABLED = 'chat-custom-open.enabled'`
- **`chat/actions.any.ts`** — adds `openChat()` action to the shared `.any` file so it is available on native
- **`chat/components/native/ChatButton.ts`** — reads `_chatCustomActionEnabled` from state; when `true`, dispatches `openChat()` instead of navigating
- **`mobile/external-api/middleware.ts`** — passes `disablePolls` config value to `openChat()` when handling the native `OPEN_CHAT` event, ensuring the correct screen is opened when the default flow is used

## Usage

```js
// React Native SDK
<JitsiMeet featureFlags={{ 'chat-custom-open.enabled': true }} />

// then listen for OPEN_CHAT action and show your own chat UI
