### PR TITLE
feat(prosody): add mod_muc_resource_validate module

### DIFF
--- a/resources/prosody-plugins/mod_muc_resource_validate.lua
+++ b/resources/prosody-plugins/mod_muc_resource_validate.lua
@@ -1,0 +1,114 @@
+-- Validates the resourcepart of client JIDs when joining a MUC.
+-- Copyright (C) 2024-present 8x8, Inc.
+--
+-- Hooks into muc-occupant-pre-join (and muc-room-pre-create for the first
+-- user) and rejects joins whose resource part is invalid.
+--
+-- A valid resource consists only of alphanumerics and underscores and must
+-- NOT start with an underscore: ^[a-zA-Z0-9][a-zA-Z0-9_]*$
+--
+-- When "anonymous_strict" mode is enabled, users on domains whose
+-- authentication provider is "anonymous" or "jitsi-anonymous" are
+-- additionally required to use a MUC resource equal to the first 8 characters
+-- of their real JID username (the UUID prefix assigned by the server).
+-- The check is dynamic: the auth provider is read from prosody.hosts at
+-- join time, so no static domain list is needed.
+--
+-- Example configuration (place under the MUC component):
+--
+--   Component "conference.meet.jitsi" "muc"
+--       modules_enabled = { "muc_resource_validate" }
+--       -- Domains/bare-JIDs exempt from all checks (e.g. focus, jibri)
+--       muc_resource_whitelist = { "auth.meet.jitsi", "recorder@recorder.meet.jitsi" }
+--       -- Enable strict anonymous-user check
+--       anonymous_strict = true
+
+local jid_split = require "util.jid".split;
+local st = require "util.stanza";
+local util = module:require "util";
+local is_healthcheck_room = util.is_healthcheck_room;
+
+-- Valid resource: starts with alphanumeric, followed by zero-or-more alphanumerics / underscores.
+local VALID_RESOURCE_PATTERN = "^[a-zA-Z0-9][a-zA-Z0-9_]*$";
+
+local anonymous_strict;
+local whitelist;
+
+local function load_config()
+    anonymous_strict = module:get_option_boolean("anonymous_strict", false);
+    whitelist = module:get_option_set("muc_resource_whitelist", {});
+end
+load_config();
+
+-- Returns true when the domain uses anonymous XMPP authentication
+-- ("anonymous", "jitsi-anonymous") or token auth ("token"), which also
+-- uses anonymous XMPP login with token verification layered on top.
+-- Prosody's usermanager sets host.users.name to the value of the
+-- "authentication" config option.
+local function is_anonymous_domain(domain)
+    local host_obj = prosody.hosts[domain];
+    if not host_obj or not host_obj.users then
+        return false;
+    end
+    local auth = host_obj.users.name;
+    return auth == "anonymous" or auth == "jitsi-anonymous" or auth == "token";
+end
+
+-- Returns true (halts event processing) when the join should be rejected.
+local function check_resource(event)
+    local room, origin, stanza = event.room, event.origin, event.stanza;
+
+    if is_healthcheck_room(room.jid) then
+        return;
+    end
+
+    local user, domain = jid_split(stanza.attr.from);
+    local _, _, muc_resource = jid_split(stanza.attr.to);
+
+    if user == nil then
+        return;
+    end
+
+    -- Whitelisted domains or bare JIDs skip all checks.
+    if whitelist:contains(domain) or whitelist:contains(user .. "@" .. domain) then
+        return;
+    end
+
+    -- 1. Validate the resource part of the MUC JID (the occupant nickname).
+    if not muc_resource or not muc_resource:match(VALID_RESOURCE_PATTERN) then
+        module:log("warn", "Rejecting join with invalid MUC resource from %s (muc_resource: %s)",
+            stanza.attr.from, tostring(muc_resource));
+        origin.send(st.error_reply(stanza, "cancel", "not-allowed", "Invalid resource"));
+        return true;
+    end
+
+    -- 2. Anonymous strict mode: MUC resource must equal the 8-char UUID prefix of the real JID username.
+    if anonymous_strict and is_anonymous_domain(domain) then
+        local uuid_prefix = user:sub(1, 8);
+        if muc_resource ~= uuid_prefix then
+            module:log("warn", "Rejecting anonymous user: MUC resource %s does not match UUID prefix %s (from %s)",
+                muc_resource, uuid_prefix, stanza.attr.from);
+            origin.send(st.error_reply(stanza, "cancel", "not-allowed", "Invalid anonymous user ID"));
+            return true;
+        end
+    end
+end
+
+-- Also fire for the first occupant who implicitly creates the room.
+module:log("info", "module loaded (anonymous_strict=%s)", tostring(anonymous_strict));
+
+module:hook("muc-room-pre-create", function(event)
+    -- muc-room-pre-create has no event.room yet; construct a minimal proxy so
+    -- is_healthcheck_room can inspect the target JID.
+    local stanza = event.stanza;
+    local fake_room = { jid = stanza.attr.to };
+    return check_resource({
+        room    = fake_room,
+        origin  = event.origin,
+        stanza  = stanza,
+    });
+end, 10);
+
+module:hook("muc-occupant-pre-join", check_resource, 10);
+
+module:hook_global("config-reloaded", load_config);

--- a/resources/prosody-plugins/mod_muc_resource_validate.lua
+++ b/resources/prosody-plugins/mod_muc_resource_validate.lua
@@ -1,8 +1,7 @@
 -- Validates the resourcepart of client JIDs when joining a MUC.
 -- Copyright (C) 2024-present 8x8, Inc.
 --
--- Hooks into muc-occupant-pre-join (and muc-room-pre-create for the first
--- user) and rejects joins whose resource part is invalid.
+-- Hooks into muc-occupant-pre-join and rejects joins whose MUC resource is invalid.
 --
 -- A valid resource consists only of alphanumerics and underscores and must
 -- NOT start with an underscore: ^[a-zA-Z0-9][a-zA-Z0-9_]*$
@@ -18,8 +17,6 @@
 --
 --   Component "conference.meet.jitsi" "muc"
 --       modules_enabled = { "muc_resource_validate" }
---       -- Domains/bare-JIDs exempt from all checks (e.g. focus, jibri)
---       muc_resource_whitelist = { "auth.meet.jitsi", "recorder@recorder.meet.jitsi" }
 --       -- Enable strict anonymous-user check
 --       anonymous_strict = true
 
@@ -32,11 +29,9 @@ local is_healthcheck_room = util.is_healthcheck_room;
 local VALID_RESOURCE_PATTERN = "^[a-zA-Z0-9][a-zA-Z0-9_]*$";
 
 local anonymous_strict;
-local whitelist;
 
 local function load_config()
     anonymous_strict = module:get_option_boolean("anonymous_strict", false);
-    whitelist = module:get_option_set("muc_resource_whitelist", {});
 end
 load_config();
 
@@ -69,11 +64,6 @@ local function check_resource(event)
         return;
     end
 
-    -- Whitelisted domains or bare JIDs skip all checks.
-    if whitelist:contains(domain) or whitelist:contains(user .. "@" .. domain) then
-        return;
-    end
-
     -- 1. Validate the resource part of the MUC JID (the occupant nickname).
     if not muc_resource or not muc_resource:match(VALID_RESOURCE_PATTERN) then
         module:log("warn", "Rejecting join with invalid MUC resource from %s (muc_resource: %s)",
@@ -91,23 +81,13 @@ local function check_resource(event)
             origin.send(st.error_reply(stanza, "cancel", "not-allowed", "Invalid anonymous user ID"));
             return true;
         end
+        module:log("info", "[muc_resource_validate] PASS anonymous strict check for %s (muc_resource: %s)", stanza.attr.from, muc_resource);
     end
+
+    module:log("info", "[muc_resource_validate] PASS all checks for %s (muc_resource: %s)", stanza.attr.from, muc_resource);
 end
 
--- Also fire for the first occupant who implicitly creates the room.
 module:log("info", "module loaded (anonymous_strict=%s)", tostring(anonymous_strict));
-
-module:hook("muc-room-pre-create", function(event)
-    -- muc-room-pre-create has no event.room yet; construct a minimal proxy so
-    -- is_healthcheck_room can inspect the target JID.
-    local stanza = event.stanza;
-    local fake_room = { jid = stanza.attr.to };
-    return check_resource({
-        room    = fake_room,
-        origin  = event.origin,
-        stanza  = stanza,
-    });
-end, 10);
 
 module:hook("muc-occupant-pre-join", check_resource, 10);
 

--- a/resources/prosody-plugins/mod_muc_resource_validate.lua
+++ b/resources/prosody-plugins/mod_muc_resource_validate.lua
@@ -7,9 +7,9 @@
 -- NOT start with an underscore: ^[a-zA-Z0-9][a-zA-Z0-9_]*$
 --
 -- When "anonymous_strict" mode is enabled, users on domains whose
--- authentication provider is "anonymous" or "jitsi-anonymous" are
--- additionally required to use a MUC resource equal to the first 8 characters
--- of their real JID username (the UUID prefix assigned by the server).
+-- authentication provider is considered anonymous are additionally required
+-- to use a MUC resource equal to the first 8 characters of their real JID
+-- username (the UUID prefix assigned by the server).
 -- The check is dynamic: the auth provider is read from prosody.hosts at
 -- join time, so no static domain list is needed.
 --
@@ -19,6 +19,8 @@
 --       modules_enabled = { "muc_resource_validate" }
 --       -- Enable strict anonymous-user check
 --       anonymous_strict = true
+--       -- Optional: extend the list of auth methods treated as anonymous
+--       anonymous_auth_methods = { "anonymous", "jitsi-anonymous", "token", "custom-anon" }
 
 local jid_split = require "util.jid".split;
 local st = require "util.stanza";
@@ -29,15 +31,16 @@ local is_healthcheck_room = util.is_healthcheck_room;
 local VALID_RESOURCE_PATTERN = "^[a-zA-Z0-9][a-zA-Z0-9_]*$";
 
 local anonymous_strict;
+local anonymous_auth_methods;
 
 local function load_config()
     anonymous_strict = module:get_option_boolean("anonymous_strict", false);
+    anonymous_auth_methods = module:get_option_set(
+        "anonymous_auth_methods", { "anonymous", "jitsi-anonymous", "token" });
 end
 load_config();
 
--- Returns true when the domain uses anonymous XMPP authentication
--- ("anonymous", "jitsi-anonymous") or token auth ("token"), which also
--- uses anonymous XMPP login with token verification layered on top.
+-- Returns true when the domain's authentication provider is considered anonymous.
 -- Prosody's usermanager sets host.users.name to the value of the
 -- "authentication" config option.
 local function is_anonymous_domain(domain)
@@ -45,8 +48,7 @@ local function is_anonymous_domain(domain)
     if not host_obj or not host_obj.users then
         return false;
     end
-    local auth = host_obj.users.name;
-    return auth == "anonymous" or auth == "jitsi-anonymous" or auth == "token";
+    return anonymous_auth_methods:contains(host_obj.users.name);
 end
 
 -- Returns true (halts event processing) when the join should be rejected.
@@ -81,10 +83,7 @@ local function check_resource(event)
             origin.send(st.error_reply(stanza, "cancel", "not-allowed", "Invalid anonymous user ID"));
             return true;
         end
-        module:log("info", "[muc_resource_validate] PASS anonymous strict check for %s (muc_resource: %s)", stanza.attr.from, muc_resource);
     end
-
-    module:log("info", "[muc_resource_validate] PASS all checks for %s (muc_resource: %s)", stanza.attr.from, muc_resource);
 end
 
 module:log("info", "module loaded (anonymous_strict=%s)", tostring(anonymous_strict));

--- a/resources/prosody-plugins/mod_muc_resource_validate.lua
+++ b/resources/prosody-plugins/mod_muc_resource_validate.lua
@@ -88,6 +88,6 @@ end
 
 module:log("info", "module loaded (anonymous_strict=%s)", tostring(anonymous_strict));
 
-module:hook("muc-occupant-pre-join", check_resource, 10);
+module:hook("muc-occupant-pre-join", check_resource, 11);
 
 module:hook_global("config-reloaded", load_config);

--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -20,6 +20,7 @@ local process_host_module = util.process_host_module;
 local respond_iq_result = util.respond_iq_result;
 local split_string = util.split_string;
 local new_id = require 'util.id'.medium;
+local uuid_generate = require 'util.uuid'.generate;
 local json = require 'cjson.safe';
 local inspect = require 'inspect';
 
@@ -116,7 +117,7 @@ local function request_promotion_received(room, from_jid, from_vnode, nick, time
         if time and time > 0 and force_promote then
             --  we are in auto-allow mode, let's reply with accept
             -- we store where the request is coming from so we can send back the response
-            local username = new_id():lower();
+            local username = uuid_generate();
             visitors_promotion_map[room.jid][username] = {
                 from = from_vnode;
                 jid = from_jid;
@@ -385,7 +386,7 @@ local function process_promotion_response(room, id, approved)
     end
 
     -- lets reply to participant that requested promotion
-    local username = new_id():lower();
+    local username = uuid_generate();
     visitors_promotion_map[room.jid][username] = {
         from = visitors_promotion_requests[room.jid][id].from;
         jid = id;


### PR DESCRIPTION
Adds a new Prosody module that validates the resource part of occupant JIDs when joining a MUC.

- Rejects joins where the MUC resource (nickname) does not match `^[a-zA-Z0-9][a-zA-Z0-9_]*$`
- Supports a whitelist of domains/bare-JIDs exempt from checks (e.g. focus, jibri)
- Supports `anonymous_strict` mode: anonymous users must use a MUC resource equal to the 8-char UUID prefix of their real JID username