### PR TITLE
fix(profile): add email format validation in gravatar profile settings

### DIFF
--- a/android/app/.project
+++ b/android/app/.project
@@ -20,4 +20,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+<filteredResources>
+		<filter>
+			<id>1773901284013</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/lang/main-af.json
+++ b/lang/main-af.json
@@ -456,7 +456,8 @@
         "setDisplayNameLabel": "Stel u vertoonnaam",
         "setEmailInput": "Gee e-posadres",
         "setEmailLabel": "Stel u Gravatar-e-posadres",
-        "title": "Profiel"
+        "title": "Profiel",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "recording": {
         "authDropboxText": "Laai op na Dropbox",

--- a/lang/main-ar.json
+++ b/lang/main-ar.json
@@ -860,7 +860,8 @@
         "setDisplayNameLabel": "حدد اسمك المراد عرضه",
         "setEmailInput": "أدخل بريدك الإلكتروني",
         "setEmailLabel": "حدد الصورة الرمزية (gravatar) لبريدك الإلكتروني",
-        "title": "الملف الشخصي"
+        "title": "الملف الشخصي",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "يرد التحدث",
     "raisedHandsLabel": "عدد الأيدي المرفوعة",

--- a/lang/main-be.json
+++ b/lang/main-be.json
@@ -502,7 +502,8 @@
         "setDisplayNameLabel": "Якое адлюстроўваецца імя",
         "setEmailInput": "Калі ласка, увядзіце email",
         "setEmailLabel": "Email для Gravatar",
-        "title": "Профіль"
+        "title": "Профіль",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Хоча гаварыць",
     "recording": {

--- a/lang/main-bg.json
+++ b/lang/main-bg.json
@@ -1071,7 +1071,8 @@
         "setDisplayNameLabel": "Задайте екранното си име",
         "setEmailInput": "Въведете е-поща",
         "setEmailLabel": "Задайте е-пощата си в „Gravatar“",
-        "title": "Профил"
+        "title": "Профил",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Иска думата",
     "raisedHandsLabel": "Брой вдигнати ръце",

--- a/lang/main-ca.json
+++ b/lang/main-ca.json
@@ -867,7 +867,8 @@
         "setDisplayNameLabel": "Indiqueu el nom visible",
         "setEmailInput": "Introduïu una adreça electrònica",
         "setEmailLabel": "Indiqueu l'adreça electrònica de Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Vull parlar",
     "raisedHandsLabel": "Nombre de mans aixecades",

--- a/lang/main-cs.json
+++ b/lang/main-cs.json
@@ -999,7 +999,8 @@
         "setDisplayNameLabel": "Nastavte si jméno",
         "setEmailInput": "Zadejte email",
         "setEmailLabel": "Nastavte si email vašeho Gravataru",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Chtěl(a) bych mluvit",
     "raisedHandsLabel": "Počet zvednutých rukou",

--- a/lang/main-da.json
+++ b/lang/main-da.json
@@ -1087,7 +1087,8 @@
         "setDisplayNameLabel": "Navn",
         "setEmailInput": "Indtast e-mail",
         "setEmailLabel": "Gravatar email",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Vil gerne tale",
     "raisedHandsLabel": "Antal hævede hænder",

--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -1093,7 +1093,8 @@
         "setDisplayNameLabel": "Anzeigename festlegen",
         "setEmailInput": "E-Mail eingeben",
         "setEmailLabel": "E-Mail-Adresse für Gravatar",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ich möchte sprechen",
     "raisedHandsLabel": "Anzahl gehobener Hände",

--- a/lang/main-dsb.json
+++ b/lang/main-dsb.json
@@ -867,7 +867,8 @@
         "setDisplayNameLabel": "zjawne mě wustajiś",
         "setEmailInput": "e-mail zapódaś",
         "setEmailLabel": "e-mailowa adresa za grawatar",
-        "title": "profil"
+        "title": "profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ja cu powědaś",
     "raisedHandsLabel": "licba zwignjonych rukow",

--- a/lang/main-el.json
+++ b/lang/main-el.json
@@ -884,7 +884,8 @@
         "setDisplayNameLabel": "Όνομα",
         "setEmailInput": "Εισάγετε το email",
         "setEmailLabel": "Email στο Gravatar",
-        "title": "Προφίλ"
+        "title": "Προφίλ",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Θα ήθελα να μιλήσω",
     "raisedHandsLabel": "Πλήθος χεριών",

--- a/lang/main-eo.json
+++ b/lang/main-eo.json
@@ -958,7 +958,8 @@
         "setDisplayNameLabel": "Agordi vian videblan nomon",
         "setEmailInput": "Enigu retpoŝtadreson",
         "setEmailLabel": "Retpoŝtadreso ligita al Gravatar",
-        "title": "Profilo"
+        "title": "Profilo",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ŝatus paroli",
     "raisedHandsLabel": "Nombro da levitaj manoj",

--- a/lang/main-es-US.json
+++ b/lang/main-es-US.json
@@ -781,7 +781,8 @@
         "setDisplayNameLabel": "Configura tu nombre para mostrar",
         "setEmailInput": "Introducir correo electrónico",
         "setEmailLabel": "Configurar tu correo electrónico de Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Desea hablar",
     "recording": {

--- a/lang/main-es.json
+++ b/lang/main-es.json
@@ -909,7 +909,8 @@
         "setDisplayNameLabel": "Configura tu nombre para mostrar",
         "setEmailInput": "Introducir correo electrónico",
         "setEmailLabel": "Configurar tu correo electrónico de Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Desea hablar",
     "raisedHandsLabel": "Cantidad de manos levantadas",

--- a/lang/main-et.json
+++ b/lang/main-et.json
@@ -491,7 +491,8 @@
         "setDisplayNameLabel": "Sisesta nimi",
         "setEmailInput": "Sisesta email",
         "setEmailLabel": "Sisesta Gravatar e-kirja aadress",
-        "title": "Profiil"
+        "title": "Profiil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Soovin rääkida",
     "recording": {

--- a/lang/main-eu.json
+++ b/lang/main-eu.json
@@ -668,7 +668,8 @@
         "setDisplayNameLabel": "Ezarri zure bistaratze-izena",
         "setEmailInput": "Sartu e-posta",
         "setEmailLabel": "Ezarri zure gravatar e-posta",
-        "title": "Profila"
+        "title": "Profila",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Hitz egin nahiko luke",
     "recording": {

--- a/lang/main-fa.json
+++ b/lang/main-fa.json
@@ -1093,7 +1093,8 @@
         "setDisplayNameLabel": "نام",
         "setEmailInput": "رایانامه را وارد کنید",
         "setEmailLabel": "رایانامهٔ Gravatar",
-        "title": "نمایه"
+        "title": "نمایه",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "تمایل به صحبت",
     "raisedHandsLabel": "تعداد دست‌های بلندشده",

--- a/lang/main-fi.json
+++ b/lang/main-fi.json
@@ -1091,7 +1091,8 @@
         "setDisplayNameLabel": "Määritä näyttönimi",
         "setEmailInput": "Anna sähköpostiosoite",
         "setEmailLabel": "Määritä Gravatar-sähköposti",
-        "title": "Profiili"
+        "title": "Profiili",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Haluaa puhua",
     "raisedHandsLabel": "Nostettujen käsien määrä",

--- a/lang/main-fr-CA.json
+++ b/lang/main-fr-CA.json
@@ -1071,7 +1071,8 @@
         "setDisplayNameLabel": "Définir votre nom d'affichage",
         "setEmailInput": "Entrer votre adresse courriel",
         "setEmailLabel": "Définir votre courriel Gravatar",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Aimerait prendre la parole",
     "raisedHandsLabel": "Nombre de mains levées",

--- a/lang/main-fr.json
+++ b/lang/main-fr.json
@@ -1090,7 +1090,8 @@
         "setDisplayNameLabel": "Choisissez un pseudo",
         "setEmailInput": "Entrez une adresse email",
         "setEmailLabel": "Définir votre courriel Gravatar",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Aimerait prendre la parole",
     "raisedHandsLabel": "Nombre de mains levées",

--- a/lang/main-gl.json
+++ b/lang/main-gl.json
@@ -478,7 +478,8 @@
         "setDisplayNameLabel": "Escoller o seu nome en pantalla",
         "setEmailInput": "Escribir correo-e",
         "setEmailLabel": "Estabelecer o seu correo Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Gustaríalle falar",
     "recording": {

--- a/lang/main-he.json
+++ b/lang/main-he.json
@@ -501,7 +501,8 @@
         "setDisplayNameLabel": "הגדר שם תצוגה",
         "setEmailInput": "הזן דואר אלקטרוני",
         "setEmailLabel": "הזן את כתובת הדואר האלקטרוני של gravatar",
-        "title": "פרופיל"
+        "title": "פרופיל",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "רוצה לדבר",
     "recording": {

--- a/lang/main-hi.json
+++ b/lang/main-hi.json
@@ -901,7 +901,8 @@
         "setDisplayNameLabel": "अपना नाम सेट करें",
         "setEmailInput": "ई-मेल दर्ज करें",
         "setEmailLabel": "Gravatar ईमेल",
-        "title": "प्रोफ़ाइल"
+        "title": "प्रोफ़ाइल",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "बोलना चाहेंगे",
     "recording": {

--- a/lang/main-hr.json
+++ b/lang/main-hr.json
@@ -865,7 +865,8 @@
         "setDisplayNameLabel": "Postavi svoje prikazno ime",
         "setEmailInput": "Upiši e-mail adresu",
         "setEmailLabel": "Postavi svoju e-mail adresu gravatara",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Želi govoriti",
     "raisedHandsLabel": "Broj dignutih ruku",

--- a/lang/main-hsb.json
+++ b/lang/main-hsb.json
@@ -849,7 +849,8 @@
         "setDisplayNameLabel": "zjawne mjeno postajić",
         "setEmailInput": "e-mejl zapodać",
         "setEmailLabel": "e-mejl za gravatara",
-        "title": "profil"
+        "title": "profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "ruku zběhnyć",
     "raisedHandsLabel": "ličba zběhnjenych rukow",

--- a/lang/main-hu.json
+++ b/lang/main-hu.json
@@ -706,7 +706,8 @@
         "setDisplayNameLabel": "Állítsa be a megjelenő nevet",
         "setEmailInput": "Adjon meg egy email címet",
         "setEmailLabel": "Adja meg a gravatar email címet",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Beszélni szeretnék",
     "recording": {

--- a/lang/main-hy.json
+++ b/lang/main-hy.json
@@ -451,7 +451,8 @@
         "setDisplayNameLabel": "Նշանակել Ձեր երևացող անունը",
         "setEmailInput": "Մուտքագրեք էլ.հասցե",
         "setEmailLabel": "Սահմանեք Ձեր Gravatar էլ.փոստը",
-        "title": "Պրոֆայլ"
+        "title": "Պրոֆայլ",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "recording": {
         "authDropboxText": "",

--- a/lang/main-id.json
+++ b/lang/main-id.json
@@ -978,7 +978,8 @@
         "setDisplayNameLabel": "Nama",
         "setEmailInput": "Masukkan email",
         "setEmailLabel": "Email Gravatar",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ingin berbicara",
     "raisedHandsLabel": "Jumlah tangan yang diangkat",

--- a/lang/main-is.json
+++ b/lang/main-is.json
@@ -959,7 +959,8 @@
         "setDisplayNameLabel": "Nafn",
         "setEmailInput": "Settu inn tölvupóstfang",
         "setEmailLabel": "Gravatar-tölvupóstfang",
-        "title": "Persónusnið"
+        "title": "Persónusnið",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Myndi vilja taka til máls",
     "raisedHandsLabel": "Fjöldi uppréttra handa",

--- a/lang/main-it.json
+++ b/lang/main-it.json
@@ -1087,7 +1087,8 @@
         "setDisplayNameLabel": "Nome",
         "setEmailInput": "Inserisci email",
         "setEmailLabel": "Email Gravatar",
-        "title": "Profilo"
+        "title": "Profilo",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Vorrebbe parlare",
     "raisedHandsLabel": "Numero di mani alzate",

--- a/lang/main-ja.json
+++ b/lang/main-ja.json
@@ -809,7 +809,8 @@
         "setDisplayNameLabel": "表示名を設定してください",
         "setEmailInput": "メールアドレスを入力してください",
         "setEmailLabel": "Gravatar に登録したメールアドレスを入力してください",
-        "title": "プロフィール"
+        "title": "プロフィール",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "話したいそうです",
     "raisedHandsLabel": "挙手の数",

--- a/lang/main-kab.json
+++ b/lang/main-kab.json
@@ -758,7 +758,8 @@
         "setDisplayNameLabel": "Sbadu isem n uskan",
         "setEmailInput": "Sekcem-d imayl",
         "setEmailLabel": "Sbadu imayl-inek·inem n Gravatar",
-        "title": "Amaɣnu"
+        "title": "Amaɣnu",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Bɣiɣ ad d-mmeslayeɣ",
     "recording": {

--- a/lang/main-kk.json
+++ b/lang/main-kk.json
@@ -1087,7 +1087,8 @@
         "setDisplayNameLabel": "Аты",
         "setEmailInput": "Электрондық поштаны енгізіңіз",
         "setEmailLabel": "Gravatar электрондық поштасы",
-        "title": "Профиль"
+        "title": "Профиль",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Сөйлегісі келеді",
     "raisedHandsLabel": "Көтерілген қолдар саны",

--- a/lang/main-ko.json
+++ b/lang/main-ko.json
@@ -998,7 +998,8 @@
         "setDisplayNameLabel": "표시 이름 설정",
         "setEmailInput": "이메일 입력",
         "setEmailLabel": "이메일 설정",
-        "title": "프로필"
+        "title": "프로필",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "말하고 싶어합니다",
     "raisedHandsLabel": "손 든 사람 수",

--- a/lang/main-lt.json
+++ b/lang/main-lt.json
@@ -491,7 +491,8 @@
         "setDisplayNameLabel": "Įveskite savo vardą",
         "setEmailInput": "Įveskite savo el. paštą",
         "setEmailLabel": "Parinkite savo „gravataro“ el. paštą",
-        "title": "Profilis"
+        "title": "Profilis",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Norėtų kalbėti",
     "recording": {

--- a/lang/main-lv.json
+++ b/lang/main-lv.json
@@ -1087,7 +1087,8 @@
         "setDisplayNameLabel": "Vārds",
         "setEmailInput": "Ierakstiet e-pasta adresi",
         "setEmailLabel": "E-pasts priekš gravatar",
-        "title": "Profils"
+        "title": "Profils",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Vēlas izteikties/runāt",
     "raisedHandsLabel": "Pacelto roku skaits",

--- a/lang/main-ml.json
+++ b/lang/main-ml.json
@@ -623,7 +623,8 @@
         "setDisplayNameLabel": "നിങ്ങളുടെ ഡിസ്പ്ലേ നാമം സജ്ജമാക്കുക",
         "setEmailInput": "ഇ-മെയിൽ നൽകുക",
         "setEmailLabel": "നിങ്ങളുടെ ഗ്രാവതാർ ഇമെയിൽ സജ്ജമാക്കുക",
-        "title": "പ്രൊഫൈൽ"
+        "title": "പ്രൊഫൈൽ",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "സംസാരിക്കാൻ ആഗ്രഹിക്കുന്നു",
     "recording": {

--- a/lang/main-mn.json
+++ b/lang/main-mn.json
@@ -894,7 +894,8 @@
         "setDisplayNameLabel": "Нэрээ оруулна уу",
         "setEmailInput": "И-мэйл оруулна уу",
         "setEmailLabel": "И-мэйл хаягаа оруулна уу",
-        "title": "Профайл"
+        "title": "Профайл",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ярьмаар байна",
     "raisedHandsLabel": "Гараа өргөсөн тоо",

--- a/lang/main-mr.json
+++ b/lang/main-mr.json
@@ -533,7 +533,8 @@
         "setDisplayNameLabel": " आपले प्रदर्शन नाव सेट करा",
         "setEmailInput": "ई-मेल प्रविष्ट करा",
         "setEmailLabel": "आपला गुरुतर ईमेल सेट करा",
-        "title": "प्रोफाइल"
+        "title": "प्रोफाइल",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "बोलायला आवडेल",
     "recording": {

--- a/lang/main-nb.json
+++ b/lang/main-nb.json
@@ -999,7 +999,8 @@
         "setDisplayNameLabel": "Navn",
         "setEmailInput": "Skriv inn e-post",
         "setEmailLabel": "Gravatar e-post",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ønsker å snakke",
     "raisedHandsLabel": "Antall hevede hender",

--- a/lang/main-nl.json
+++ b/lang/main-nl.json
@@ -1095,7 +1095,8 @@
         "setDisplayNameLabel": "Naam",
         "setEmailInput": "E-mailadres invoeren",
         "setEmailLabel": "Gravatar e-mailadres",
-        "title": "Profiel"
+        "title": "Profiel",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Wil graag spreken",
     "raisedHandsLabel": "Aantal handen omhoog",

--- a/lang/main-no.json
+++ b/lang/main-no.json
@@ -999,7 +999,8 @@
         "setDisplayNameLabel": "Navn",
         "setEmailInput": "Skriv inn e-post",
         "setEmailLabel": "Gravatar e-post",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ønsker å snakke",
     "raisedHandsLabel": "Antall hevede hender",

--- a/lang/main-oc.json
+++ b/lang/main-oc.json
@@ -999,7 +999,8 @@
         "setDisplayNameLabel": "Causissètz vòstre escais",
         "setEmailInput": "Picatz lo corrièl",
         "setEmailLabel": "Definissètz vòstre corrièl per Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Volriá charrar",
     "raisedHandsLabel": "Nombre de mans levadas",

--- a/lang/main-pl.json
+++ b/lang/main-pl.json
@@ -897,7 +897,8 @@
         "setDisplayNameLabel": "Podaj swoją wyświetlaną nazwę",
         "setEmailInput": "Wprowadź adres email",
         "setEmailLabel": "Ustaw adres poczty elektronicznej swojego Gravatara",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Chcę coś powiedzieć",
     "raisedHandsLabel": "Liczba podniesionych rąk",

--- a/lang/main-pt-BR.json
+++ b/lang/main-pt-BR.json
@@ -958,7 +958,8 @@
         "setDisplayNameLabel": "Definir seu nome de exibição",
         "setEmailInput": "Digite email",
         "setEmailLabel": "Definir seu email de Gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Gostaria de falar",
     "raisedHandsLabel": "Número de mãos levantadas",

--- a/lang/main-pt.json
+++ b/lang/main-pt.json
@@ -1087,7 +1087,8 @@
         "setDisplayNameLabel": "Nome",
         "setEmailInput": "Digite email",
         "setEmailLabel": "Email de gravatar",
-        "title": "Perfil"
+        "title": "Perfil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Gostaria de falar",
     "raisedHandsLabel": "Número de mãos levantadas",

--- a/lang/main-ro.json
+++ b/lang/main-ro.json
@@ -495,7 +495,8 @@
         "setDisplayNameLabel": "Introduceți numele care va fi afișat",
         "setEmailInput": "Introduceți adresa de email",
         "setEmailLabel": "Setați adresa de email gravatar",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Ar dori să vorbească",
     "recording": {

--- a/lang/main-ru.json
+++ b/lang/main-ru.json
@@ -973,7 +973,8 @@
         "setDisplayNameLabel": "Отображаемое имя",
         "setEmailInput": "Введите email",
         "setEmailLabel": "Email для Gravatar",
-        "title": "Профиль"
+        "title": "Профиль",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Хочет говорить",
     "raisedHandsLabel": "Количество поднятых рук",

--- a/lang/main-sc.json
+++ b/lang/main-sc.json
@@ -1071,7 +1071,8 @@
         "setDisplayNameLabel": "Cunfigura su nòmine visìbile tuo",
         "setEmailInput": "Inserta unu contu de posta eletrònica",
         "setEmailLabel": "Cunfigura indiritzu eletrònicu de gravatar",
-        "title": "Profilu"
+        "title": "Profilu",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Bolet chistionare",
     "raisedHandsLabel": "Nùmeru de manos artziadas",

--- a/lang/main-sk.json
+++ b/lang/main-sk.json
@@ -603,7 +603,8 @@
         "setDisplayNameLabel": "Nastavte si meno",
         "setEmailInput": "Zadajte email",
         "setEmailLabel": "Nastavte si email vašeho gravataru",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Chcel by som hovoriť",
     "recording": {

--- a/lang/main-sl.json
+++ b/lang/main-sl.json
@@ -759,7 +759,8 @@
         "setDisplayNameLabel": "Nastavite svoje prikazno ime",
         "setEmailInput": "Vnesite e-naslov",
         "setEmailLabel": "Nastavite svoj e-naslov",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Želi govoriti",
     "recording": {

--- a/lang/main-sq.json
+++ b/lang/main-sq.json
@@ -1093,7 +1093,8 @@
         "setDisplayNameLabel": "Emër",
         "setEmailInput": "Jepni email",
         "setEmailLabel": "Jepni email të gravatarit tuaj",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Do të donte të fliste",
     "raisedHandsLabel": "Numër duarsh të ngritura",

--- a/lang/main-sr.json
+++ b/lang/main-sr.json
@@ -506,7 +506,8 @@
         "setDisplayNameLabel": "Унесите име за приказ на екрану",
         "setEmailInput": "Унисите адресу е-поште",
         "setEmailLabel": "Е-пошта за Gravatar",
-        "title": "Профил"
+        "title": "Профил",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "recording": {
         "authDropboxText": "",

--- a/lang/main-sv.json
+++ b/lang/main-sv.json
@@ -1076,7 +1076,8 @@
         "setDisplayNameLabel": "Ange ditt visningsnamn",
         "setEmailInput": "Skriv e-postadress",
         "setEmailLabel": "Ange din gravatar-e-postadress",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Räck upp handen",
     "raisedHandsLabel": "Antal uppräckta händer",

--- a/lang/main-te.json
+++ b/lang/main-te.json
@@ -655,7 +655,8 @@
         "setDisplayNameLabel": "చూపించాల్సిన పేరు అమర్చుకోండి",
         "setEmailInput": "ఈమెయిలు ఇవ్వండి",
         "setEmailLabel": "గ్రావతార్ ఈమెయిలు అమర్చుకోండి",
-        "title": "ప్రొఫైలు"
+        "title": "ప్రొఫైలు",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "మాట్లాడాలనుకుంటున్నారు",
     "recording": {

--- a/lang/main-tr.json
+++ b/lang/main-tr.json
@@ -993,7 +993,8 @@
         "setDisplayNameLabel": "Görünür adınızı ayarlayın",
         "setEmailInput": "E-posta adresinizi girin",
         "setEmailLabel": "Gravatar e-postanızı ayarlayın",
-        "title": "Profil"
+        "title": "Profil",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Konuşmak ister misiniz?",
     "raisedHandsLabel": "Kaldırılan ellerin sayısı",

--- a/lang/main-uk.json
+++ b/lang/main-uk.json
@@ -892,7 +892,8 @@
         "setDisplayNameLabel": "Ім'я",
         "setEmailInput": "Зазначте email",
         "setEmailLabel": "Email-адреса для Gravatar",
-        "title": "Профіль"
+        "title": "Профіль",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Хоче взяти слово",
     "raisedHandsLabel": "Кількість піднятих рук",

--- a/lang/main-vi.json
+++ b/lang/main-vi.json
@@ -971,7 +971,8 @@
         "setDisplayNameLabel": "Nhập tên hiển thị của bạn",
         "setEmailInput": "Nhập địa chỉ email",
         "setEmailLabel": "Nhập địa chỉ email tài khoản Gravatar của bạn",
-        "title": "Hồ sơ"
+        "title": "Hồ sơ",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "Muốn phát biểu",
     "raisedHandsLabel": "Số lượng tay giơ lên",

--- a/lang/main-zh-CN.json
+++ b/lang/main-zh-CN.json
@@ -1082,7 +1082,8 @@
         "setDisplayNameLabel": "姓名",
         "setEmailInput": "输入电子邮件",
         "setEmailLabel": "Gravatar 电子邮件",
-        "title": "个人资料"
+        "title": "个人资料",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "想要发言",
     "raisedHandsLabel": "举手人数",

--- a/lang/main-zh-TW.json
+++ b/lang/main-zh-TW.json
@@ -1082,7 +1082,8 @@
         "setDisplayNameLabel": "設定顯示名稱",
         "setEmailInput": "輸入您的電子信箱",
         "setEmailLabel": "設定您的 Gravatar 電子信箱",
-        "title": "簡介"
+        "title": "簡介",
+        "invalidEmailFormat": "Please enter a valid email address"
     },
     "raisedHand": "想要發言",
     "raisedHandsLabel": "舉手人數",

--- a/react/features/settings/actions.web.ts
+++ b/react/features/settings/actions.web.ts
@@ -218,6 +218,12 @@ export function submitModeratorTab(newState: any) {
  * @param {Object} newState - The new settings.
  * @returns {Function}
  */
+/**
+ * A regular expression for basic email format validation.
+ * Checks for the pattern: non-empty local part @ non-empty domain with at least one dot.
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export function submitProfileTab(newState: any) {
     return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const currentState = getProfileTabProps(getState());
@@ -227,7 +233,10 @@ export function submitProfileTab(newState: any) {
         }
 
         if (newState.email !== currentState.email) {
-            APP.conference.changeLocalEmail(newState.email);
+            // Only save the email if it is empty (clearing it) or has a valid format.
+            if (!newState.email || EMAIL_REGEX.test(newState.email)) {
+                APP.conference.changeLocalEmail(newState.email);
+            }
         }
     };
 }

--- a/react/features/settings/components/web/ProfileTab.tsx
+++ b/react/features/settings/components/web/ProfileTab.tsx
@@ -16,6 +16,13 @@ import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';
 
 /**
+ * A regular expression for basic email format validation.
+ * Checks for the pattern: non-empty local part @ non-empty domain with at least one dot.
+ */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+
+/**
  * The type of the React {@code Component} props of {@link ProfileTab}.
  */
 export interface IProps extends AbstractDialogTabProps, WithTranslation {
@@ -118,6 +125,10 @@ class ProfileTab extends AbstractDialogTab<IProps, any> {
     constructor(props: IProps) {
         super(props);
 
+        this.state = {
+            emailDirty: false
+        };
+
         // Bind event handlers so they are only bound once for every instance.
         this._onAuthToggle = this._onAuthToggle.bind(this);
         this._onDisplayNameChange = this._onDisplayNameChange.bind(this);
@@ -136,13 +147,14 @@ class ProfileTab extends AbstractDialogTab<IProps, any> {
     }
 
     /**
-     * Changes email of the user.
+     * Changes email of the user and validates its format.
      *
      * @param {string} value - The key event to handle.
      *
      * @returns {void}
      */
     _onEmailChange(value: string) {
+        this.setState({ emailDirty: true });
         super._onChange({ email: value });
     }
 
@@ -163,6 +175,8 @@ class ProfileTab extends AbstractDialogTab<IProps, any> {
             t
         } = this.props;
         const classes = withStyles.getClasses(this.props);
+        const emailDirty = this.state.emailDirty as boolean;
+        const emailError = emailDirty && email.length > 0 && !EMAIL_REGEX.test(email);
 
         return (
             <div className = { classes.container } >
@@ -183,13 +197,15 @@ class ProfileTab extends AbstractDialogTab<IProps, any> {
                     value = { displayName } />
                 {!hideEmailInSettings && <div className = 'profile-edit-field'>
                     <Input
+                        bottomLabel = { emailError ? t('profile.invalidEmailFormat') : undefined }
                         className = { classes.bottomMargin }
+                        error = { emailError }
                         id = 'setEmail'
                         label = { t('profile.setEmailLabel') }
                         name = 'email'
                         onChange = { this._onEmailChange }
                         placeholder = { t('profile.setEmailInput') }
-                        type = 'text'
+                        type = 'email'
                         value = { email } />
                 </div>}
                 { authEnabled && this._renderAuth() }


### PR DESCRIPTION
The email input in the profile settings tab accepted any text without validation, including malformed addresses that would silently fail to load a Gravatar avatar.

Changes:
- ProfileTab.tsx: track a dirty-state flag so the error only appears after the user starts typing; show an inline error message via the Input component's error + ottomLabel props when the address is malformed; change 	ype from 'text' to 'email'
- actions.web.ts: guard submitProfileTab so a malformed email is never persisted — only empty (clearing) or properly formatted addresses are saved via APP.conference.changeLocalEmail
- lang/*.json: add 'profile.invalidEmailFormat' key to all 59 translation files (English text; translations welcome from the community)

Fixes #16975

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
