### PR TITLE
GSoC: Fix inconsistent displayName handling

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -582,7 +582,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
                 const user = this._participants[userID];
 
                 if (user) {
-                    user.displayName = data.displayname;
+                    user.displayName = data.displayName ?? data.displayname;
                     user.formattedDisplayName = data.formattedDisplayName;
                 }
                 break;
@@ -1065,11 +1065,13 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * information like participant id, display name, avatar URL and email.
      */
     getParticipantsInfo() {
-    return Object.entries(this._participants).map(([id, participant]) => ({
-        participantId: id,
-        ...participant
-    }));
-}
+        return Object.entries(this._participants).map(([ participantId, participant ]) => {
+            return {
+                participantId,
+                ...participant
+            };
+        });
+    }
 
     /**
      * Returns the current video quality setting.

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1065,15 +1065,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * information like participant id, display name, avatar URL and email.
      */
     getParticipantsInfo() {
-        const participantIds = Object.keys(this._participants);
-        const participantsInfo = Object.values(this._participants);
-
-        participantsInfo.forEach((participant, idx) => {
-            participant.participantId = participantIds[idx];
-        });
-
-        return participantsInfo;
-    }
+    return Object.entries(this._participants).map(([id, participant]) => ({
+        participantId: id,
+        ...participant
+    }));
+}
 
     /**
      * Returns the current video quality setting.


### PR DESCRIPTION
## Description
This PR fixes inconsistent handling of the `displayName` field in the external API.

Previously, the code could mutate participant information when retrieving
`displayName`, which could lead to unexpected behavior for consumers of the API.

This change ensures that the participant information is handled safely
without mutating the original data structure.

## Changes made
- Fixed displayName handling logic
- Prevented mutation of participant data
- Ensured consistent return values

## Testing
- Ran `npm run lint`
- Verified no ESLint errors
- Confirmed functionality works as expected

## Related issue
Fixes: GSoC task related to displayName handling
