### PR TITLE
gsoc : refactor(connection-indicator): extract local stats batch expansion

### DIFF
--- a/react/features/connection-indicator/expandLocalConnectionQualityStatsBatch.ts
+++ b/react/features/connection-indicator/expandLocalConnectionQualityStatsBatch.ts
@@ -1,0 +1,112 @@
+import { union } from 'lodash-es';
+
+/**
+ * Expands lib-jitsi-meet LOCAL_STATS_UPDATED batches where framerate, resolution,
+ * and codec are maps keyed by participant id. Connection indicators subscribe
+ * per participant and expect scalar or per-track values, not full maps
+ * (see statsEmitter).
+ */
+export type ParticipantMediaStatsMap = Record<string, unknown>;
+
+export interface IExpandedLocalConnectionQualityStats {
+
+    /**
+     * Full stats object for the local user's subscribers: same shape as
+     * {@code stats} but with framerate, resolution, and codec taken from the
+     * per-participant maps for {@code localUserId}.
+     */
+    localStats: Record<string, unknown>;
+
+    /**
+     * Partial stat objects to emit for each remote participant appearing in any
+     * of the three maps (only keys present for that id are included).
+     */
+    remoteEmissions: Array<{
+
+        /**
+         * Subset of stats (framerate / resolution / codec) for that id.
+         */
+        partialStats: Record<string, unknown>;
+
+        /**
+         * Remote participant id.
+         */
+        participantId: string;
+    }>;
+}
+
+/**
+ * Coerces a value from lib-jitsi-meet into a participant-id → stat map, or
+ * empty object if the value is not a plain object map.
+ *
+ * @param {unknown} value - Raw field from stats batch.
+ * @returns {ParticipantMediaStatsMap}
+ */
+function asParticipantMap(value: unknown): ParticipantMediaStatsMap {
+    if (value !== null && value !== undefined && typeof value === 'object' && !Array.isArray(value)) {
+        return value as ParticipantMediaStatsMap;
+    }
+
+    return {};
+}
+
+/**
+ * Expands one {@code LOCAL_STATS_UPDATED} batch into a local full payload and
+ * per-remote partial emissions so {@link statsEmitter} can fan out to
+ * per-participant subscriptions.
+ *
+ * @param {string} localUserId - The local participant id.
+ * @param {Record<string, unknown>} stats - Raw stats object from lib-jitsi-meet.
+ * @returns {IExpandedLocalConnectionQualityStats}
+ */
+export function expandLocalConnectionQualityStatsBatch(
+        localUserId: string,
+        stats: Record<string, unknown>): IExpandedLocalConnectionQualityStats {
+    const allUserFramerates = asParticipantMap(stats.framerate);
+    const allUserResolutions = asParticipantMap(stats.resolution);
+    const allUserCodecs = asParticipantMap(stats.codec);
+
+    const localStats = {
+        ...stats,
+        framerate: allUserFramerates[localUserId],
+        resolution: allUserResolutions[localUserId],
+        codec: allUserCodecs[localUserId]
+    };
+
+    const framerateUserIds = Object.keys(allUserFramerates);
+    const resolutionUserIds = Object.keys(allUserResolutions);
+    const codecUserIds = Object.keys(allUserCodecs);
+
+    const remoteEmissions = union(framerateUserIds, resolutionUserIds, codecUserIds)
+        .filter(id => id !== localUserId)
+        .map(participantId => {
+            const partialStats: Record<string, unknown> = {};
+            const framerate = allUserFramerates[participantId];
+
+            if (framerate) {
+                partialStats.framerate = framerate;
+            }
+
+            const resolution = allUserResolutions[participantId];
+
+            if (resolution) {
+                partialStats.resolution = resolution;
+            }
+
+            const codec = allUserCodecs[participantId];
+
+            if (codec) {
+                partialStats.codec = codec;
+            }
+
+            return {
+                partialStats,
+                participantId
+            };
+        });
+
+    return {
+        localStats,
+        remoteEmissions
+    };
+}

--- a/react/features/connection-indicator/statsEmitter.ts
+++ b/react/features/connection-indicator/statsEmitter.ts
@@ -1,11 +1,19 @@
-import { union } from 'lodash-es';
-
 import { IJitsiConference } from '../base/conference/reducer';
 import {
     JitsiConnectionQualityEvents
 } from '../base/lib-jitsi-meet';
 import { trackCodecChanged } from '../base/tracks/actions.any';
 import { getLocalTracks } from '../base/tracks/functions.any';
+
+import { expandLocalConnectionQualityStatsBatch } from './expandLocalConnectionQualityStatsBatch';
+
+/**
+ * Connection-quality stats passed to subscribers after normalization.
+ * For {@code LOCAL_STATS_UPDATED}, framerate / resolution / codec are
+ * per-participant values; lib-jitsi-meet supplies them as participant-id maps
+ * and {@link expandLocalConnectionQualityStatsBatch} flattens them first.
+ */
+export type IConnectionQualitySubscriberStats = Record<string, unknown>;
 
 /**
  * Contains all the callbacks to be notified when stats are updated.
@@ -16,13 +24,7 @@ import { getLocalTracks } from '../base/tracks/functions.any';
  * }
  * ```
  */
-const subscribers: any = {};
-
-interface IStats {
-    codec?: Object;
-    framerate?: Object;
-    resolution?: Object;
-}
+const subscribers: { [id: string]: Array<Function>; } = {};
 
 /**
  * A singleton that acts as a pub/sub service for connection stat updates.
@@ -38,10 +40,11 @@ const statsEmitter = {
      */
     startListeningForStats(conference: IJitsiConference) {
         conference.on(JitsiConnectionQualityEvents.LOCAL_STATS_UPDATED,
-            (stats: IStats) => this._onStatsUpdated(conference.myUserId(), stats));
+            (stats: Record<string, unknown>) =>
+                this._onStatsUpdated(conference.myUserId(), stats));
 
         conference.on(JitsiConnectionQualityEvents.REMOTE_STATS_UPDATED,
-            (id: string, stats: IStats) => this._emitStatsUpdate(id, stats));
+            (id: string, stats: Record<string, unknown>) => this._emitStatsUpdate(id, stats));
     },
 
     /**
@@ -98,7 +101,7 @@ const statsEmitter = {
      * @param {Object} stats - New connection stats for the user.
      * @returns {void}
      */
-    _emitStatsUpdate(id: string, stats: IStats = {}) {
+    _emitStatsUpdate(id: string, stats: IConnectionQualitySubscriberStats = {}) {
         const callbacks = subscribers[id] || [];
 
         callbacks.forEach((callback: Function) => {
@@ -116,58 +119,20 @@ const statsEmitter = {
      * by the library.
      * @returns {void}
      */
-    _onStatsUpdated(localUserId: string, stats: IStats) {
-        const allUserFramerates = stats.framerate || {};
-        const allUserResolutions = stats.resolution || {};
-        const allUserCodecs = stats.codec || {};
+    _onStatsUpdated(localUserId: string, stats: Record<string, unknown>) {
+        const { localStats, remoteEmissions } = expandLocalConnectionQualityStatsBatch(
+            localUserId, stats);
 
-        // FIXME resolution and framerate are maps keyed off of user ids with
-        // stat values. Receivers of stats expect resolution and framerate to
-        // be primitives, not maps, so here we override the 'lib-jitsi-meet'
-        // stats objects.
-        const modifiedLocalStats = Object.assign({}, stats, {
-            framerate: allUserFramerates[localUserId as keyof typeof allUserFramerates],
-            resolution: allUserResolutions[localUserId as keyof typeof allUserResolutions],
-            codec: allUserCodecs[localUserId as keyof typeof allUserCodecs]
+        const localCodec = localStats.codec;
+
+        localCodec && Object.keys(localCodec as object).length
+            && this._updateLocalCodecs(localCodec);
+
+        this._emitStatsUpdate(localUserId, localStats);
+
+        remoteEmissions.forEach(({ participantId, partialStats }) => {
+            this._emitStatsUpdate(participantId, partialStats);
         });
-
-        modifiedLocalStats.codec
-            && Object.keys(modifiedLocalStats.codec).length
-            && this._updateLocalCodecs(modifiedLocalStats.codec);
-
-        this._emitStatsUpdate(localUserId, modifiedLocalStats);
-
-        // Get all the unique user ids from the framerate and resolution stats
-        // and update remote user stats as needed.
-        const framerateUserIds = Object.keys(allUserFramerates);
-        const resolutionUserIds = Object.keys(allUserResolutions);
-        const codecUserIds = Object.keys(allUserCodecs);
-
-        union(framerateUserIds, resolutionUserIds, codecUserIds)
-            .filter(id => id !== localUserId)
-            .forEach(id => {
-                const remoteUserStats: IStats = {};
-
-                const framerate = allUserFramerates[id as keyof typeof allUserFramerates];
-
-                if (framerate) {
-                    remoteUserStats.framerate = framerate;
-                }
-
-                const resolution = allUserResolutions[id as keyof typeof allUserResolutions];
-
-                if (resolution) {
-                    remoteUserStats.resolution = resolution;
-                }
-
-                const codec = allUserCodecs[id as keyof typeof allUserCodecs];
-
-                if (codec) {
-                    remoteUserStats.codec = codec;
-                }
-
-                this._emitStatsUpdate(id, remoteUserStats);
-            });
     },
 
     /**


### PR DESCRIPTION
Issue - LOCAL_STATS_UPDATED fires a batch where `framerate`, `resolution`, and `codec` are `{ participantId → value }` maps, but `subscribeToClientStats` subscribers expect per-participant values. The expansion logic was inline in `statsEmitter` with a FIXME noting the shape mismatch.
Fix : 
Pulled it into `expandLocalConnectionQualityStatsBatch(localUserId, stats)` which returns `{ localStats, remoteEmissions }`. `statsEmitter` is now wiring-only. Also added an `asParticipantMap()` guard (safer than `|| {}`) and tightened the types around raw vs normalized stats.

Validation
tsc:web , tsc:native , lint:ci runs without giving error 