### PR TITLE
fix(accessibility): poll and checkbox structure

### DIFF
--- a/lang/main-de.json
+++ b/lang/main-de.json
@@ -1052,6 +1052,7 @@
             "empty": "Es gibt bisher keine Umfragen in dieser Konferenz.",
             "hideDetailedResults": "Details verbergen",
             "showDetailedResults": "Details anzeigen",
+            "value": "{{ percent }} Prozent",
             "vote": "Vote"
         }
     },

--- a/lang/main.json
+++ b/lang/main.json
@@ -1052,6 +1052,7 @@
             "empty": "There are no polls in the meeting yet.",
             "hideDetailedResults": "Hide details",
             "showDetailedResults": "Show details",
+            "value": "{{ percent }} percent",
             "vote": "Vote"
         }
     },

--- a/react/features/base/ui/Tokens.ts
+++ b/react/features/base/ui/Tokens.ts
@@ -327,7 +327,7 @@ export const colorMap = {
     pollsSendLabel: 'text01',                // Poll send button label
     pollsSendDisabled: 'text03',             // Poll send button disabled label
     pollsPaneBackground: 'ui01',             // Poll pane container background
-    pollsPaneBorder: 'ui05',                 // Poll pane border
+    pollsPaneBorder: 'ui04',                 // Poll pane border
     pollsCreateBackground: 'uiBackground',   // Poll create dialog background
     pollsCreateBorder: 'ui06',               // Poll create dialog border
 

--- a/react/features/base/ui/components/web/Checkbox.tsx
+++ b/react/features/base/ui/components/web/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { makeStyles } from 'tss-react/mui';
 
 import { isMobileBrowser } from '../../../environment/utils';
@@ -59,6 +59,10 @@ const useStyles = makeStyles()(theme => {
 
         disabled: {
             cursor: 'not-allowed'
+        },
+
+        clickableLabel: {
+            cursor: 'pointer'
         },
 
         activeArea: {
@@ -159,26 +163,64 @@ const Checkbox = ({
 }: ICheckboxProps) => {
     const { classes: styles, cx, theme } = useStyles();
     const isMobile = isMobileBrowser();
+    const labelRef = useRef<HTMLLabelElement>(null);
+
+    const toggleCheckbox = useCallback(() => {
+        labelRef.current?.click();
+    }, [ labelRef ]);
+
+    let inputId = id;
+
+    // Hack the useId hook.
+    // This is used rarely and the entropy is high enough to not worry about duplication.
+    // TODO: When v17->v18 is completed, remove this! Ref: https://github.com/jitsi/jitsi-meet/issues/15709
+    const useId = () => {
+        const alphabet = 'abcdefghijklmnopqrstuvwxyz1234567890';
+
+        let newId = '';
+
+        for (let i = 0; i < 10; i++) {
+            const index = Math.floor(Math.random() * alphabet.length);
+
+            newId += alphabet[index];
+        }
+
+        return newId;
+    };
+
+    if (!inputId) {
+        if (name) {
+            inputId = name;
+        } else {
+            inputId = `checkbox-${useId()}`;
+        }
+    }
 
     return (
-        <label className = { cx(styles.formControl, isMobile && 'is-mobile', className) }>
+        <div className = { cx(styles.formControl, isMobile && 'is-mobile', className) }>
             <div className = { cx(styles.activeArea, isMobile && 'is-mobile', disabled && styles.disabled) }>
                 <input
                     checked = { checked }
                     disabled = { disabled }
-                    id = { id }
+                    id = { inputId }
                     name = { name }
                     onChange = { onChange }
                     type = 'checkbox' />
                 <Icon
                     aria-hidden = { true }
                     className = 'checkmark'
-                    color = { disabled ? theme.palette.checkboxIconDisabled : theme.palette.checkboxIcon }
+                    color = { disabled ? theme.palette.icon03 : theme.palette.icon01 }
+                    onClick = { toggleCheckbox }
                     size = { 18 }
                     src = { IconCheck } />
             </div>
-            <div>{label}</div>
-        </label>
+            <label
+                className = { cx(styles.clickableLabel) }
+                htmlFor = { inputId }
+                ref = { labelRef }>
+                {label}
+            </label>
+        </div>
     );
 };
 

--- a/react/features/base/ui/components/web/Checkbox.tsx
+++ b/react/features/base/ui/components/web/Checkbox.tsx
@@ -189,7 +189,7 @@ const Checkbox = ({
 
     const toggleCheckbox = useCallback(() => {
         labelRef.current?.click();
-    }, [ labelRef ]);
+    }, []);
 
     let inputId = id;
 

--- a/react/features/base/ui/components/web/Checkbox.tsx
+++ b/react/features/base/ui/components/web/Checkbox.tsx
@@ -152,6 +152,27 @@ const useStyles = makeStyles()(theme => {
     };
 });
 
+/**
+ * Hack the useId hook.
+ * This is used rarely and the entropy is high enough to not worry about duplication.
+ * TODO: When v17->v18 is completed, remove this! Ref: https://github.com/jitsi/jitsi-meet/issues/15709.
+ *
+ * @returns {string} Random ten digit ID string.
+ */
+const useId = (): string => {
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz1234567890';
+
+    let newId = '';
+
+    for (let i = 0; i < 10; i++) {
+        const index = Math.floor(Math.random() * alphabet.length);
+
+        newId += alphabet[index];
+    }
+
+    return newId;
+};
+
 const Checkbox = ({
     checked,
     className,
@@ -163,7 +184,8 @@ const Checkbox = ({
 }: ICheckboxProps) => {
     const { classes: styles, cx, theme } = useStyles();
     const isMobile = isMobileBrowser();
-    const labelRef = useRef<HTMLLabelElement>(null);
+    const labelRef = useRef<HTMLLabelElement | null>(null);
+    const generatedIdRef = useRef<string | null>(null);
 
     const toggleCheckbox = useCallback(() => {
         labelRef.current?.click();
@@ -171,29 +193,12 @@ const Checkbox = ({
 
     let inputId = id;
 
-    // Hack the useId hook.
-    // This is used rarely and the entropy is high enough to not worry about duplication.
-    // TODO: When v17->v18 is completed, remove this! Ref: https://github.com/jitsi/jitsi-meet/issues/15709
-    const useId = () => {
-        const alphabet = 'abcdefghijklmnopqrstuvwxyz1234567890';
-
-        let newId = '';
-
-        for (let i = 0; i < 10; i++) {
-            const index = Math.floor(Math.random() * alphabet.length);
-
-            newId += alphabet[index];
-        }
-
-        return newId;
-    };
-
     if (!inputId) {
-        if (name) {
-            inputId = name;
-        } else {
-            inputId = `checkbox-${useId()}`;
+        if (!generatedIdRef.current) {
+            generatedIdRef.current = name ? `checkbox-${name}-${useId()}` : `checkbox-${useId()}`;
         }
+
+        inputId = generatedIdRef.current;
     }
 
     return (

--- a/react/features/polls/components/web/PollAnswer.tsx
+++ b/react/features/polls/components/web/PollAnswer.tsx
@@ -19,15 +19,13 @@ const useStyles = makeStyles()(theme => {
             margin: '24px',
             padding: '16px',
             backgroundColor: theme.palette.pollsBackground,
+            border: `1px solid ${theme.palette.contrastBorder02}`,
             borderRadius: '8px',
             wordBreak: 'break-word'
         },
         closeBtn: {
             cursor: 'pointer',
             float: 'right'
-        },
-        header: {
-            marginBottom: '24px'
         },
         question: {
             ...theme.typography.heading6,
@@ -36,7 +34,8 @@ const useStyles = makeStyles()(theme => {
         },
         creator: {
             ...theme.typography.bodyShortRegular,
-            color: theme.palette.pollsSubtitle
+            color: theme.palette.pollsSubtitle,
+            marginBottom: '12px'
         },
         answerList: {
             listStyleType: 'none',
@@ -76,7 +75,7 @@ const PollAnswer = ({
     const { classes } = useStyles();
 
     return (
-        <div
+        <form
             className = { classes.container }
             id = { `poll-${poll.pollId}` }>
             {
@@ -88,31 +87,27 @@ const PollAnswer = ({
                     src = { IconCloseLarge }
                     tabIndex = { 0 } />
             }
-            <div className = { classes.header }>
-                <div className = { classes.question }>
+            <fieldset className = { classes.answerList }>
+                <legend
+                    className = { classes.question }>
                     { poll.question }
-                </div>
-                <div className = { classes.creator }>
+                </legend>
+                <p className = { classes.creator }>
                     { t('polls.by', { name: creatorName }) }
-                </div>
-            </div>
-            <ul className = { classes.answerList }>
+                </p>
                 {
                     poll.answers.map((answer, index: number) => (
-                        <li
+                        <Checkbox
+                            checked = { checkBoxStates[index] }
                             className = { classes.answer }
-                            key = { index }>
-                            <Checkbox
-                                checked = { checkBoxStates[index] }
-                                disabled = { poll.saved }
-                                id = { `poll-answer-checkbox-${poll.pollId}-${index}` }
-                                key = { index }
-                                label = { answer.name }
-                                onChange = { ev => setCheckbox(index, ev.target.checked) } />
-                        </li>
+                            disabled = { poll.saved }
+                            id = { `poll-answer-checkbox-${poll.pollId}-${index}` }
+                            key = { index }
+                            label = { answer.name }
+                            onChange = { ev => setCheckbox(index, ev.target.checked) } />
                     ))
                 }
-            </ul>
+            </fieldset>
             <div className = { classes.footer } >
                 {
                     pollSaved ? <>
@@ -144,7 +139,7 @@ const PollAnswer = ({
                     </>
                 }
             </div>
-        </div>
+        </form>
     );
 };
 

--- a/react/features/polls/components/web/PollAnswer.tsx
+++ b/react/features/polls/components/web/PollAnswer.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles()(theme => {
             margin: '24px',
             padding: '16px',
             backgroundColor: theme.palette.pollsBackground,
-            border: `1px solid ${theme.palette.contrastBorder02}`,
+            border: `1px solid ${theme.palette.pollsPaneBorder}`,
             borderRadius: '8px',
             wordBreak: 'break-word'
         },

--- a/react/features/polls/components/web/PollResults.tsx
+++ b/react/features/polls/components/web/PollResults.tsx
@@ -121,52 +121,79 @@ const PollResults = ({
 }: AbstractProps) => {
     const { classes } = useStyles();
 
+    const handleKeyDown = React.useCallback((fn: Function): React.KeyboardEventHandler<HTMLButtonElement> =>
+        (event: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (event.key === 'Enter') {
+                fn();
+            }
+        }, []);
+
     return (
         <div
+            aria-labelledby = { `poll-question-${pollId}` }
             className = { classes.container }
             id = { `poll-${pollId}` }>
             <div className = { classes.header }>
-                <div className = { classes.question }>
+                <h2
+                    className = { classes.question }
+                    id = { `poll-question-${pollId}` }>
                     {question}
-                </div>
-                <div className = { classes.creator }>
+                </h2>
+                <p className = { classes.creator }>
                     {t('polls.by', { name: creatorName })}
-                </div>
+                </p>
             </div>
-            <ul className = { classes.resultList }>
+            <ul
+                aria-label = { question }
+                className = { classes.resultList }>
                 {answers.map(({ name, percentage, voters, voterCount }, index) =>
                     (<li key = { index }>
-                        <div className = { classes.answerName }>
+                        <p className = { classes.answerName }>
                             {name}
-                        </div>
+                        </p>
                         <div
+                            aria-label = { name }
                             className = { classes.answerResultContainer }
-                            id = { `poll-result-${pollId}-${index}` }>
-                            <span className = { classes.barContainer }>
+                            id = { `poll-result-${pollId}-${index}` }
+                            role = 'group'>
+                            <div className = { classes.barContainer }>
                                 <div
+                                    aria-label = { name }
+                                    aria-valuemax = { 100 }
+                                    aria-valuemin = { 0 }
+                                    aria-valuenow = { percentage }
+                                    aria-valuetext = { t('polls.result.value', { percent: percentage }) }
                                     className = { classes.bar }
+                                    role = 'progressbar'
                                     style = {{ width: `${percentage}%` }} />
-                            </span>
-                            <div className = { classes.voteCount }>
-                                {voterCount} ({percentage}%)
                             </div>
+                            <p
+                                aria-hidden = 'true'
+                                className = { classes.voteCount }>
+                                {voterCount} ({percentage}%)
+                            </p>
                         </div>
-                        {showDetails && voters && voterCount > 0
-                        && <ul className = { classes.voters }>
-                            { voters.map(voter =>
-                                <li key = { voter.id }>{ voter.name }</li>
-                            )}
-                        </ul>}
+                        {showDetails && voters && voterCount > 0 && (
+                            <div aria-label = { `Voters for ${name}` }>
+                                <ul className = { classes.voters }>
+                                    { voters.map(voter => (
+                                        <li key = { voter.id }>{ voter.name }</li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
                     </li>)
                 )}
             </ul>
             <div className = { classes.buttonsContainer }>
                 <button
-                    onClick = { toggleIsDetailed }>
+                    onClick = { toggleIsDetailed }
+                    onKeyDown = { handleKeyDown(toggleIsDetailed) }>
                     {showDetails ? t('polls.results.hideDetailedResults') : t('polls.results.showDetailedResults')}
                 </button>
                 <button
-                    onClick = { changeVote }>
+                    onClick = { changeVote }
+                    onKeyDown = { handleKeyDown(changeVote) }>
                     {haveVoted ? t('polls.results.changeVote') : t('polls.results.vote')}
                 </button>
             </div>

--- a/react/features/polls/components/web/PollsList.tsx
+++ b/react/features/polls/components/web/PollsList.tsx
@@ -77,7 +77,7 @@ const PollsList = ({ setCreateMode }: IPollListProps) => {
                         className = { classes.emptyIcon }
                         color = { theme.palette.icon03 }
                         src = { IconMessage } />
-                    <span className = { classes.emptyMessage }>{t('polls.results.empty')}</span>
+                    <p className = { classes.emptyMessage }>{t('polls.results.empty')}</p>
                 </div>
                 : listPolls.map((id, index) => (
                     <PollItem


### PR DESCRIPTION
When using a screen reader the polls are not easily perceivable.

This is related to [WCAG Success Criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).

- Checkbox changes:
The checkbox component now uses the given id, name or a random id to link it's input to the label. This further optimizes the perception with assistive technologies.
- Poll:
The question and answers were not grouped together logically enough for assistive technologies like a screen reader. Wrapping in a form and fieldset with a legend binds them together better instead of the `ul` element. The poll result is logically still an unordered list.
- PollsList:
The message `There are no polls in the meeting yet. Start a poll here!` was wrapped in a `<span>`. According to the WCAG compliance test, a `<span>` must only be used inside of `<p>` (paragraph) to mark specific text passages. A single `<span>` element as simple text wrapper is discouraged. 

This is the revive of #15645