### PR TITLE
GSoC: Cleanup Trans usage in StartLiveStreamDialog

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -701,6 +701,7 @@
         "changeSignIn": "Switch accounts.",
         "choose": "Choose a live stream",
         "chooseCTA": "Choose a streaming option. You're currently logged in as {{email}}.",
+        "chooseCTAWithChangeSignIn": "Choose a streaming option. You're currently logged in as {{email}}. <0>Switch accounts.</0>",
         "enterStreamKey": "Enter your YouTube live stream key here.",
         "error": "Live Streaming failed. Please try again.",
         "errorAPI": "An error occurred while accessing your YouTube broadcasts. Please try logging in again.",

--- a/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.tsx
+++ b/react/features/recording/components/LiveStream/web/StartLiveStreamDialog.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { Trans } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
-import { translate } from '../../../../base/i18n/functions';
+import { translate } from '../../../../base/i18n/functions.web';
 import Dialog from '../../../../base/ui/components/web/Dialog';
 import Spinner from '../../../../base/ui/components/web/Spinner';
 import {
@@ -275,19 +276,14 @@ class StartLiveStreamDialog
                 ;
             }
 
-            /**
-             * FIXME: Ideally this help text would be one translation string
-             * that also accepts the anchor. This can be done using the Trans
-             * component of react-i18next but I couldn't get it working...
-             */
             helpText = (
-                <div>
-                    { `${t('liveStreaming.chooseCTA',
-                        { email: _googleProfileEmail })} ` }
-                    <a onClick = { this._onRequestGoogleSignIn }>
-                        { t('liveStreaming.changeSignIn') }
-                    </a>
-                </div>
+                <Trans
+                    components = { [ <a
+                        key = 'change-sign-in'
+                        onClick = { this._onRequestGoogleSignIn } /> ] }
+                    i18nKey = 'liveStreaming.chooseCTAWithChangeSignIn'
+                    t = { t }
+                    values = {{ email: _googleProfileEmail }} />
             );
 
             break;


### PR DESCRIPTION
This PR cleans up translation usage in StartLiveStreamDialog by replacing split text and a standalone anchor with a single Trans based implementation.

 Changes
- Replaced fragmented rendering with a single `Trans` component
-Fixed import path to `functions.web` (previous path caused a module resolution error)
-Added `liveStreaming.chooseCTAWithChangeSignIn` to `lang/main.json`
- Updated `components` prop to array form and resolved lint issues

Verification
- Verified UI output in the Start Live Stream dialog
- `npm run lint:ci` passed
- `npm run tsc:web` passed

This resolves the FIXME related to translation handling in this component.