### PR TITLE
GSOC: FIXME : refactor(overlay)

### DIFF
--- a/react/features/overlay/actionTypes.ts
+++ b/react/features/overlay/actionTypes.ts
@@ -1,0 +1,4 @@
+/**
+ * The type of the Redux action which sends page reload log.
+ */
+export const PAGE_RELOAD_APPLICATION_LOG = 'PAGE_RELOAD_APPLICATION_LOG';

--- a/react/features/overlay/actions.any.ts
+++ b/react/features/overlay/actions.any.ts
@@ -1,0 +1,14 @@
+import { PAGE_RELOAD_APPLICATION_LOG } from './actionTypes';
+
+/**
+ * Sends a page reload application log message.
+ *
+ * @param {string} reason - The reason for the reload.
+ * @returns {Object}
+ */
+export function sendPageReloadApplicationLog(reason?: string) {
+    return {
+        type: PAGE_RELOAD_APPLICATION_LOG,
+        reason
+    };
+}

--- a/react/features/overlay/components/web/AbstractPageReloadOverlay.tsx
+++ b/react/features/overlay/components/web/AbstractPageReloadOverlay.tsx
@@ -11,6 +11,7 @@ import {
     isFatalJitsiConferenceError,
     isFatalJitsiConnectionError
 } from '../../../base/lib-jitsi-meet/functions.web';
+import { sendPageReloadApplicationLog } from '../../actions.any';
 import logger from '../../logger';
 
 import ReloadButton from './ReloadButton';
@@ -152,13 +153,7 @@ export default class AbstractPageReloadOverlay<P extends IProps>
      * @returns {void}
      */
     override componentDidMount() {
-        // FIXME: We should dispatch action for this.
-        if (typeof APP !== 'undefined' && APP.conference?._room) {
-            APP.conference._room.sendApplicationLog(JSON.stringify({
-                name: 'page.reload',
-                label: this.props.reason
-            }));
-        }
+        this.props.dispatch(sendPageReloadApplicationLog(this.props.reason));
 
         sendAnalytics(createPageReloadScheduledEvent(
             this.props.reason ?? '',

--- a/react/features/overlay/middleware.ts
+++ b/react/features/overlay/middleware.ts
@@ -1,11 +1,14 @@
 import { IStore } from '../app/types';
+import { getCurrentConference } from '../base/conference/functions';
 import { JitsiConferenceErrors, JitsiConnectionErrors } from '../base/lib-jitsi-meet';
 import {
     isFatalJitsiConferenceError,
     isFatalJitsiConnectionError
 } from '../base/lib-jitsi-meet/functions.any';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../base/redux/StateListenerRegistry';
 
+import { PAGE_RELOAD_APPLICATION_LOG } from './actionTypes';
 import { openPageReloadDialog } from './actions';
 import logger from './logger';
 
@@ -128,3 +131,25 @@ StateListenerRegistry.register(
         }
     }
 );
+
+/**
+ * Middleware for overlay specific actions.
+ *
+ * @param {Store} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register(({ getState }) => next => action => {
+    const result = next(action);
+
+    if (action.type === PAGE_RELOAD_APPLICATION_LOG) {
+        const state = getState();
+        const conference = getCurrentConference(state) ?? state['features/base/conference']?.leaving;
+
+        conference?.sendApplicationLog(JSON.stringify({
+            name: 'page.reload',
+            label: action.reason
+        }));
+    }
+
+    return result;
+});


### PR DESCRIPTION
refactor(overlay): move page reload app logging to middleware

Resolves a FIXME in `AbstractPageReloadOverlay` that was calling `APP.conference._room` directly to log `page.reload` events.

Moved the side effect into Redux middleware where it belongs — conference is now resolved via `getCurrentConference(state)` with a `leaving` fallback to cover teardown paths.

**Changes**
- Added `PAGE_RELOAD_APPLICATION_LOG` action and `sendPageReloadApplicationLog(reason?)` in `actions.any.ts`
- `AbstractPageReloadOverlay` now dispatches the action on mount instead of accessing `_room` directly
- Middleware handles the log via `getCurrentConference` + `leaving` fallback
- Payload unchanged: `{ name: 'page.reload', label: reason }`
