### PR TITLE
fix(prosody): A nil check.

### DIFF
--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -419,7 +419,9 @@ function process_lobby_muc_loaded(lobby_muc, host_module)
             if room and room._data.lobby_disabled then
                 -- we cannot remove the child from the stanza so let's just change the type
                 local lobby_identity = reply:get_child_with_attr('identity', nil, 'type', LOBBY_IDENTITY_TYPE);
-                lobby_identity.attr.type = 'DISABLED_'..LOBBY_IDENTITY_TYPE;
+                if lobby_identity then
+                    lobby_identity.attr.type = 'DISABLED_'..LOBBY_IDENTITY_TYPE;
+                end
             end
 
             if check_display_name_required and room and room._data.lobbyroom then


### PR DESCRIPTION
If you have some virtual host used by the client, and you do not load jiconop (sip-jibri, jibri, guest) you can hit this error which timeouts a disco-info query.


