### PR TITLE
fix(mobile): handle undefined URI in appNavigate to prevent crash on disconnect

### DIFF
--- a/react/features/app/actions.native.ts
+++ b/react/features/app/actions.native.ts
@@ -69,17 +69,28 @@ export function appNavigate(uri?: string, options: IReloadNowOptions = {}) {
                     = defaultLocation.pathname + location.pathname.substr(1);
                 location.port = defaultLocation.port;
                 location.protocol = defaultLocation.protocol;
-            } else {
+            } else if (uri !== undefined) {
                 location = defaultLocation;
             }
+        }
+
+        logger.info(`location ${location}`);
+
+        if (!location) {
+
+            dispatch(disconnect());
+
+            goBackToRoot(getState(), dispatch);
+            return;
         }
 
         location.protocol || (location.protocol = 'https:');
         const { contextRoot, host, hostname, pathname, room } = location;
         const locationURL = new URL(location.toString());
-        const { conference } = getConferenceState(getState());
 
         if (room) {
+            const { conference } = getConferenceState(getState());
+
             if (conference) {
 
                 // We need to check if the location is the same with the previous one.


### PR DESCRIPTION
## Problem

Calling `appNavigate(undefined)` on React Native — which happens when leaving a
conference or on an unexpected disconnect — could lead to one of two failure modes:

1. **TypeError crash**: execution continued past the `undefined` check and hit
   `location.protocol` on an `undefined` value.
2. **Silent wrong navigation**: the `else` branch unconditionally assigned
   `location = defaultLocation`, so `appNavigate(undefined)` navigated to the
   default server URL instead of exiting the conference.

## Root cause

The original `else` branch did not distinguish between `uri === undefined` (explicit
exit intent) and `uri` being a valid string that simply had no host part (relative
room name). Both cases fell into the same branch and assigned `defaultLocation`.

## Fix

**`react/features/app/actions.native.ts`**

- `else` → `else if (uri !== undefined)`: `defaultLocation` is only used when `uri`
  is a relative room name, not when it is `undefined`.
- Added explicit guard: if `location` is still `undefined` after parsing, dispatch
  `disconnect()` and call `goBackToRoot()` to cleanly exit the conference and return
  to the root screen.

## Behaviour

| Call | Before | After |
|---|---|---|
| `appNavigate(undefined)` | Crash or navigates to server URL | Clean disconnect + go to root |
| `appNavigate('roomName')` | Works | Unchanged |
| `appNavigate('https://...')` | Works | Unchanged |
