### PR TITLE
feat(i18n): add config.supportedLanguages to filter and order UI language list

### DIFF
--- a/config.js
+++ b/config.js
@@ -764,6 +764,12 @@ var config = {
     // For iframe integrations, use the `lang` option directly instead.
     // defaultLanguage: 'en',
 
+    // List of supported languages displayed in the UI language selector.
+    // The order of the array defines the order in the list.
+    // If not set, all available languages are shown.
+    // Available language codes can be found in lang/languages.json.
+    // supportedLanguages: [ 'en', 'ru', 'de', 'fr' ],
+
     // Disables profile and the edit of all fields from the profile settings (display name and email)
     // disableProfile: false,
 

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -253,6 +253,7 @@ export interface IConfig {
     customToolbarButtons?: Array<{ backgroundColor?: string; icon: string; id: string; text: string; }>;
     deeplinking?: IDeeplinkingConfig;
     defaultLanguage?: string;
+    supportedLanguages?: Array<string>;
     defaultLocalDisplayName?: string;
     defaultLogoUrl?: string;
     defaultRemoteDisplayName?: string;

--- a/react/features/base/i18n/functions.any.ts
+++ b/react/features/base/i18n/functions.any.ts
@@ -1,7 +1,9 @@
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 
-import i18next from './i18next';
+import { IReduxState } from '../../app/types';
+
+import i18next, { LANGUAGES } from './i18next';
 
 /**
  * Changes the main translation bundle.
@@ -16,6 +18,24 @@ export async function changeLanguageBundle(language: string, url: string, ns = '
     const bundle = await res.json();
 
     i18next.addResourceBundle(language, ns, bundle, true, true);
+}
+
+/**
+ * Returns the list of languages to show in the UI language selector.
+ * Respects config.supportedLanguages order and filtering if configured.
+ * Works on both web (config loaded before bundle) and native (config from Redux).
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {Array<string>}
+ */
+export function getSupportedLanguages(state: IReduxState): Array<string> {
+    const supported = state['features/base/config']?.supportedLanguages;
+
+    if (Array.isArray(supported) && supported.length > 0) {
+        return supported.filter(lang => LANGUAGES.includes(lang));
+    }
+
+    return LANGUAGES;
 }
 
 /**

--- a/react/features/base/i18n/i18next.ts
+++ b/react/features/base/i18n/i18next.ts
@@ -7,6 +7,10 @@ import LANGUAGES_RESOURCES from '../../../../lang/languages.json';
 import MAIN_RESOURCES from '../../../../lang/main.json';
 import TRANSLATION_LANGUAGES_RESOURCES from '../../../../lang/translation-languages.json';
 
+export { LANGUAGES, SUPPORTED_LANGUAGES } from './supportedLanguages';
+
+import { LANGUAGES, SUPPORTED_LANGUAGES } from './supportedLanguages';
+
 import { I18NEXT_INITIALIZED, LANGUAGE_CHANGED } from './actionTypes';
 import languageDetector from './languageDetector';
 
@@ -23,14 +27,6 @@ const COUNTRIES_RESOURCES_OVERRIDES = {
  * Merged country names.
  */
 const COUNTRIES = merge({}, COUNTRIES_RESOURCES, COUNTRIES_RESOURCES_OVERRIDES);
-
-/**
- * The available/supported languages.
- *
- * @public
- * @type {Array<string>}
- */
-export const LANGUAGES: Array<string> = Object.keys(LANGUAGES_RESOURCES);
 
 /**
  * The available/supported translation languages.
@@ -99,9 +95,10 @@ const options: i18next.InitOptions = {
     returnEmptyString: false,
     returnNull: false,
 
-    // XXX i18next modifies the array lngWhitelist so make sure to clone
-    // LANGUAGES.
-    whitelist: LANGUAGES.slice()
+    // XXX i18next modifies the array lngWhitelist so make sure to clone.
+    // DEFAULT_LANGUAGE is always included so fallbackLng has a valid target
+    // even if it is absent from config.supportedLanguages.
+    whitelist: Array.from(new Set([ DEFAULT_LANGUAGE, ...SUPPORTED_LANGUAGES ]))
 };
 
 i18next

--- a/react/features/base/i18n/languageDetector.native.ts
+++ b/react/features/base/i18n/languageDetector.native.ts
@@ -1,8 +1,6 @@
 import { NativeModules } from 'react-native';
 
-import LANGUAGES_RESOURCES from '../../../../lang/languages.json';
-
-const LANGUAGES = Object.keys(LANGUAGES_RESOURCES);
+import { LANGUAGES } from './supportedLanguages';
 
 /**
  * The singleton language detector for React Native which uses the system-wide

--- a/react/features/base/i18n/languageDetector.web.ts
+++ b/react/features/base/i18n/languageDetector.web.ts
@@ -1,21 +1,20 @@
 import BrowserLanguageDetector from 'i18next-browser-languagedetector';
 import { noop } from 'lodash-es';
 
-import LANGUAGES_RESOURCES from '../../../../lang/languages.json';
-
 import configLanguageDetector from './configLanguageDetector';
+import { LANGUAGES } from './supportedLanguages';
 
-// Map from lowercased key → original key (e.g. 'fr-ca' → 'fr-CA') for
-// case-insensitive lookup that still returns the exact casing i18next expects.
-const SUPPORTED_LANGUAGES = new Map(
-    Object.keys(LANGUAGES_RESOURCES).map(lang => [ lang.toLowerCase(), lang ])
+// Map from lowercased key → original key (e.g. 'fr-CA' → 'fr-CA') for
+// case-insensitive normalization before passing to i18next.
+// Filtering against config.supportedLanguages is handled by i18next whitelist.
+const LANG_NORMALIZE_MAP = new Map(
+    LANGUAGES.map(lang => [ lang.toLowerCase(), lang ])
 );
 
 /**
- * Custom querystring language detector that validates the raw `lang` query
- * parameter against the application's supported-language allowlist before
- * returning it. This prevents unsanitized user-controlled input from reaching
- * i18next internals (defence-in-depth on top of i18next's own whitelist).
+ * Custom querystring language detector that normalizes the raw `lang` query
+ * parameter to the exact casing i18next expects (e.g. 'fr-ca' → 'fr-CA').
+ * Filtering against config.supportedLanguages is delegated to i18next whitelist.
  */
 const safeLangQueryDetector = {
     name: 'safeLangQuery',
@@ -23,7 +22,7 @@ const safeLangQueryDetector = {
     lookup() {
         const value = new URLSearchParams(window.location.search).get('lang');
 
-        const lang = value && SUPPORTED_LANGUAGES.get(value.toLowerCase());
+        const lang = value && LANG_NORMALIZE_MAP.get(value.toLowerCase());
 
         if (lang) {
             return lang;

--- a/react/features/base/i18n/supportedLanguages.ts
+++ b/react/features/base/i18n/supportedLanguages.ts
@@ -1,0 +1,22 @@
+import LANGUAGES_RESOURCES from '../../../../lang/languages.json';
+
+/**
+ * All available languages derived from the languages resource file.
+ */
+export const LANGUAGES: Array<string> = Object.keys(LANGUAGES_RESOURCES);
+
+/**
+ * The languages shown in the UI language selector and used for language detection.
+ * If config.supportedLanguages is set, filters and reorders LANGUAGES accordingly.
+ * Falls back to the full LANGUAGES list if not configured.
+ */
+export const SUPPORTED_LANGUAGES: Array<string> = (() => {
+    const cfg = (globalThis as Record<string, any>).config as { supportedLanguages?: Array<string> } | undefined;
+    const supported = cfg?.supportedLanguages;
+
+    if (Array.isArray(supported) && supported.length > 0) {
+        return supported.filter(lang => LANGUAGES.includes(lang));
+    }
+
+    return LANGUAGES;
+})();

--- a/react/features/settings/components/native/LanguageSelectView.tsx
+++ b/react/features/settings/components/native/LanguageSelectView.tsx
@@ -6,7 +6,8 @@ import { Edge } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 
 import { IReduxState } from '../../../app/types';
-import i18next, { DEFAULT_LANGUAGE, LANGUAGES } from '../../../base/i18n/i18next';
+import i18next, { DEFAULT_LANGUAGE } from '../../../base/i18n/i18next';
+import { getSupportedLanguages } from '../../../base/i18n/functions.any';
 import { IconArrowLeft } from '../../../base/icons/svg';
 import JitsiScreen from '../../../base/modal/components/JitsiScreen';
 import BaseThemeNative from '../../../base/ui/components/BaseTheme.native';
@@ -22,6 +23,7 @@ const LanguageSelectView = ({ goBack, isInWelcomePage }: {
     const navigation = useNavigation();
     const { conference } = useSelector((state: IReduxState) => state['features/base/conference']);
     const { language: currentLanguage = DEFAULT_LANGUAGE } = i18next;
+    const displayLanguages = useSelector(getSupportedLanguages);
 
     const setLanguage = useCallback(language => () => {
         i18next.changeLanguage(language);
@@ -53,7 +55,7 @@ const LanguageSelectView = ({ goBack, isInWelcomePage }: {
                 bounces = { isInWelcomePage }
                 contentContainerStyle = { styles.profileView as ViewStyle }>
                 {
-                    LANGUAGES.map(language => (
+                    displayLanguages.map(language => (
                         <TouchableHighlight
                             disabled = { currentLanguage === language }
                             key = { language }

--- a/react/features/settings/functions.any.ts
+++ b/react/features/settings/functions.any.ts
@@ -5,7 +5,7 @@ import { IStateful } from '../base/app/types';
 import { isNameReadOnly } from '../base/config/functions.any';
 import { SERVER_URL_CHANGE_ENABLED } from '../base/flags/constants';
 import { getFeatureFlag } from '../base/flags/functions';
-import i18next, { DEFAULT_LANGUAGE, LANGUAGES } from '../base/i18n/i18next';
+import i18next, { DEFAULT_LANGUAGE, LANGUAGES, SUPPORTED_LANGUAGES } from '../base/i18n/i18next';
 import { getLocalParticipant } from '../base/participants/functions';
 import { toState } from '../base/redux/functions';
 import { getHideSelfView } from '../base/settings/functions.any';
@@ -136,7 +136,7 @@ export function getMoreTabProps(stateful: IStateful) {
         disableHideSelfView: disableSelfViewSettings || disableSelfView,
         hideSelfView: getHideSelfView(state),
         iAmVisitor: iAmVisitor(state),
-        languages: LANGUAGES,
+        languages: SUPPORTED_LANGUAGES,
         maxStageParticipants: state['features/base/settings'].maxStageParticipants,
         showLanguageSettings: configuredTabs.includes('language'),
         showSubtitlesOnStage: state['features/base/settings'].showSubtitlesOnStage,


### PR DESCRIPTION
## Summary

- Added `config.supportedLanguages` option to restrict and reorder the language list shown in UI settings
- Introduced `supportedLanguages.ts` as the single source of truth for all language constants
- Language filtering works correctly on both web (static init) and native (reactive via Redux)

## Changes

| File | Details |
|---|---|
| `config.js` | Added `// supportedLanguages: ['en', 'ru', 'de']` option near `defaultLanguage` |
| `configType.ts` | Added `supportedLanguages?: Array<string>` to `IConfig` |
| `base/i18n/supportedLanguages.ts` | New file: exports `LANGUAGES` (all) and `SUPPORTED_LANGUAGES` (filtered by config) |
| `base/i18n/i18next.ts` | Re-exports from `supportedLanguages.ts`; whitelist uses `[DEFAULT_LANGUAGE, ...SUPPORTED_LANGUAGES]` |
| `base/i18n/languageDetector.web.ts` | Uses `LANGUAGES` for case normalization only; filtering delegated to i18next whitelist |
| `base/i18n/languageDetector.native.ts` | Uses `LANGUAGES` for locale detection (consistent with web) |
| `base/i18n/functions.any.ts` | Added `getSupportedLanguages(state)` Redux selector |
| `settings/components/native/LanguageSelectView.tsx` | Uses `useSelector(getSupportedLanguages)` for reactive language list on native |
| `settings/functions.any.ts` | Uses `SUPPORTED_LANGUAGES` for web language selector |

## How it works

**Web**: `window.config` is available before the JS bundle loads → `SUPPORTED_LANGUAGES` is correctly computed at module init time → used directly in i18next whitelist and settings UI.

**Native**: config arrives via Redux after connecting → `getSupportedLanguages(state)` selector reads `config.supportedLanguages` reactively → `LanguageSelectView` re-renders with the correct filtered list.

**Responsibilities:**

| Layer | Responsibility |
|---|---|
| `supportedLanguages.ts` | Compute filtered list from `window.config` (web) |
| `i18next whitelist` | Enforce allowed languages in i18next engine |
| Language detectors | Normalize/detect only — no filtering |
| `getSupportedLanguages` selector | Filter for native UI from Redux state |
