### PR TITLE
GSOC : Fix chat replytoid redux

### DIFF
--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -406,7 +406,7 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
         JitsiConferenceEvents.MESSAGE_RECEIVED,
         /* eslint-disable max-params */
         (participantId: string, message: string, timestamp: number,
-                displayName: string, isFromVisitor: boolean, messageId: string, source: string) => {
+                displayName: string, isFromVisitor: boolean, messageId: string, source: string, replyToId?: string) => {
         /* eslint-enable max-params */
             _onConferenceMessageReceived(store, {
                 // in case of messages coming from visitors we can have unknown id
@@ -416,6 +416,7 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
                 displayName,
                 isFromVisitor,
                 messageId,
+                replyToMessageId: replyToId,
                 source,
                 privateMessage: false
             });
@@ -441,7 +442,8 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
 
     conference.on(
         JitsiConferenceEvents.PRIVATE_MESSAGE_RECEIVED,
-        (participantId: string, message: string, timestamp: number, messageId: string, displayName?: string, isFromVisitor?: boolean) => {
+        (participantId: string, message: string, timestamp: number, messageId: string, displayName?: string,
+                isFromVisitor?: boolean, replyToId?: string) => {
             _onConferenceMessageReceived(store, {
                 participantId,
                 message,
@@ -449,7 +451,8 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
                 displayName,
                 messageId,
                 privateMessage: true,
-                isFromVisitor
+                isFromVisitor,
+                replyToMessageId: replyToId
             });
         }
     );
@@ -468,9 +471,9 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
  * @returns {void}
  */
 function _onConferenceMessageReceived(store: IStore,
-        { displayName, isFromVisitor, message, messageId, participantId, privateMessage, timestamp, source }: {
+        { displayName, isFromVisitor, message, messageId, participantId, privateMessage, replyToMessageId, timestamp, source }: {
             displayName?: string; isFromVisitor?: boolean; message: string; messageId?: string;
-            participantId: string; privateMessage: boolean; source?: string; timestamp: number; }
+            participantId: string; privateMessage: boolean; replyToMessageId?: string; source?: string; timestamp: number; }
 ) {
 
     const isGif = isGifEnabled(store.getState()) && isGifMessage(message);
@@ -490,6 +493,7 @@ function _onConferenceMessageReceived(store: IStore,
         lobbyChat: false,
         timestamp,
         messageId,
+        replyToMessageId,
         source
     }, true, isGif);
 }
@@ -599,9 +603,10 @@ function getLobbyChatDisplayName(state: IReduxState, participantId: string) {
  * @returns {void}
  */
 function _handleReceivedMessage({ dispatch, getState }: IStore,
-        { displayName, isFromVisitor, lobbyChat, message, messageId, participantId, privateMessage, source, timestamp }: {
+        { displayName, isFromVisitor, lobbyChat, message, messageId, participantId, privateMessage, replyToMessageId, source, timestamp }: {
             displayName?: string; isFromVisitor?: boolean; lobbyChat: boolean; message: string;
-            messageId?: string; participantId: string; privateMessage: boolean; source?: string; timestamp: number; },
+            messageId?: string; participantId: string; privateMessage: boolean; replyToMessageId?: string;
+            source?: string; timestamp: number; },
         shouldPlaySound = true,
         isReaction = false
 ) {
@@ -652,6 +657,7 @@ function _handleReceivedMessage({ dispatch, getState }: IStore,
         recipient: getParticipantDisplayName(state, localParticipant?.id ?? ''),
         timestamp: millisecondsTimestamp,
         messageId,
+        replyToMessageId,
         isReaction,
         isFromVisitor,
         isFromGuest: source === 'guest'

--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -83,6 +83,7 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             privateMessage: action.privateMessage,
             lobbyChat: action.lobbyChat,
             recipient: action.recipient,
+            replyToMessageId: action.replyToMessageId,
             sentToVisitor: Boolean(action.sentToVisitor),
             timestamp: action.timestamp
         };

--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -18,6 +18,10 @@ export interface IMessage {
     privateMessage: boolean;
     reactions: Map<string, Set<string>>;
     recipient: string;
+    /**
+     * When set, XMPP message id of the message this one replies to (XEP-0461), from lib-jitsi-meet.
+     */
+    replyToMessageId?: string;
     sentToVisitor?: boolean;
     timestamp: number;
 }


### PR DESCRIPTION
**fix(chat): forward replyToId from MESSAGE_RECEIVED to Redux**

LJM emits `replyToId` as the last argument on `MESSAGE_RECEIVED` and `PRIVATE_MESSAGE_RECEIVED`. The listeners in `_addChatMsgListener()` never declared it, so it was removed - reply metadata never reached Redux or the UI.

Changes
- Both listeners now accept optional `replyToId`, forwarded as `replyToMessageId` through `_handleReceivedMessage`
- `IMessage` extended with optional `replyToMessageId`, persisted in the reducer on `ADD_MESSAGE`
- Scoped to receive/forward only — XEP-0461 send/parse stays in LJM

Testing
`tsc:web` ,  `tsc:native` , `lint:ci` runs and everything works. 

Closes #17212