### PR TITLE
GSoc : fix(chat) ensure reactions is always a Map and avoid type mismatch

### DIFF
--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -29,7 +29,7 @@ const DEFAULT_STATE = {
     isOpen: false,
     messages: [],
     notifyPrivateRecipientsChangedTimestamp: undefined,
-    reactions: {},
+    reactions: new Map(),
     unreadMessagesCount: 0,
     unreadFilesCount: 0,
     privateMessageRecipient: undefined,
@@ -79,7 +79,7 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             messageId: action.messageId,
             messageType: action.messageType,
             message: action.message,
-            reactions: action.reactions,
+            reactions: action.reactions ?? new Map(),
             privateMessage: action.privateMessage,
             lobbyChat: action.lobbyChat,
             recipient: action.recipient,
@@ -112,7 +112,7 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
 
         const messages = state.messages.map(message => {
             if (messageId === message.messageId) {
-                const newReactions = new Map(message.reactions);
+                const newReactions = new Map(message.reactions ?? []);
 
                 reactionList.forEach((reaction: string) => {
                     let participants = newReactions.get(reaction);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
## Summary
Fixes a type inconsistency between IMessage and chat reducer state where reactions is defined as a Map but initialized and handled as a plain object or possibly undefined.

## Problem
1) `IMessage.reactions` is expected to be a `Map`
2) `DEFAULT_STATE`initializes it as {} (plain object)
3) `ADD_MESSAGE` assigns `action.reactions` without fallback

This leads to inconsistent runtime types.

Additionally:

new Map(message.reactions)

can silently convert {} into an empty Map, masking the issue.

### Fix

1) Ensure `reactions` is always initialized as a `Map`
2) Add fallback in `ADD_MESSAGE` to prevent `undefined`
3) Safeguard Map construction in `ADD_MESSAGE_REACTION`

This keeps runtime behavior consistent and avoids relying on implicit `{}` → `Map` conversion.

## Testing
1) Verified sending messages without reactions
2) Verified adding reactions works correctly
