### PR TITLE
feat(chat): add message editing with edit history

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -110,6 +110,8 @@
     },
     "chat": {
         "disabled": "Sending chat messages is disabled.",
+        "editMessage": "Edit message",
+        "editedLabel": "(edited)",
         "enter": "Enter room",
         "error": "Error: your message was not sent. Reason: {{error}}",
         "everyone": "Everyone",
@@ -157,6 +159,7 @@
         "titleWithFeatures": "Chat and",
         "titleWithFileSharing": "Files",
         "titleWithPolls": "Polls",
+        "viewEditHistory": "View edit history",
         "you": "you"
     },
     "chromeExtensionBanner": {

--- a/react/features/chat/actionTypes.ts
+++ b/react/features/chat/actionTypes.ts
@@ -35,6 +35,15 @@ export const ADD_MESSAGE_REACTION = 'ADD_MESSAGE_REACTION';
 export const CLEAR_CHAT_STATE = 'CLEAR_CHAT_STATE';
 
 /**
+ * The type of the action which clears the currently edited chat message target.
+ *
+ * {
+ *     type: CLEAR_EDIT_MESSAGE_TARGET
+ * }
+ */
+export const CLEAR_EDIT_MESSAGE_TARGET = 'CLEAR_EDIT_MESSAGE_TARGET';
+
+/**
  * The type of the action which signals the cancellation the chat panel.
  *
  * {
@@ -52,6 +61,17 @@ export const CLOSE_CHAT = 'CLOSE_CHAT';
  * }
  */
 export const EDIT_MESSAGE = 'EDIT_MESSAGE';
+
+/**
+ * The type of the action which sets the chat message being edited.
+ *
+ * {
+ *     type: SET_EDIT_MESSAGE_TARGET,
+ *     message: string,
+ *     messageId: string
+ * }
+ */
+export const SET_EDIT_MESSAGE_TARGET = 'SET_EDIT_MESSAGE_TARGET';
 
 /**
  * The type of the action which signals to display the chat panel.
@@ -73,6 +93,16 @@ export const OPEN_CHAT = 'OPEN_CHAT';
  * }
  */
 export const SEND_MESSAGE = 'SEND_MESSAGE';
+
+/**
+ * The type of action which signals broadcasting an edited group chat message.
+ *
+ * {
+ *     type: SEND_MESSAGE_EDIT,
+ *     message: Object
+ * }
+ */
+export const SEND_MESSAGE_EDIT = 'SEND_MESSAGE_EDIT';
 
 /**
  * The type of the action which signals a reaction to a message.

--- a/react/features/chat/actions.any.ts
+++ b/react/features/chat/actions.any.ts
@@ -8,19 +8,23 @@ import {
     ADD_MESSAGE,
     ADD_MESSAGE_REACTION,
     CLEAR_CHAT_STATE,
+    CLEAR_EDIT_MESSAGE_TARGET,
     CLOSE_CHAT,
     EDIT_MESSAGE,
     NOTIFY_PRIVATE_RECIPIENTS_CHANGED,
     OPEN_CHAT,
     REMOVE_LOBBY_CHAT_PARTICIPANT,
     SEND_MESSAGE,
+    SEND_MESSAGE_EDIT,
     SEND_REACTION,
+    SET_EDIT_MESSAGE_TARGET,
     SET_FOCUSED_TAB,
     SET_LOBBY_CHAT_ACTIVE_STATE,
     SET_LOBBY_CHAT_RECIPIENT,
     SET_PRIVATE_MESSAGE_RECIPIENT
 } from './actionTypes';
-import { ChatTabs } from './constants';
+import { ChatTabs, MESSAGE_TYPE_LOCAL } from './constants';
+import { IMessage } from './types';
 
 /**
  * Adds a chat message to the collection of messages.
@@ -78,17 +82,122 @@ export function addMessageReaction(reactionDetails: Object) {
 /**
  * Edits an existing chat message.
  *
- * @param {Object} message - The chat message to edit/override. The messages will be matched from the state
+ * @param {IMessage} message - The chat message to edit/override. The messages will be matched from the state
  * comparing the messageId.
  * @returns {{
  *     type: EDIT_MESSAGE,
- *     message: Object
+ *     message: IMessage
  * }}
  */
-export function editMessage(message: Object) {
+export function editMessage(message: IMessage) {
     return {
         type: EDIT_MESSAGE,
         message
+    };
+}
+
+/**
+ * Finds a local, editable (non-reaction, non-file, non-private, non-lobby) message by id.
+ *
+ * @param {IMessage[]} messages - The list of messages to search.
+ * @param {string} messageId - The id of the message to find.
+ * @returns {IMessage | undefined}
+ */
+function _findEditableLocalMessage(messages: IMessage[], messageId: string): IMessage | undefined {
+    return messages.find(m =>
+        m.messageId === messageId
+        && m.messageType === MESSAGE_TYPE_LOCAL
+        && !m.privateMessage
+        && !m.lobbyChat
+        && !m.isReaction
+        && !m.fileMetadata
+    );
+}
+
+/**
+ * Sets a local message as the active editing target.
+ *
+ * @param {string} messageId - The id of the message to edit.
+ * @returns {Function}
+ */
+export function setEditMessageTarget(messageId: string) {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const { messages } = getState()['features/chat'];
+        const messageToEdit = _findEditableLocalMessage(messages, messageId);
+
+        if (!messageToEdit) {
+            return;
+        }
+
+        dispatch({
+            type: SET_EDIT_MESSAGE_TARGET,
+            messageId,
+            message: messageToEdit.message
+        });
+    };
+}
+
+/**
+ * Clears the active chat message editing target.
+ *
+ * @returns {{
+ *     type: CLEAR_EDIT_MESSAGE_TARGET
+ * }}
+ */
+export function clearEditMessageTarget() {
+    return {
+        type: CLEAR_EDIT_MESSAGE_TARGET
+    };
+}
+
+/**
+ * Submits an updated text for a local chat message.
+ *
+ * @param {string} messageId - The id of the message being edited.
+ * @param {string} updatedText - The new message text.
+ * @returns {Function}
+ */
+export function submitEditedMessage(messageId: string, updatedText: string) {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const trimmedText = updatedText.trim();
+        const { messages } = getState()['features/chat'];
+        const messageToEdit = _findEditableLocalMessage(messages, messageId);
+
+        if (!messageToEdit) {
+            dispatch(clearEditMessageTarget());
+
+            return;
+        }
+
+        if (!trimmedText || trimmedText === messageToEdit.message) {
+            dispatch(clearEditMessageTarget());
+
+            return;
+        }
+
+        const editedAt = Date.now();
+        const versions = [
+            ...(messageToEdit.versions ?? []),
+            {
+                editedAt,
+                message: messageToEdit.message
+            }
+        ];
+
+        const editedMessage = {
+            ...messageToEdit,
+            isEdited: true,
+            lastEditedTimestamp: editedAt,
+            message: trimmedText,
+            versions
+        };
+
+        dispatch(editMessage(editedMessage));
+        dispatch({
+            type: SEND_MESSAGE_EDIT,
+            message: editedMessage
+        });
+        dispatch(clearEditMessageTarget());
     };
 }
 

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -22,6 +22,7 @@ import {
     setPrivateMessageRecipient,
     setPrivateMessageRecipientById,
     setUserChatWidth,
+    submitEditedMessage,
     toggleChat
 } from '../../actions.web';
 import {
@@ -415,6 +416,17 @@ const Chat = ({
     }, []);
 
     /**
+    * Saves the edited message text.
+    *
+    * @param {string} messageId - The message id to update.
+    * @param {string} text - The edited message text.
+    * @returns {void}
+    */
+    const onEditMessage = useCallback((messageId: string, text: string) => {
+        dispatch(submitEditedMessage(messageId, text));
+    }, [ dispatch ]);
+
+    /**
     * Toggles the chat window.
     *
     * @returns {Function}
@@ -495,6 +507,7 @@ const Chat = ({
                             value = { privateMessageRecipient?.id || OPTION_GROUPCHAT } />
                     )}
                     <ChatInput
+                        onEdit = { onEditMessage }
                         onSend = { onSendMessage } />
                 </div>) }
                 { _isPollsEnabled && (

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -59,6 +59,14 @@ interface IProps extends WithTranslation {
     _chatWidth: number;
 
     /**
+     * The currently edited message target, if any.
+     */
+    _editMessageTarget?: {
+        message: string;
+        messageId: string;
+    };
+
+    /**
      * Whether sending group chat messages is disabled.
      */
     _isSendGroupChatDisabled: boolean;
@@ -77,6 +85,11 @@ interface IProps extends WithTranslation {
      * Invoked to send chat messages.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Callback to invoke on message edit save.
+     */
+    onEdit?: (messageId: string, text: string) => void;
 
     /**
      * Callback to invoke on message send.
@@ -155,6 +168,14 @@ class ChatInput extends Component<IProps, IState> {
         if (prevProps._privateMessageRecipientId !== this.props._privateMessageRecipientId) {
             this._textArea?.current?.focus();
         }
+
+        const previousEditId = prevProps._editMessageTarget?.messageId;
+        const currentEditId = this.props._editMessageTarget?.messageId;
+
+        if (previousEditId !== currentEditId) {
+            this.setState({ message: this.props._editMessageTarget?.message ?? '' });
+            this._textArea?.current?.focus();
+        }
     }
 
     /**
@@ -228,8 +249,10 @@ class ChatInput extends Component<IProps, IState> {
      */
     _onSubmitMessage() {
         const {
+            _editMessageTarget,
             _isSendGroupChatDisabled,
             _privateMessageRecipientId,
+            onEdit,
             onSend
         } = this.props;
 
@@ -240,7 +263,11 @@ class ChatInput extends Component<IProps, IState> {
         const trimmed = this.state.message.trim();
 
         if (trimmed) {
-            onSend(trimmed);
+            if (_editMessageTarget && onEdit) {
+                onEdit(_editMessageTarget.messageId, trimmed);
+            } else {
+                onSend(trimmed);
+            }
 
             this.setState({ message: '' });
 
@@ -342,11 +369,12 @@ class ChatInput extends Component<IProps, IState> {
  * }}
  */
 const mapStateToProps = (state: IReduxState) => {
-    const { privateMessageRecipient, width } = state['features/chat'];
+    const { editMessageTarget, privateMessageRecipient, width } = state['features/chat'];
     const isGroupChatDisabled = isSendGroupChatDisabled(state);
 
     return {
         _areSmileysDisabled: areSmileysDisabled(state),
+        _editMessageTarget: editMessageTarget,
         _privateMessageRecipientId: privateMessageRecipient?.id,
         _isSendGroupChatDisabled: isGroupChatDisabled,
         _chatWidth: width.current ?? CHAT_SIZE,

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@mui/material';
-import React, { useCallback, useMemo, useState } from 'react';
-import { connect } from 'react-redux';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { IReduxState } from '../../../app/types';
@@ -8,6 +8,7 @@ import { translate } from '../../../base/i18n/functions';
 import { getParticipantById, getParticipantDisplayName, isPrivateChatEnabled } from '../../../base/participants/functions';
 import Popover from '../../../base/popover/components/Popover.web';
 import Message from '../../../base/react/components/web/Message';
+import { setEditMessageTarget } from '../../actions.web';
 import { MESSAGE_TYPE_LOCAL } from '../../constants';
 import { getDisplayNameSuffix, getFormattedTimestamp, getMessageText, getPrivateNoticeMessage, isFileMessage } from '../../functions';
 import { IChatMessageProps } from '../../types';
@@ -172,6 +173,31 @@ const useStyles = makeStyles()((theme: Theme) => {
             whiteSpace: 'nowrap',
             flexShrink: 0
         },
+        editedLabel: {
+            ...theme.typography.labelRegular,
+            color: theme.palette.chatTimestamp,
+            marginTop: theme.spacing(1),
+            whiteSpace: 'nowrap'
+        },
+        editHistoryPopover: {
+            padding: theme.spacing(2),
+            backgroundColor: theme.palette.chatInputBackground,
+            borderRadius: theme.shape.borderRadius,
+            maxWidth: '250px',
+            maxHeight: '400px',
+            overflowY: 'auto',
+            color: theme.palette.chatMessageText
+        },
+        editHistoryItem: {
+            marginBottom: theme.spacing(1),
+            paddingBottom: theme.spacing(1),
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            '&:last-child': {
+                borderBottom: 'none',
+                paddingBottom: 0,
+                marginBottom: 0
+            }
+        },
         reactionsPopover: {
             padding: theme.spacing(2),
             backgroundColor: theme.palette.chatInputBackground,
@@ -217,8 +243,33 @@ const ChatMessage = ({
     t
 }: IProps) => {
     const { classes, cx } = useStyles();
+    const dispatch = useDispatch();
+    const historyCardRef = useRef<HTMLDivElement>(null);
     const [ isHovered, setIsHovered ] = useState(false);
     const [ isReactionsOpen, setIsReactionsOpen ] = useState(false);
+    const [ isHistoryOpen, setIsHistoryOpen ] = useState(false);
+
+    useEffect(() => {
+        if (!isHistoryOpen) {
+            return;
+        }
+
+        const handleDocumentPointerDown = (event: PointerEvent) => {
+            const target = event.target as Node;
+
+            if (historyCardRef.current?.contains(target)) {
+                return;
+            }
+
+            setIsHistoryOpen(false);
+        };
+
+        document.addEventListener('pointerdown', handleDocumentPointerDown);
+
+        return () => {
+            document.removeEventListener('pointerdown', handleDocumentPointerDown);
+        };
+    }, [ isHistoryOpen ]);
 
     const handleMouseEnter = useCallback(() => {
         setIsHovered(true);
@@ -234,6 +285,21 @@ const ChatMessage = ({
 
     const handleReactionsClose = useCallback(() => {
         setIsReactionsOpen(false);
+    }, []);
+
+    const handleEditMessage = useCallback(() => {
+        setIsHistoryOpen(false);
+        dispatch(setEditMessageTarget(message.messageId));
+    }, [ dispatch, message.messageId ]);
+
+    const handleToggleHistory = useCallback(() => {
+        setIsHistoryOpen(value => !value);
+    }, []);
+
+    const handleHistoryKeyDown = useCallback((event: React.KeyboardEvent) => {
+        if (event.key === 'Escape') {
+            setIsHistoryOpen(false);
+        }
     }, []);
 
     /**
@@ -280,6 +346,36 @@ const ChatMessage = ({
             </div>
         );
     }
+
+    const editedLabel = message.isEdited
+        ? (
+            <span className = { classes.editedLabel }>
+                {t('chat.editedLabel')}
+            </span>
+        )
+        : null;
+
+    const editHistory = (isHistoryOpen && message.versions?.length)
+        ? (
+            <div
+                aria-label = { t('chat.viewEditHistory') }
+                aria-modal = { false }
+                className = { classes.editHistoryPopover }
+                onKeyDown = { handleHistoryKeyDown }
+                ref = { historyCardRef }
+                role = 'dialog'
+                tabIndex = { -1 }>
+                {message.versions.map((version, index) => (
+                    <div
+                        className = { classes.editHistoryItem }
+                        key = { `${version.editedAt}-${index}` }>
+                        <p>{new Date(version.editedAt).toLocaleString()}</p>
+                        <p>{version.message}</p>
+                    </div>
+                ))}
+            </div>
+        )
+        : null;
 
     /**
      * Renders the reactions for the message.
@@ -347,6 +443,13 @@ const ChatMessage = ({
         );
     }, [ message?.reactions, isHovered, isReactionsOpen ]);
 
+    const canEditMessage = message.messageType === MESSAGE_TYPE_LOCAL
+        && !message.privateMessage
+        && !message.lobbyChat
+        && !message.isReaction
+        && !isFileMessage(message);
+    const hasEditHistory = Boolean(message.versions?.length);
+
     return (
         <div
             className = { cx(classes.chatMessageWrapper, className) }
@@ -358,13 +461,18 @@ const ChatMessage = ({
                 {!shouldDisplayMenuOnRight && (
                     <div className = { classes.optionsButtonContainer }>
                         {isHovered && <MessageMenu
+                            canEditMessage = { canEditMessage }
                             displayName = { message.displayName }
                             enablePrivateChat = { Boolean(enablePrivateChat) }
+                            hasEditHistory = { hasEditHistory }
                             isFileMessage = { isFileMessage(message) }
                             isFromVisitor = { message.isFromVisitor }
                             isLobbyMessage = { message.lobbyChat }
                             message = { message.message }
+                            onEditMessage = { handleEditMessage }
+                            onShowEditHistory = { handleToggleHistory }
                             participantId = { message.participantId } />}
+                        {editHistory}
                     </div>
                 )}
                 <div
@@ -407,6 +515,7 @@ const ChatMessage = ({
                                                 {renderReactions}
                                             </>
                                         )}
+                                        {editedLabel}
                                     </div>
                                     {_renderTimestamp()}
                                 </div>
@@ -427,13 +536,18 @@ const ChatMessage = ({
                         <div>
                             <div className = { classes.optionsButtonContainer }>
                                 {isHovered && <MessageMenu
+                                    canEditMessage = { canEditMessage }
                                     displayName = { message.displayName }
                                     enablePrivateChat = { Boolean(enablePrivateChat) }
+                                    hasEditHistory = { hasEditHistory }
                                     isFileMessage = { isFileMessage(message) }
                                     isFromVisitor = { message.isFromVisitor }
                                     isLobbyMessage = { message.lobbyChat }
                                     message = { message.message }
+                                    onEditMessage = { handleEditMessage }
+                                    onShowEditHistory = { handleToggleHistory }
                                     participantId = { message.participantId } />}
+                                {editHistory}
                             </div>
                         </div>
                     </div>

--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -15,13 +15,17 @@ import { handleLobbyChatInitialized, openChat } from '../../actions.web';
 import logger from '../../logger';
 
 export interface IProps {
+    canEditMessage?: boolean;
     className?: string;
     displayName?: string;
     enablePrivateChat: boolean;
+    hasEditHistory?: boolean;
     isFileMessage?: boolean;
     isFromVisitor?: boolean;
     isLobbyMessage: boolean;
     message: string;
+    onEditMessage?: () => void;
+    onShowEditHistory?: () => void;
     participantId: string;
 }
 
@@ -62,7 +66,19 @@ const useStyles = makeStyles()(theme => {
     };
 });
 
-const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, enablePrivateChat, displayName, isFileMessage }: IProps) => {
+const MessageMenu = ({
+    canEditMessage,
+    message,
+    participantId,
+    isFromVisitor,
+    isLobbyMessage,
+    enablePrivateChat,
+    displayName,
+    hasEditHistory,
+    isFileMessage,
+    onEditMessage,
+    onShowEditHistory
+}: IProps) => {
     const dispatch = useDispatch();
     const { classes, cx } = useStyles();
     const { t } = useTranslation();
@@ -75,7 +91,12 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
     const participant = useSelector((state: IReduxState) => getParticipantById(state, participantId));
 
     // If no menu items will be shown, don't render the menu button.
-    if (!enablePrivateChat && isFileMessage) {
+    const hasMenuItems = enablePrivateChat
+        || !isFileMessage
+        || Boolean(canEditMessage)
+        || Boolean(hasEditHistory);
+
+    if (!hasMenuItems) {
         return null;
     }
 
@@ -135,6 +156,16 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
         handleClose();
     }, [ message ]);
 
+    const handleEditClick = useCallback(() => {
+        onEditMessage?.();
+        handleClose();
+    }, [ onEditMessage, handleClose ]);
+
+    const handleShowHistoryClick = useCallback(() => {
+        onShowEditHistory?.();
+        handleClose();
+    }, [ onShowEditHistory, handleClose ]);
+
     const popoverContent = (
         <div className = { classes.menuPanel }>
             {enablePrivateChat && (
@@ -149,6 +180,20 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
                     className = { classes.menuItem }
                     onClick = { handleCopyClick }>
                     {t('Copy')}
+                </div>
+            )}
+            {canEditMessage && (
+                <div
+                    className = { classes.menuItem }
+                    onClick = { handleEditClick }>
+                    {t('chat.editMessage')}
+                </div>
+            )}
+            {hasEditHistory && (
+                <div
+                    className = { classes.menuItem }
+                    onClick = { handleShowHistoryClick }>
+                    {t('chat.viewEditHistory')}
                 </div>
             )}
         </div>

--- a/react/features/chat/constants.ts
+++ b/react/features/chat/constants.ts
@@ -74,3 +74,8 @@ export const TIMESTAMP_FORMAT = 'H:mm';
 export const MESSAGE_TYPE_SYSTEM = 'system_chat_message';
 
 export const OPTION_GROUPCHAT = 'groupchat';
+
+/**
+ * The payload name for endpoint/datachannel chat message edit events.
+ */
+export const ENDPOINT_CHAT_EDIT_NAME = 'endpoint-chat-edit';

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -45,6 +45,7 @@ import {
     CLOSE_CHAT,
     OPEN_CHAT,
     SEND_MESSAGE,
+    SEND_MESSAGE_EDIT,
     SEND_REACTION,
     SET_FOCUSED_TAB
 } from './actionTypes';
@@ -53,6 +54,7 @@ import {
     addMessageReaction,
     clearChatState,
     closeChat,
+    editMessage,
     notifyPrivateRecipientsChanged,
     openChat,
     setPrivateMessageRecipient
@@ -60,6 +62,7 @@ import {
 import { ChatPrivacyDialog } from './components';
 import {
     ChatTabs,
+    ENDPOINT_CHAT_EDIT_NAME,
     INCOMING_MSG_SOUND_ID,
     LOBBY_CHAT_MESSAGE,
     MESSAGE_TYPE_ERROR,
@@ -142,21 +145,33 @@ MiddlewareRegistry.register(store => next => action => {
 
     case ENDPOINT_MESSAGE_RECEIVED: {
         const state = store.getState();
+        const { participant, data } = action;
+        const participantId = participant?.getId?.();
+
+        if (data?.name === ENDPOINT_CHAT_EDIT_NAME && participantId) {
+            _onMessageEditReceived(store, {
+                editedAt: data.editedAt,
+                message: data.message,
+                messageId: data.messageId,
+                participantId,
+                versions: data.versions
+            });
+
+            break;
+        }
 
         if (!isReactionsEnabled(state)) {
             return next(action);
         }
 
-        const { participant, data } = action;
-
-        if (data?.name === ENDPOINT_REACTION_NAME) {
+        if (data?.name === ENDPOINT_REACTION_NAME && participantId) {
             // Skip duplicates, keep just 3.
             const reactions = Array.from(new Set(data.reactions)).slice(0, 3) as string[];
 
             store.dispatch(pushReactions(reactions));
 
             _handleReceivedMessage(store, {
-                participantId: participant.getId(),
+                participantId,
                 message: getReactionMessageFromBuffer(reactions),
                 privateMessage: false,
                 lobbyChat: false,
@@ -315,6 +330,24 @@ MiddlewareRegistry.register(store => next => action => {
             const { reaction, messageId, receiverId } = action;
 
             conference.sendReaction(reaction, messageId, receiverId);
+        }
+        break;
+    }
+
+    case SEND_MESSAGE_EDIT: {
+        const state = store.getState();
+        const conference = getCurrentConference(state);
+
+        if (conference) {
+            const { message } = action;
+
+            conference.sendEndpointMessage('', {
+                editedAt: message.lastEditedTimestamp,
+                message: message.message,
+                messageId: message.messageId,
+                name: ENDPOINT_CHAT_EDIT_NAME,
+                versions: message.versions ?? []
+            });
         }
         break;
     }
@@ -513,6 +546,64 @@ function _onReactionReceived(store: IStore, { participantId, reactionList, messa
     };
 
     store.dispatch(addMessageReaction(reactionPayload));
+}
+
+/**
+ * Handles receiving an edited chat message over endpoint transport.
+ *
+ * @param {IStore} store - The Redux store.
+ * @param {Object} payload - Incoming message edit payload.
+ * @param {number} payload.editedAt - Edit timestamp.
+ * @param {string} payload.message - Edited message text.
+ * @param {string} payload.messageId - Message id to update.
+ * @param {string} payload.participantId - Participant id who edited the message.
+ * @param {Array<Object>} payload.versions - Full version history of previous texts.
+ * @returns {void}
+ */
+function _onMessageEditReceived(store: IStore, {
+    editedAt,
+    message,
+    messageId,
+    participantId,
+    versions
+}: {
+    editedAt?: number;
+    message?: string;
+    messageId?: string;
+    participantId: string;
+    versions?: Array<{ editedAt: number; message: string; }>;
+}) {
+    if (!messageId || typeof message !== 'string') {
+        return;
+    }
+
+    const { dispatch, getState } = store;
+    const { messages } = getState()['features/chat'];
+    const original = messages.find(chatMessage => chatMessage.messageId === messageId);
+
+    // Only allow message authors to edit their own non-file, non-reaction messages.
+    if (!original
+        || original.participantId !== participantId
+        || original.messageType !== MESSAGE_TYPE_REMOTE
+        || original.privateMessage
+        || original.lobbyChat
+        || original.isReaction
+        || original.fileMetadata) {
+        return;
+    }
+
+    // Ignore out-of-order edits to avoid reverting to older versions.
+    if (editedAt && original.lastEditedTimestamp && editedAt <= original.lastEditedTimestamp) {
+        return;
+    }
+
+    dispatch(editMessage({
+        ...original,
+        isEdited: true,
+        lastEditedTimestamp: editedAt ?? Date.now(),
+        message,
+        versions: versions ?? original.versions ?? []
+    }));
 }
 
 /**

--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -8,6 +8,7 @@ import {
     ADD_MESSAGE,
     ADD_MESSAGE_REACTION,
     CLEAR_CHAT_STATE,
+    CLEAR_EDIT_MESSAGE_TARGET,
     CLOSE_CHAT,
     EDIT_MESSAGE,
     NOTIFY_PRIVATE_RECIPIENTS_CHANGED,
@@ -15,6 +16,7 @@ import {
     REMOVE_LOBBY_CHAT_PARTICIPANT,
     SET_CHAT_IS_RESIZING,
     SET_CHAT_WIDTH,
+    SET_EDIT_MESSAGE_TARGET,
     SET_FOCUSED_TAB,
     SET_LOBBY_CHAT_ACTIVE_STATE,
     SET_LOBBY_CHAT_RECIPIENT,
@@ -25,6 +27,7 @@ import { CHAT_SIZE, ChatTabs } from './constants';
 import { IMessage } from './types';
 
 const DEFAULT_STATE = {
+    editMessageTarget: undefined,
     groupChatWithPermissions: false,
     isOpen: false,
     messages: [],
@@ -44,6 +47,10 @@ const DEFAULT_STATE = {
 };
 
 export interface IChatState {
+    editMessageTarget?: {
+        message: string;
+        messageId: string;
+    };
     focusedTab?: ChatTabs;
     groupChatWithPermissions: boolean;
     isLobbyChatActive: boolean;
@@ -74,8 +81,10 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             fileMetadata: action.fileMetadata,
             isFromGuest: Boolean(action.isFromGuest),
             isFromVisitor: Boolean(action.isFromVisitor),
+            isEdited: Boolean(action.isEdited),
             participantId: action.participantId,
             isReaction: action.isReaction,
+            lastEditedTimestamp: action.lastEditedTimestamp,
             messageId: action.messageId,
             messageType: action.messageType,
             message: action.message,
@@ -84,7 +93,8 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             lobbyChat: action.lobbyChat,
             recipient: action.recipient,
             sentToVisitor: Boolean(action.sentToVisitor),
-            timestamp: action.timestamp
+            timestamp: action.timestamp,
+            versions: action.versions
         };
 
         // React native, unlike web, needs a reverse sorted message list.
@@ -169,6 +179,21 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             messages
         };
     }
+
+    case SET_EDIT_MESSAGE_TARGET:
+        return {
+            ...state,
+            editMessageTarget: {
+                message: action.message,
+                messageId: action.messageId
+            }
+        };
+
+    case CLEAR_EDIT_MESSAGE_TARGET:
+        return {
+            ...state,
+            editMessageTarget: undefined
+        };
 
     case SET_PRIVATE_MESSAGE_RECIPIENT:
         return {

--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -3,13 +3,20 @@ import { WithTranslation } from 'react-i18next';
 import { IStore } from '../app/types';
 import { IFileMetadata } from '../file-sharing/types';
 
+export interface IMessageVersion {
+    editedAt: number;
+    message: string;
+}
+
 export interface IMessage {
     displayName: string;
     error?: Object;
     fileMetadata?: IFileMetadata;
+    isEdited?: boolean;
     isFromGuest?: boolean;
     isFromVisitor?: boolean;
     isReaction: boolean;
+    lastEditedTimestamp?: number;
     lobbyChat: boolean;
     message: string;
     messageId: string;
@@ -20,6 +27,7 @@ export interface IMessage {
     recipient: string;
     sentToVisitor?: boolean;
     timestamp: number;
+    versions?: IMessageVersion[];
 }
 
 /**


### PR DESCRIPTION
## What Is Done

- Added support to edit previously sent local chat messages (web)

### Chat Store Updates
- `editMessageTarget`
- `isEdited`
- `lastEditedTimestamp`
- `versions` (previous message snapshots)

### Web Chat UI
- Edit message action in message menu
- `(edited)` indicator on edited messages
- View edit history action and history popover

### Broadcast Flow for Edits
- Local edit dispatches `SEND_MESSAGE_EDIT`
- Edit payload is sent over endpoint message
- Remote participants update existing message in place

### Guardrails
- Editing allowed only for eligible messages (non-reaction, non-file, non-private, non-lobby)
- Ignore out-of-order incoming edits
- Ensure sender can only edit their own remote message instance

---

## What Is Pending / Follow-ups

- Native mobile support (`.native.ts` / `.native.tsx`) not included yet

### UX Polish (History Popover)
- Keyboard/focus behavior review
- Confirm desired mobile-friendly behavior

### Decisions Needed
- Whether to cap/trim versions persistently in reducer/middleware (not just UI)
- Policy for late joiners:
  - See latest edited message/history **vs** original message only
- Timestamp formatting consistency (locale/timezone)

---

## Open Questions for Review

- Should users be allowed to edit private and lobby messages, or keep group-chat-only for now?
- Should there be a time window for editing (e.g., 5/15 minutes)?
- Should edit history be visible to everyone or only to message author/moderators?
- Should we limit the number of stored versions per message?
  - Proposed: keep last **N** (e.g., 20–50) and drop oldest
- Should empty-edit behavior be:
  - “Cancel edit” (current)
  - or “Delete message” (not implemented)?
- Do we need server-side validation/enforcement for edit events to prevent tampering?
- Should edited messages trigger notifications/sounds for other participants?

## demo video

https://github.com/user-attachments/assets/956a39a8-1942-4994-a409-5ac5bd9c5d3a



