### PR TITLE
GSoC: Fix mutation issue in getParticipantsInfo in external API

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1065,15 +1065,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * information like participant id, display name, avatar URL and email.
      */
     getParticipantsInfo() {
-        const participantIds = Object.keys(this._participants);
-        const participantsInfo = Object.values(this._participants);
-
-        participantsInfo.forEach((participant, idx) => {
-            participant.participantId = participantIds[idx];
-        });
-
-        return participantsInfo;
-    }
+    return Object.entries(this._participants).map(([id, participant]) => ({
+        participantId: id,
+        ...participant
+    }));
+}
 
     /**
      * Returns the current video quality setting.


### PR DESCRIPTION
### What is the problem?

Currently, getParticipantsInfo() modifies the internal _participants object by adding participantId directly to each participant.

This can cause unexpected behavior because if someone changes the returned data, it also affects the internal state.

---

### What I changed

Instead of modifying the original objects, I created new objects using Object.entries().map().

This way, the internal _participants data remains unchanged.

---

### Why this matters

It prevents side effects and makes the API safer to use, since external changes won’t affect internal data anymore.


Let me know if you'd like me to add tests for this behavior.