### PR TITLE
fix(mobile/navigation): fix conference join hang when SDK launched in background

### DIFF
--- a/react/features/app/components/App.native.tsx
+++ b/react/features/app/components/App.native.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentType } from 'react';
-import { NativeModules, Platform, StyleSheet, View } from 'react-native';
+import { AppState, NativeModules, Platform, StyleSheet, View } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 // @ts-ignore
@@ -153,7 +153,17 @@ export class App extends AbstractApp<IProps> {
             }, 50);
         });
 
-        await rootNavigationReady;
+        // SDK launched in background (device locked, no screen unlock):
+        // - AppState !== 'active' means UI is not on screen
+        // - url is already set meaning host app started SDK with a specific room
+        // In this case NavigationContainer.onReady will never fire until the screen
+        // is unlocked, causing the polling loop to hang indefinitely.
+        const isBackgroundSDKLaunch = AppState.currentState !== 'active'
+            && typeof url !== 'undefined';
+
+        if (!isBackgroundSDKLaunch) {
+            await rootNavigationReady;
+        }
 
         // Update specified server URL.
         if (typeof url !== 'undefined') {

--- a/react/features/mobile/navigation/components/RootNavigationContainer.tsx
+++ b/react/features/mobile/navigation/components/RootNavigationContainer.tsx
@@ -4,6 +4,7 @@ import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 
 import { IReduxState, IStore } from '../../../app/types';
+import { getConferenceState } from '../../../base/conference/functions';
 import DialInSummary from '../../../invite/components/dial-in-summary/native/DialInSummary';
 import Prejoin from '../../../prejoin/components/native/Prejoin';
 import UnsafeRoomWarning from '../../../prejoin/components/native/UnsafeRoomWarning';
@@ -50,12 +51,20 @@ interface IProps {
     * Is welcome page available?
     */
     isWelcomePageAvailable: boolean;
+
+    /**
+     * True if a room is already set at launch time (background SDK launch).
+     */
+    hasRoomOnLaunch: boolean;
 }
 
 
-const RootNavigationContainer = ({ dispatch, isUnsafeRoomWarningAvailable, isWelcomePageAvailable }: IProps) => {
+const RootNavigationContainer = ({ dispatch, hasRoomOnLaunch, isUnsafeRoomWarningAvailable, isWelcomePageAvailable }: IProps) => {
     const initialRouteName = isWelcomePageAvailable
-        ? screen.welcome.main : screen.connecting;
+        ? screen.welcome.main
+        : hasRoomOnLaunch
+            ? screen.conference.root  // background SDK launch: go directly to conference
+            : screen.connecting;      // normal launch: show connecting spinner
     const onReady = useCallback(() => {
         dispatch({
             type: _ROOT_NAVIGATION_READY,
@@ -121,7 +130,10 @@ const RootNavigationContainer = ({ dispatch, isUnsafeRoomWarningAvailable, isWel
  * @returns {IProps}
  */
 function mapStateToProps(state: IReduxState) {
+    const { room } = getConferenceState(state);
+
     return {
+        hasRoomOnLaunch: Boolean(room),
         isUnsafeRoomWarningAvailable: isUnsafeRoomWarningEnabled(state),
         isWelcomePageAvailable: isWelcomePageEnabled(state)
     };


### PR DESCRIPTION
## Problem

When the Jitsi Meet SDK is embedded in a host app and the host app launches the SDK
programmatically in response to an incoming call notification — while the device is
locked and the screen is off — joining the conference room hangs indefinitely.

**Root cause:** `App.native._extraInit()` awaits a `rootNavigationReady` promise that
resolves only when `NavigationContainer` fires its `onReady` callback. When the app
runs in the background (device locked, no UI on screen), React Navigation never renders
or fires `onReady`, so the polling loop spins forever and the conference join never
proceeds.

A secondary issue: without Welcome Page (embedded SDK mode), `initialRouteName` was
`screen.connecting`, but when a room URL is already known at launch the navigator
should start at `screen.conference.root` to avoid an unnecessary intermediate screen.

## Solution

**`App.native.tsx`** — detect background SDK launch using `AppState.currentState !== 'active'`
combined with the presence of a `url` prop. Skip `await rootNavigationReady` in this case
so the join flow proceeds immediately without waiting for UI to become visible.

**`RootNavigationContainer.tsx`** — derive `initialRouteName` from Redux state:
if a `room` is already set at mount time (meaning the SDK was started with a conference
URL), navigate directly to `screen.conference.root`; otherwise use `screen.connecting`
as before.

## Behaviour

| Scenario | `AppState` | `url` prop | `await` skipped | `initialRoute` |
|---|---|---|---|---|
| User opens app normally | `active` | ❌ | ❌ | `connecting` |
| User opens app via deep link | `active` | ✅ | ❌ | `connecting` → navigate |
| **Host app starts SDK in background** | `background` | ✅ | ✅ | `conference.root` |
