### PR TITLE
feat(toolbox): add DESTRUCTIVE button type for hangup button on native

### DIFF
--- a/react/features/base/color-scheme/defaultScheme.ts
+++ b/react/features/base/color-scheme/defaultScheme.ts
@@ -25,6 +25,6 @@ export default {
         button: 'rgb(255, 255, 255)',
         buttonToggled: 'rgb(38, 58, 76)',
         buttonToggledBorder: getRGBAFormat('#a4b8d1', 0.6),
-        hangup: 'rgb(227,79,86)'
+        hangup: ColorPalette.red
     }
 };

--- a/react/features/base/react/components/native/styles.ts
+++ b/react/features/base/react/components/native/styles.ts
@@ -147,6 +147,11 @@ export default {
         backgroundColor: BaseTheme.palette.action02
     },
 
+    iconButtonContainerDestructive: {
+        ...iconButtonContainer,
+        backgroundColor: BaseTheme.palette.actionDanger
+    },
+
     iconButtonContainerDisabled: {
         ...iconButtonContainer,
         backgroundColor: BaseTheme.palette.disabled01

--- a/react/features/base/ui/components/native/IconButton.tsx
+++ b/react/features/base/ui/components/native/IconButton.tsx
@@ -6,6 +6,7 @@ import styles from '../../../react/components/native/styles';
 import { IIconButtonProps } from '../../../react/types';
 import { BUTTON_TYPES } from '../../constants.native';
 import BaseTheme from '../BaseTheme.native';
+import { ColorPalette } from "../../../styles/components/styles/ColorPalette";
 
 
 const IconButton: React.FC<IIconButtonProps> = ({
@@ -20,7 +21,7 @@ const IconButton: React.FC<IIconButtonProps> = ({
     tapColor,
     type
 }: IIconButtonProps) => {
-    const { PRIMARY, SECONDARY, TERTIARY } = BUTTON_TYPES;
+    const { PRIMARY, SECONDARY, TERTIARY, DESTRUCTIVE } = BUTTON_TYPES;
 
     let color;
     let underlayColor;
@@ -38,6 +39,10 @@ const IconButton: React.FC<IIconButtonProps> = ({
         color = iconColor;
         iconButtonContainerStyles = styles.iconButtonContainer;
         underlayColor = BaseTheme.palette.action03;
+    } else if (type === DESTRUCTIVE) {
+            color = BaseTheme.palette.icon01;
+            iconButtonContainerStyles = styles.iconButtonContainerDestructive;
+            underlayColor = ColorPalette.darkGrey;
     } else {
         color = iconColor;
         underlayColor = tapColor;

--- a/react/features/toolbox/components/native/HangupMenuButton.tsx
+++ b/react/features/toolbox/components/native/HangupMenuButton.tsx
@@ -25,7 +25,7 @@ const HangupMenuButton = (): JSX.Element => {
             accessibilityLabel = 'toolbar.accessibilityLabel.hangup'
             onPress = { onSelect }
             src = { IconHangup }
-            type = { BUTTON_TYPES.PRIMARY } />
+            type = { BUTTON_TYPES.DESTRUCTIVE } />
     );
 };
 

--- a/react/features/toolbox/components/native/styles.ts
+++ b/react/features/toolbox/components/native/styles.ts
@@ -156,7 +156,7 @@ ColorSchemeRegistry.register('Toolbox', {
         iconStyle: whiteToolbarButtonIcon,
         style: {
             ...toolbarButton,
-            backgroundColor: schemeColor('hangup')
+            backgroundColor: BaseTheme.palette.actionDanger // schemeColor('hangup')
         },
         underlayColor: BaseTheme.palette.ui04
     },


### PR DESCRIPTION
## Summary

- Added `DESTRUCTIVE` button type to `IconButton` for native, styled with design system danger tokens
- Applied `DESTRUCTIVE` type to the hangup button, replacing custom color scheme with semantic styling
- Replaced hardcoded hangup color `rgb(227,79,86)` with `ColorPalette.red` and `BaseTheme.palette.actionDanger`

## Changes

| File | Details |
|---|---|
| `base/ui/components/native/IconButton.tsx` | Added `DESTRUCTIVE` branch: white icon, `actionDanger` background, `darkGrey` underlay |
| `base/react/components/native/styles.ts` | Added `iconButtonContainerDestructive` style with `actionDanger` background |
| `toolbox/components/native/HangupMenuButton.tsx` | Changed button type from `PRIMARY` to `DESTRUCTIVE` |
| `toolbox/components/native/styles.ts` | Hangup button background switched to `BaseTheme.palette.actionDanger` |
| `base/color-scheme/defaultScheme.ts` | Replaced hardcoded `rgb(227,79,86)` with `ColorPalette.red` |

## Motivation

The hangup button is a destructive action — ending a call. Using a generic `PRIMARY` type with a custom color bypassed the design system. The new `DESTRUCTIVE` type uses semantic tokens (`actionDanger`) making the color consistent with other danger actions across the app and easy to theme.