### PR TITLE
fix(dynamic-branding): custom palette not applied to semantic tokens

### DIFF
--- a/react/features/base/ui/utils.ts
+++ b/react/features/base/ui/utils.ts
@@ -2,15 +2,20 @@ import { merge } from 'lodash-es';
 
 import * as jitsiTokens from './jitsiTokens.json';
 import * as tokens from './tokens.json';
+import { IPalette } from './types';
 
 /**
  * Creates the color tokens based on the color theme and the association map.
  *
  * @param {Object} colorMap - A map between the token name and the actual color value.
+ * @param {Object} customTokens - Optional custom token overrides to merge before resolution.
+ * This allows custom branding colors to propagate through semantic token references.
+ * For example, if customTokens contains { action01: '#custom' }, then any semantic token
+ * that references 'action01' (like 'prejoinActionButtonPrimary') will resolve to '#custom'.
  * @returns {Object}
  */
-export function createColorTokens(colorMap: Object): any {
-    const allTokens = merge({}, tokens, jitsiTokens);
+export function createColorTokens(colorMap: Object, customTokens?: Partial<IPalette>): any {
+    const allTokens = merge({}, tokens, jitsiTokens, customTokens || {});
     const result: any = {};
 
     // First pass: resolve tokens that reference allTokens directly

--- a/react/features/dynamic-branding/functions.web.ts
+++ b/react/features/dynamic-branding/functions.web.ts
@@ -53,8 +53,13 @@ export function createMuiBrandingTheme(customTheme: Theme) {
         spacing: customSpacing
     } = customTheme;
 
-    const newPalette = createColorTokens(colorMap);
+    // Pass customPalette to createColorTokens so that custom colors are merged
+    // BEFORE token resolution. This ensures that semantic tokens (like prejoinActionButtonPrimary)
+    // that reference base tokens (like action01) will resolve to the custom color values.
+    const newPalette = createColorTokens(colorMap, customPalette);
 
+    // Also apply overwriteRecurrsive for any direct palette key overrides that may not be
+    // handled through token resolution (e.g., if customer provides semantic token names directly).
     if (customPalette) {
         overwriteRecurrsive(newPalette, customPalette);
     }


### PR DESCRIPTION
Fixes a regression introduced by semantic tokens, released in 6626 where components switched from using base tokens (e.g., action01) to semantic tokens (e.g., prejoinActionButtonPrimary).

This caused custom branding palette overrides to stop working because semantic tokens were resolved BEFORE the custom palette was merged.

