### PR TITLE
fix(filmstrip): sync remoteParticipants between itemKey and ThumbnailWrapper

### DIFF
--- a/react/features/filmstrip/components/web/Filmstrip.tsx
+++ b/react/features/filmstrip/components/web/Filmstrip.tsx
@@ -996,6 +996,7 @@ class Filmstrip extends PureComponent <IProps, IState> {
             _filmstripWidth,
             _hasScroll,
             _isVerticalFilmstrip,
+            _remoteParticipants,
             _remoteParticipantsLength,
             _resizableFilmstrip,
             _rows,
@@ -1020,7 +1021,7 @@ class Filmstrip extends PureComponent <IProps, IState> {
                     height = { _filmstripHeight }
                     initialScrollLeft = { 0 }
                     initialScrollTop = { 0 }
-                    itemData = {{ filmstripType }}
+                    itemData = {{ filmstripType, remoteParticipants: _remoteParticipants }}
                     itemKey = { this._gridItemKey }
                     onItemsRendered = { this._onGridItemsRendered }
                     overscanRowCount = { 1 }
@@ -1039,6 +1040,7 @@ class Filmstrip extends PureComponent <IProps, IState> {
             itemCount: _remoteParticipantsLength,
             className: `filmstrip__videos remote-videos ${_resizableFilmstrip ? '' : 'height-transition'}`,
             height: _filmstripHeight,
+            itemData: { remoteParticipants: _remoteParticipants },
             itemKey: this._listItemKey,
             itemSize: 0,
             onItemsRendered: this._onListItemsRendered,

--- a/react/features/filmstrip/components/web/ThumbnailWrapper.tsx
+++ b/react/features/filmstrip/components/web/ThumbnailWrapper.tsx
@@ -136,7 +136,7 @@ class ThumbnailWrapper extends Component<IProps> {
  * @returns {IProps}
  */
 function _mapStateToProps(state: IReduxState, ownProps: { columnIndex: number;
-    data: { filmstripType: string; }; index?: number; rowIndex: number; }) {
+    data: { filmstripType: string; remoteParticipants?: string[]; }; index?: number; rowIndex: number; }) {
     const _currentLayout = getCurrentLayout(state);
     const { remoteParticipants: remote } = state['features/filmstrip'];
     const activeParticipants = getActiveParticipantsIds(state);
@@ -145,7 +145,16 @@ function _mapStateToProps(state: IReduxState, ownProps: { columnIndex: number;
     const filmstripType = ownProps.data?.filmstripType;
     const stageFilmstrip = filmstripType === FILMSTRIP_TYPE.STAGE;
     const sortedActiveParticipants = activeParticipants.sort();
-    const remoteParticipants = stageFilmstrip ? sortedActiveParticipants : remote;
+
+    // Use the remoteParticipants snapshot passed via itemData to ensure
+    // consistency with Filmstrip's itemKey functions, which reference
+    // the same array from the parent's render cycle. Reading directly
+    // from Redux could yield a newer array if the store updated between
+    // the parent render and this selector call, causing key/participant
+    // mismatches (wrong video shown in a tile).
+    const remoteParticipants = stageFilmstrip
+        ? sortedActiveParticipants
+        : (ownProps.data?.remoteParticipants ?? remote);
     const remoteParticipantsLength = remoteParticipants.length;
     const localId = getLocalParticipant(state)?.id;
 


### PR DESCRIPTION
## Summary

Fixes a race condition where the wrong participant's video is displayed in a tile. `Filmstrip._gridItemKey` / `_listItemKey` and `ThumbnailWrapper._mapStateToProps` each independently read `remoteParticipants` — the former from `this.props` (captured at the parent's render time), the latter directly from Redux state. When a participant joins or leaves between these two reads, the arrays diverge: a tile keyed for participant A ends up rendering participant B's video.

## How we found it

We operate a customized Jitsi Meet deployment serving ~200 users, where a manager oversees up to 50 participants simultaneously in tile view. With frequent join/leave activity at that scale, the mismatch became consistently reproducible.

## Root cause

`react-window` renders child components (`ThumbnailWrapper`) independently from the parent (`Filmstrip`). The parent's `itemKey` callback captures `_remoteParticipants` from its own render-cycle props, but `ThumbnailWrapper._mapStateToProps` reads a potentially newer snapshot from Redux. If the store updates between these two reads, index-to-participant mapping breaks.

## Fix

Pass `_remoteParticipants` through react-window's `itemData` prop so that `ThumbnailWrapper` uses the same array snapshot as the `itemKey` functions. This is the intended use of `itemData` — sharing parent-scoped data with virtualized children.

## Test plan

- [ ] Join a tile-view call with 3+ participants
- [ ] Have participants rapidly join and leave
- [ ] Verify each tile consistently shows the correct participant's video and name