### PR TITLE
fix(prosody-plugins): redact transcription HTTP header values from metadata log

### DIFF
--- a/resources/prosody-plugins/mod_room_metadata_component.lua
+++ b/resources/prosody-plugins/mod_room_metadata_component.lua
@@ -222,7 +222,20 @@ function process_main_muc_loaded(main_muc, host_module)
         local room = event.room;
         local json_msg = getMetadataJSON(room);
 
-        module:log('info', 'Metadata changed internally in room:%s,meeting_id:%s - broadcasting data:%s', room.jid, room._data.meetingId, json_msg);
+        local log_json = json_msg;
+        if room.jitsiMetadata and room.jitsiMetadata.transcription
+                and room.jitsiMetadata.transcription.httpHeaders then
+            local metadata_copy = table_shallow_copy(room.jitsiMetadata);
+            local transcription_copy = table_shallow_copy(metadata_copy.transcription);
+            local headers_redacted = {};
+            for k, _ in pairs(transcription_copy.httpHeaders) do
+                headers_redacted[k] = '***';
+            end
+            transcription_copy.httpHeaders = headers_redacted;
+            metadata_copy.transcription = transcription_copy;
+            log_json = getMetadataJSON(room, metadata_copy) or log_json;
+        end
+        module:log('info', 'Metadata changed internally in room:%s,meeting_id:%s - broadcasting data:%s', room.jid, room._data.meetingId, log_json);
         broadcastMetadata(room, json_msg);
     end);
 


### PR DESCRIPTION
## Summary

- In `mod_room_metadata_component`, the `room-metadata-changed` handler logs the full metadata JSON, which can include HTTP header values set on `room.jitsiMetadata.transcription.httpHeaders` (e.g. API keys for custom transcribers).
- Redact all values under `transcription.httpHeaders` before logging by shallow-copying the metadata and replacing each header value with `***`. The broadcast stanza is unaffected.

