### PR TITLE
GSoC: Fix inconsistent displayName handling

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1065,15 +1065,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * information like participant id, display name, avatar URL and email.
      */
     getParticipantsInfo() {
-        const participantIds = Object.keys(this._participants);
-        const participantsInfo = Object.values(this._participants);
-
-        participantsInfo.forEach((participant, idx) => {
-            participant.participantId = participantIds[idx];
-        });
-
-        return participantsInfo;
-    }
+    return Object.entries(this._participants).map(([id, participant]) => ({
+        participantId: id,
+        ...participant
+    }));
+}
 
     /**
      * Returns the current video quality setting.


### PR DESCRIPTION

Hi,

I noticed that in some places both `displayName` and `displayname` are used, which can lead to inconsistent behavior.

I updated the code to handle both cases safely by using:
data.displayName ?? data.displayname

This ensures that the participant name is always set correctly regardless of the field format.

Thanks!