### PR TITLE
test: add custom matchers for descriptive assertion failure messages

### DIFF
--- a/tests/helpers/matchers.ts
+++ b/tests/helpers/matchers.ts
@@ -1,0 +1,45 @@
+import { expect } from '@wdio/globals';
+
+expect.extend({
+    toPartiallyMatch(received: string, other: string, receivedLabel = 'received', otherLabel = 'other') {
+        const pass = received.includes(other) || other.includes(received);
+
+        return {
+            pass,
+            message: () => pass
+                ? `Expected ${receivedLabel} NOT to partially match ${otherLabel}.\n  ${receivedLabel}: "${received}"\n  ${otherLabel}: "${other}"`
+                : `Expected ${receivedLabel} to partially match ${otherLabel} (one should contain the other).\n  ${receivedLabel}: "${received}"\n  ${otherLabel}: "${other}"`
+        };
+    },
+
+    toStartWith(received: string, prefix: string, label = 'value') {
+        const pass = received.startsWith(prefix);
+
+        return {
+            pass,
+            message: () => pass
+                ? `Expected ${label} NOT to start with "${prefix}".\n  ${label}: "${received}"`
+                : `Expected ${label} to start with "${prefix}".\n  ${label}: "${received}"`
+        };
+    },
+
+    toBeInteger(received: unknown, label = 'value') {
+        const pass = Number.isInteger(received);
+
+        return {
+            pass,
+            message: () => pass
+                ? `Expected ${label} NOT to be an integer.\n  ${label}: ${JSON.stringify(received)}`
+                : `Expected ${label} to be an integer.\n  ${label}: ${JSON.stringify(received)}`
+        };
+    }
+});
+
+declare module 'expect' {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface Matchers<R> {
+        toBeInteger: (label?: string) => R;
+        toPartiallyMatch: (other: string, receivedLabel?: string, otherLabel?: string) => R;
+        toStartWith: (prefix: string, label?: string) => R;
+    }
+}

--- a/tests/specs/jaas/dial/dialin.spec.ts
+++ b/tests/specs/jaas/dial/dialin.spec.ts
@@ -1,3 +1,6 @@
+import { expect } from '@wdio/globals';
+
+import '../../../helpers/matchers';
 import type { Participant } from '../../../helpers/Participant';
 import { setTestProperties } from '../../../helpers/TestProperties';
 import { config as testsConfig } from '../../../helpers/TestsConfig';
@@ -57,7 +60,7 @@ describe('Dial-in', () => {
     it('dial-in', async () => {
         const dialInPin = await p1.getDialInPin();
 
-        expect(dialInPin.length >= 8).toBe(true);
+        expect(dialInPin.length).toBeGreaterThanOrEqual(8);
 
         await dialIn(dialInPin);
         await waitForMedia(p1);

--- a/tests/specs/jaas/recording.spec.ts
+++ b/tests/specs/jaas/recording.spec.ts
@@ -1,3 +1,6 @@
+import { expect } from '@wdio/globals';
+
+import '../../helpers/matchers';
 import { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { config as testsConfig } from '../../helpers/TestsConfig';
@@ -85,9 +88,9 @@ describe('Recording and live-streaming', () => {
             timeoutMsg: 'recordingLinkAvailable event not received'
         });
 
-        expect(linkEvent.link.startsWith('https://')).toBe(true);
-        expect(linkEvent.link.includes(tenant)).toBe(true);
-        expect(linkEvent.ttl > 0).toBe(true);
+        expect(linkEvent.link).toStartWith('https://', 'recording link');
+        expect(linkEvent.link).toContain(tenant);
+        expect(linkEvent.ttl).toBeGreaterThan(0);
     }
 
     /**

--- a/tests/specs/jaas/transcriptions.spec.ts
+++ b/tests/specs/jaas/transcriptions.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@wdio/globals';
 
+import '../../helpers/matchers';
 import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import type WebhookProxy from '../../helpers/WebhookProxy';
@@ -197,7 +198,7 @@ async function checkReceivingChunks(p1: Participant, p2: Participant, webhooksPr
     const p1Transcript = p1Event.data.stable || p1Event.data.final;
     const p2Transcript = p2Event.data.stable || p2Event.data.final;
 
-    expect(p2Transcript.includes(p1Transcript) || p1Transcript.includes(p2Transcript)).toBe(true);
+    expect(p2Transcript).toPartiallyMatch(p1Transcript, 'p2 transcript', 'p1 transcript');
     expect(p2Event.data.language).toBe(p1Event.data.language);
     expect(p2Event.data.messageID).toBe(p1Event.data.messageID);
     expect(p1Event.data.participant.id).toBe(p1Id);
@@ -227,7 +228,7 @@ async function checkReceivingChunks(p1: Participant, p2: Participant, webhooksPr
 
         const webhookTranscript = event.data.final;
 
-        expect(webhookTranscript.includes(p1Transcript) || p1Transcript.includes(webhookTranscript)).toBe(true);
+        expect(webhookTranscript).toPartiallyMatch(p1Transcript, 'webhook transcript', 'p1 transcript');
         if (p1Event.data.language) {
             expect(event.data.language).toBe(p1Event.data.language);
         }

--- a/tests/specs/misc/connectivity.spec.ts
+++ b/tests/specs/misc/connectivity.spec.ts
@@ -1,3 +1,6 @@
+import { expect } from '@wdio/globals';
+
+import '../../helpers/matchers';
 import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { config as testsConfig } from '../../helpers/TestsConfig';
@@ -26,8 +29,8 @@ describe('Connectivity', () => {
         const port1 = await getRemotePort(p1);
         const port2 = await getRemotePort(p2);
 
-        expect(Number.isInteger(port1)).toBe(true);
-        expect(Number.isInteger(port2)).toBe(true);
+        expect(port1).toBeInteger('p1 remote port');
+        expect(port2).toBeInteger('p2 remote port');
         expect(port1).toBe(port2);
     });
 });

--- a/tests/specs/moderation/grantModerator.spec.ts
+++ b/tests/specs/moderation/grantModerator.spec.ts
@@ -1,3 +1,5 @@
+import { expect } from '@wdio/globals';
+
 import { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { expectations } from '../../helpers/expectations';
@@ -23,10 +25,11 @@ describe('Grant moderator', () => {
         p1 = ctx.p1;
         expect(await p1.isModerator()).toBe(true);
 
-        const functionAvailable = await p1.execute(() => typeof APP.conference._room.grantOwner === 'function');
+        const grantOwnerType = await p1.execute(() => typeof APP.conference._room.grantOwner);
+        const functionAvailable = grantOwnerType === 'function';
 
         if (expectations.moderation.grantModerator) {
-            expect(functionAvailable).toBe(true);
+            expect(grantOwnerType).toBe('function');
         } else {
             if (!functionAvailable) {
                 ctx.skipSuiteTests = 'grantModerator is not available and not expected';

--- a/tests/specs/moderation/lobby.spec.ts
+++ b/tests/specs/moderation/lobby.spec.ts
@@ -1,3 +1,6 @@
+import { expect } from '@wdio/globals';
+
+import '../../helpers/matchers';
 import { P1, P3, Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { expectations } from '../../helpers/expectations';
@@ -39,8 +42,8 @@ describe('Lobby', () => {
 
         const notificationText = await p2.getNotifications().getLobbyParticipantAccessGranted();
 
-        expect(notificationText.includes(P1)).toBe(true);
-        expect(notificationText.includes(P3)).toBe(true);
+        expect(notificationText).toContain(P1);
+        expect(notificationText).toContain(P3);
 
         await p2.getNotifications().closeLobbyParticipantAccessGranted();
 
@@ -72,8 +75,8 @@ describe('Lobby', () => {
         // deny notification on 2nd participant
         const notificationText = await p2.getNotifications().getLobbyParticipantAccessDenied();
 
-        expect(notificationText.includes(P1)).toBe(true);
-        expect(notificationText.includes(P3)).toBe(true);
+        expect(notificationText).toContain(P1);
+        expect(notificationText).toContain(P3);
 
         await p2.getNotifications().closeLobbyParticipantAccessDenied();
 
@@ -392,7 +395,7 @@ async function enableLobby() {
     await p1SecurityDialog.toggleLobby();
     await p1SecurityDialog.waitForLobbyEnabled();
 
-    expect((await p2.getNotifications().getLobbyEnabledText()).includes(p1.name)).toBe(true);
+    expect(await p2.getNotifications().getLobbyEnabledText()).toContain(p1.name);
 
     await p2.getNotifications().closeLobbyEnabled();
 
@@ -470,7 +473,7 @@ async function enterLobby(participant: Participant, enterDisplayName = false, us
 
         if (!usePreJoin) {
             // check join button is disabled
-            expect(classes.includes('disabled')).toBe(true);
+            expect(classes).toContain('disabled');
         }
 
         // TODO check that password is hidden as the room does not have password
@@ -481,7 +484,7 @@ async function enterLobby(participant: Participant, enterDisplayName = false, us
 
         // check join button is enabled
         classes = await joinButton.getAttribute('class') || '';
-        expect(classes.includes('disabled')).toBe(false);
+        expect(classes).not.toContain('disabled');
     }
 
     // click join button


### PR DESCRIPTION
Replace `expect(booleanExpression).toBe(true)` assertions that produce unhelpful
`Expected: true / Received: false` messages with custom matchers that show what
actually failed.

## New matchers (`tests/helpers/matchers.ts`)

- **`toPartiallyMatch(other, receivedLabel?, otherLabel?)`** — one string should contain the other (or vice versa). Used for transcript comparisons where partial overlap is acceptable.
- **`toStartWith(prefix, label?)`** — string starts-with check with the actual value shown on failure.
- **`toBeInteger(label?)`** — `Number.isInteger` check with the actual value shown on failure.

All matchers accept optional labels so the failure message names what is being compared:

```
Expected webhook transcript to partially match p1 transcript (one should contain the other).
  webhook transcript: "Good morning everyone"
  p1 transcript:      "Hello from participant one"
```

## Files updated

- `tests/specs/jaas/transcriptions.spec.ts` — `toPartiallyMatch` for p2/webhook transcript checks
- `tests/specs/jaas/recording.spec.ts` — `toStartWith`, `toContain`, `toBeGreaterThan` for recording link assertions
- `tests/specs/jaas/dial/dialin.spec.ts` — `toBeGreaterThanOrEqual` for PIN length
- `tests/specs/moderation/lobby.spec.ts` — `toContain` / `not.toContain` for notification text and CSS class checks
- `tests/specs/misc/connectivity.spec.ts` — `toBeInteger` for remote port checks
- `tests/specs/moderation/grantModerator.spec.ts` — assert `typeof` directly instead of storing boolean