### PR TITLE
fix(recording): resolve race conditions in recording/transcription notifications

### DIFF
--- a/lang/main-fr-CA.json
+++ b/lang/main-fr-CA.json
@@ -1120,6 +1120,8 @@
         "noStreams": "Aucun flux audio ou vidéo détectés.",
         "off": "L'enregistrement est arrêté",
         "offBy": "{{name}} a arrêté l'enregistrement",
+        "offByWithTranscription": "{{name}} a arrêté l'enregistrement et la transcription",
+        "offWithTranscription": "L'enregistrement et la transcription sont arrêtés",
         "on": "Enregistrement",
         "onBy": "{{name}} a démarré l'enregistrement",
         "onlyRecordSelf": "Enregistrer seulement mon audio et ma vidéo.",

--- a/lang/main-fr.json
+++ b/lang/main-fr.json
@@ -1139,6 +1139,8 @@
         "noStreams": "Aucun flux audio ou vidéo détectés.",
         "off": "Enregistrement arrêté",
         "offBy": "{{name}} a arrêté l'enregistrement",
+        "offByWithTranscription": "{{name}} a arrêté l'enregistrement et la transcription",
+        "offWithTranscription": "L'enregistrement et la transcription sont arrêtés",
         "on": "Enregistrement",
         "onBy": "{{name}} a démarré l'enregistrement",
         "onlyRecordSelf": "Enregistrer seulement mon audio et ma vidéo.",

--- a/lang/main.json
+++ b/lang/main.json
@@ -1147,6 +1147,8 @@
         "noStreams": "No audio or video stream detected.",
         "off": "Recording stopped",
         "offBy": "{{name}} stopped the recording",
+        "offByWithTranscription": "{{name}} stopped the recording and transcription",
+        "offWithTranscription": "Recording and transcription stopped",
         "on": "Recording started",
         "onBy": "{{name}} started the recording",
         "onByWithTranscription": "{{name}} started the recording. A transcript will also be available after the meeting.",

--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -66,6 +66,7 @@ export interface IConferenceMetadata {
         };
     };
     recording?: {
+        isRecordingRequested?: boolean;
         isTranscribingEnabled: boolean;
     };
     visitors?: {

--- a/react/features/recording/actionTypes.ts
+++ b/react/features/recording/actionTypes.ts
@@ -113,3 +113,15 @@ export const SET_START_RECORDING_NOTIFICATION_SHOWN = 'SET_START_RECORDING_NOTIF
  * }
  */
 export const SET_START_RECORDING_INTENT = 'SET_START_RECORDING_INTENT';
+
+/**
+ * Stores what the user is stopping (recording and/or transcription). Mirrors
+ * SET_START_RECORDING_INTENT. Seeded from the stop dialog on the local side and
+ * from metadata true→false transitions on remote observers.
+ *
+ * {
+ *     type: SET_STOP_RECORDING_INTENT,
+ *     intent: Object | null
+ * }
+ */
+export const SET_STOP_RECORDING_INTENT = 'SET_STOP_RECORDING_INTENT';

--- a/react/features/recording/actionTypes.ts
+++ b/react/features/recording/actionTypes.ts
@@ -102,3 +102,14 @@ export const STOP_LOCAL_RECORDING = 'STOP_LOCAL_RECORDING';
  * }
  */
 export const SET_START_RECORDING_NOTIFICATION_SHOWN = 'SET_START_RECORDING_NOTIFICATION_SHOWN';
+
+/**
+ * Stores the user's intent when starting recording (with or without transcription).
+ * Set synchronously before any async operations begin.
+ *
+ * {
+ *     type: SET_START_RECORDING_INTENT,
+ *     intent: Object | null
+ * }
+ */
+export const SET_START_RECORDING_INTENT = 'SET_START_RECORDING_INTENT';

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -204,21 +204,36 @@ export function showRecordingWarning(props: Object) {
  * @param {string} streamType - The type of the stream ({@code file} or
  * {@code stream}).
  * @param {string?} participantName - The participant name stopping the recording.
+ * @param {boolean} wasWithTranscription - Whether transcription was active alongside
+ * recording when it was started.
  * @returns {showNotification}
  */
-export function showStoppedRecordingNotification(streamType: string, participantName?: string) {
+export function showStoppedRecordingNotification(
+        streamType: string, participantName?: string, wasWithTranscription?: boolean) {
     const isLiveStreaming
         = streamType === JitsiMeetJS.constants.recording.mode.STREAM;
     const descriptionArguments = { name: participantName };
-    const dialogProps = isLiveStreaming ? {
-        descriptionKey: participantName ? 'liveStreaming.offBy' : 'liveStreaming.off',
-        descriptionArguments,
-        titleKey: 'dialog.liveStreaming'
-    } : {
-        descriptionKey: participantName ? 'recording.offBy' : 'recording.off',
-        descriptionArguments,
-        titleKey: 'dialog.recording'
-    };
+    let dialogProps;
+
+    if (isLiveStreaming) {
+        dialogProps = {
+            descriptionKey: participantName ? 'liveStreaming.offBy' : 'liveStreaming.off',
+            descriptionArguments,
+            titleKey: 'dialog.liveStreaming'
+        };
+    } else if (wasWithTranscription) {
+        dialogProps = {
+            descriptionKey: participantName ? 'recording.offByWithTranscription' : 'recording.offWithTranscription',
+            descriptionArguments,
+            titleKey: 'dialog.recording'
+        };
+    } else {
+        dialogProps = {
+            descriptionKey: participantName ? 'recording.offBy' : 'recording.off',
+            descriptionArguments,
+            titleKey: 'dialog.recording'
+        };
+    }
 
     return showNotification(dialogProps, NOTIFICATION_TIMEOUT_TYPE.SHORT);
 }
@@ -230,12 +245,16 @@ export function showStoppedRecordingNotification(streamType: string, participant
  * @param {string} mode - The type of the recording: Stream of File.
  * @param {string | Object } initiator - The participant who started recording.
  * @param {string} sessionId - The recording session id.
+ * @param {boolean} willTranscribe - Whether transcription is/will be active alongside recording,
+ * as determined by the middleware when the sound was played. Ensures the notification text matches
+ * the audio cue.
  * @returns {Function}
  */
 export function showStartedRecordingNotification(
         mode: string,
         initiator: { getId: Function; } | string,
-        sessionId: string) {
+        sessionId: string,
+        willTranscribe?: boolean) {
     return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const initiatorId = getResourceId(initiator);
@@ -256,7 +275,11 @@ export function showStartedRecordingNotification(
             const recordingSharingUrl = getRecordingSharingUrl(state);
             const iAmRecordingInitiator = getLocalParticipant(state)?.id === initiatorId;
             const { showRecordingLink } = state['features/base/config'].recordings || {};
-            const isTranscribing = isRecorderTranscriptionsRunning(state);
+
+            // Use the willTranscribe value passed from the middleware for consistency
+            // with the sound that was already played. Fall back to live state check
+            // if not provided.
+            const isTranscribing = willTranscribe ?? isRecorderTranscriptionsRunning(state);
             const isRecording = isRecordingRunning(state);
 
             // Case 1: Transcription only (no recording)

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -25,12 +25,13 @@ import {
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
     SET_SELECTED_RECORDING_SERVICE,
+    SET_START_RECORDING_INTENT,
     SET_START_RECORDING_NOTIFICATION_SHOWN,
     SET_STREAM_KEY,
     START_LOCAL_RECORDING,
     STOP_LOCAL_RECORDING
 } from './actionTypes';
-import { START_RECORDING_NOTIFICATION_ID } from './constants';
+import { RECORDING_METADATA_ID, START_RECORDING_NOTIFICATION_ID } from './constants';
 import {
     getRecordButtonProps,
     getRecordingLink,
@@ -42,6 +43,7 @@ import {
     shouldAutoTranscribeOnRecord
 } from './functions';
 import logger from './logger';
+import { IStartRecordingIntent } from './reducer';
 
 
 /**
@@ -499,13 +501,23 @@ export function showStartRecordingNotificationWithCallback(openRecordingDialog: 
                     const { conference } = state['features/base/conference'];
                     const autoTranscribeOnRecord = shouldAutoTranscribeOnRecord(state);
 
+                    dispatch(setStartRecordingIntent({
+                        recording: true,
+                        transcription: autoTranscribeOnRecord
+                    }));
+
                     conference?.startRecording({
                         mode: JitsiRecordingConstants.mode.FILE,
                         appData: JSON.stringify(options)
                     });
 
                     if (autoTranscribeOnRecord) {
-                        dispatch(setRequestingSubtitles(true, false, null));
+                        dispatch(setRequestingSubtitles(true, false, null, false, true));
+                    } else {
+                        conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                            isRecordingRequested: true,
+                            isTranscribingEnabled: false
+                        });
                     }
                 } else {
                     openRecordingDialog();
@@ -529,5 +541,19 @@ export function markConsentRequested(sessionId: string) {
     return {
         type: MARK_CONSENT_REQUESTED,
         sessionId
+    };
+}
+
+/**
+ * Sets the user's recording + transcription intent from the dialog.
+ * Used to coordinate sound/notification timing when both services are requested.
+ *
+ * @param {Object|null} intent - The intent, or null to clear.
+ * @returns {Object}
+ */
+export function setStartRecordingIntent(intent: IStartRecordingIntent | null) {
+    return {
+        type: SET_START_RECORDING_INTENT,
+        intent
     };
 }

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -27,6 +27,7 @@ import {
     SET_SELECTED_RECORDING_SERVICE,
     SET_START_RECORDING_INTENT,
     SET_START_RECORDING_NOTIFICATION_SHOWN,
+    SET_STOP_RECORDING_INTENT,
     SET_STREAM_KEY,
     START_LOCAL_RECORDING,
     STOP_LOCAL_RECORDING
@@ -43,7 +44,7 @@ import {
     shouldAutoTranscribeOnRecord
 } from './functions';
 import logger from './logger';
-import { IStartRecordingIntent } from './reducer';
+import { IStartRecordingIntent, IStopRecordingIntent } from './reducer';
 
 
 /**
@@ -554,6 +555,21 @@ export function markConsentRequested(sessionId: string) {
 export function setStartRecordingIntent(intent: IStartRecordingIntent | null) {
     return {
         type: SET_START_RECORDING_INTENT,
+        intent
+    };
+}
+
+/**
+ * Sets what the user is stopping (recording and/or transcription). Mirrors
+ * {@link setStartRecordingIntent}. Consumed by {@code maybeNotifyRecordingStop}
+ * to coordinate the off-sound/notification across stop events.
+ *
+ * @param {Object|null} intent - The intent, or null to clear.
+ * @returns {Object}
+ */
+export function setStopRecordingIntent(intent: IStopRecordingIntent | null) {
+    return {
+        type: SET_STOP_RECORDING_INTENT,
         intent
     };
 }

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -12,7 +12,7 @@ import { updateDropboxToken } from '../../../dropbox/actions';
 import { getDropboxData, getNewAccessToken, isEnabled as isDropboxEnabled } from '../../../dropbox/functions.any';
 import { showErrorNotification } from '../../../notifications/actions';
 import { setRequestingSubtitles } from '../../../subtitles/actions.any';
-import { setSelectedRecordingService, startLocalVideoRecording } from '../../actions';
+import { setSelectedRecordingService, setStartRecordingIntent, startLocalVideoRecording } from '../../actions';
 import { RECORDING_METADATA_ID, RECORDING_TYPES } from '../../constants';
 import { isRecordingSharingEnabled, shouldAutoTranscribeOnRecord, supportsLocalRecording } from '../../functions';
 
@@ -367,6 +367,13 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             type?: string;
         } = {};
 
+        // Dispatch intent synchronously before any async operations.
+        // This coordinates sound/notification timing between recording and transcription.
+        dispatch(setStartRecordingIntent({
+            recording: this.state.shouldRecordAudioAndVideo,
+            transcription: this.state.shouldRecordTranscription
+        }));
+
         if (this.state.shouldRecordAudioAndVideo) {
             switch (this.state.selectedRecordingService) {
             case RECORDING_TYPES.DROPBOX: {
@@ -423,9 +430,12 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
 
         if (this.state.selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE
                 && this.state.shouldRecordTranscription) {
-            dispatch(setRequestingSubtitles(true, _displaySubtitles, _subtitlesLanguage, true));
+            dispatch(setRequestingSubtitles(
+                true, _displaySubtitles, _subtitlesLanguage, true,
+                this.state.shouldRecordAudioAndVideo));
         } else {
             _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                isRecordingRequested: this.state.shouldRecordAudioAndVideo,
                 isTranscribingEnabled: this.state.shouldRecordTranscription
             });
         }

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -112,6 +112,7 @@ export default class AbstractStopRecordingDialog<P extends IProps>
             setRequestingSubtitles(Boolean(_displaySubtitles), _displaySubtitles, _subtitlesLanguage, true));
 
         this.props._conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+            isRecordingRequested: false,
             isTranscribingEnabled: false
         });
 

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -8,7 +8,8 @@ import { IJitsiConference } from '../../../base/conference/reducer';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
 import { setVideoMuted } from '../../../base/media/actions';
 import { setRequestingSubtitles } from '../../../subtitles/actions.any';
-import { stopLocalVideoRecording } from '../../actions';
+import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
+import { setStopRecordingIntent, stopLocalVideoRecording } from '../../actions';
 import { RECORDING_METADATA_ID } from '../../constants';
 import { getActiveSession } from '../../functions';
 import { ISessionData } from '../../reducer';
@@ -45,6 +46,11 @@ export interface IProps extends WithTranslation {
      * The selected language for subtitles.
      */
     _subtitlesLanguage: string | null;
+
+    /**
+     * Whether a transcription session is running.
+     */
+    _transcriptionRunning: boolean;
 
     /**
      * The redux dispatch function.
@@ -93,9 +99,25 @@ export default class AbstractStopRecordingDialog<P extends IProps>
             _fileRecordingSession,
             _localRecording,
             _subtitlesLanguage,
+            _transcriptionRunning,
             dispatch,
             localRecordingVideoStop
         } = this.props;
+
+        // Pre-seed stopRecordingIntent from current running state so the
+        // off-sound/notification coordinator (maybeNotifyRecordingStop) knows
+        // what to wait for. Local recording has its own inline sound path and
+        // does not flow through this coordinator.
+        if (!_localRecording) {
+            const recordingRunning = Boolean(_fileRecordingSession);
+
+            if (recordingRunning || _transcriptionRunning) {
+                dispatch(setStopRecordingIntent({
+                    recording: recordingRunning,
+                    transcription: _transcriptionRunning
+                }));
+            }
+        }
 
         if (_localRecording) {
             dispatch(stopLocalVideoRecording());
@@ -149,6 +171,7 @@ export function _mapStateToProps(state: IReduxState) {
         _fileRecordingSession:
             getActiveSession(state, JitsiRecordingConstants.mode.FILE),
         _localRecording: LocalRecordingManager.isRecordingLocally(),
-        _subtitlesLanguage
+        _subtitlesLanguage,
+        _transcriptionRunning: isRecorderTranscriptionsRunning(state)
     };
 }

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -31,13 +31,14 @@ import {
 import { TRACK_ADDED } from '../base/tracks/actionTypes';
 import { hideNotification, showErrorNotification, showNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
-import { isRecorderTranscriptionsRunning } from '../transcribing/functions';
+import { isRecorderTranscriptionsRunning, isTranscribing } from '../transcribing/functions';
 
 import { RECORDING_SESSION_UPDATED, START_LOCAL_RECORDING, STOP_LOCAL_RECORDING } from './actionTypes';
 import {
     clearRecordingSessions,
     hidePendingRecordingNotification,
     markConsentRequested,
+    setStartRecordingIntent,
     showPendingRecordingNotification,
     showRecordingError,
     showRecordingWarning,
@@ -55,7 +56,8 @@ import {
     RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID,
     RECORDING_OFF_SOUND_ID,
     RECORDING_ON_SOUND_ID,
-    START_RECORDING_NOTIFICATION_ID
+    START_RECORDING_NOTIFICATION_ID,
+    TRANSCRIPTION_ON_SOUND_ID
 } from './constants';
 import {
     getResourceId,
@@ -72,6 +74,119 @@ import logger from './logger';
 const sessionsWithTranscription = new Map<string, boolean>();
 
 /**
+ * Pending notification data stored when the notification is deferred
+ * until both recording and transcription have resolved.
+ */
+let pendingNotificationInitiator: { getId: Function; } | string | undefined;
+let pendingNotificationSessionId: string | undefined;
+let pendingNotificationMode: string | undefined;
+
+/**
+ * Evaluates whether all intended services (recording and/or transcription) have
+ * resolved (succeeded or failed) and plays the appropriate start sound and notification.
+ *
+ * Intent source:
+ *  - Local client: startRecordingIntent (synchronous Redux flag from dialog).
+ *  - Remote client: room metadata (isRecordingRequested + isTranscribingEnabled).
+ *
+ * Resolution is derived from existing Redux state — no separate tracking needed.
+ *
+ * Called from:
+ *  - Recording middleware when RECORDING_SESSION_UPDATED arrives with ON or error.
+ *  - Transcription subscriber when isRecorderTranscriptionsRunning becomes true.
+ *  - Subtitles middleware when conference.dial() fails.
+ *  - Transcribing middleware when TRANSCRIBER_LEFT abruptly.
+ *  - Metadata change listener when room metadata updates.
+ *
+ * @param {Function} dispatch - Redux dispatch.
+ * @param {Function} getState - Redux getState.
+ * @returns {void}
+ */
+export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState: IStore['getState']) {
+    const state = getState();
+
+    // Determine intent: local client uses Redux flag, remote uses metadata.
+    const localIntent = state['features/recording'].startRecordingIntent;
+    const metadata = state['features/base/conference'].metadata?.recording;
+
+    const wantsRecording = localIntent?.recording ?? metadata?.isRecordingRequested ?? false;
+    const wantsTranscription = localIntent?.transcription ?? metadata?.isTranscribingEnabled ?? false;
+
+    // No intent from either source — nothing to coordinate.
+    if (!wantsRecording && !wantsTranscription) {
+        return;
+    }
+
+    const { sessionDatas } = state['features/recording'];
+    const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
+
+    // Derive recording resolution from session data.
+    const recordingOn = sessionDatas.some(
+        sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON);
+    const recordingFailed = sessionDatas.some(
+        sd => sd.mode === modeConstants.FILE && sd.error);
+    const recordingResolved = !wantsRecording || recordingOn || recordingFailed;
+
+    // Derive transcription resolution from existing state.
+    const transcriptionOn = isRecorderTranscriptionsRunning(state) || isTranscribing(state);
+    const transcriptionFailed = state['features/subtitles']._hasError;
+    const transcriptionResolved = !wantsTranscription || transcriptionOn || transcriptionFailed;
+
+    // Wait until all intended services have resolved.
+    if (!recordingResolved || !transcriptionResolved) {
+        return;
+    }
+
+    // Both resolved — determine which sound to play.
+    let soundID: string | undefined;
+
+    if (recordingOn && transcriptionOn) {
+        soundID = RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID;
+    } else if (recordingOn) {
+        soundID = RECORDING_ON_SOUND_ID;
+    } else if (transcriptionOn) {
+        soundID = TRANSCRIPTION_ON_SOUND_ID;
+    }
+    // If both failed — no start sound (error notifications handle it).
+
+    if (soundID) {
+        dispatch(playSound(soundID));
+    }
+
+    // Store final state in sessionsWithTranscription for the stop sound later.
+    const activeSession = sessionDatas.find(
+        sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON);
+
+    if (activeSession?.id) {
+        sessionsWithTranscription.set(activeSession.id, recordingOn && transcriptionOn);
+    }
+
+    // Show deferred notification if we have a pending initiator.
+    if (pendingNotificationInitiator && pendingNotificationMode && pendingNotificationSessionId) {
+        const finalWillTranscribe = recordingOn && transcriptionOn;
+
+        dispatch(showStartedRecordingNotification(
+            pendingNotificationMode, pendingNotificationInitiator,
+            pendingNotificationSessionId, finalWillTranscribe));
+        pendingNotificationInitiator = undefined;
+        pendingNotificationSessionId = undefined;
+        pendingNotificationMode = undefined;
+    } else if (transcriptionOn && !recordingOn) {
+        // Transcription-only case (recording failed or wasn't requested).
+        // Show transcription notification since there's no pending recording notification.
+        dispatch(showNotification({
+            descriptionKey: 'transcribing.on',
+            titleKey: 'dialog.recording'
+        }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
+    }
+
+    // Clear local intent — prevents re-triggering.
+    if (localIntent) {
+        dispatch(setStartRecordingIntent(null));
+    }
+}
+
+/**
  * StateListenerRegistry provides a reliable way to detect the leaving of a
  * conference, where we need to clean up the recording sessions.
  */
@@ -81,6 +196,22 @@ StateListenerRegistry.register(
         if (!conference) {
             dispatch(clearRecordingSessions());
             sessionsWithTranscription.clear();
+            pendingNotificationInitiator = undefined;
+            pendingNotificationSessionId = undefined;
+            pendingNotificationMode = undefined;
+        }
+    }
+);
+
+/**
+ * Listen for metadata changes to trigger sound coordination on the remote side.
+ * When metadata arrives with recording intent, re-evaluate whether we can play the sound.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => state['features/base/conference'].metadata?.recording,
+    /* listener */ (recordingMetadata, { dispatch, getState }, previousValue) => {
+        if (!previousValue && recordingMetadata) {
+            maybeNotifyRecordingStart(dispatch, getState);
         }
     }
 );
@@ -242,40 +373,6 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         if (updatedSessionData?.status === ON) {
             const sessionId = action.sessionData.id;
 
-            // Determine willTranscribe once for consistent sound + notification.
-            // On the first ON update we compute and store it; on subsequent ON
-            // updates (e.g. the jicofo update that carries the initiator) we
-            // read the stored value so the notification text matches the sound.
-            let willTranscribe: boolean | undefined;
-
-            if (mode === JitsiRecordingConstants.mode.FILE) {
-                if (oldSessionData?.status !== ON) {
-                    const isTranscribing = isRecorderTranscriptionsRunning(state);
-                    const isRequestingTranscription = state['features/subtitles']._requestingSubtitles;
-
-                    willTranscribe = isTranscribing || isRequestingTranscription;
-
-                    if (sessionId) {
-                        sessionsWithTranscription.set(sessionId, willTranscribe);
-                    }
-                } else {
-                    // On subsequent ON updates, start from the stored value
-                    // but also re-check live state: if transcription started
-                    // between the first and second ON update, upgrade to true
-                    // so the notification text reflects reality.
-                    const storedValue = sessionId
-                        ? sessionsWithTranscription.get(sessionId) : undefined;
-                    const currentlyTranscribing = isRecorderTranscriptionsRunning(state)
-                        || state['features/subtitles']._requestingSubtitles;
-
-                    willTranscribe = storedValue || currentlyTranscribing;
-
-                    if (willTranscribe && !storedValue && sessionId) {
-                        sessionsWithTranscription.set(sessionId, true);
-                    }
-                }
-            }
-
             // We receive 2 updates of the session status ON. The first one is from jibri when it joins.
             // The second one is from jicofo which will deliver the initiator value. Since the start
             // recording notification uses the initiator value we skip the jibri update and show the
@@ -283,32 +380,38 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
             // FIXME: simplify checks when the backend start sending only one status ON update containing
             // the initiator.
             if (initiator && !oldSessionData?.initiator) {
-                dispatch(showStartedRecordingNotification(mode, initiator, sessionId, willTranscribe));
+                const localIntent = state['features/recording'].startRecordingIntent;
+                const metadata = state['features/base/conference'].metadata?.recording;
+                const wantsTranscription = localIntent?.transcription ?? metadata?.isTranscribingEnabled ?? false;
+
+                if (wantsTranscription) {
+                    // Defer notification — maybeNotifyRecordingStart will show it
+                    // once both recording and transcription have resolved.
+                    pendingNotificationInitiator = initiator;
+                    pendingNotificationSessionId = sessionId;
+                    pendingNotificationMode = mode;
+
+                    // Re-evaluate in case both services already resolved.
+                    maybeNotifyRecordingStart(dispatch, getState);
+                } else {
+                    dispatch(showStartedRecordingNotification(mode, initiator, sessionId, false));
+                }
             }
 
             if (oldSessionData?.status !== ON) {
                 sendAnalytics(createRecordingEvent('start', mode));
 
-                let soundID;
-
                 if (mode === JitsiRecordingConstants.mode.FILE) {
-                    if (willTranscribe) {
-                        soundID = RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID;
-                    } else {
-                        soundID = RECORDING_ON_SOUND_ID;
-                    }
+                    // maybeNotifyRecordingStart handles both local (via startRecordingIntent)
+                    // and remote (via metadata). It waits for all intended services to resolve.
+                    maybeNotifyRecordingStart(dispatch, getState);
                 } else if (mode === JitsiRecordingConstants.mode.STREAM) {
-                    soundID = LIVE_STREAMING_ON_SOUND_ID;
-                }
-
-                if (soundID) {
-                    dispatch(playSound(soundID));
+                    dispatch(playSound(LIVE_STREAMING_ON_SOUND_ID));
                 }
 
                 if (typeof APP !== 'undefined') {
                     APP.API.notifyRecordingStatusChanged(
-                        true, mode, undefined,
-                        willTranscribe ?? isRecorderTranscriptionsRunning(state));
+                        true, mode, undefined, isRecorderTranscriptionsRunning(state));
                 }
             }
         } else if (updatedSessionData?.status === OFF && oldSessionData?.status !== OFF) {
@@ -461,6 +564,15 @@ function _showRecordingErrorNotification(session: any, dispatch: IStore['dispatc
 
     if (typeof APP !== 'undefined') {
         APP.API.notifyRecordingStatusChanged(false, mode, error, isRecorderTranscriptionsRunning(getState()));
+    }
+
+    // Recording failed — re-evaluate. maybeNotifyRecordingStart derives state from
+    // sessionDatas (which now has the error) and will play transcription-only sound
+    // if transcription succeeded.
+    const intent = getState()['features/recording'].startRecordingIntent;
+
+    if (intent) {
+        maybeNotifyRecordingStart(dispatch, getState);
     }
 }
 

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -39,6 +39,7 @@ import {
     hidePendingRecordingNotification,
     markConsentRequested,
     setStartRecordingIntent,
+    setStopRecordingIntent,
     showPendingRecordingNotification,
     showRecordingError,
     showRecordingWarning,
@@ -57,6 +58,7 @@ import {
     RECORDING_OFF_SOUND_ID,
     RECORDING_ON_SOUND_ID,
     START_RECORDING_NOTIFICATION_ID,
+    TRANSCRIPTION_OFF_SOUND_ID,
     TRANSCRIPTION_ON_SOUND_ID
 } from './constants';
 import {
@@ -67,32 +69,24 @@ import {
     unregisterRecordingAudioFiles
 } from './functions';
 import logger from './logger';
-
-/**
- * Map to track which recording sessions have transcription enabled.
- */
-const sessionsWithTranscription = new Map<string, boolean>();
-
-/**
- * Pending notification data stored when the notification is deferred
- * until both recording and transcription have resolved.
- */
-let pendingNotificationInitiator: { getId: Function; } | string | undefined;
-let pendingNotificationSessionId: string | undefined;
-let pendingNotificationMode: string | undefined;
+import { ISessionData } from './reducer';
 
 /**
  * Evaluates whether all intended services (recording and/or transcription) have
  * resolved (succeeded or failed) and plays the appropriate start sound and notification.
  *
- * Intent source:
- *  - Local client: startRecordingIntent (synchronous Redux flag from dialog).
- *  - Remote client: room metadata (isRecordingRequested + isTranscribingEnabled).
+ * Intent source: {@code startRecordingIntent} — populated on the local side by the
+ * start dialog / auto-start callback, and on remote observers by the metadata listener
+ * when a false→true transition of isRecordingRequested / isTranscribingEnabled is seen.
  *
  * Resolution is derived from existing Redux state — no separate tracking needed.
+ * The recording notification's "started by …" name is read directly from the active
+ * FILE session in {@code sessionDatas}. When recording is on but the initiator has not
+ * yet been delivered by jicofo, the function waits — keeping the intent alive.
  *
  * Called from:
- *  - Recording middleware when RECORDING_SESSION_UPDATED arrives with ON or error.
+ *  - Recording middleware when RECORDING_SESSION_UPDATED arrives with the initiator
+ *    (jicofo update) or with an error.
  *  - Transcription subscriber when isRecorderTranscriptionsRunning becomes true.
  *  - Subtitles middleware when conference.dial() fails.
  *  - Transcribing middleware when TRANSCRIBER_LEFT abruptly.
@@ -105,14 +99,12 @@ let pendingNotificationMode: string | undefined;
 export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState: IStore['getState']) {
     const state = getState();
 
-    // Determine intent: local client uses Redux flag, remote uses metadata.
-    const localIntent = state['features/recording'].startRecordingIntent;
-    const metadata = state['features/base/conference'].metadata?.recording;
+    const intent = state['features/recording'].startRecordingIntent;
 
-    const wantsRecording = localIntent?.recording ?? metadata?.isRecordingRequested ?? false;
-    const wantsTranscription = localIntent?.transcription ?? metadata?.isTranscribingEnabled ?? false;
+    const wantsRecording = Boolean(intent?.recording);
+    const wantsTranscription = Boolean(intent?.transcription);
 
-    // No intent from either source — nothing to coordinate. Most probably we haven't received the metadata yet.
+    // No intent — nothing to coordinate.
     if (!wantsRecording && !wantsTranscription) {
         return;
     }
@@ -120,11 +112,11 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
     const { sessionDatas } = state['features/recording'];
     const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
 
-    // Derive recording resolution from session data.
-    const recordingOn = sessionDatas.some(
-        sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON);
-    const recordingFailed = sessionDatas.some(
-        sd => sd.mode === modeConstants.FILE && sd.error);
+    // Locate the active FILE recording session (if any) and derive its state.
+    const fileSession = sessionDatas.find(sd => sd.mode === modeConstants.FILE
+        && (sd.status === statusConstants.ON || sd.error));
+    const recordingOn = fileSession?.status === statusConstants.ON;
+    const recordingFailed = Boolean(fileSession?.error);
     const recordingResolved = !wantsRecording || recordingOn || recordingFailed;
 
     // Derive transcription resolution from existing state.
@@ -141,7 +133,19 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
         return;
     }
 
-    // Both resolved — determine which sound to play.
+    // Recording is on but jicofo hasn't yet delivered the initiator. Wait for it
+    // so the notification text reflects who started the recording.
+    if (recordingOn && (!fileSession?.initiator || !fileSession.id)) {
+        return;
+    }
+
+    // Clear the intent BEFORE dispatching below to avoid a re-entrancy double
+    // fire — see the matching comment in maybeNotifyRecordingStop.
+    if (intent) {
+        dispatch(setStartRecordingIntent(null));
+    }
+
+    // Determine sound to play now that all intended services have resolved.
     let soundID: string | undefined;
 
     if (recordingOn && transcriptionOn) {
@@ -157,39 +161,117 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
         dispatch(playSound(soundID));
     }
 
-    // Store final state in sessionsWithTranscription for the stop sound later.
-    const activeSession = sessionDatas.find(
-        sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON);
-
-    if (activeSession?.id) {
-        sessionsWithTranscription.set(activeSession.id, recordingOn && transcriptionOn);
-    }
-
-    // Show deferred notification if we have a pending initiator.
-    if (pendingNotificationInitiator && pendingNotificationMode && pendingNotificationSessionId) {
-        const finalWillTranscribe = recordingOn && transcriptionOn;
-
+    if (recordingOn && fileSession?.initiator && fileSession.id) {
         dispatch(showStartedRecordingNotification(
-            pendingNotificationMode,
-            pendingNotificationInitiator,
-            pendingNotificationSessionId,
-            finalWillTranscribe));
-
-        pendingNotificationInitiator = undefined;
-        pendingNotificationSessionId = undefined;
-        pendingNotificationMode = undefined;
+            modeConstants.FILE,
+            fileSession.initiator,
+            fileSession.id,
+            recordingOn && transcriptionOn));
     } else if (transcriptionOn && !recordingOn) {
         // Transcription-only case (recording failed or wasn't requested).
-        // Show transcription notification since there's no pending recording notification.
         dispatch(showNotification({
             descriptionKey: 'transcribing.on',
             titleKey: 'dialog.recording'
         }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
     }
+}
 
-    // Clear local intent — prevents re-triggering.
-    if (localIntent) {
-        dispatch(setStartRecordingIntent(null));
+/**
+ * Evaluates whether all intended services (recording and/or transcription) that
+ * are being stopped have resolved, and plays the appropriate off sound and
+ * notification. Mirror of {@link maybeNotifyRecordingStart}.
+ *
+ * Intent source: {@code stopRecordingIntent} — populated on the local side by the
+ * stop dialog, and on remote observers by the metadata listener when a true→false
+ * transition of isRecordingRequested / isTranscribingEnabled is seen.
+ *
+ * Called from:
+ *  - Metadata change listener on true→false transitions.
+ *  - Recording middleware when RECORDING_SESSION_UPDATED arrives with OFF.
+ *  - Transcription subscriber when isRecorderTranscriptionsRunning becomes false.
+ *  - Transcribing middleware when TRANSCRIBER_LEFT abruptly.
+ *
+ * @param {Function} dispatch - Redux dispatch.
+ * @param {Function} getState - Redux getState.
+ * @returns {void}
+ */
+export function maybeNotifyRecordingStop(dispatch: IStore['dispatch'], getState: IStore['getState']) {
+    const state = getState();
+    const intent = state['features/recording'].stopRecordingIntent;
+
+    if (!intent) {
+        return;
+    }
+
+    const { sessionDatas } = state['features/recording'];
+    const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
+
+    // Recording resolves when there's no active/pending FILE session.
+    const activeFileSession = sessionDatas.find(sd =>
+        sd.mode === modeConstants.FILE
+        && (sd.status === statusConstants.ON || sd.status === statusConstants.PENDING));
+    const recordingResolved = !intent.recording || !activeFileSession;
+
+    // Transcription resolves when the selector flips false.
+    const transcriptionResolved = !intent.transcription || !isRecorderTranscriptionsRunning(state);
+
+    if (!recordingResolved || !transcriptionResolved) {
+        return;
+    }
+
+    // Determine sounds + notification.
+    let onSoundID: string | undefined;
+    let offSoundID: string | undefined;
+
+    if (intent.recording && intent.transcription) {
+        onSoundID = RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID;
+        offSoundID = RECORDING_AND_TRANSCRIPTION_OFF_SOUND_ID;
+    } else if (intent.recording) {
+        onSoundID = RECORDING_ON_SOUND_ID;
+        offSoundID = RECORDING_OFF_SOUND_ID;
+    } else if (intent.transcription) {
+        onSoundID = TRANSCRIPTION_ON_SOUND_ID;
+        offSoundID = TRANSCRIPTION_OFF_SOUND_ID;
+    }
+
+    // Clear the intent BEFORE dispatching below. Otherwise the first dispatch
+    // re-enters StateListenerRegistry synchronously; the isRecorderTranscriptionsRunning
+    // subscriber (in ../transcribing/subscriber) can fire in that nested walk
+    // with an unresolved prevSel and call back into this function while intent
+    // is still set — producing a duplicate notification. Reading intent into a
+    // local const above keeps the branches below correct.
+    dispatch(setStopRecordingIntent(null));
+
+    if (offSoundID) {
+        if (onSoundID) {
+            dispatch(stopSound(onSoundID));
+        }
+        dispatch(playSound(offSoundID));
+    }
+
+    if (intent.recording) {
+        // Pick the most recent FILE OFF session so the "stopped by …" name
+        // reflects the current stop, not a stale earlier cycle left in
+        // sessionDatas. sessionDatas is append-order, so the last match wins.
+        let offSession: ISessionData | undefined;
+
+        sessionDatas.forEach(sd => {
+            if (sd.mode === modeConstants.FILE && sd.status === statusConstants.OFF) {
+                offSession = sd;
+            }
+        });
+
+        const participantName = offSession?.terminator
+            ? getParticipantDisplayName(state, getResourceId(offSession.terminator))
+            : undefined;
+
+        dispatch(showStoppedRecordingNotification(
+            modeConstants.FILE, participantName, intent.transcription));
+    } else if (intent.transcription) {
+        dispatch(showNotification({
+            descriptionKey: 'transcribing.off',
+            titleKey: 'dialog.recording'
+        }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
     }
 }
 
@@ -202,23 +284,52 @@ StateListenerRegistry.register(
     /* listener */ (conference, { dispatch }) => {
         if (!conference) {
             dispatch(clearRecordingSessions());
-            sessionsWithTranscription.clear();
-            pendingNotificationInitiator = undefined;
-            pendingNotificationSessionId = undefined;
-            pendingNotificationMode = undefined;
         }
     }
 );
 
 /**
- * Listen for metadata changes to trigger sound coordination on the remote side.
- * When metadata arrives with recording intent, re-evaluate whether we can play the sound.
+ * Listen for metadata changes to coordinate start/stop sound on the remote side.
+ * Detects false↔true transitions for {@code isRecordingRequested} and
+ * {@code isTranscribingEnabled} and seeds the corresponding intent for remote
+ * observers. Local initiators already have the intent set synchronously from
+ * their dialog — the {@code if (!existing)} guard prevents clobbering.
  */
 StateListenerRegistry.register(
     /* selector */ state => state['features/base/conference'].metadata?.recording,
     /* listener */ (recordingMetadata, { dispatch, getState }, previousValue) => {
-        if (!previousValue && recordingMetadata) {
+        const prevRec = Boolean(previousValue?.isRecordingRequested);
+        const prevTrans = Boolean(previousValue?.isTranscribingEnabled);
+        const curRec = Boolean(recordingMetadata?.isRecordingRequested);
+        const curTrans = Boolean(recordingMetadata?.isTranscribingEnabled);
+
+        const recordingStarting = !prevRec && curRec;
+        const transcriptionStarting = !prevTrans && curTrans;
+        const recordingStopping = prevRec && !curRec;
+        const transcriptionStopping = prevTrans && !curTrans;
+
+        if (recordingStarting || transcriptionStarting) {
+            const existing = getState()['features/recording'].startRecordingIntent;
+
+            if (!existing) {
+                dispatch(setStartRecordingIntent({
+                    recording: recordingStarting,
+                    transcription: transcriptionStarting
+                }));
+            }
             maybeNotifyRecordingStart(dispatch, getState);
+        }
+
+        if (recordingStopping || transcriptionStopping) {
+            const existing = getState()['features/recording'].stopRecordingIntent;
+
+            if (!existing) {
+                dispatch(setStopRecordingIntent({
+                    recording: recordingStopping,
+                    transcription: transcriptionStopping
+                }));
+            }
+            maybeNotifyRecordingStop(dispatch, getState);
         }
     }
 );
@@ -378,8 +489,6 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         dispatch(hidePendingRecordingNotification(mode));
 
         if (updatedSessionData?.status === ON) {
-            const sessionId = action.sessionData.id;
-
             // We receive 2 updates of the session status ON. The first one is from jibri when it joins.
             // The second one is from jicofo which will deliver the initiator value. Since the start
             // recording notification uses the initiator value we skip the jibri update and show the
@@ -387,34 +496,19 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
             // FIXME: simplify checks when the backend start sending only one status ON update containing
             // the initiator.
             if (initiator && !oldSessionData?.initiator) {
-                const localIntent = state['features/recording'].startRecordingIntent;
-                const metadata = state['features/base/conference'].metadata?.recording;
-                const wantsTranscription = localIntent?.transcription ?? metadata?.isTranscribingEnabled ?? false;
-
-                if (wantsTranscription) {
-                    // Defer notification — maybeNotifyRecordingStart will show it
-                    // once both recording and transcription have resolved.
-                    pendingNotificationInitiator = initiator;
-                    pendingNotificationSessionId = sessionId;
-                    pendingNotificationMode = mode;
-
-                    // Re-evaluate in case both services already resolved.
-                    maybeNotifyRecordingStart(dispatch, getState);
-                } else {
-                    dispatch(showStartedRecordingNotification(mode, initiator, sessionId, false));
-                }
+                // Initiator just became known — let maybeNotifyRecordingStart
+                // decide whether to emit the notification now. It reads the
+                // initiator directly from sessionDatas and gates on its presence.
+                maybeNotifyRecordingStart(dispatch, getState);
             }
 
             if (oldSessionData?.status !== ON) {
                 sendAnalytics(createRecordingEvent('start', mode));
 
-                if (mode === JitsiRecordingConstants.mode.FILE) {
-                    // maybeNotifyRecordingStart handles both local (via startRecordingIntent)
-                    // and remote (via metadata). It waits for all intended services to resolve.
-                    maybeNotifyRecordingStart(dispatch, getState);
-                } else if (mode === JitsiRecordingConstants.mode.STREAM) {
+                if (mode === JitsiRecordingConstants.mode.STREAM) {
                     dispatch(playSound(LIVE_STREAMING_ON_SOUND_ID));
                 }
+                // FILE: no call here — handled by the initiator branch above with maybeNotifyRecordingStart.
 
                 if (typeof APP !== 'undefined') {
                     APP.API.notifyRecordingStatusChanged(
@@ -422,17 +516,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                 }
             }
         } else if (updatedSessionData?.status === OFF && oldSessionData?.status !== OFF) {
-            const participantName = terminator
-                ? getParticipantDisplayName(state, getResourceId(terminator))
-                : undefined;
-
-            // Check if transcription was enabled when the recording started
-            const sessionId = action.sessionData.id;
-            const wasWithTranscription = sessionId ? sessionsWithTranscription.get(sessionId) ?? false : false;
-
-            dispatch(showStoppedRecordingNotification(mode, participantName, wasWithTranscription));
-
-            let duration = 0, soundOff, soundOn;
+            let duration = 0;
 
             if (oldSessionData?.timestamp) {
                 duration
@@ -441,26 +525,18 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
             sendAnalytics(createRecordingEvent('stop', mode, duration));
 
             if (mode === JitsiRecordingConstants.mode.FILE) {
-                if (wasWithTranscription) {
-                    soundOff = RECORDING_AND_TRANSCRIPTION_OFF_SOUND_ID;
-                    soundOn = RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID;
-                } else {
-                    soundOff = RECORDING_OFF_SOUND_ID;
-                    soundOn = RECORDING_ON_SOUND_ID;
-                }
-
-                // Clean up the entry when recording stops
-                if (sessionId) {
-                    sessionsWithTranscription.delete(sessionId);
-                }
+                // Recording OFF is one of the resolution points — let the stop
+                // coordinator decide which sound/notification to play based on
+                // stopRecordingIntent (combined vs recording-only).
+                maybeNotifyRecordingStop(dispatch, getState);
             } else if (mode === JitsiRecordingConstants.mode.STREAM) {
-                soundOff = LIVE_STREAMING_OFF_SOUND_ID;
-                soundOn = LIVE_STREAMING_ON_SOUND_ID;
-            }
+                const participantName = terminator
+                    ? getParticipantDisplayName(state, getResourceId(terminator))
+                    : undefined;
 
-            if (soundOff && soundOn) {
-                dispatch(stopSound(soundOn));
-                dispatch(playSound(soundOff));
+                dispatch(showStoppedRecordingNotification(mode, participantName, false));
+                dispatch(stopSound(LIVE_STREAMING_ON_SOUND_ID));
+                dispatch(playSound(LIVE_STREAMING_OFF_SOUND_ID));
             }
 
             if (typeof APP !== 'undefined') {

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -80,6 +80,7 @@ StateListenerRegistry.register(
     /* listener */ (conference, { dispatch }) => {
         if (!conference) {
             dispatch(clearRecordingSessions());
+            sessionsWithTranscription.clear();
         }
     }
 );
@@ -239,6 +240,41 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         dispatch(hidePendingRecordingNotification(mode));
 
         if (updatedSessionData?.status === ON) {
+            const sessionId = action.sessionData.id;
+
+            // Determine willTranscribe once for consistent sound + notification.
+            // On the first ON update we compute and store it; on subsequent ON
+            // updates (e.g. the jicofo update that carries the initiator) we
+            // read the stored value so the notification text matches the sound.
+            let willTranscribe: boolean | undefined;
+
+            if (mode === JitsiRecordingConstants.mode.FILE) {
+                if (oldSessionData?.status !== ON) {
+                    const isTranscribing = isRecorderTranscriptionsRunning(state);
+                    const isRequestingTranscription = state['features/subtitles']._requestingSubtitles;
+
+                    willTranscribe = isTranscribing || isRequestingTranscription;
+
+                    if (sessionId) {
+                        sessionsWithTranscription.set(sessionId, willTranscribe);
+                    }
+                } else {
+                    // On subsequent ON updates, start from the stored value
+                    // but also re-check live state: if transcription started
+                    // between the first and second ON update, upgrade to true
+                    // so the notification text reflects reality.
+                    const storedValue = sessionId
+                        ? sessionsWithTranscription.get(sessionId) : undefined;
+                    const currentlyTranscribing = isRecorderTranscriptionsRunning(state)
+                        || state['features/subtitles']._requestingSubtitles;
+
+                    willTranscribe = storedValue || currentlyTranscribing;
+
+                    if (willTranscribe && !storedValue && sessionId) {
+                        sessionsWithTranscription.set(sessionId, true);
+                    }
+                }
+            }
 
             // We receive 2 updates of the session status ON. The first one is from jibri when it joins.
             // The second one is from jicofo which will deliver the initiator value. Since the start
@@ -247,25 +283,15 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
             // FIXME: simplify checks when the backend start sending only one status ON update containing
             // the initiator.
             if (initiator && !oldSessionData?.initiator) {
-                dispatch(showStartedRecordingNotification(mode, initiator, action.sessionData.id));
+                dispatch(showStartedRecordingNotification(mode, initiator, sessionId, willTranscribe));
             }
 
             if (oldSessionData?.status !== ON) {
                 sendAnalytics(createRecordingEvent('start', mode));
 
                 let soundID;
-                const isTranscribing = isRecorderTranscriptionsRunning(state);
-                const isRequestingTranscription = state['features/subtitles']._requestingSubtitles;
-                const willTranscribe = isTranscribing || isRequestingTranscription;
 
-                // Store whether transcription was enabled when recording started
                 if (mode === JitsiRecordingConstants.mode.FILE) {
-                    const sessionId = action.sessionData.id;
-
-                    if (sessionId) {
-                        sessionsWithTranscription.set(sessionId, willTranscribe);
-                    }
-
                     if (willTranscribe) {
                         soundID = RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID;
                     } else {
@@ -281,7 +307,8 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
                 if (typeof APP !== 'undefined') {
                     APP.API.notifyRecordingStatusChanged(
-                        true, mode, undefined, isRecorderTranscriptionsRunning(state));
+                        true, mode, undefined,
+                        willTranscribe ?? isRecorderTranscriptionsRunning(state));
                 }
             }
         } else if (updatedSessionData?.status === OFF && oldSessionData?.status !== OFF) {
@@ -289,7 +316,11 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                 ? getParticipantDisplayName(state, getResourceId(terminator))
                 : undefined;
 
-            dispatch(showStoppedRecordingNotification(mode, participantName));
+            // Check if transcription was enabled when the recording started
+            const sessionId = action.sessionData.id;
+            const wasWithTranscription = sessionId ? sessionsWithTranscription.get(sessionId) ?? false : false;
+
+            dispatch(showStoppedRecordingNotification(mode, participantName, wasWithTranscription));
 
             let duration = 0, soundOff, soundOn;
 
@@ -298,10 +329,6 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                     = (Date.now() / 1000) - oldSessionData.timestamp;
             }
             sendAnalytics(createRecordingEvent('stop', mode, duration));
-
-            // Check if transcription was enabled when the recording started
-            const sessionId = action.sessionData.id;
-            const wasWithTranscription = sessionId ? sessionsWithTranscription.get(sessionId) ?? false : false;
 
             if (mode === JitsiRecordingConstants.mode.FILE) {
                 if (wasWithTranscription) {

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -112,7 +112,7 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
     const wantsRecording = localIntent?.recording ?? metadata?.isRecordingRequested ?? false;
     const wantsTranscription = localIntent?.transcription ?? metadata?.isTranscribingEnabled ?? false;
 
-    // No intent from either source — nothing to coordinate.
+    // No intent from either source — nothing to coordinate. Most probably we haven't received the metadata yet.
     if (!wantsRecording && !wantsTranscription) {
         return;
     }
@@ -133,6 +133,10 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
     const transcriptionResolved = !wantsTranscription || transcriptionOn || transcriptionFailed;
 
     // Wait until all intended services have resolved.
+    // Note: In theory (it should never happen here) wantsTranscription/wantsRecording might be false and in the same
+    // time the transcriptionOn/recordingOn might be true. In this case we would play a notification no matter that
+    // wantsTranscription/wantsRecording is false. This is better because the recording/transcription are on and the
+    // user has to be informed. Also if this ever happens it will be noticeable and we will be able to debug/fix.
     if (!recordingResolved || !transcriptionResolved) {
         return;
     }
@@ -166,8 +170,11 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
         const finalWillTranscribe = recordingOn && transcriptionOn;
 
         dispatch(showStartedRecordingNotification(
-            pendingNotificationMode, pendingNotificationInitiator,
-            pendingNotificationSessionId, finalWillTranscribe));
+            pendingNotificationMode,
+            pendingNotificationInitiator,
+            pendingNotificationSessionId,
+            finalWillTranscribe));
+
         pendingNotificationInitiator = undefined;
         pendingNotificationSessionId = undefined;
         pendingNotificationMode = undefined;

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -7,6 +7,7 @@ import {
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
     SET_SELECTED_RECORDING_SERVICE,
+    SET_START_RECORDING_INTENT,
     SET_START_RECORDING_NOTIFICATION_SHOWN,
     SET_STREAM_KEY
 } from './actionTypes';
@@ -30,6 +31,15 @@ export interface ISessionData {
     timestamp?: number;
 }
 
+/**
+ * Tracks the user's intent when starting recording with or without transcription.
+ * Set synchronously before any async operations begin to coordinate sound/notification timing.
+ */
+export interface IStartRecordingIntent {
+    recording: boolean;
+    transcription: boolean;
+}
+
 export interface IRecordingState {
     consentRequested: Set<any>;
     disableHighlightMeetingMoment: boolean;
@@ -38,6 +48,7 @@ export interface IRecordingState {
     };
     selectedRecordingService: string;
     sessionDatas: Array<ISessionData>;
+    startRecordingIntent?: IStartRecordingIntent | null;
     streamKey?: string;
     wasStartRecordingSuggested?: boolean;
 }
@@ -65,7 +76,8 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
         case CLEAR_RECORDING_SESSIONS:
             return {
                 ...state,
-                sessionDatas: []
+                sessionDatas: [],
+                startRecordingIntent: null
             };
 
         case MARK_CONSENT_REQUESTED:
@@ -114,6 +126,12 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
             return {
                 ...state,
                 disableHighlightMeetingMoment: action.disabled
+            };
+
+        case SET_START_RECORDING_INTENT:
+            return {
+                ...state,
+                startRecordingIntent: action.intent
             };
 
         case SET_START_RECORDING_NOTIFICATION_SHOWN:

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -9,6 +9,7 @@ import {
     SET_SELECTED_RECORDING_SERVICE,
     SET_START_RECORDING_INTENT,
     SET_START_RECORDING_NOTIFICATION_SHOWN,
+    SET_STOP_RECORDING_INTENT,
     SET_STREAM_KEY
 } from './actionTypes';
 
@@ -40,6 +41,16 @@ export interface IStartRecordingIntent {
     transcription: boolean;
 }
 
+/**
+ * Tracks what is being stopped (recording and/or transcription). Mirrors
+ * IStartRecordingIntent. Used by maybeNotifyRecordingStop to coordinate the
+ * off-sound/notification across the recording and transcription stop events.
+ */
+export interface IStopRecordingIntent {
+    recording: boolean;
+    transcription: boolean;
+}
+
 export interface IRecordingState {
     consentRequested: Set<any>;
     disableHighlightMeetingMoment: boolean;
@@ -49,6 +60,7 @@ export interface IRecordingState {
     selectedRecordingService: string;
     sessionDatas: Array<ISessionData>;
     startRecordingIntent?: IStartRecordingIntent | null;
+    stopRecordingIntent?: IStopRecordingIntent | null;
     streamKey?: string;
     wasStartRecordingSuggested?: boolean;
 }
@@ -77,7 +89,8 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
             return {
                 ...state,
                 sessionDatas: [],
-                startRecordingIntent: null
+                startRecordingIntent: null,
+                stopRecordingIntent: null
             };
 
         case MARK_CONSENT_REQUESTED:
@@ -132,6 +145,12 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
             return {
                 ...state,
                 startRecordingIntent: action.intent
+            };
+
+        case SET_STOP_RECORDING_INTENT:
+            return {
+                ...state,
+                stopRecordingIntent: action.intent
             };
 
         case SET_START_RECORDING_NOTIFICATION_SHOWN:

--- a/react/features/subtitles/actions.any.ts
+++ b/react/features/subtitles/actions.any.ts
@@ -84,11 +84,14 @@ export function toggleRequestingSubtitles() {
  * @param {boolean} displaySubtitles - Whether to display subtitles or not.
  * @param {string} language - The language of the subtitles.
  * @param {boolean} forceBackendRecordingOn - Whether to force that backend recording is on.
+ * @param {boolean} isRecordingRequested - Whether recording was also requested alongside transcription.
+ * Passed through to metadata so remote clients receive both intent fields in a single atomic update.
  * @returns {{
  *    type: SET_REQUESTING_SUBTITLES,
  *    backendRecordingOn: boolean,
  *    enabled: boolean,
  *    displaySubtitles: boolean,
+ *    isRecordingRequested: boolean,
  *    language: string
  * }}
  */
@@ -96,12 +99,14 @@ export function setRequestingSubtitles(
         enabled: boolean,
         displaySubtitles = true,
         language: string | null = `translation-languages:${DEFAULT_LANGUAGE}`,
-        forceBackendRecordingOn: boolean = false) {
+        forceBackendRecordingOn: boolean = false,
+        isRecordingRequested: boolean = false) {
     return {
         type: SET_REQUESTING_SUBTITLES,
         displaySubtitles,
         enabled,
         forceBackendRecordingOn,
+        isRecordingRequested,
         language
     };
 }

--- a/react/features/subtitles/actions.any.ts
+++ b/react/features/subtitles/actions.any.ts
@@ -86,13 +86,17 @@ export function toggleRequestingSubtitles() {
  * @param {boolean} forceBackendRecordingOn - Whether to force that backend recording is on.
  * @param {boolean} isRecordingRequested - Whether recording was also requested alongside transcription.
  * Passed through to metadata so remote clients receive both intent fields in a single atomic update.
+ * @param {boolean} skipMetadataUpdate - When true, skips setting room metadata. Used when reacting
+ * to a transcriber started by someone else (e.g. autoCaptionOnTranscribe) to avoid overwriting
+ * the initiator's metadata.
  * @returns {{
  *    type: SET_REQUESTING_SUBTITLES,
  *    backendRecordingOn: boolean,
  *    enabled: boolean,
  *    displaySubtitles: boolean,
  *    isRecordingRequested: boolean,
- *    language: string
+ *    language: string,
+ *    skipMetadataUpdate: boolean
  * }}
  */
 export function setRequestingSubtitles(
@@ -100,14 +104,16 @@ export function setRequestingSubtitles(
         displaySubtitles = true,
         language: string | null = `translation-languages:${DEFAULT_LANGUAGE}`,
         forceBackendRecordingOn: boolean = false,
-        isRecordingRequested: boolean = false) {
+        isRecordingRequested: boolean = false,
+        skipMetadataUpdate: boolean = false) {
     return {
         type: SET_REQUESTING_SUBTITLES,
         displaySubtitles,
         enabled,
         forceBackendRecordingOn,
         isRecordingRequested,
-        language
+        language,
+        skipMetadataUpdate
     };
 }
 

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -93,7 +93,10 @@ MiddlewareRegistry.register(store => next => action => {
         const { transcription } = store.getState()['features/base/config'];
 
         if (transcription?.autoCaptionOnTranscribe) {
-            store.dispatch(setRequestingSubtitles(true));
+            // The transcriber was started by someone else — skip metadata update
+            // to avoid overwriting the initiator's isRecordingRequested flag.
+            store.dispatch(setRequestingSubtitles(
+                true, undefined, undefined, undefined, undefined, true));
         }
 
         break;
@@ -101,7 +104,8 @@ MiddlewareRegistry.register(store => next => action => {
     case SET_REQUESTING_SUBTITLES:
         _requestingSubtitlesChange(
             store, action.enabled, action.language,
-            action.forceBackendRecordingOn, action.isRecordingRequested);
+            action.forceBackendRecordingOn, action.isRecordingRequested,
+            action.skipMetadataUpdate);
         break;
     }
 
@@ -351,6 +355,9 @@ function _getPrimaryLanguageCode(language: string) {
  * we start recording, stopping is based on whether isTranscribingEnabled is already set.
  * @param {boolean} isRecordingRequested - Whether recording was also requested alongside transcription.
  * Passed through to metadata so remote clients receive both intent fields in a single atomic update.
+ * @param {boolean} skipMetadataUpdate - When true, skips setting room metadata. Used when reacting
+ * to a transcriber started by someone else (e.g. autoCaptionOnTranscribe) to avoid overwriting
+ * the initiator's metadata.
  * @private
  * @returns {void}
  */
@@ -359,7 +366,8 @@ function _requestingSubtitlesChange(
         enabled: boolean,
         language?: string | null,
         forceBackendRecordingOn: boolean = false,
-        isRecordingRequested: boolean = false) {
+        isRecordingRequested: boolean = false,
+        skipMetadataUpdate: boolean = false) {
     const state = getState();
     const { conference } = state['features/base/conference'];
     const backendRecordingOn = conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription;
@@ -395,7 +403,7 @@ function _requestingSubtitlesChange(
                 });
         }
 
-        if (backendRecordingOn || forceBackendRecordingOn) {
+        if (!skipMetadataUpdate && (backendRecordingOn || forceBackendRecordingOn)) {
             conference?.getMetadataHandler()?.setMetadata(RECORDING_METADATA_ID, {
                 isTranscribingEnabled: true,
                 ...(isRecordingRequested && { isRecordingRequested: true })

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -9,6 +9,7 @@ import { TRANSCRIBER_ID } from '../base/participants/constants';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { showErrorNotification } from '../notifications/actions';
 import { RECORDING_METADATA_ID } from '../recording/constants';
+import { maybeNotifyRecordingStart } from '../recording/middleware';
 import { TRANSCRIBER_JOINED } from '../transcribing/actionTypes';
 
 import {
@@ -98,7 +99,9 @@ MiddlewareRegistry.register(store => next => action => {
         break;
     }
     case SET_REQUESTING_SUBTITLES:
-        _requestingSubtitlesChange(store, action.enabled, action.language, action.forceBackendRecordingOn);
+        _requestingSubtitlesChange(
+            store, action.enabled, action.language,
+            action.forceBackendRecordingOn, action.isRecordingRequested);
         break;
     }
 
@@ -346,6 +349,8 @@ function _getPrimaryLanguageCode(language: string) {
  * @param {string} language - The language to use for translation.
  * @param {boolean} forceBackendRecordingOn - Whether to force backend recording is on or not. This is used only when
  * we start recording, stopping is based on whether isTranscribingEnabled is already set.
+ * @param {boolean} isRecordingRequested - Whether recording was also requested alongside transcription.
+ * Passed through to metadata so remote clients receive both intent fields in a single atomic update.
  * @private
  * @returns {void}
  */
@@ -353,7 +358,8 @@ function _requestingSubtitlesChange(
         { dispatch, getState }: IStore,
         enabled: boolean,
         language?: string | null,
-        forceBackendRecordingOn: boolean = false) {
+        forceBackendRecordingOn: boolean = false,
+        isRecordingRequested: boolean = false) {
     const state = getState();
     const { conference } = state['features/base/conference'];
     const backendRecordingOn = conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription;
@@ -377,12 +383,22 @@ function _requestingSubtitlesChange(
                         titleKey: 'transcribing.failed'
                     }));
                     dispatch(setSubtitlesError(true));
+
+                    // Transcription failed — re-evaluate. _hasError is now true,
+                    // so maybeNotifyRecordingStart will see transcription as resolved-failed
+                    // and play recording-only sound if recording succeeded.
+                    const intent = getState()['features/recording'].startRecordingIntent;
+
+                    if (intent) {
+                        maybeNotifyRecordingStart(dispatch, getState);
+                    }
                 });
         }
 
         if (backendRecordingOn || forceBackendRecordingOn) {
             conference?.getMetadataHandler()?.setMetadata(RECORDING_METADATA_ID, {
-                isTranscribingEnabled: true
+                isTranscribingEnabled: true,
+                ...(isRecordingRequested && { isRecordingRequested: true })
             });
         }
     }
@@ -396,6 +412,7 @@ function _requestingSubtitlesChange(
     if (!enabled && (backendRecordingOn || forceBackendRecordingOn)
         && conference?.getMetadataHandler()?.getMetadata()[RECORDING_METADATA_ID]?.isTranscribingEnabled) {
         conference?.getMetadataHandler()?.setMetadata(RECORDING_METADATA_ID, {
+            isRecordingRequested: false,
             isTranscribingEnabled: false
         });
     }

--- a/react/features/transcribing/middleware.ts
+++ b/react/features/transcribing/middleware.ts
@@ -1,5 +1,7 @@
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { showErrorNotification } from '../notifications/actions';
+import { maybeNotifyRecordingStart } from '../recording/middleware';
+import { setSubtitlesError } from '../subtitles/actions.any';
 
 import { TRANSCRIBER_LEFT } from './actionTypes';
 import './subscriber';
@@ -10,15 +12,26 @@ import './subscriber';
  * @param {Store} store - The redux store.
  * @returns {Function}
  */
-MiddlewareRegistry.register(({ dispatch }) => next => action => {
+MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
     switch (action.type) {
-    case TRANSCRIBER_LEFT:
+    case TRANSCRIBER_LEFT: {
         if (action.abruptly) {
             dispatch(showErrorNotification({
                 titleKey: 'transcribing.failed'
             }));
+
+            // TRANSCRIBER_LEFT resets subtitles state to default (_hasError: false).
+            // If we're in the coordinated start flow, we need _hasError = true
+            // so maybeNotifyRecordingStart sees transcription as resolved-failed.
+            const intent = getState()['features/recording'].startRecordingIntent;
+
+            if (intent) {
+                dispatch(setSubtitlesError(true));
+                maybeNotifyRecordingStart(dispatch, getState);
+            }
         }
         break;
+    }
     }
 
     return next(action);

--- a/react/features/transcribing/middleware.ts
+++ b/react/features/transcribing/middleware.ts
@@ -1,6 +1,6 @@
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import { showErrorNotification } from '../notifications/actions';
-import { maybeNotifyRecordingStart } from '../recording/middleware';
+import { maybeNotifyRecordingStart, maybeNotifyRecordingStop } from '../recording/middleware';
 import { setSubtitlesError } from '../subtitles/actions.any';
 
 import { TRANSCRIBER_LEFT } from './actionTypes';
@@ -23,11 +23,19 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
             // TRANSCRIBER_LEFT resets subtitles state to default (_hasError: false).
             // If we're in the coordinated start flow, we need _hasError = true
             // so maybeNotifyRecordingStart sees transcription as resolved-failed.
-            const intent = getState()['features/recording'].startRecordingIntent;
+            const startIntent = getState()['features/recording'].startRecordingIntent;
 
-            if (intent) {
+            if (startIntent) {
                 dispatch(setSubtitlesError(true));
                 maybeNotifyRecordingStart(dispatch, getState);
+            }
+
+            // If we're in the coordinated stop flow, the transcriber leaving is
+            // the transcription resolution — re-evaluate.
+            const stopIntent = getState()['features/recording'].stopRecordingIntent;
+
+            if (stopIntent) {
+                maybeNotifyRecordingStop(dispatch, getState);
             }
         }
         break;

--- a/react/features/transcribing/subscriber.ts
+++ b/react/features/transcribing/subscriber.ts
@@ -12,6 +12,7 @@ import {
     TRANSCRIPTION_ON_SOUND_ID
 } from '../recording/constants';
 import { isLiveStreamingRunning, isRecordingRunning } from '../recording/functions';
+import { maybeNotifyRecordingStart } from '../recording/middleware';
 
 import { isRecorderTranscriptionsRunning, isTranscribing } from './functions';
 
@@ -27,7 +28,10 @@ StateListenerRegistry.register(
         }
 
         if (isRecorderTranscriptionsRunningValue) {
-            maybeEmitRecordingNotification(dispatch, getState, true);
+            // Always go through maybeNotifyRecordingStart which checks metadata for the
+            // full intent before deciding what sound/notification to play. This ensures
+            // we never play a transcription-only sound when recording was also requested.
+            maybeNotifyRecordingStart(dispatch, getState);
         } else {
             maybeEmitRecordingNotification(dispatch, getState, false);
         }
@@ -62,7 +66,15 @@ StateListenerRegistry.register(
 function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: IStore['getState'], on: boolean) {
     const state = getState();
     const { sessionDatas } = state['features/recording'];
+    const localIntent = state['features/recording'].startRecordingIntent;
+    const metadata = state['features/base/conference'].metadata?.recording;
     const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
+
+    // If a coordinated recording+transcription start is in progress (local or remote), suppress.
+    // maybeNotifyRecordingStart will emit the appropriate combined notification instead.
+    if (localIntent?.recording || metadata?.isRecordingRequested) {
+        return;
+    }
 
     if (sessionDatas.some(sd => sd.mode === modeConstants.FILE
         && (sd.status === statusConstants.ON || sd.status === statusConstants.PENDING))) {

--- a/react/features/transcribing/subscriber.ts
+++ b/react/features/transcribing/subscriber.ts
@@ -64,8 +64,18 @@ function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: 
     const { sessionDatas } = state['features/recording'];
     const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
 
-    if (sessionDatas.some(sd => sd.mode === modeConstants.FILE && sd.status === statusConstants.ON)) {
-        // If a recording is still ongoing, don't send any notification.
+    if (sessionDatas.some(sd => sd.mode === modeConstants.FILE
+        && (sd.status === statusConstants.ON || sd.status === statusConstants.PENDING))) {
+        // If a recording is ongoing or about to start, don't send a transcription-only notification.
+        // The recording middleware will emit the appropriate combined notification instead.
+        return;
+    }
+
+    // When transcription is turning off and a FILE recording recently stopped (status OFF),
+    // the recording middleware already played the combined stop sound/notification.
+    // Suppress the duplicate transcription-only stop notification.
+    if (!on && sessionDatas.some(sd => sd.mode === modeConstants.FILE
+        && sd.status === statusConstants.OFF)) {
         return;
     }
 
@@ -91,11 +101,24 @@ function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: 
 function notifyTranscribingStatusChanged(getState: IStore['getState'], on: boolean) {
     if (typeof APP !== 'undefined') {
         const state = getState();
+        const { sessionDatas } = state['features/recording'];
+        const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
         const isRecording = isRecordingRunning(state);
         const isStreaming = isLiveStreamingRunning(state);
-        const mode = isRecording ? JitsiRecordingConstants.mode.FILE : JitsiRecordingConstants.mode.STREAM;
 
-        APP.API.notifyRecordingStatusChanged(isRecording || isStreaming, mode, undefined, on);
+        // Only call notifyRecordingStatusChanged when there is no active FILE recording
+        // session. During recording session transitions (ON/PENDING), the recording
+        // middleware already reports the recording + transcription state accurately.
+        // This avoids duplicate or contradictory API calls.
+        const hasActiveFileSession = sessionDatas.some(sd => sd.mode === modeConstants.FILE
+            && (sd.status === statusConstants.ON || sd.status === statusConstants.PENDING));
+
+        if (!hasActiveFileSession) {
+            const mode = isRecording ? modeConstants.FILE : modeConstants.STREAM;
+
+            APP.API.notifyRecordingStatusChanged(isRecording || isStreaming, mode, undefined, on);
+        }
+
         APP.API.notifyTranscribingStatusChanged(on);
     }
 }

--- a/react/features/transcribing/subscriber.ts
+++ b/react/features/transcribing/subscriber.ts
@@ -1,18 +1,8 @@
-import { batch } from 'react-redux';
-
 import { IStore } from '../app/types';
 import { JitsiRecordingConstants } from '../base/lib-jitsi-meet';
 import StateListenerRegistry from '../base/redux/StateListenerRegistry';
-import { playSound } from '../base/sounds/actions';
-import { showNotification } from '../notifications/actions';
-import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
-import { INotificationProps } from '../notifications/types';
-import {
-    TRANSCRIPTION_OFF_SOUND_ID,
-    TRANSCRIPTION_ON_SOUND_ID
-} from '../recording/constants';
 import { isLiveStreamingRunning, isRecordingRunning } from '../recording/functions';
-import { maybeNotifyRecordingStart } from '../recording/middleware';
+import { maybeNotifyRecordingStart, maybeNotifyRecordingStop } from '../recording/middleware';
 
 import { isRecorderTranscriptionsRunning, isTranscribing } from './functions';
 
@@ -28,12 +18,11 @@ StateListenerRegistry.register(
         }
 
         if (isRecorderTranscriptionsRunningValue) {
-            // Always go through maybeNotifyRecordingStart which checks metadata for the
-            // full intent before deciding what sound/notification to play. This ensures
-            // we never play a transcription-only sound when recording was also requested.
+            // Coordinate the start sound/notification with any concurrent recording start.
             maybeNotifyRecordingStart(dispatch, getState);
         } else {
-            maybeEmitRecordingNotification(dispatch, getState, false);
+            // Coordinate the stop sound/notification with any concurrent recording stop.
+            maybeNotifyRecordingStop(dispatch, getState);
         }
     }
 );
@@ -52,56 +41,6 @@ StateListenerRegistry.register(
         }
     }
 );
-
-/**
- * Emit a recording started / stopped notification if the transcription started / stopped. Only
- * if there is no recording in progress.
- *
- * @param {Dispatch} dispatch - The Redux dispatch function.
- * @param {Function} getState - The Redux state.
- * @param {boolean} on - Whether the transcription is on or not.
- *
- * @returns {void}
- */
-function maybeEmitRecordingNotification(dispatch: IStore['dispatch'], getState: IStore['getState'], on: boolean) {
-    const state = getState();
-    const { sessionDatas } = state['features/recording'];
-    const localIntent = state['features/recording'].startRecordingIntent;
-    const metadata = state['features/base/conference'].metadata?.recording;
-    const { mode: modeConstants, status: statusConstants } = JitsiRecordingConstants;
-
-    // If a coordinated recording+transcription start is in progress (local or remote), suppress.
-    // maybeNotifyRecordingStart will emit the appropriate combined notification instead.
-    if (localIntent?.recording || metadata?.isRecordingRequested) {
-        return;
-    }
-
-    if (sessionDatas.some(sd => sd.mode === modeConstants.FILE
-        && (sd.status === statusConstants.ON || sd.status === statusConstants.PENDING))) {
-        // If a recording is ongoing or about to start, don't send a transcription-only notification.
-        // The recording middleware will emit the appropriate combined notification instead.
-        return;
-    }
-
-    // When transcription is turning off and a FILE recording recently stopped (status OFF),
-    // the recording middleware already played the combined stop sound/notification.
-    // Suppress the duplicate transcription-only stop notification.
-    if (!on && sessionDatas.some(sd => sd.mode === modeConstants.FILE
-        && sd.status === statusConstants.OFF)) {
-        return;
-    }
-
-    // Show transcription-specific notification when there's no recording
-    const notifyProps: INotificationProps = {
-        descriptionKey: on ? 'transcribing.on' : 'transcribing.off',
-        titleKey: 'dialog.recording'
-    };
-
-    batch(() => {
-        dispatch(showNotification(notifyProps, NOTIFICATION_TIMEOUT_TYPE.SHORT));
-        dispatch(playSound(on ? TRANSCRIPTION_ON_SOUND_ID : TRANSCRIPTION_OFF_SOUND_ID));
-    });
-}
 
 /**
  * Notify external application (if API is enabled) that transcribing has started or stopped.

--- a/resources/prosody-plugins/mod_filter_iq_rayo.lua
+++ b/resources/prosody-plugins/mod_filter_iq_rayo.lua
@@ -260,6 +260,7 @@ module:hook('jitsi-metadata-allow-moderation', function (event)
             and is_feature_allowed('transcription', session.jitsi_meet_context_features) then
                 local res = {};
                 res.isTranscribingEnabled = data.isTranscribingEnabled;
+                res.isRecordingRequested = data.isRecordingRequested;
                 return res;
         elseif not session.jitsi_meet_context_features and occupant.role == 'moderator' then
             return data;


### PR DESCRIPTION
## Summary
- Coordinates sound and notification timing when both recording and transcription are started together
- Introduces `startRecordingIntent` Redux state to track what the user requested from the dialog
- Adds `maybeNotifyRecordingStart` to wait until all intended services (recording and/or transcription) have resolved before playing the appropriate combined sound
- Remote clients use room metadata (`isRecordingRequested` + `isTranscribingEnabled`) to derive intent, ensuring they also wait for both services

## Problem
When a user starts recording with transcription, remote participants could hear separate start sounds (e.g. "transcription started" followed by "recording + transcription started") instead of a single combined notification, because the two services resolve at different times.

## Test plan
- [ ] Start recording + transcription from the dialog — verify remote participants hear a single combined sound/notification
- [ ] Start recording only — verify the recording-only sound plays as before
- [ ] Start transcription only — verify the transcription-only sound plays as before
- [ ] Verify stop sounds still play correctly for all combinations
- [ ] Test with 2 participants (P2P) and 3+ participants (JVB)