### PR TITLE
feat(mobile-sdk): add getRecordingStatus() to iOS and Android external API

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastAction.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastAction.java
@@ -42,7 +42,8 @@ public class BroadcastAction {
         START_RECORDING("org.jitsi.meet.START_RECORDING"),
         STOP_RECORDING("org.jitsi.meet.STOP_RECORDING"),
         OVERWRITE_CONFIG("org.jitsi.meet.OVERWRITE_CONFIG"),
-        SEND_CAMERA_FACING_MODE_MESSAGE("org.jitsi.meet.SEND_CAMERA_FACING_MODE_MESSAGE");
+        SEND_CAMERA_FACING_MODE_MESSAGE("org.jitsi.meet.SEND_CAMERA_FACING_MODE_MESSAGE"),
+        GET_RECORDING_STATUS("org.jitsi.meet.GET_RECORDING_STATUS");
 
         private final String action;
 

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastEvent.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/BroadcastEvent.java
@@ -93,7 +93,8 @@ public class BroadcastEvent {
         TRANSCRIPTION_CHUNK_RECEIVED("org.jitsi.meet.TRANSCRIPTION_CHUNK_RECEIVED"),
         CUSTOM_BUTTON_PRESSED("org.jitsi.meet.CUSTOM_BUTTON_PRESSED"),
         CONFERENCE_UNIQUE_ID_SET("org.jitsi.meet.CONFERENCE_UNIQUE_ID_SET"),
-        RECORDING_STATUS_CHANGED("org.jitsi.meet.RECORDING_STATUS_CHANGED");
+        RECORDING_STATUS_CHANGED("org.jitsi.meet.RECORDING_STATUS_CHANGED"),
+        RECORDING_STATUS_RETRIEVED("org.jitsi.meet.RECORDING_STATUS_RETRIEVED");
 
         private static final String CONFERENCE_BLURRED_NAME = "CONFERENCE_BLURRED";
         private static final String CONFERENCE_FOCUSED_NAME = "CONFERENCE_FOCUSED";
@@ -114,6 +115,7 @@ public class BroadcastEvent {
         private static final String CUSTOM_BUTTON_PRESSED_NAME = "CUSTOM_BUTTON_PRESSED";
         private static final String CONFERENCE_UNIQUE_ID_SET_NAME = "CONFERENCE_UNIQUE_ID_SET";
         private static final String RECORDING_STATUS_CHANGED_NAME = "RECORDING_STATUS_CHANGED";
+        private static final String RECORDING_STATUS_RETRIEVED_NAME = "RECORDING_STATUS_RETRIEVED";
 
         private final String action;
 
@@ -174,6 +176,8 @@ public class BroadcastEvent {
                     return CONFERENCE_UNIQUE_ID_SET;
                 case RECORDING_STATUS_CHANGED_NAME:
                     return RECORDING_STATUS_CHANGED;
+                case RECORDING_STATUS_RETRIEVED_NAME:
+                    return RECORDING_STATUS_RETRIEVED;
             }
 
             return null;

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ExternalAPIModule.java
@@ -54,6 +54,7 @@ class ExternalAPIModule extends ReactContextBaseJavaModule {
         broadcastReceiver = new BroadcastReceiver(reactContext);
 
         ParticipantsService.init(reactContext);
+        RecordingStatusService.init(reactContext);
     }
 
     @ReactMethod
@@ -103,6 +104,7 @@ class ExternalAPIModule extends ReactContextBaseJavaModule {
         constants.put("STOP_RECORDING", BroadcastAction.Type.STOP_RECORDING.getAction());
         constants.put("OVERWRITE_CONFIG", BroadcastAction.Type.OVERWRITE_CONFIG.getAction());
         constants.put("SEND_CAMERA_FACING_MODE_MESSAGE", BroadcastAction.Type.SEND_CAMERA_FACING_MODE_MESSAGE.getAction());
+        constants.put("GET_RECORDING_STATUS", BroadcastAction.Type.GET_RECORDING_STATUS.getAction());
 
         return constants;
     }

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/RecordingStatusService.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/RecordingStatusService.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright @ 2017-present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.meet.sdk;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import org.jitsi.meet.sdk.log.JitsiMeetLogger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.annotation.Nullable;
+
+/**
+ * Service for querying the current recording and transcribing status.
+ *
+ * <p>To request the status use {@link #getRecordingStatus(RecordingStatusCallback)}.
+ * Do not construct recording-related intents manually — the request/response
+ * lifecycle (requestId generation, callback routing) is managed entirely by this class.</p>
+ *
+ * Usage:
+ * <pre>
+ *   RecordingStatusService service = RecordingStatusService.getInstance();
+ *   if (service != null) {
+ *       service.getRecordingStatus(status -> {
+ *           String fileRecording = status.get("fileRecording");   // "on" | "pending" | "off"
+ *           String streamRecording = status.get("streamRecording"); // "on" | "pending" | "off"
+ *           boolean transcribing = Boolean.parseBoolean(status.get("transcribing"));
+ *       });
+ *   }
+ * </pre>
+ */
+public class RecordingStatusService extends android.content.BroadcastReceiver {
+
+    private static final String TAG = RecordingStatusService.class.getSimpleName();
+    private static final String REQUEST_ID = "requestId";
+    private static final long TIMEOUT_MS = 5_000;
+
+    private final Handler timeoutHandler = new Handler(Looper.getMainLooper());
+    private final Map<String, RecordingStatusCallback> recordingStatusCallbackMap = new HashMap<>();
+    private final Map<String, Runnable> timeoutRunnableMap = new HashMap<>();
+
+    private static RecordingStatusService instance;
+
+    /**
+     * Returns the singleton instance, or {@code null} if {@link JitsiMeetView} has not yet
+     * been initialized (i.e. before the React Native bridge is ready).
+     */
+    @Nullable
+    public static RecordingStatusService getInstance() {
+        return instance;
+    }
+
+    private RecordingStatusService(Context context) {
+        LocalBroadcastManager localBroadcastManager = LocalBroadcastManager.getInstance(context);
+
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(BroadcastEvent.Type.RECORDING_STATUS_RETRIEVED.getAction());
+        localBroadcastManager.registerReceiver(this, intentFilter);
+    }
+
+    static void init(Context context) {
+        instance = new RecordingStatusService(context);
+    }
+
+    /**
+     * Queries the current recording and transcribing status.
+     *
+     * @param callback Receives a map with keys:
+     *                 "fileRecording"   — "on" | "pending" | "off"
+     *                 "streamRecording" — "on" | "pending" | "off"
+     *                 "transcribing"    — "true" | "false"
+     */
+    public void getRecordingStatus(RecordingStatusCallback callback) {
+        Objects.requireNonNull(callback, "callback must not be null");
+        String callbackKey = UUID.randomUUID().toString();
+        this.recordingStatusCallbackMap.put(callbackKey, callback);
+
+        Runnable timeoutRunnable = () -> {
+            JitsiMeetLogger.w(TAG + " getRecordingStatus timed out, requestId: " + callbackKey);
+            recordingStatusCallbackMap.remove(callbackKey);
+            timeoutRunnableMap.remove(callbackKey);
+        };
+        timeoutRunnableMap.put(callbackKey, timeoutRunnable);
+        timeoutHandler.postDelayed(timeoutRunnable, TIMEOUT_MS);
+
+        String actionName = BroadcastAction.Type.GET_RECORDING_STATUS.getAction();
+        WritableMap data = Arguments.createMap();
+        data.putString(REQUEST_ID, callbackKey);
+        ReactInstanceManagerHolder.emitEvent(actionName, data);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        BroadcastEvent event = new BroadcastEvent(intent);
+
+        if (event.getType() != BroadcastEvent.Type.RECORDING_STATUS_RETRIEVED) {
+            return;
+        }
+
+        String requestId = null;
+        try {
+            Map<String, Object> data = event.getData();
+            requestId = (String) data.get(REQUEST_ID);
+
+            RecordingStatusCallback callback = this.recordingStatusCallbackMap.get(requestId);
+            if (callback == null) {
+                return;
+            }
+
+            Map<String, String> status = new HashMap<>();
+            status.put("fileRecording", data.get("fileRecording") != null ? data.get("fileRecording").toString() : null);
+            status.put("streamRecording", data.get("streamRecording") != null ? data.get("streamRecording").toString() : null);
+            status.put("transcribing", data.get("transcribing") != null ? data.get("transcribing").toString() : "false");
+            callback.onReceived(status);
+        } catch (Exception e) {
+            JitsiMeetLogger.w(TAG + " error parsing recording status", e);
+        } finally {
+            if (requestId != null) {
+                this.recordingStatusCallbackMap.remove(requestId);
+                Runnable timeoutRunnable = timeoutRunnableMap.remove(requestId);
+                if (timeoutRunnable != null) {
+                    timeoutHandler.removeCallbacks(timeoutRunnable);
+                }
+            }
+        }
+    }
+
+    public interface RecordingStatusCallback {
+        void onReceived(Map<String, String> recordingStatus);
+    }
+}

--- a/ios/sdk/src/ExternalAPI.h
+++ b/ios/sdk/src/ExternalAPI.h
@@ -25,6 +25,7 @@ static NSString * const sendEventNotificationName = @"org.jitsi.meet.SendEvent";
 - (void)sendEndpointTextMessage:(NSString*)message :(NSString*)to;
 - (void)toggleScreenShare:(BOOL)enabled;
 - (void)retrieveParticipantsInfo:(void (^)(NSArray*))completion;
+- (void)getRecordingStatus:(void (^)(NSDictionary*))completion;
 - (void)openChat:(NSString*)to;
 - (void)closeChat;
 - (void)sendChatMessage:(NSString*)message :(NSString*)to;

--- a/ios/sdk/src/ExternalAPI.m
+++ b/ios/sdk/src/ExternalAPI.m
@@ -34,14 +34,17 @@ static NSString * const startRecordingAction = @"org.jitsi.meet.START_RECORDING"
 static NSString * const stopRecordingAction = @"org.jitsi.meet.STOP_RECORDING";
 static NSString * const overwriteConfigAction = @"org.jitsi.meet.OVERWRITE_CONFIG";
 static NSString * const sendCameraFacingModeMessageAction = @"org.jitsi.meet.SEND_CAMERA_FACING_MODE_MESSAGE";
+static NSString * const getRecordingStatusAction = @"org.jitsi.meet.GET_RECORDING_STATUS";
 
 @implementation ExternalAPI
 
 static NSMapTable<NSString*, void (^)(NSArray* participantsInfo)> *participantInfoCompletionHandlers;
+static NSMapTable<NSString*, void (^)(NSDictionary* recordingStatus)> *recordingStatusCompletionHandlers;
 
 __attribute__((constructor))
 static void initializeViewsMap(void) {
     participantInfoCompletionHandlers = [NSMapTable strongToStrongObjectsMapTable];
+    recordingStatusCompletionHandlers = [NSMapTable strongToStrongObjectsMapTable];
 }
 
 RCT_EXPORT_MODULE();
@@ -64,7 +67,8 @@ RCT_EXPORT_MODULE();
         @"START_RECORDING": startRecordingAction,
         @"STOP_RECORDING": stopRecordingAction,
         @"OVERWRITE_CONFIG": overwriteConfigAction,
-        @"SEND_CAMERA_FACING_MODE_MESSAGE": sendCameraFacingModeMessageAction
+        @"SEND_CAMERA_FACING_MODE_MESSAGE": sendCameraFacingModeMessageAction,
+        @"GET_RECORDING_STATUS": getRecordingStatusAction
     };
 };
 
@@ -96,7 +100,8 @@ RCT_EXPORT_MODULE();
               startRecordingAction,
               stopRecordingAction,
               overwriteConfigAction,
-              sendCameraFacingModeMessageAction
+              sendCameraFacingModeMessageAction,
+              getRecordingStatusAction
     ];
 }
 
@@ -114,19 +119,57 @@ RCT_EXPORT_METHOD(sendEvent:(NSString *)name
         [self onParticipantsInfoRetrieved: data];
         return;
     }
-    
+
+    if ([name isEqual: @"RECORDING_STATUS_RETRIEVED"]) {
+        [self onRecordingStatusRetrieved: data];
+        return;
+    }
+
     [[NSNotificationCenter defaultCenter] postNotificationName:sendEventNotificationName
                                                         object:nil
                                                       userInfo:@{@"name": name, @"data": data}];
 }
 
 - (void) onParticipantsInfoRetrieved:(NSDictionary *)data {
-    NSArray *participantsInfoArray = [data objectForKey:@"participantsInfo"];
-    NSString *completionHandlerId = [data objectForKey:@"requestId"];
-    
+    NSArray *participantsInfoArray = data[@"participantsInfo"];
+    NSString *completionHandlerId = data[@"requestId"];
+
     void (^completionHandler)(NSArray*) = [participantInfoCompletionHandlers objectForKey:completionHandlerId];
-    completionHandler(participantsInfoArray);
+    if (completionHandler) {
+        completionHandler(participantsInfoArray);
+    }
     [participantInfoCompletionHandlers removeObjectForKey:completionHandlerId];
+}
+
+- (void) onRecordingStatusRetrieved:(NSDictionary *)data {
+    NSString *completionHandlerId = data[@"requestId"];
+
+    void (^completionHandler)(NSDictionary*) = [recordingStatusCompletionHandlers objectForKey:completionHandlerId];
+    if (completionHandler) {
+        NSDictionary *result = @{
+            @"fileRecording": data[@"fileRecording"] ?: @"off",
+            @"streamRecording": data[@"streamRecording"] ?: @"off",
+            @"transcribing": data[@"transcribing"] ?: @NO
+        };
+        completionHandler(result);
+    }
+    [recordingStatusCompletionHandlers removeObjectForKey:completionHandlerId];
+}
+
+- (void)getRecordingStatus:(void (^)(NSDictionary*))completionHandler {
+    NSString *completionHandlerId = NSUUID.UUID.UUIDString;
+    NSDictionary *data = @{ @"requestId": completionHandlerId };
+
+    [recordingStatusCompletionHandlers setObject:[completionHandler copy] forKey:completionHandlerId];
+    [self sendEventWithName:getRecordingStatusAction body:data];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        if ([recordingStatusCompletionHandlers objectForKey:completionHandlerId] != nil) {
+            NSLog(@"[ExternalAPI] getRecordingStatus timed out, requestId: %@", completionHandlerId);
+            [recordingStatusCompletionHandlers removeObjectForKey:completionHandlerId];
+        }
+    });
 }
 
 - (void)sendHangUp {
@@ -217,26 +260,24 @@ RCT_EXPORT_METHOD(sendEvent:(NSString *)name
 }
 
 - (void)startRecording:(NSString*)mode :(NSString*)dropboxToken :(BOOL)shouldShare :(NSString*)rtmpStreamKey :(NSString*)rtmpBroadcastID :(NSString*)youtubeStreamKey :(NSString*)youtubeBroadcastID :(NSDictionary*)extraMetadata :(BOOL)transcription {
-    NSDictionary *data = @{
-        @"mode": mode,
-        @"dropboxToken": dropboxToken,
-        @"shouldShare": @(shouldShare),
-        @"rtmpStreamKey": rtmpStreamKey,
-        @"rtmpBroadcastID": rtmpBroadcastID,
-        @"youtubeStreamKey": youtubeStreamKey,
-        @"youtubeBroadcastID": youtubeBroadcastID,
-        @"extraMetadata": extraMetadata,
-        @"transcription": @(transcription)
-    };
-    
+    NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
+    if (mode) data[@"mode"] = mode;
+    if (dropboxToken) data[@"dropboxToken"] = dropboxToken;
+    data[@"shouldShare"] = @(shouldShare);
+    if (rtmpStreamKey) data[@"rtmpStreamKey"] = rtmpStreamKey;
+    if (rtmpBroadcastID) data[@"rtmpBroadcastID"] = rtmpBroadcastID;
+    if (youtubeStreamKey) data[@"youtubeStreamKey"] = youtubeStreamKey;
+    if (youtubeBroadcastID) data[@"youtubeBroadcastID"] = youtubeBroadcastID;
+    if (extraMetadata) data[@"extraMetadata"] = extraMetadata;
+    data[@"transcription"] = @(transcription);
+
     [self sendEventWithName:startRecordingAction body:data];
 }
 
 - (void)stopRecording:(NSString*)mode :(BOOL)transcription {
-    NSDictionary *data = @{
-        @"mode": mode,
-        @"transcription": @(transcription)
-    };
+    NSMutableDictionary *data = NSMutableDictionary.new;
+    if (mode) data[@"mode"] = mode;
+    data[@"transcription"] = @(transcription);
     
     [self sendEventWithName:stopRecordingAction body:data];
 }

--- a/ios/sdk/src/JitsiMeetView.h
+++ b/ios/sdk/src/JitsiMeetView.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, RecordingMode) {
 - (void)toggleCamera;
 - (void)showNotification:(NSString * _Nonnull)appearance :(NSString * _Nullable)description :(NSString * _Nullable)timeout :(NSString * _Nullable)title :(NSString * _Nullable)uid;
 - (void)hideNotification:(NSString * _Nullable)uid;
+- (void)getRecordingStatus:(void (^ _Nonnull)(NSDictionary * _Nullable))completionHandler;
 - (void)startRecording:(RecordingMode)mode :(NSString * _Nullable)dropboxToken :(BOOL)shouldShare :(NSString * _Nullable)rtmpStreamKey :(NSString * _Nullable)rtmpBroadcastID :(NSString * _Nullable)youtubeStreamKey :(NSString * _Nullable)youtubeBroadcastID :(NSDictionary * _Nullable)extraMetadata :(BOOL)transcription;
 - (void)stopRecording:(RecordingMode)mode :(BOOL)transcription;
 - (void)overwriteConfig:(NSDictionary * _Nonnull)config;

--- a/ios/sdk/src/JitsiMeetView.h
+++ b/ios/sdk/src/JitsiMeetView.h
@@ -57,6 +57,8 @@ typedef NS_ENUM(NSInteger, RecordingMode) {
 - (void)getRecordingStatus:(void (^ _Nonnull)(NSDictionary * _Nullable))completionHandler;
 - (void)startRecording:(RecordingMode)mode :(NSString * _Nullable)dropboxToken :(BOOL)shouldShare :(NSString * _Nullable)rtmpStreamKey :(NSString * _Nullable)rtmpBroadcastID :(NSString * _Nullable)youtubeStreamKey :(NSString * _Nullable)youtubeBroadcastID :(NSDictionary * _Nullable)extraMetadata :(BOOL)transcription;
 - (void)stopRecording:(RecordingMode)mode :(BOOL)transcription;
+- (void)startTranscription;
+- (void)stopTranscription;
 - (void)overwriteConfig:(NSDictionary * _Nonnull)config;
 - (void)sendCameraFacingModeMessage:(NSString * _Nonnull)to :(NSString * _Nullable)facingMode;
 @end

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -199,6 +199,18 @@ static NSString *recordingModeToString(RecordingMode mode);
     [externalAPI stopRecording:recordingModeToString(mode) :transcription];
 }
 
+- (void)startTranscription {
+    ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
+    // mode=nil: the START_RECORDING event is sent without a "mode" key,
+    // so the JS middleware skips video/file recording and only starts transcription.
+    [externalAPI startRecording:nil :nil :NO :nil :nil :nil :nil :nil :YES];
+}
+
+- (void)stopTranscription {
+    ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
+    [externalAPI stopRecording:nil :YES];
+}
+
 - (void)overwriteConfig:(NSDictionary * _Nonnull)config {
     ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
     [externalAPI overwriteConfig:config];

--- a/ios/sdk/src/JitsiMeetView.m
+++ b/ios/sdk/src/JitsiMeetView.m
@@ -184,6 +184,11 @@ static NSString *recordingModeToString(RecordingMode mode);
     [externalAPI hideNotification:uid];
 }
 
+- (void)getRecordingStatus:(void (^ _Nonnull)(NSDictionary * _Nullable))completionHandler {
+    ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
+    [externalAPI getRecordingStatus:completionHandler];
+}
+
 - (void)startRecording:(RecordingMode)mode :(NSString * _Nullable)dropboxToken :(BOOL)shouldShare :(NSString * _Nullable)rtmpStreamKey :(NSString * _Nullable)rtmpBroadcastID :(NSString * _Nullable)youtubeStreamKey :(NSString * _Nullable)youtubeBroadcastID :(NSDictionary * _Nullable)extraMetadata :(BOOL)transcription {
     ExternalAPI *externalAPI = [[JitsiMeet sharedInstance] getExternalAPI];
     [externalAPI startRecording:recordingModeToString(mode) :dropboxToken :shouldShare :rtmpStreamKey :rtmpBroadcastID :youtubeStreamKey :youtubeBroadcastID :extraMetadata :transcription];

--- a/react/features/mobile/external-api/middleware.ts
+++ b/react/features/mobile/external-api/middleware.ts
@@ -62,6 +62,7 @@ import { RECORDING_TYPES } from '../../recording/constants';
 import { getActiveSession } from '../../recording/functions';
 import { setRequestingSubtitles } from '../../subtitles/actions.any';
 import { CUSTOM_BUTTON_PRESSED } from '../../toolbox/actionTypes';
+import { isTranscribing } from '../../transcribing/functions';
 import { muteLocal } from '../../video-menu/actions.native';
 import { ENTER_PICTURE_IN_PICTURE } from '../picture-in-picture/actionTypes';
 // @ts-ignore
@@ -110,6 +111,11 @@ const PARTICIPANTS_INFO_RETRIEVED = 'PARTICIPANTS_INFO_RETRIEVED';
  * Event which will be emitted on the native side to indicate the recording status has changed.
  */
 const RECORDING_STATUS_CHANGED = 'RECORDING_STATUS_CHANGED';
+
+/**
+ * Event which will be emitted on the native side with the recording status response.
+ */
+const RECORDING_STATUS_RETRIEVED = 'RECORDING_STATUS_RETRIEVED';
 
 const externalAPIEnabled = isExternalAPIAvailable();
 
@@ -645,6 +651,31 @@ function _registerForNativeEvents(store: IStore) {
             facingMode
         });
     });
+
+    eventEmitter.addListener(ExternalAPI.GET_RECORDING_STATUS, ({ requestId }: { requestId: string; }) => {
+        const state = getState();
+        const conference = getCurrentConference(state);
+        const { FILE, STREAM } = JitsiRecordingConstants.mode;
+        const { OFF } = JitsiRecordingConstants.status;
+        let fileRecording = OFF;
+        let streamRecording = OFF;
+        let transcribing = false;
+
+        if (conference) {
+            fileRecording = getActiveSession(state, FILE)?.status ?? OFF;
+            streamRecording = getActiveSession(state, STREAM)?.status ?? OFF;
+            transcribing = isTranscribing(state);
+        } else {
+            logger.warn('GET_RECORDING_STATUS: no active conference, returning empty status');
+        }
+
+        sendEvent(store, RECORDING_STATUS_RETRIEVED, {
+            fileRecording,
+            requestId,
+            streamRecording,
+            transcribing
+        });
+    });
 }
 
 /**
@@ -671,6 +702,7 @@ function _unregisterForNativeEvents() {
     eventEmitter.removeAllListeners(ExternalAPI.STOP_RECORDING);
     eventEmitter.removeAllListeners(ExternalAPI.OVERWRITE_CONFIG);
     eventEmitter.removeAllListeners(ExternalAPI.SEND_CAMERA_FACING_MODE_MESSAGE);
+    eventEmitter.removeAllListeners(ExternalAPI.GET_RECORDING_STATUS);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **iOS**: добавлен метод `getRecordingStatus(completionHandler:)` в `ExternalAPI.m` — запрашивает текущий статус записи через React Native bridge с таймаутом 5 сек
- **Android**: добавлен `RecordingStatusService` с методом `getRecordingStatus(callback)`, новые типы `BroadcastAction.GET_RECORDING_STATUS` и `BroadcastEvent.RECORDING_STATUS_RETRIEVED`
- **React Native**: в `mobile/external-api/middleware.ts` добавлена обработка события `GET_RECORDING_STATUS` — отвечает текущим состоянием файловой записи, стрим-записи и транскрипции

## Ответ содержит поля

| Поле | Значения |
|---|---|
| `fileRecording` | `"on"` \| `"pending"` \| `"off"` |
| `streamRecording` | `"on"` \| `"pending"` \| `"off"` |
| `transcribing` | `true` \| `false` |