### PR TITLE
 GSOC : refactor(pip): extract reusable PiP lifecycle hooks 

### DIFF
--- a/react/features/pip/components/PiPVideoElement.tsx
+++ b/react/features/pip/components/PiPVideoElement.tsx
@@ -1,19 +1,23 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState, IStore } from '../../app/types';
 import { getAvatarFont, getAvatarInitialsColor } from '../../base/avatar/components/web/styles';
 import { getLocalParticipant, getParticipantDisplayName } from '../../base/participants/functions';
+import { ITrack } from '../../base/tracks/types';
 import { isTrackStreamingStatusActive } from '../../connection-indicator/functions';
 import { getDisplayNameColor } from '../../display-name/components/web/styles';
 import { getThumbnailBackgroundColor } from '../../filmstrip/functions.web';
 import { getLargeVideoParticipant } from '../../large-video/functions';
 import { isPrejoinPageVisible } from '../../prejoin/functions.any';
-import { handlePiPLeaveEvent, handlePipEnterEvent, handleWindowBlur, handleWindowFocus } from '../actions';
 import { getPiPVideoTrack } from '../functions';
-import { useCanvasAvatar } from '../hooks';
-import logger from '../logger';
+import {
+    useCanvasAvatar,
+    usePiPBrowserEvents,
+    usePiPVideoSource,
+    usePiPWindowLifecycle
+} from '../hooks';
 
 const useStyles = makeStyles()(() => {
     return {
@@ -31,7 +35,7 @@ const useStyles = makeStyles()(() => {
 
 /**
  * Component that renders a hidden video element for Picture-in-Picture.
- * Automatically switches between real video track and canvas-based avatar
+ * This will Automatically switches between real video track and canvas-based avatar
  * depending on video availability.
  *
  * @returns {JSX.Element} The hidden video element.
@@ -39,17 +43,14 @@ const useStyles = makeStyles()(() => {
 const PiPVideoElement: React.FC = () => {
     const { classes, theme } = useStyles();
     const videoRef = useRef<HTMLVideoElement>(null);
-    const previousTrackRef = useRef<any>(null);
+    const previousTrackRef = useRef<ITrack | undefined>(undefined);
 
     // Redux selectors.
     const isOnPrejoin = useSelector(isPrejoinPageVisible);
     const localParticipant = useSelector(getLocalParticipant);
     const largeVideoParticipant = useSelector(getLargeVideoParticipant);
-
-    // Use local participant during prejoin, otherwise large video participant.
     const participant = isOnPrejoin ? localParticipant : largeVideoParticipant;
 
-    // Get appropriate video track based on prejoin state.
     const videoTrack = useSelector((state: IReduxState) =>
         getPiPVideoTrack(state, participant)
     );
@@ -76,148 +77,13 @@ const PiPVideoElement: React.FC = () => {
         initialsColor,
         displayNameColor
     });
-
-    // Determine if we should show avatar instead of video.
     const shouldShowAvatar = !videoTrack
         || videoTrack.muted
         || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
 
-    /**
-     * Effect: Handle switching between real video track and canvas avatar stream.
-     */
-    useEffect(() => {
-        const videoElement = videoRef.current;
-
-        if (!videoElement) {
-            return;
-        }
-
-        const previousTrack = previousTrackRef.current;
-
-        // Detach previous track.
-        if (previousTrack?.jitsiTrack) {
-            try {
-                previousTrack.jitsiTrack.detach(videoElement);
-            } catch (error) {
-                logger.error('Error detaching previous track:', error);
-            }
-        }
-
-        if (shouldShowAvatar) {
-            // Use canvas stream for avatar.
-            // Access ref inside effect - stream is created in useCanvasAvatar's effect.
-            const canvasStream = canvasStreamRef.current;
-
-            // Only set srcObject if it's different to avoid interrupting playback.
-            if (canvasStream && videoElement.srcObject !== canvasStream) {
-                videoElement.srcObject = canvasStream;
-            }
-        } else if (videoTrack?.jitsiTrack) {
-            // Attach real video track.
-            videoTrack.jitsiTrack.attach(videoElement)
-                .catch((error: Error) => {
-                    logger.error('Error attaching video track:', error);
-                });
-        }
-
-        previousTrackRef.current = videoTrack;
-
-        // Cleanup on unmount or track change.
-        return () => {
-            if (videoTrack?.jitsiTrack && videoElement) {
-                try {
-                    videoTrack.jitsiTrack.detach(videoElement);
-                } catch (error) {
-                    logger.error('Error during cleanup:', error);
-                }
-            }
-        };
-    }, [ videoTrack, shouldShowAvatar ]);
-
-    /**
-     * Effect: Window blur/focus and visibility change listeners.
-     * Enters PiP on blur, exits on focus (matches old AOT behavior).
-     */
-    useEffect(() => {
-        const videoElement = videoRef.current;
-
-        if (!videoElement) {
-            return;
-        }
-
-        const onWindowBlur = () => dispatch(handleWindowBlur(videoElement));
-        const onWindowFocus = () => {
-
-            // In the use case where the PiP is closed by the 'X' or 'back to main window' buttons, this handler is
-            // called before the leavepictureinpicture handler. From there we call document.exitPictureInPicture()
-            // which seems to put Chrome into a weird state - document.exitPictureInPicture() never resolves, the
-            // leavepictureinpicture is never triggered and it is not possible to display PiP again.
-            // This is probably a browser bug. To workaround it we have the 100ms timeout here. This way this event
-            // is triggered after the leavepictureinpicture event and everything seems to work well.
-            setTimeout(() => {
-                dispatch(handleWindowFocus());
-            }, 100);
-        };
-        const onVisibilityChange = () => {
-            if (document.hidden) {
-                onWindowBlur();
-            }
-        };
-
-        window.addEventListener('blur', onWindowBlur);
-        window.addEventListener('focus', onWindowFocus);
-        document.addEventListener('visibilitychange', onVisibilityChange);
-
-        // Check if window is already blurred on mount (handles PiP enable while app is in background).
-        // Wait for video to be ready before attempting PiP (canvas stream may not be attached yet).
-        const checkFocusAndEnterPiP = () => {
-            if (!document.hasFocus()) {
-                onWindowBlur();
-            }
-        };
-
-        if (videoElement.readyState >= 1) {
-            // Video already has metadata loaded (e.g., real video track was already attached).
-            checkFocusAndEnterPiP();
-        } else {
-            // Wait for video source to be ready (e.g., canvas stream being created).
-            videoElement.addEventListener('loadedmetadata', checkFocusAndEnterPiP, { once: true });
-        }
-
-        return () => {
-            window.removeEventListener('blur', onWindowBlur);
-            window.removeEventListener('focus', onWindowFocus);
-            document.removeEventListener('visibilitychange', onVisibilityChange);
-            videoElement.removeEventListener('loadedmetadata', checkFocusAndEnterPiP);
-        };
-    }, [ dispatch ]);
-
-    /**
-     * Effect: PiP enter/leave event listeners.
-     * Updates Redux state when browser PiP events occur.
-     */
-    useEffect(() => {
-        const videoElement = videoRef.current;
-
-        if (!videoElement) {
-            return;
-        }
-
-        const onEnterPiP = () => {
-            dispatch(handlePipEnterEvent());
-        };
-        const onLeavePiP = () => {
-            dispatch(handlePiPLeaveEvent());
-        };
-
-        videoElement.addEventListener('enterpictureinpicture', onEnterPiP);
-        videoElement.addEventListener('leavepictureinpicture', onLeavePiP);
-
-        return () => {
-            videoElement.removeEventListener('enterpictureinpicture', onEnterPiP);
-            videoElement.removeEventListener('leavepictureinpicture', onLeavePiP);
-        };
-    }, [ dispatch ]);
+    usePiPVideoSource(videoRef, previousTrackRef, videoTrack, shouldShowAvatar, canvasStreamRef);
+    usePiPWindowLifecycle(videoRef, dispatch);
+    usePiPBrowserEvents(videoRef, dispatch);
 
     return (
         <video

--- a/react/features/pip/hooks.ts
+++ b/react/features/pip/hooks.ts
@@ -1,9 +1,12 @@
 import React, { useEffect, useRef } from 'react';
 
+import { IStore } from '../app/types';
 import IconUserSVG from '../base/icons/svg/user.svg?raw';
 import { IParticipant } from '../base/participants/types';
+import { ITrack } from '../base/tracks/types';
 import { TILE_ASPECT_RATIO } from '../filmstrip/constants';
 
+import { handlePiPLeaveEvent, handlePipEnterEvent, handleWindowBlur, handleWindowFocus } from './actions';
 import { renderAvatarOnCanvas } from './functions';
 import logger from './logger';
 
@@ -18,6 +21,12 @@ const CANVAS_HEIGHT = Math.floor(CANVAS_WIDTH / TILE_ASPECT_RATIO);
  * We manually request frames after drawing to ensure capture.
  */
 const CANVAS_FRAME_RATE = 0;
+
+/**
+ * Delay before exiting PiP on focus to avoid Chrome getting stuck when the PiP
+ * window is closed by browser chrome controls.
+ */
+const WINDOW_FOCUS_EXIT_DELAY_MS = 100;
 
 /**
  * Options for the useCanvasAvatar hook.
@@ -180,4 +189,162 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
     return {
         canvasStreamRef: streamRef
     };
+}
+
+/**
+ * Keeps the hidden PiP video element in sync with the currently selected video
+ * source, switching between the participant track and the generated avatar
+ * canvas stream.
+ *
+ * @param {React.RefObject<HTMLVideoElement | null>} videoRef - Ref to the PiP
+ * video element.
+ * @param {React.MutableRefObject<ITrack | undefined>} previousTrackRef - Ref to
+ * the previously attached video track.
+ * @param {ITrack | undefined} videoTrack - Current video track to display.
+ * @param {boolean} shouldShowAvatar - Whether the avatar canvas should be used
+ * instead of a participant video track.
+ * @param {React.MutableRefObject<MediaStream | null>} canvasStreamRef - Ref to
+ * the generated avatar canvas stream.
+ * @returns {void}
+ */
+export function usePiPVideoSource(
+        videoRef: React.RefObject<HTMLVideoElement | null>,
+        previousTrackRef: React.MutableRefObject<ITrack | undefined>,
+        videoTrack: ITrack | undefined,
+        shouldShowAvatar: boolean,
+        canvasStreamRef: React.MutableRefObject<MediaStream | null>
+) {
+    useEffect(() => {
+        const videoElement = videoRef.current;
+
+        if (!videoElement) {
+            return;
+        }
+
+        const previousTrack = previousTrackRef.current;
+
+        if (previousTrack?.jitsiTrack) {
+            try {
+                previousTrack.jitsiTrack.detach(videoElement);
+            } catch (error) {
+                logger.error('Error detaching previous track:', error);
+            }
+        }
+
+        if (shouldShowAvatar) {
+            const canvasStream = canvasStreamRef.current;
+
+            if (canvasStream && videoElement.srcObject !== canvasStream) {
+                videoElement.srcObject = canvasStream;
+            }
+        } else if (videoTrack?.jitsiTrack) {
+            videoTrack.jitsiTrack.attach(videoElement)
+                .catch((error: Error) => {
+                    logger.error('Error attaching video track:', error);
+                });
+        }
+
+        previousTrackRef.current = videoTrack;
+
+        return () => {
+            if (videoTrack?.jitsiTrack && videoElement) {
+                try {
+                    videoTrack.jitsiTrack.detach(videoElement);
+                } catch (error) {
+                    logger.error('Error during cleanup:', error);
+                }
+            }
+        };
+    }, [ canvasStreamRef, previousTrackRef, shouldShowAvatar, videoRef, videoTrack ]);
+}
+
+/**
+ * Registers the window and document events that automatically enter/exit PiP
+ * based on app focus.
+ *
+ * @param {Object} videoRef - Ref to the PiP video element.
+ * @param {Function} dispatch - Redux dispatch function.
+ * @returns {void}
+ */
+export function usePiPWindowLifecycle(
+        videoRef: React.RefObject<HTMLVideoElement | null>,
+        dispatch: IStore['dispatch']
+) {
+    useEffect(() => {
+        const videoElement = videoRef.current;
+
+        if (!videoElement) {
+            return;
+        }
+
+        const onWindowBlur = () => dispatch(handleWindowBlur(videoElement));
+        const onWindowFocus = () => {
+            setTimeout(() => {
+                dispatch(handleWindowFocus());
+            }, WINDOW_FOCUS_EXIT_DELAY_MS);
+        };
+        const onVisibilityChange = () => {
+            if (document.hidden) {
+                onWindowBlur();
+            }
+        };
+        const checkFocusAndEnterPiP = () => {
+            if (!document.hasFocus()) {
+                onWindowBlur();
+            }
+        };
+
+        window.addEventListener('blur', onWindowBlur);
+        window.addEventListener('focus', onWindowFocus);
+        document.addEventListener('visibilitychange', onVisibilityChange);
+
+        if (videoElement.readyState >= 1) {
+            checkFocusAndEnterPiP();
+        } else {
+            videoElement.addEventListener('loadedmetadata', checkFocusAndEnterPiP, { once: true });
+        }
+
+        return () => {
+            window.removeEventListener('blur', onWindowBlur);
+            window.removeEventListener('focus', onWindowFocus);
+            document.removeEventListener('visibilitychange', onVisibilityChange);
+            videoElement.removeEventListener('loadedmetadata', checkFocusAndEnterPiP);
+        };
+    }, [ dispatch, videoRef ]);
+}
+
+/**
+ * Registers browser PiP enter/leave events for the hidden PiP video element
+ * and forwards them to the Redux handlers.
+ *
+ * @param {Object} videoRef - Ref to the PiP video element.
+ * @param {Function} dispatch - Redux dispatch function.
+ * @returns {void}
+ */
+export function usePiPBrowserEvents(
+        videoRef: React.RefObject<HTMLVideoElement | null>,
+        dispatch: IStore['dispatch']
+) {
+    useEffect(() => {
+        const videoElement = videoRef.current;
+
+        if (!videoElement) {
+            return;
+        }
+
+        const onEnterPiP = () => {
+            dispatch(handlePipEnterEvent());
+        };
+        const onLeavePiP = () => {
+            dispatch(handlePiPLeaveEvent());
+        };
+
+        videoElement.addEventListener('enterpictureinpicture', onEnterPiP);
+        videoElement.addEventListener('leavepictureinpicture', onLeavePiP);
+
+        return () => {
+            videoElement.removeEventListener('enterpictureinpicture', onEnterPiP);
+            videoElement.removeEventListener('leavepictureinpicture', onLeavePiP);
+        };
+    }, [ dispatch, videoRef ]);
 }


### PR DESCRIPTION
## Summary
This PR refactors the current web PiP implementation by extracting lifecycle logic from `PiPVideoElement` into reusable react component hooks

## Some major changes are-- 
- extract video source attachment logic into a hook
- extract window focus/blur PiP lifecycle handling into a hook
- extract browser PiP enter/leave event handling into a hook
- replace the untyped previous-track ref with a typed ref
