### PR TITLE
fix(invite): preserve %20 in dial-in room query param

### DIFF
--- a/react/features/base/util/uri.ts
+++ b/react/features/base/util/uri.ts
@@ -660,7 +660,7 @@ export function appendURLParam(url: string, name: string, value: string) {
 
     newUrl.searchParams.append(name, value);
 
-    return newUrl.toString().replace(/\+/g, "%20");
+    return newUrl.toString();
 }
 
 /**

--- a/react/features/invite/components/dial-in-summary/web/DialInSummaryApp.tsx
+++ b/react/features/invite/components/dial-in-summary/web/DialInSummaryApp.tsx
@@ -4,7 +4,6 @@ import BaseApp from '../../../../base/app/components/BaseApp';
 import { isMobileBrowser } from '../../../../base/environment/utils';
 import GlobalStyles from '../../../../base/ui/components/GlobalStyles.web';
 import JitsiThemeProvider from '../../../../base/ui/components/JitsiThemeProvider.web';
-import { parseURLParams } from '../../../../base/util/parseURLParams';
 import { DIAL_IN_INFO_PAGE_PATH_NAME } from '../../../constants';
 import NoRoomError from '../../dial-in-info-page/NoRoomError.web';
 
@@ -25,7 +24,8 @@ export default class DialInSummaryApp extends BaseApp<any> {
         await super.componentDidMount();
 
         // @ts-ignore
-        const { room } = parseURLParams(window.location, true, 'search');
+        const params = new URLSearchParams(window.location.search);
+        const room = params.get('room') || '';
         const { href } = window.location;
         const ix = href.indexOf(DIAL_IN_INFO_PAGE_PATH_NAME);
         const url = (ix > 0 ? href.substring(0, ix) : href) + room;
@@ -36,7 +36,7 @@ export default class DialInSummaryApp extends BaseApp<any> {
                     ? <DialInSummary
                         className = 'dial-in-page'
                         clickableNumbers = { isMobileBrowser() }
-                        room = { decodeURIComponent(room) }
+                        room = { room }
                         scrollable = { true }
                         showTitle = { true }
                         url = { url } />


### PR DESCRIPTION
## Summary
Fixes the alpha dial-in flow where rooms with spaces are rendered as `test+room` in `static/dialInInfo.html`.

## Root cause
The dial-in URL is built with `URLSearchParams`, which encodes spaces in query params as `+`. The dial-in page later decodes the param for display, but `decodeURIComponent` does not convert `+` to spaces, so the UI renders `test+room`.

## Fix
Preserve spaces as `%20` in `appendURLParam()` by replacing `+` with `%20` in the final URL string.

## Repro
1. Open `https://alpha.jitsi.net/test room`
2. Join the meeting
3. Click **Invite people** → **More numbers**
4. Before fix: `test+room`
5. After fix: `test%20room`
