### PR TITLE
Add session termination reason in Arabic localization

### DIFF
--- a/lang/main-ar.json
+++ b/lang/main-ar.json
@@ -370,6 +370,7 @@
         "sendPrivateMessageTitle": "أترسل ردًا خاصًا؟",
         "serviceUnavailable": "الخدمة غير متاحة",
         "sessTerminated": "أُنهيَت المكالمة",
+        "sessTerminatedReason": "تم إنهاء الإجتماع",
         "sessionRestarted": "إعادة الاتصال من الجسر",
         "shareAudio": "استمر",
         "shareAudioTitle": "كيفية مشاركة الصوت",


### PR DESCRIPTION
<!--
## Problem
The sessTerminatedReason dialog message is missing in Arabic local.

## Fix
added the termination message in Arabic (main-ar.json) language file to be more accurate.

## Files Changed
- lang/main-ar.json
-->
