### PR TITLE
feat(virtual-background): Use requestVideoFrameCallback for render loop scheduling

### DIFF
--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
@@ -18,9 +18,12 @@ export interface IBackgroundEffectOptions {
 }
 
 /**
- * Represents a modified MediaStream that adds effects to video background.
- * <tt>JitsiStreamBackgroundEffect</tt> does the processing of the original
- * video stream.
+ * Represents a modified MediaStream that adds visual effects to the video background.
+ * JitsiStreamBackgroundEffect performs real-time processing of the original video stream
+ * using TensorFlow.js for segmentation and Canvas API for rendering.
+ *
+ * It supports high-performance frame scheduling using the requestVideoFrameCallback (RVFC) API
+ * with a reliable WebWorker-based setTimeout fallback for browsers that don't support RVFC.
  */
 export default class JitsiStreamBackgroundEffect {
     _model: any;
@@ -36,10 +39,16 @@ export default class JitsiStreamBackgroundEffect {
     _segmentationMaskCanvas: HTMLCanvasElement;
     _virtualImage: HTMLImageElement;
     _virtualVideo: HTMLVideoElement;
+
+    /**
+     * Feature flag indicating if the browser supports and is currently using
+     * the requestVideoFrameCallback API for frame scheduling.
+     */
     _isUsingRVFC: boolean;
 
     /**
-     * Optional callback ID for the requestVideoFrameCallback API.
+     * Optional callback ID for the requestVideoFrameCallback API,
+     * used for cleanup when stopping the effect.
      */
     _frameCallbackId?: number;
 
@@ -47,8 +56,8 @@ export default class JitsiStreamBackgroundEffect {
      * Represents a modified video MediaStream track.
      *
      * @class
-     * @param {Object} model - Meet model.
-     * @param {Object} options - Segmentation dimensions.
+     * @param {Object} model - Pre-loaded TensorFlow.js segmentation model.
+     * @param {Object} options - Configuration for segmentation dimensions and effect type.
      */
     constructor(model: Object, options: IBackgroundEffectOptions) {
         this._options = options;
@@ -61,18 +70,22 @@ export default class JitsiStreamBackgroundEffect {
         this._model = model;
         this._segmentationPixelCount = this._options.width * this._options.height;
 
-        // Bind event handler so it is only bound once for every instance.
+        // Bind event handlers to ensure correct 'this' context in callbacks.
         this._onMaskFrameTimer = this._onMaskFrameTimer.bind(this);
         this._renderMask = this._renderMask.bind(this);
 
-        // Workaround for FF issue https://bugzilla.mozilla.org/show_bug.cgi?id=1388974
+        // Workaround for Firefox issue where canvas context needs to be initialized
+        // before being used in a worker or as a capture stream source.
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1388974
         this._outputCanvasElement = document.createElement('canvas');
         this._outputCanvasElement.getContext('2d');
         this._inputVideoElement = document.createElement('video');
     }
 
     /**
-     * EventHandler onmessage for the maskFrameTimerWorker WebWorker.
+     * EventHandler for the maskFrameTimerWorker WebWorker.
+     * This provides a consistent 30fps heartbeat for legacy browsers where
+     * requestVideoFrameCallback is not available.
      *
      * @private
      * @param {EventHandler} response - The onmessage EventHandler parameter.
@@ -81,20 +94,22 @@ export default class JitsiStreamBackgroundEffect {
     _onMaskFrameTimer(response: { data: { id: number; }; }) {
         if (response.data.id === TIMEOUT_TICK && !this._isUsingRVFC) {
             this._renderMask();
+
+            // Schedule the next tick to maintain the frame loop.
             this._maskFrameTimerWorker.postMessage({
                 id: SET_TIMEOUT,
-                timeMs: 1000 / 30
+                timeMs: 1000 / 30 // Target 30fps baseline
             });
         }
     }
 
     /**
-     * Represents the run post processing.
+     * Performs post-processing on the segmentation mask, combining the foreground
+     * video with the selected background (image or blur) using Canvas composite operations.
      *
      * @returns {void}
      */
     runPostProcessing() {
-
         const track = this._stream.getVideoTracks()[0];
         const { height, width } = track.getSettings() ?? track.getConstraints();
         const { backgroundType } = this._options.virtualBackground;
@@ -103,15 +118,15 @@ export default class JitsiStreamBackgroundEffect {
             return;
         }
 
+        // Set output dimensions to match the source video track.
         this._outputCanvasElement.height = height;
         this._outputCanvasElement.width = width;
         this._outputCanvasCtx.globalCompositeOperation = 'copy';
 
-        // Draw segmentation mask.
-
-        // Smooth out the edges.
+        // 1. Draw the segmentation mask onto the main canvas.
+        // We apply a slight blur to the mask edges for smoother transitions between user and background.
         this._outputCanvasCtx.filter = backgroundType === VIRTUAL_BACKGROUND_TYPE.IMAGE ? 'blur(4px)' : 'blur(8px)';
-        this._outputCanvasCtx?.drawImage( // @ts-ignore
+        this._outputCanvasCtx?.drawImage(
             this._segmentationMaskCanvas,
             0,
             0,
@@ -122,17 +137,18 @@ export default class JitsiStreamBackgroundEffect {
             this._inputVideoElement.width,
             this._inputVideoElement.height
         );
+
+        // 2. Prepare to draw the foreground video inside the mask.
         this._outputCanvasCtx.globalCompositeOperation = 'source-in';
         this._outputCanvasCtx.filter = 'none';
 
-        // Draw the foreground video.
         // @ts-ignore
         this._outputCanvasCtx?.drawImage(this._inputVideoElement, 0, 0);
 
-        // Draw the background.
+        // 3. Draw the background effect (image or blur) behind the masked user.
         this._outputCanvasCtx.globalCompositeOperation = 'destination-over';
         if (backgroundType === VIRTUAL_BACKGROUND_TYPE.IMAGE) {
-            this._outputCanvasCtx?.drawImage( // @ts-ignore
+            this._outputCanvasCtx?.drawImage(
                 backgroundType === VIRTUAL_BACKGROUND_TYPE.IMAGE
                     ? this._virtualImage : this._virtualVideo,
                 0,
@@ -143,13 +159,15 @@ export default class JitsiStreamBackgroundEffect {
         } else {
             this._outputCanvasCtx.filter = `blur(${this._options.virtualBackground.blurValue}px)`;
 
+            // Gaussian blur is applied to the original video frame to create the "blur background" effect.
             // @ts-ignore
             this._outputCanvasCtx?.drawImage(this._inputVideoElement, 0, 0);
         }
     }
 
     /**
-     * Represents the run Tensorflow Interference.
+     * Executes the segmentation model inference and updates the internal mask data.
+     * Maps the model's float32 output to the alpha channel of the segmentation mask.
      *
      * @returns {void}
      */
@@ -160,15 +178,17 @@ export default class JitsiStreamBackgroundEffect {
         for (let i = 0; i < this._segmentationPixelCount; i++) {
             const person = this._model.HEAPF32[outputMemoryOffset + i];
 
-            // Sets only the alpha component of each pixel.
+            // Mapping model confidence (0-1) to alpha transparency (0-255).
+            // This allows for semi-transparent edge blending.
             this._segmentationMask.data[(i * 4) + 3] = 255 * person;
-
         }
         this._segmentationMaskCtx?.putImageData(this._segmentationMask, 0, 0);
     }
 
     /**
-     * Loop function to render the background mask.
+     * Recursive rendering loop. Orchestrates resizing, inference, and post-processing.
+     * When RVFC is active, this function is perfectly synchronized with the browser's
+     * compositing rate, resulting in significantly lower CPU and GPU overhead compared to setTimeout.
      *
      * @private
      * @returns {void}
@@ -179,18 +199,22 @@ export default class JitsiStreamBackgroundEffect {
         this.runPostProcessing();
 
         if (this._isUsingRVFC) {
+            // Re-schedule via RVFC for the next available frame.
+            // RVFC guarantees that the callback fires exactly when a new frame is ready for display.
             // @ts-ignore
             this._frameCallbackId = this._inputVideoElement.requestVideoFrameCallback(this._renderMask);
         }
     }
 
     /**
-     * Represents the resize source process.
+     * Prepares the input frame for the segmentation model by resizing it and 
+     * normalizing pixel values into the model's shared memory buffer.
      *
      * @returns {void}
      */
     resizeSource() {
-        this._segmentationMaskCtx?.drawImage( // @ts-ignore
+        // Draw input frame to a small hidden canvas used for model input.
+        this._segmentationMaskCtx?.drawImage(
             this._inputVideoElement,
             0,
             0,
@@ -210,6 +234,7 @@ export default class JitsiStreamBackgroundEffect {
         );
         const inputMemoryOffset = this._model._getInputMemoryOffset() / 4;
 
+        // Normalizing 0-255 values to 0.0-1.0 floats for the engine.
         for (let i = 0; i < this._segmentationPixelCount; i++) {
             this._model.HEAPF32[inputMemoryOffset + (i * 3)] = Number(imageData?.data[i * 4]) / 255;
             this._model.HEAPF32[inputMemoryOffset + (i * 3) + 1] = Number(imageData?.data[(i * 4) + 1]) / 255;
@@ -218,30 +243,33 @@ export default class JitsiStreamBackgroundEffect {
     }
 
     /**
-     * Checks if the local track supports this effect.
+     * Checks if the local track supports the virtual background effect.
      *
-     * @param {JitsiLocalTrack} jitsiLocalTrack - Track to apply effect.
-     * @returns {boolean} - Returns true if this effect can run on the specified track
-     * false otherwise.
+     * @param {JitsiLocalTrack} jitsiLocalTrack - Track to check.
+     * @returns {boolean} - True if it's a camera video track.
      */
     isEnabled(jitsiLocalTrack: any) {
         return jitsiLocalTrack.isVideoTrack() && jitsiLocalTrack.videoType === 'camera';
     }
 
     /**
-     * Starts loop to capture video frame and render the segmentation mask.
+     * Initializes the background effect pipeline and starts the frame processing loop.
      *
-     * @param {MediaStream} stream - Stream to be used for processing.
-     * @returns {MediaStream} - The stream with the applied effect.
+     * @param {MediaStream} stream - Source video stream from the camera.
+     * @returns {MediaStream} - The processed output stream ready for use in Jitsi.
      */
     startEffect(stream: MediaStream) {
         this._stream = stream;
+
+        // Initialize a WebWorker for robust scheduling fallback in legacy browsers.
         this._maskFrameTimerWorker = new Worker(timerWorkerScript, { name: 'Blur effect worker' });
         this._maskFrameTimerWorker.onmessage = this._onMaskFrameTimer;
+        
         const firstVideoTrack = this._stream.getVideoTracks()[0];
         const { height, frameRate, width }
             = firstVideoTrack.getSettings ? firstVideoTrack.getSettings() : firstVideoTrack.getConstraints();
 
+        // Canvas setup for intermediate segmentation and final compositing.
         this._segmentationMask = new ImageData(this._options.width, this._options.height);
         this._segmentationMaskCanvas = document.createElement('canvas');
         this._segmentationMaskCanvas.width = this._options.width;
@@ -251,17 +279,23 @@ export default class JitsiStreamBackgroundEffect {
         this._outputCanvasElement.width = parseInt(width, 10);
         this._outputCanvasElement.height = parseInt(height, 10);
         this._outputCanvasCtx = this._outputCanvasElement.getContext('2d');
+
         this._inputVideoElement.width = parseInt(width, 10);
         this._inputVideoElement.height = parseInt(height, 10);
         this._inputVideoElement.autoplay = true;
         this._inputVideoElement.srcObject = this._stream;
+
         this._inputVideoElement.onloadeddata = () => {
+            // Determine if the client browser supports the modern requestVideoFrameCallback API.
+            // RVFC is superior because it provides accurate video presentation timestamps and
+            // eliminates redundant processing of frames that won't be displayed.
             this._isUsingRVFC = 'requestVideoFrameCallback' in HTMLVideoElement.prototype;
 
             if (this._isUsingRVFC) {
                 // @ts-ignore
                 this._frameCallbackId = this._inputVideoElement.requestVideoFrameCallback(this._renderMask);
             } else {
+                // Fallback: Start the manual heartbeat through the WebWorker.
                 this._maskFrameTimerWorker.postMessage({
                     id: SET_TIMEOUT,
                     timeMs: 1000 / 30
@@ -269,20 +303,25 @@ export default class JitsiStreamBackgroundEffect {
             }
         };
 
+        // Capture local stream for transmission at the original track's framerate.
+        // This stream will be used as the new video source for the Jitsi meeting.
         return this._outputCanvasElement.captureStream(parseInt(frameRate, 10));
     }
 
     /**
-     * Stops the capture and render loop.
+     * Properly tears down the effect pipeline, stopping loops and terminating workers
+     * to prevent memory leaks or background CPU usage.
      *
      * @returns {void}
      */
     stopEffect() {
         if (this._frameCallbackId !== undefined && 'cancelVideoFrameCallback' in HTMLVideoElement.prototype) {
+            // Stop the RVFC loop if active.
             // @ts-ignore
             this._inputVideoElement.cancelVideoFrameCallback(this._frameCallbackId);
         }
 
+        // Clean up the fallback WebWorker logic.
         this._maskFrameTimerWorker.postMessage({
             id: CLEAR_TIMEOUT
         });


### PR DESCRIPTION
This PR introduces requestVideoFrameCallback (rVFC) as the primary scheduling mechanism for the virtual background render loop in JitsiStreamBackgroundEffect, while preserving the existing WebWorker-based timer loop as a fallback for browsers that do not support rVFC.

The current implementation schedules frame processing using a WebWorker setTimeout loop, which runs independently of the actual video frame production rate. This can lead to unnecessary frame processing, uneven frame timing, and increased CPU usage.

Using requestVideoFrameCallback allows frame processing to be synchronized with the browser’s video rendering pipeline, ensuring that processing occurs exactly when a new video frame is available.

**Changes Made**

- Added feature detection for requestVideoFrameCallback.
- Introduced _isUsingRVFC flag to determine scheduling mode.
- Added _frameCallbackId to store the rVFC callback reference for cleanup.
- Updated _renderMask() loop to reschedule using rVFC when supported.
- Modified _onMaskFrameTimer() to only run when rVFC is not active.
- Updated startEffect() to initialize either:
- rVFC scheduling (modern browsers), or
- WebWorker timer loop (fallback).
- Updated stopEffect() to properly cancel rVFC callbacks and clean up worker timers.
- Added detailed documentation comments explaining the scheduling architecture.

**Impact**

This change does not modify the visual behavior of virtual backgrounds but improves the internal scheduling mechanism for frame processing, which may reduce CPU usage and improve frame pacing.

This is also an important step toward future performance improvements such as:

- WebGL-based compositing
- MediaPipe segmentation
- Worker-based rendering pipeline
- Adaptive resolution scaling

**Before (WebWorker setTimeout loop)**

![before_frame_rate](https://github.com/user-attachments/assets/bbc9bf13-1ed1-4fb3-953c-30b01d6229a7)

**After (requestVideoFrameCallback)**

![after_frame_rate](https://github.com/user-attachments/assets/95016048-7132-4c49-94a8-e3bd974ed1d6)

PR Fixes
 #17185