### PR TITLE
feat(keyboard-shortcuts): support Ctrl+Alt modifier combos

### DIFF
--- a/react/features/keyboard-shortcuts/reducer.ts
+++ b/react/features/keyboard-shortcuts/reducer.ts
@@ -38,7 +38,16 @@ ReducerRegistry.register<IKeyboardShortcutsState>(STORE_NAME,
             enabled: false
         };
     case REGISTER_KEYBOARD_SHORTCUT: {
-        const shortcutKey = action.shortcut.alt ? `:${action.shortcut.character}` : action.shortcut.character;
+        const { alt, character, ctrl } = action.shortcut;
+        let shortcutKey = character;
+
+        if (ctrl && alt) {
+            shortcutKey = `-:${character}`;
+        } else if (alt) {
+            shortcutKey = `:${character}`;
+        } else if (ctrl) {
+            shortcutKey = `-${character}`;
+        }
 
         return {
             ...state,
@@ -51,7 +60,15 @@ ReducerRegistry.register<IKeyboardShortcutsState>(STORE_NAME,
         };
     }
     case UNREGISTER_KEYBOARD_SHORTCUT: {
-        const shortcutKey = action.alt ? `:${action.character}` : action.character;
+        let shortcutKey = action.character;
+
+        if (action.ctrl && action.alt) {
+            shortcutKey = `-:${action.character}`;
+        } else if (action.alt) {
+            shortcutKey = `:${action.character}`;
+        } else if (action.ctrl) {
+            shortcutKey = `-${action.character}`;
+        }
         const shortcuts = new Map(state.shortcuts);
 
         shortcuts.delete(shortcutKey);

--- a/react/features/keyboard-shortcuts/types.ts
+++ b/react/features/keyboard-shortcuts/types.ts
@@ -6,6 +6,9 @@ export interface IKeyboardShortcut {
     // the character to be pressed that triggers the action
     character: string;
 
+    // whether or not the ctrl key must be pressed
+    ctrl?: boolean;
+
     // the function to be executed when the shortcut is pressed
     handler: Function;
 

--- a/react/features/keyboard-shortcuts/utils.ts
+++ b/react/features/keyboard-shortcuts/utils.ts
@@ -41,6 +41,10 @@ export const getKeyboardKey = (e: KeyboardEvent): string => {
 
     const replacedKey = code.replace('Key', '');
 
+    if (ctrlKey && altKey) {
+        return `-:${replacedKey}`;
+    }
+
     if (altKey) {
         return `:${replacedKey}`;
     }


### PR DESCRIPTION
## Summary
- Add `ctrl` flag to `IKeyboardShortcut` interface alongside the existing `alt` flag
- Update `getKeyboardKey()` to return `-:KEY` for Ctrl+Alt combos, checked before the existing Alt-only path
- Update reducer to compute shortcut keys using the `-:` prefix for Ctrl+Alt, consistent with existing `:` (Alt) and `-` (Ctrl) conventions

## Test plan
- [ ] Register a shortcut with `{ ctrl: true, alt: true, character: 'X' }` and verify it fires on Ctrl+Alt+X
- [ ] Verify existing Alt+key shortcuts (reactions) still work
- [ ] Verify existing plain key shortcuts (A, C, D, etc.) still work
- [ ] Verify Ctrl+C/V/A browser shortcuts are not intercepted