### PR TITLE
fix(tests): Report session-init crash in allure report

### DIFF
--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -472,9 +472,11 @@ export const config: WebdriverIO.MultiremoteConfig = {
 
     /**
      * Gets executed after a worker process has exited.
-     * If the worker crashed (e.g. session DELETE timeout), the JUnit reporter never flushes,
-     * leaving a zero-byte XML file. This hook detects that and writes a failure entry so the
-     * report generator has something to show.
+     * Handles two crash scenarios:
+     * 1. Session DELETE timeout: JUnit reporter never flushes, leaving a zero-byte XML.
+     * 2. Session INIT timeout: JUnit reporter writes a non-empty XML but with empty name/classname,
+     *    and the allure reporter never fires (no beforeTest hook ran).
+     * In both cases, synthesise a failure entry for JUnit and allure so the crash shows up in reports.
      */
     onWorkerEnd(cid, exitCode, workerSpecs) {
         if (exitCode === 0) {
@@ -482,18 +484,30 @@ export const config: WebdriverIO.MultiremoteConfig = {
         }
         const xmlPath = path.join(TEST_RESULTS_DIR, `results-${cid}.xml`);
 
-        try {
-            if (fs.statSync(xmlPath).size > 0) {
-                return;
-            }
-        } catch {
-            // file doesn't exist yet — fall through and create it
-        }
-
         const specName = workerSpecs?.[0] ? path.basename(workerSpecs[0], '.spec.ts') : 'unknown';
         const dirMatch = workerSpecs?.[0]?.match(/\/tests\/specs\/([^/]+)\//);
         const dir = dirMatch ? dirMatch[1] : 'unknown';
         const message = `Worker exited with code ${exitCode} before results were written. Test result is unknown - tests may have passed.`;
+
+        // Check whether the XML has real test content. The JUnit reporter writes a non-empty XML
+        // even for session-init failures, but the testcase has empty name/classname in that case.
+        // If real test results were written, the allure reporter will have already produced its
+        // own result files, so we skip both. If the XML is missing or has no named test cases,
+        // we need to synthesise both.
+        let xmlHasNamedTests = false;
+
+        try {
+            const xmlContent = fs.readFileSync(xmlPath, 'utf8');
+
+            xmlHasNamedTests = xmlContent.includes('name="') && !xmlContent.includes('name=""');
+        } catch {
+            // file doesn't exist — fall through and create it
+        }
+
+        if (xmlHasNamedTests) {
+            // Real test results were written; allure reporter handled this worker normally.
+            return;
+        }
 
         const b = junitReportBuilder.newBuilder();
 


### PR DESCRIPTION
When the WebDriver session POST times out (grid unavailable at init time), the JUnit reporter writes a non-empty XML with empty `name`/`classname`, but the allure reporter never fires since no `beforeTest` hook ran. The `onWorkerEnd` hook previously bailed out on any non-empty XML, so the failure was invisible in the allure report.

Now the hook reads the XML content to distinguish real test results (named testcases) from a crashed-runner placeholder (empty name). Only in the latter case does it synthesise allure and JUnit entries.

Extends the fix from #17211 which only handled the session DELETE timeout (zero-byte XML) case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)