### PR TITLE
fix(external-api): prevent unload listener accumulation on SET_CONFIG

### DIFF
--- a/react/features/external-api/middleware.ts
+++ b/react/features/external-api/middleware.ts
@@ -34,6 +34,13 @@ import { iAmVisitor } from '../visitors/functions';
 import './subscriber';
 
 /**
+ * Track the current unload handler so it can be removed
+ * before registering a new one on each SET_CONFIG dispatch.
+ */
+let _location: string | undefined;
+let _unloadHandler: (() => void) | undefined;
+
+/**
  * The middleware of the feature {@code external-api}.
  *
  * @returns {Function}
@@ -240,15 +247,26 @@ MiddlewareRegistry.register(store => next => action => {
     case SET_CONFIG: {
         const state = store.getState();
         const { disableBeforeUnloadHandlers = false } = state['features/base/config'];
+        const eventName = disableBeforeUnloadHandlers ? 'unload' : 'beforeunload';
+
+        // Remove the previous unload handler to avoid duplicate listeners
+        // accumulating across multiple SET_CONFIG dispatches.
+        if (_location && _unloadHandler) {
+            window.removeEventListener(_location, _unloadHandler);
+        }
+
+        _location = eventName;
 
         /**
          * Disposing the API when the user closes the page.
          */
-        window.addEventListener(disableBeforeUnloadHandlers ? 'unload' : 'beforeunload', () => {
+        _unloadHandler = () => {
             APP.API.notifyConferenceLeft(APP.conference.roomName);
             APP.API.dispose();
             getJitsiMeetTransport().dispose();
-        });
+        };
+
+        window.addEventListener(eventName, _unloadHandler);
 
         break;
     }


### PR DESCRIPTION
### Motivation and Context
Fixes #17245

Currently, the `SET_CONFIG` middleware in the External API registers an anonymous `unload` (or `beforeunload`) event listener every time it is dispatched:
https://github.com/jitsi/jitsi-meet/blob/master/react/features/external-api/middleware.ts#L244

Because the handler is an anonymous function, the listeners accumulate over the lifecycle of a long-lived session if `SET_CONFIG` is updated multiple times, leading to redundant `notifyConferenceLeft` and `dispose()` calls on window unload.

### Description
This PR resolves the issue by hoisting the unload handler into module-level variables (`_location` and `_unloadHandler`). 
Before registering a new listener during the `SET_CONFIG` dispatch, any previously registered listener is removed using `window.removeEventListener()`. This ensures that exactly one unload listener exists at any given time.

### Testing Performed
- Validated that dispatching `SET_CONFIG` no longer creates orphaned unload event listeners on the `window` object.
- Validated that when the page unloads, `notifyConferenceLeft()` and `dispose()` are gracefully executed exactly once.
