### PR TITLE
fix(android): skip Google Sign-In package on devices without GMS

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactInstanceManagerHolder.java
@@ -81,7 +81,7 @@ class ReactInstanceManagerHolder {
         return Collections.emptyList();
     }
 
-    static List<ReactPackage> getReactNativePackages() {
+    static List<ReactPackage> getReactNativePackages(Application app) {
         List<ReactPackage> packages
             = new ArrayList<>(Arrays.asList(
             new com.reactnativecommunity.asyncstorage.AsyncStoragePackage(),
@@ -140,16 +140,37 @@ class ReactInstanceManagerHolder {
         }
 
         // RNGoogleSignInPackage
+        // Skip on devices without Google Mobile Services (e.g. Huawei) to avoid unnecessary alerts.
         try {
-            Class<?> googlePackageClass = Class.forName("com.reactnativegooglesignin.RNGoogleSigninPackage");
-            Constructor<?> constructor = googlePackageClass.getConstructor();
-            packages.add((ReactPackage)constructor.newInstance());
+            if (isGooglePlayServicesAvailable(app)) {
+                Class<?> googlePackageClass = Class.forName("com.reactnativegooglesignin.RNGoogleSigninPackage");
+                Constructor<?> constructor = googlePackageClass.getConstructor();
+                packages.add((ReactPackage) constructor.newInstance());
+            } else {
+                JitsiMeetLogger.d(TAG, "Skipping RNGoogleSignInPackage: GMS not available");
+            }
         } catch (Exception e) {
             // Ignore any error, the module is not compiled when LIBRE_BUILD is enabled.
             JitsiMeetLogger.d(TAG, "Not loading RNGoogleSignInPackage");
         }
 
         return packages;
+    }
+
+    /**
+     * Checks whether Google Play Services (GMS) are available on this device.
+     * Uses PackageManager — no GMS dependency, safe to call on Huawei/AOSP devices.
+     *
+     * @param context {@code Context} to use for PackageManager query.
+     * @return {@code true} if GMS package is installed, {@code false} otherwise.
+     */
+    private static boolean isGooglePlayServicesAvailable(android.content.Context context) {
+        try {
+            context.getPackageManager().getPackageInfo("com.google.android.gms", 0);
+            return true;
+        } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+            return false;
+        }
     }
 
     /**
@@ -235,7 +256,7 @@ class ReactInstanceManagerHolder {
                 .setBundleAssetName("index.android.bundle")
                 .setJSMainModulePath("index.android")
                 .setJavaScriptExecutorFactory(new HermesExecutorFactory())
-                .addPackages(getReactNativePackages())
+                .addPackages(getReactNativePackages(app))
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
                 .build();


### PR DESCRIPTION
## Problem

On Huawei devices (and other Android devices without Google Mobile Services),
loading `RNGoogleSigninPackage` via reflection triggers unnecessary system alerts
warning the user that Google Play Services are missing. This happens even when
Google Sign-In is never actually used in the app.

## Solution

Before loading `RNGoogleSigninPackage`, check whether Google Play Services are
installed using `PackageManager`. If GMS are not present, the package is silently
skipped and a debug log entry is written instead.

## Changes

- **`ReactInstanceManagerHolder.java`**:
  - `getReactNativePackages()` now accepts `Application` context to enable the GMS check
  - Added `isGooglePlayServicesAvailable(Context)` — queries `PackageManager` for
    `com.google.android.gms`, no GMS dependency required, safe on any device
  - `RNGoogleSigninPackage` is only registered when GMS are confirmed available
  - `initReactInstanceManager(app)` passes `app` to `getReactNativePackages(app)`

## Why PackageManager instead of GoogleApiAvailability

`GoogleApiAvailability.isGooglePlayServicesAvailable()` itself requires GMS to be
present and can trigger the same alerts we are trying to avoid. The `PackageManager`
approach has no GMS dependency and works correctly on Huawei/AOSP devices.

## Behaviour

| Device | GMS installed | Result |
|---|---|---|
| Standard Android | ✅ | `RNGoogleSigninPackage` loaded as before |
| Huawei (no GMS) | ❌ | Package skipped, debug log written, no alert |
| AOSP / emulator without GMS | ❌ | Package skipped silently |
