### PR TITLE
fix(breakout-rooms): bypass disableInitialGUM when joining breakout room

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -389,6 +389,7 @@ export default {
      * Returns an object containing a promise which resolves with the created tracks &
      * the errors resulting from that process.
      * @param {object} options
+     * @param {boolean} option.isBreakoutRoom - true if we are creating the initial local tracks in breakout room.
      * @param {boolean} options.startAudioOnly=false - if <tt>true</tt> then
      * only audio track will be created and the audio only mode will be turned
      * on.
@@ -403,14 +404,16 @@ export default {
      */
     createInitialLocalTracks(options = {}, recordTimeMetrics = false) {
         const errors = {};
+        const { isBreakoutRoom = false } = options;
 
         // Always get a handle on the audio input device so that we have statistics (such as "No audio input" or
         // "Are you trying to speak?" ) even if the user joins the conference muted.
-        const initialDevices = config.startSilent || config.disableInitialGUM ? [] : [ MEDIA_TYPE.AUDIO ];
-        const requestedAudio = !config.disableInitialGUM;
+        const initialDevices
+            = config.startSilent || (config.disableInitialGUM && !isBreakoutRoom) ? [] : [ MEDIA_TYPE.AUDIO ];
+        const requestedAudio = !config.disableInitialGUM || isBreakoutRoom;
         let requestedVideo = false;
 
-        if (!config.disableInitialGUM
+        if ((!config.disableInitialGUM || isBreakoutRoom)
                 && !options.startWithVideoMuted
                 && !options.startAudioOnly
                 && !options.startScreenSharing) {

--- a/react/features/breakout-rooms/actions.ts
+++ b/react/features/breakout-rooms/actions.ts
@@ -254,6 +254,7 @@ export function moveToRoom(roomId?: string) {
             }
 
             APP.conference.joinRoom(_roomId, {
+                isBreakoutRoom: true,
                 startWithAudioMuted: isAudioMuted,
                 startWithVideoMuted: isVideoMuted
             });


### PR DESCRIPTION
## Summary
- When `disableInitialGUM` is enabled, moving to a breakout room would skip creating initial local tracks, leaving the user without audio and video.
- This passes `isBreakoutRoom: true` from the breakout room join flow and uses it in `createInitialLocalTracks` to bypass `disableInitialGUM`, ensuring GUM is always requested when entering a breakout room.

## Test plan
- [ ] Enable `disableInitialGUM` in config
- [ ] Join a conference — verify no initial GUM request is made (existing behavior preserved)
- [ ] Move to a breakout room — verify audio and video tracks are created
- [ ] Verify normal breakout room flow (without `disableInitialGUM`) still works as expected