### PR TITLE
feat(chat): implement XEP-0461 threaded reply UI

### DIFF
--- a/react/features/chat/actionTypes.ts
+++ b/react/features/chat/actionTypes.ts
@@ -172,3 +172,13 @@ export const SET_CHAT_IS_RESIZING = 'SET_CHAT_IS_RESIZING';
   * }
   */
  export const NOTIFY_PRIVATE_RECIPIENTS_CHANGED = 'NOTIFY_PRIVATE_RECIPIENTS_CHANGED';
+
+/**
+ * The type of action which signals to set the reply message.
+ *
+ * {
+ *     type: SET_REPLY_MESSAGE,
+ *     message: IMessage
+ * }
+ */
+export const SET_REPLY_MESSAGE = 'SET_REPLY_MESSAGE';

--- a/react/features/chat/actions.any.ts
+++ b/react/features/chat/actions.any.ts
@@ -18,9 +18,11 @@ import {
     SET_FOCUSED_TAB,
     SET_LOBBY_CHAT_ACTIVE_STATE,
     SET_LOBBY_CHAT_RECIPIENT,
-    SET_PRIVATE_MESSAGE_RECIPIENT
+    SET_PRIVATE_MESSAGE_RECIPIENT,
+    SET_REPLY_MESSAGE
 } from './actionTypes';
 import { ChatTabs } from './constants';
+import { IMessage } from './types';
 
 /**
  * Adds a chat message to the collection of messages.
@@ -129,11 +131,12 @@ export function closeChat() {
  *     message: string
  * }}
  */
-export function sendMessage(message: string, ignorePrivacy = false) {
+export function sendMessage(message: string, ignorePrivacy = false, replyToMessageId?: string) {
     return {
         type: SEND_MESSAGE,
         ignorePrivacy,
-        message
+        message,
+        replyToMessageId
     };
 }
 
@@ -383,5 +386,21 @@ export function handleLobbyChatInitialized(participantId: string) {
 
         // notify other moderators.
         return conference?.sendLobbyMessage(payload);
+    };
+}
+
+/**
+ * Sets the message that is being replied to.
+ *
+ * @param {IMessage} message - The message to reply to.
+ * @returns {{
+ *     type: SET_REPLY_MESSAGE,
+ *     message: IMessage
+ * }}
+ */
+export function setReplyMessage(message?: IMessage) {
+    return {
+        type: SET_REPLY_MESSAGE,
+        message
     };
 }

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -410,8 +410,8 @@ const Chat = ({
     * @returns {void}
     * @type {Function}
     */
-    const onSendMessage = useCallback((text: string) => {
-        dispatch(sendMessage(text));
+    const onSendMessage = useCallback((text: string, replyToMessageId?: string) => {
+        dispatch(sendMessage(text, false, replyToMessageId));
     }, []);
 
     /**

--- a/react/features/chat/components/web/ChatInput.tsx
+++ b/react/features/chat/components/web/ChatInput.tsx
@@ -12,6 +12,7 @@ import Button from '../../../base/ui/components/web/Button';
 import Input from '../../../base/ui/components/web/Input';
 import { CHAT_SIZE } from '../../constants';
 import { areSmileysDisabled, isSendGroupChatDisabled } from '../../functions';
+import { setReplyMessage } from '../../actions.any';
 
 import SmileysPanel from './SmileysPanel';
 
@@ -67,6 +68,8 @@ interface IProps extends WithTranslation {
      * The id of the message recipient, if any.
      */
     _privateMessageRecipientId?: string;
+
+    _replyMessage?: any;
 
     /**
      * An object containing the CSS classes.
@@ -164,19 +167,56 @@ class ChatInput extends Component<IProps, IState> {
      * @returns {ReactElement}
      */
     override render() {
+        const { _replyMessage, dispatch, t } = this.props;
         const classes = withStyles.getClasses(this.props);
         const hideInput = this.props._isSendGroupChatDisabled && !this.props._privateMessageRecipientId;
 
         if (hideInput) {
             return (
                 <div className = { classes.chatDisabled }>
-                    {this.props.t('chat.disabled')}
+                    {t('chat.disabled')}
                 </div>
             );
         }
 
         return (
             <div className = { `chat-input-container${this.state.message.trim().length ? ' populated' : ''}` }>
+                {_replyMessage && (
+                    <div style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        padding: '6px 12px',
+                        backgroundColor: 'rgba(255,255,255,0.08)',
+                        borderLeft: '3px solid #1e90ff',
+                        marginBottom: '4px',
+                        fontSize: '0.8rem',
+                        color: 'white'
+                    }}>
+                        <div style={{ overflow: 'hidden' }}>
+                            <div style={{ fontWeight: 'bold', color: '#1e90ff' }}>
+                                {_replyMessage.displayName ?? 'Unknown'}
+                            </div>
+                            <div style={{
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis'
+                            }}>
+                                {_replyMessage.message}
+                            </div>
+                        </div>
+                        <div
+                            onClick={() => dispatch(setReplyMessage(undefined))}
+                            style={{
+                                cursor: 'pointer',
+                                padding: '4px 8px',
+                                fontSize: '1rem',
+                                color: 'white'
+                            }}>
+                            ✕
+                        </div>
+                    </div>
+                )}
                 <div id = 'chat-input' >
                     {!this.props._areSmileysDisabled && this.state.showSmileysPanel && (
                         <div
@@ -196,12 +236,12 @@ class ChatInput extends Component<IProps, IState> {
                         maxRows = { 5 }
                         onChange = { this._onMessageChange }
                         onKeyPress = { this._onDetectSubmit }
-                        placeholder = { this.props.t('chat.messagebox') }
+                        placeholder = { t('chat.messagebox') }
                         ref = { this._textArea }
                         textarea = { true }
                         value = { this.state.message } />
                     <Button
-                        accessibilityLabel = { this.props.t('chat.sendButton') }
+                        accessibilityLabel = { t('chat.sendButton') }
                         disabled = { !this.state.message.trim() }
                         icon = { IconSend }
                         onClick = { this._onSubmitMessage }
@@ -240,7 +280,11 @@ class ChatInput extends Component<IProps, IState> {
         const trimmed = this.state.message.trim();
 
         if (trimmed) {
-            onSend(trimmed);
+            onSend(trimmed, this.props._replyMessage?.messageId);
+
+            if (this.props._replyMessage) {
+                this.props.dispatch(setReplyMessage(undefined));
+            }
 
             this.setState({ message: '' });
 
@@ -342,7 +386,7 @@ class ChatInput extends Component<IProps, IState> {
  * }}
  */
 const mapStateToProps = (state: IReduxState) => {
-    const { privateMessageRecipient, width } = state['features/chat'];
+    const { privateMessageRecipient, width, replyMessage } = state['features/chat'];
     const isGroupChatDisabled = isSendGroupChatDisabled(state);
 
     return {
@@ -350,6 +394,7 @@ const mapStateToProps = (state: IReduxState) => {
         _privateMessageRecipientId: privateMessageRecipient?.id,
         _isSendGroupChatDisabled: isGroupChatDisabled,
         _chatWidth: width.current ?? CHAT_SIZE,
+        _replyMessage: replyMessage
     };
 };
 

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -126,6 +126,35 @@ const useStyles = makeStyles()((theme: Theme) => {
         replyButton: {
             padding: '2px'
         },
+        replyPreview: {
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: 'rgba(0, 0, 0, 0.1)',
+            padding: theme.spacing(1),
+            borderRadius: '4px',
+            borderLeft: `3px solid ${theme.palette.chatSenderName}`,
+            marginBottom: theme.spacing(1),
+            cursor: 'pointer',
+            maxWidth: '100%',
+            overflow: 'hidden'
+        },
+        replyPreviewName: {
+            ...theme.typography.labelBold,
+            color: theme.palette.chatSenderName,
+            fontSize: '0.75rem',
+            marginBottom: '2px',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden'
+        },
+        replyPreviewText: {
+            ...theme.typography.labelRegular,
+            color: theme.palette.chatMessageText,
+            fontSize: '0.85rem',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden'
+        },
         replyWrapper: {
             display: 'flex',
             flexDirection: 'row' as const,
@@ -282,6 +311,34 @@ const ChatMessage = ({
     }
 
     /**
+     * Renders a preview of the message being replied to.
+     *
+     * @returns {React$Element<*>}
+     */
+    function _renderReplyPreview() {
+        if (!message.replyToMessageId || !state) {
+            return null;
+        }
+
+        const originalMessage = state['features/chat']?.messages?.find(
+            (m: any) => m.messageId === message.replyToMessageId
+        );
+
+        return (
+            <div className = { cx(classes.replyPreview) }>
+                <span className = { cx(classes.replyPreviewName) }>
+                    { originalMessage?.displayName ?? 'Unknown' }
+                </span>
+                <span className = { cx(classes.replyPreviewText) }>
+                    { originalMessage
+                        ? (isFileMessage(originalMessage) ? '📎 File' : (originalMessage.message ?? 'Original message'))
+                        : 'Original message' }
+                </span>
+            </div>
+        );
+    }
+
+    /**
      * Renders the reactions for the message.
      *
      * @returns {React$Element<*>}
@@ -364,6 +421,7 @@ const ChatMessage = ({
                             isFromVisitor = { message.isFromVisitor }
                             isLobbyMessage = { message.lobbyChat }
                             message = { message.message }
+                            messageId = { message.messageId }
                             participantId = { message.participantId } />}
                     </div>
                 )}
@@ -379,6 +437,7 @@ const ChatMessage = ({
                     <div className = { classes.replyWrapper }>
                         <div className = { cx('messagecontent', classes.messageContent) }>
                             {showDisplayName && _renderDisplayName()}
+                            {message.replyToMessageId && _renderReplyPreview()}
                             <div className = { cx('usermessage', classes.userMessage) }>
                                 {isFileMessage(message) ? (
                                     <FileMessage
@@ -433,6 +492,7 @@ const ChatMessage = ({
                                     isFromVisitor = { message.isFromVisitor }
                                     isLobbyMessage = { message.lobbyChat }
                                     message = { message.message }
+                                    messageId = { message.messageId }
                                     participantId = { message.participantId } />}
                             </div>
                         </div>

--- a/react/features/chat/components/web/MessageMenu.tsx
+++ b/react/features/chat/components/web/MessageMenu.tsx
@@ -11,7 +11,7 @@ import Popover from '../../../base/popover/components/Popover.web';
 import Button from '../../../base/ui/components/web/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.any';
 import { copyText } from '../../../base/util/copyText.web';
-import { handleLobbyChatInitialized, openChat } from '../../actions.web';
+import { handleLobbyChatInitialized, openChat, setReplyMessage } from '../../actions.web';
 import logger from '../../logger';
 
 export interface IProps {
@@ -22,6 +22,7 @@ export interface IProps {
     isFromVisitor?: boolean;
     isLobbyMessage: boolean;
     message: string;
+    messageId?: string;
     participantId: string;
 }
 
@@ -62,7 +63,7 @@ const useStyles = makeStyles()(theme => {
     };
 });
 
-const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, enablePrivateChat, displayName, isFileMessage }: IProps) => {
+const MessageMenu = ({ message, messageId, participantId, isFromVisitor, isLobbyMessage, enablePrivateChat, displayName, isFileMessage }: IProps) => {
     const dispatch = useDispatch();
     const { classes, cx } = useStyles();
     const { t } = useTranslation();
@@ -135,8 +136,27 @@ const MessageMenu = ({ message, participantId, isFromVisitor, isLobbyMessage, en
         handleClose();
     }, [ message ]);
 
+    const handleReplyClick = useCallback(() => {
+    handleClose();
+    setTimeout(() => {
+        dispatch(setReplyMessage({
+            message,
+            messageId,
+            participantId,
+            displayName
+        } as any));
+    }, 50);
+}, [ dispatch, message, messageId, participantId, displayName ]);
+
     const popoverContent = (
         <div className = { classes.menuPanel }>
+            {!isFileMessage && (
+            <div
+                className = { classes.menuItem }
+                onClick = { handleReplyClick }>
+                {t('Reply')}
+            </div>
+        )}
             {enablePrivateChat && (
                 <div
                     className = { classes.menuItem }

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -299,9 +299,9 @@ MiddlewareRegistry.register(store => next => action => {
                 _persistSentPrivateMessage(store, lobbyMessageRecipient, action.message, true);
             } else if (privateMessageRecipient) {
                 conference.sendPrivateTextMessage(privateMessageRecipient.id, action.message, 'body', isVisitorChatParticipant(privateMessageRecipient));
-                _persistSentPrivateMessage(store, privateMessageRecipient, action.message);
+                _persistSentPrivateMessage(store, privateMessageRecipient, action.message, false, action.replyToMessageId);
             } else {
-                conference.sendTextMessage(action.message);
+                conference.sendTextMessage(action.message, 'body', action.replyToMessageId);
             }
         }
         break;
@@ -406,7 +406,7 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
         JitsiConferenceEvents.MESSAGE_RECEIVED,
         /* eslint-disable max-params */
         (participantId: string, message: string, timestamp: number,
-                displayName: string, isFromVisitor: boolean, messageId: string, source: string) => {
+                displayName: string, isFromVisitor: boolean, messageId: string, source: string, replyToId?: string) => {
         /* eslint-enable max-params */
             _onConferenceMessageReceived(store, {
                 // in case of messages coming from visitors we can have unknown id
@@ -417,7 +417,8 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
                 isFromVisitor,
                 messageId,
                 source,
-                privateMessage: false
+                privateMessage: false,
+                replyToId
             });
 
             if (isSendGroupChatDisabled(store.getState()) && participantId) {
@@ -441,7 +442,7 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
 
     conference.on(
         JitsiConferenceEvents.PRIVATE_MESSAGE_RECEIVED,
-        (participantId: string, message: string, timestamp: number, messageId: string, displayName?: string, isFromVisitor?: boolean) => {
+        (participantId: string, message: string, timestamp: number, messageId: string, displayName?: string, isFromVisitor?: boolean, replyToId?: string) => {
             _onConferenceMessageReceived(store, {
                 participantId,
                 message,
@@ -449,7 +450,8 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
                 displayName,
                 messageId,
                 privateMessage: true,
-                isFromVisitor
+                isFromVisitor,
+                replyToId
             });
         }
     );
@@ -468,9 +470,9 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
  * @returns {void}
  */
 function _onConferenceMessageReceived(store: IStore,
-        { displayName, isFromVisitor, message, messageId, participantId, privateMessage, timestamp, source }: {
+        { displayName, isFromVisitor, message, messageId, participantId, privateMessage, timestamp, source, replyToId }: {
             displayName?: string; isFromVisitor?: boolean; message: string; messageId?: string;
-            participantId: string; privateMessage: boolean; source?: string; timestamp: number; }
+            participantId: string; privateMessage: boolean; replyToId?: string; source?: string; timestamp: number;  }
 ) {
 
     const isGif = isGifEnabled(store.getState()) && isGifMessage(message);
@@ -490,7 +492,8 @@ function _onConferenceMessageReceived(store: IStore,
         lobbyChat: false,
         timestamp,
         messageId,
-        source
+        source,
+        replyToId
     }, true, isGif);
 }
 
@@ -599,9 +602,9 @@ function getLobbyChatDisplayName(state: IReduxState, participantId: string) {
  * @returns {void}
  */
 function _handleReceivedMessage({ dispatch, getState }: IStore,
-        { displayName, isFromVisitor, lobbyChat, message, messageId, participantId, privateMessage, source, timestamp }: {
+        { displayName, isFromVisitor, lobbyChat, message, messageId, participantId, privateMessage, source, timestamp, replyToId }: {
             displayName?: string; isFromVisitor?: boolean; lobbyChat: boolean; message: string;
-            messageId?: string; participantId: string; privateMessage: boolean; source?: string; timestamp: number; },
+            messageId?: string; participantId: string; privateMessage: boolean; replyToId?: string; source?: string; timestamp: number; },
         shouldPlaySound = true,
         isReaction = false
 ) {
@@ -654,7 +657,8 @@ function _handleReceivedMessage({ dispatch, getState }: IStore,
         messageId,
         isReaction,
         isFromVisitor,
-        isFromGuest: source === 'guest'
+        isFromGuest: source === 'guest',
+        replyToMessageId: replyToId ?? undefined
     };
 
     dispatch(addMessage(newMessage));
@@ -715,7 +719,7 @@ interface IRecipient {
  * @returns {void}
  */
 function _persistSentPrivateMessage({ dispatch, getState }: IStore, recipient: IRecipient,
-        message: string, isLobbyPrivateMessage = false) {
+        message: string, isLobbyPrivateMessage = false, replyToMessageId?: string) {
     const state = getState();
     const localParticipant = getLocalParticipant(state);
 
@@ -742,7 +746,8 @@ function _persistSentPrivateMessage({ dispatch, getState }: IStore, recipient: I
         lobbyChat: isLobbyPrivateMessage,
         recipient: recipientName,
         sentToVisitor: recipient.isVisitor,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        replyToMessageId
     }));
 }
 

--- a/react/features/chat/reducer.ts
+++ b/react/features/chat/reducer.ts
@@ -19,6 +19,7 @@ import {
     SET_LOBBY_CHAT_ACTIVE_STATE,
     SET_LOBBY_CHAT_RECIPIENT,
     SET_PRIVATE_MESSAGE_RECIPIENT,
+    SET_REPLY_MESSAGE,
     SET_USER_CHAT_WIDTH
 } from './actionTypes';
 import { CHAT_SIZE, ChatTabs } from './constants';
@@ -37,6 +38,7 @@ const DEFAULT_STATE = {
     isLobbyChatActive: false,
     focusedTab: undefined,
     isResizing: false,
+    replyMessage: undefined,
     width: {
         current: CHAT_SIZE,
         userSet: null
@@ -57,6 +59,7 @@ export interface IChatState {
     messages: IMessage[];
     notifyPrivateRecipientsChangedTimestamp?: number;
     privateMessageRecipient?: IParticipant | IVisitorChatParticipant;
+    replyMessage?: IMessage;
     unreadFilesCount: number;
     unreadMessagesCount: number;
     width: {
@@ -84,7 +87,8 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             lobbyChat: action.lobbyChat,
             recipient: action.recipient,
             sentToVisitor: Boolean(action.sentToVisitor),
-            timestamp: action.timestamp
+            timestamp: action.timestamp,
+            replyToMessageId: action.replyToMessageId
         };
 
         // React native, unlike web, needs a reverse sorted message list.
@@ -292,6 +296,11 @@ ReducerRegistry.register<IChatState>('features/chat', (state = DEFAULT_STATE, ac
             unreadFilesCount: remoteFilesCount
         };
     }
+    case SET_REPLY_MESSAGE:
+    return {
+        ...state,
+        replyMessage: action.message
+    };
     }
 
     return state;

--- a/react/features/chat/types.ts
+++ b/react/features/chat/types.ts
@@ -19,6 +19,7 @@ export interface IMessage {
     reactions: Map<string, Set<string>>;
     recipient: string;
     sentToVisitor?: boolean;
+    replyToMessageId?: string;
     timestamp: number;
 }
 


### PR DESCRIPTION
### Description

This PR adds full reply-to support in the Jitsi Meet chat panel.

It captures `replyToId` from both `MESSAGE_RECEIVED` and `PRIVATE_MESSAGE_RECEIVED`, passes it through `_onConferenceMessageReceived()` and `_handleReceivedMessage()`, stores it as `replyToMessageId` in the reducer, and extends `IMessage` with the same field.

It also adds reply state handling in the UI:
- `SET_REPLY_MESSAGE` action and `setReplyMessage()` action creator.
- Reply preview banner above `ChatInput` with a dismiss button.
- Inline reply preview inside `ChatMessage`.
- Reply option in the message menu.

Finally, `replyToMessageId` is passed through `sendMessage()` and `sendTextMessage()` so XEP-0461 reply stanzas are sent over XMPP.

### Related Issue

jitsi/jitsi-meet#17196

### Motivation and Context

This change adds the UI and state-management side of XEP-0461 threaded replies. The XMPP stanza construction fix is handled in `lib-jitsi-meet`.

### How Has This Been Tested?

Manually tested the chat reply flow in Jitsi Meet. Verified that reply state appears in the input, reply previews render correctly, and reply messages are sent with the expected metadata.

### Screenshots or GIF (In case of UI changes):

Before:
<img width="1759" height="944" alt="image" src="https://github.com/user-attachments/assets/207084ea-408f-42e1-95fe-2b85e933b263" />

- No threaded reply UI in chat.

After:
<img width="1856" height="1048" alt="Screenshot from 2026-04-19 14-42-56" src="https://github.com/user-attachments/assets/8376e30b-f68a-4aba-adfe-d8fc4f50416a" />

- Reply preview shown in chat input and message flow.

### Related PRs
- lib-jitsi-meet fix: https://github.com/jitsi/lib-jitsi-meet/pull/3024