### PR TITLE
fix(dial-in): point JaaS dial-in URLs to a Cloudflare-fronted host

### DIFF
--- a/config.js
+++ b/config.js
@@ -1922,7 +1922,7 @@ var config = {
 
 // Set the default values for JaaS customers
 if (enableJaaS) {
-    config.dialInNumbersUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access/dids';
+    config.dialInNumbersUrl = 'https://8x8.vc/v1/_jaas/vmms-conference-mapper/v1/access/dids';
     config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';
     config.roomPasswordNumberOfDigits = 10; // skip re-adding it (do not remove comment)
 }

--- a/config.js
+++ b/config.js
@@ -1923,6 +1923,6 @@ var config = {
 // Set the default values for JaaS customers
 if (enableJaaS) {
     config.dialInNumbersUrl = 'https://8x8.vc/v1/_jaas/vmms-conference-mapper/v1/access/dids';
-    config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';
+    config.dialInConfCodeUrl = 'https://8x8.vc/v1/_jaas/vmms-conference-mapper/v1/access';
     config.roomPasswordNumberOfDigits = 10; // skip re-adding it (do not remove comment)
 }

--- a/config.js
+++ b/config.js
@@ -1922,7 +1922,7 @@ var config = {
 
 // Set the default values for JaaS customers
 if (enableJaaS) {
-    config.dialInNumbersUrl = 'https://conference-mapper.jitsi.net/v1/access/dids';
-    config.dialInConfCodeUrl = 'https://conference-mapper.jitsi.net/v1/access';
+    config.dialInNumbersUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access/dids';
+    config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';
     config.roomPasswordNumberOfDigits = 10; // skip re-adding it (do not remove comment)
 }

--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -166,7 +166,7 @@ case "$1" in
                 # old config, let's add the lines at the end. Adding var enableJaaS to avoid adding it on update again
                 echo "var enableJaaS = true;" >> $JITSI_MEET_CONFIG
                 echo "config.dialInNumbersUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access/dids';" >> $JITSI_MEET_CONFIG
-                echo "config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';" >> $JITSI_MEET_CONFIG
+                echo "config.dialInConfCodeUrl = 'https://8x8.vc/v1/_jaas/vmms-conference-mapper/v1/access';" >> $JITSI_MEET_CONFIG
 
                 # Sets roomPasswordNumberOfDigits only if there was not already set
                 if ! cat $JITSI_MEET_CONFIG | grep roomPasswordNumberOfDigits | grep -qv //; then

--- a/debian/jitsi-meet-web-config.postinst
+++ b/debian/jitsi-meet-web-config.postinst
@@ -165,8 +165,8 @@ case "$1" in
             else
                 # old config, let's add the lines at the end. Adding var enableJaaS to avoid adding it on update again
                 echo "var enableJaaS = true;" >> $JITSI_MEET_CONFIG
-                echo "config.dialInNumbersUrl = 'https://conference-mapper.jitsi.net/v1/access/dids';" >> $JITSI_MEET_CONFIG
-                echo "config.dialInConfCodeUrl = 'https://conference-mapper.jitsi.net/v1/access';" >> $JITSI_MEET_CONFIG
+                echo "config.dialInNumbersUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access/dids';" >> $JITSI_MEET_CONFIG
+                echo "config.dialInConfCodeUrl = 'https://api-vo.cloudflare.jitsi.net/vmms-conference-mapper/v1/access';" >> $JITSI_MEET_CONFIG
 
                 # Sets roomPasswordNumberOfDigits only if there was not already set
                 if ! cat $JITSI_MEET_CONFIG | grep roomPasswordNumberOfDigits | grep -qv //; then


### PR DESCRIPTION
## Summary

Swap the bundled JaaS defaults for `config.dialInConfCodeUrl` / `config.dialInNumbersUrl` from `conference-mapper.jitsi.net` to `api-vo.cloudflare.jitsi.net`.

Touched:
- `config.js` — the runtime JaaS branch (`if (enableJaaS)`)
- `debian/jitsi-meet-web-config.postinst` — the package's first-install defaults

## Test plan

- [ ] Install the debian package on a fresh VM with `JAAS_INPUT=true`, verify the generated `dialInNumbersUrl` / `dialInConfCodeUrl` lines point at `api-vo.cloudflare.jitsi.net`.
- [ ] Build jitsi-meet with `enableJaaS = true`, open the dial-in modal, verify the numbers list loads.