### PR TITLE
fix(prosody): allow recording-only metadata moderation

### DIFF
--- a/resources/prosody-plugins/mod_filter_iq_rayo.lua
+++ b/resources/prosody-plugins/mod_filter_iq_rayo.lua
@@ -253,7 +253,7 @@ end);
 module:hook('jitsi-metadata-allow-moderation', function (event)
     local data, key, occupant, session = event.data, event.key, event.actor, event.session;
 
-    if key == 'recording' and data and data.isTranscribingEnabled ~= nil then
+    if key == 'recording' and data and (data.isTranscribingEnabled ~= nil or data.isRecordingRequested ~= nil) then
         -- if it is recording we want to allow setting in metadata if not moderator but features
         -- are present
         if session.jitsi_meet_context_features


### PR DESCRIPTION
## Summary
- The `jitsi-metadata-allow-moderation` filter in `mod_filter_iq_rayo.lua` only matched when `isTranscribingEnabled` was present in the metadata diff. A metadata update that carries only `isRecordingRequested` would skip the sanitization path and fall through to the default moderator-only rule, so remote participants never saw the recording intent.
- Broaden the condition to also match when only `isRecordingRequested` is present. The rest of the block is unchanged.

## Test plan
- [ ] Start recording only (no transcription) on a deployment using this filter — remote participants should see `isRecordingRequested: true` in room metadata.
- [ ] Start recording + transcription together — still works as before.
- [ ] Start transcription only — still works as before.