### PR TITLE
fix(e2ee): fix SET_MEDIA_ENCRYPTION_KEY pipeline and add participantId support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ deploy-lib-jitsi-meet:
 
 deploy-olm:
 	cp \
+		$(OLM_DIR)/olm.js \
+		$(OLM_DIR)/olm_legacy.js \
 		$(OLM_DIR)/olm.wasm \
 		$(DEPLOY_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_DIR = build
 CLEANCSS = ./node_modules/.bin/cleancss
 DEPLOY_DIR = libs
-LIBJITSIMEET_DIR = node_modules/lib-jitsi-meet
+LIBJITSIMEET_DIR = ../lib-jitsi-meet
 OLM_DIR = node_modules/@matrix-org/olm
 TF_WASM_DIR = node_modules/@tensorflow/tfjs-backend-wasm/dist/
 RNNOISE_WASM_DIR = node_modules/@jitsi/rnnoise-wasm/dist

--- a/app.js
+++ b/app.js
@@ -6,7 +6,10 @@ import $ from 'jquery';
 
 window.$ = window.jQuery = $;
 
-import '@matrix-org/olm';
+import './olm-options.js';
+import Olm from '@matrix-org/olm';
+
+window.Olm = Olm;
 
 import 'focus-visible';
 

--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@
     </script>
     <script><!--#include virtual="/config.js" --></script><!-- adapt to your needs, i.e. set hosts and bosh path -->
     <script><!--#include virtual="/interface_config.js" --></script>
+    <script src="libs/olm.js"></script>
     <script src="libs/lib-jitsi-meet.min.js?v=139"></script>
     <script src="libs/app.bundle.min.js?v=139"></script>
     <!--#include virtual="title.html" -->

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1657,9 +1657,9 @@ class API {
     notifyOlmMessageReceived(from, type, payload) {
         this._sendEvent({
             name: 'olm-message-received',
-            data: { from,
-                payload,
-                type }
+            from,
+            payload,
+            type
         });
     }
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -605,6 +605,9 @@ function initCommands() {
         'set-media-encryption-key': keyInfo => {
             APP.store.dispatch(setMediaEncryptionKey(JSON.parse(keyInfo)));
         },
+        'send-olm-message': (participantId, type, payload) => {
+            APP.conference._room?.sendOlmMessage(participantId, type, JSON.parse(payload));
+        },
         'set-video-quality': frameHeight => {
             sendAnalytics(createApiEvent('set.video.quality'));
             APP.store.dispatch(setVideoQuality(frameHeight));
@@ -1640,6 +1643,23 @@ class API {
         this._sendEvent({
             name: 'endpoint-text-message-received',
             data
+        });
+    }
+
+    /**
+     * Notify external application that a custom OLM message was received.
+     *
+     * @param {string} from - The sender participant ID.
+     * @param {string} type - Application-defined message type.
+     * @param {object} payload - Arbitrary JSON payload.
+     * @returns {void}
+     */
+    notifyOlmMessageReceived(from, type, payload) {
+        this._sendEvent({
+            name: 'olm-message-received',
+            data: { from,
+                payload,
+                type }
         });
     }
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -606,6 +606,7 @@ function initCommands() {
             APP.store.dispatch(setMediaEncryptionKey(JSON.parse(keyInfo)));
         },
         'send-olm-message': (participantId, type, payload) => {
+            console.log(`[encedo:olm] API send-olm-message handler to=${participantId} type=${type} hasRoom=${!!APP.conference._room} hasMethod=${!!APP.conference._room?.sendOlmMessage}`);
             APP.conference._room?.sendOlmMessage(participantId, type, JSON.parse(payload));
         },
         'set-video-quality': frameHeight => {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1566,26 +1566,41 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
-     * Sets the key and keyIndex for e2ee.
+     * Sets the encryption key and key index for E2EE.
      *
-     * @param {Object} keyInfo - Json containing key information.
-     * @param {CryptoKey} [keyInfo.encryptionKey] - The encryption key.
-     * @param {number} [keyInfo.index] - The index of the encryption key.
-     * @returns {void}
+     * The key is exported to raw bytes before crossing the iframe boundary because
+     * {@code CryptoKey} objects are not transferable via {@code postMessage}.  Inside the
+     * Jitsi iframe the raw bytes are fed into the HKDF-SHA-256 derivation pipeline to produce
+     * the final AES-GCM-128 frame encryption key.
+     *
+     * @param {Object} keyInfo - Key descriptor.
+     * @param {CryptoKey} [keyInfo.key] - The raw-exportable {@code CryptoKey} to use for
+     *   encryption.  Pass {@code undefined} or omit to disable encryption for the participant.
+     * @param {number} [keyInfo.index] - Key ring slot index (0–15).  Incrementing the index
+     *   during rotation allows receivers to continue decrypting in-flight frames that were
+     *   encrypted under the previous key.
+     * @param {string} [keyInfo.participantId] - ID of the participant whose E2EE context is
+     *   being updated.  When omitted the key is applied to the local participant's outgoing
+     *   (encode) context.  Supply the remote participant's ID to set the key used for decrypting
+     *   their incoming frames (required when {@code e2ee.externallyManagedSharedKey} is
+     *   {@code false} in the Jitsi server config).
+     * @returns {Promise<void>}
      */
     async setMediaEncryptionKey(keyInfo) {
-        const { key, index } = keyInfo;
+        const { key, index, participantId } = keyInfo;
 
         if (key) {
             const exportedKey = await crypto.subtle.exportKey('raw', key);
 
             this.executeCommand('setMediaEncryptionKey', JSON.stringify({
                 exportedKey: Array.from(new Uint8Array(exportedKey)),
-                index }));
+                index,
+                participantId }));
         } else {
             this.executeCommand('setMediaEncryptionKey', JSON.stringify({
                 exportedKey: false,
-                index }));
+                index,
+                participantId }));
         }
     }
 

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -148,6 +148,7 @@ const events = {
     'mouse-move': 'mouseMove',
     'non-participant-message-received': 'nonParticipantMessageReceived',
     'notification-triggered': 'notificationTriggered',
+    'olm-message-received': 'olmMessageReceived',
     'outgoing-message': 'outgoingMessage',
     'p2p-status-changed': 'p2pStatusChanged',
     'participant-joined': 'participantJoined',

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -59,6 +59,7 @@ const commands = {
     sendCameraFacingMode: 'send-camera-facing-mode-message',
     sendChatMessage: 'send-chat-message',
     sendEndpointTextMessage: 'send-endpoint-text-message',
+    sendOlmMessage: 'send-olm-message',
     sendParticipantToRoom: 'send-participant-to-room',
     sendTones: 'send-tones',
     setAudioOnly: 'set-audio-only',

--- a/olm-options.js
+++ b/olm-options.js
@@ -1,0 +1,5 @@
+// Tell Emscripten where to find olm.wasm when @matrix-org/olm is bundled by webpack.
+// This must evaluate before the @matrix-org/olm module is initialized.
+window.OLM_OPTIONS = {
+    locateFile: filename => `libs/${filename}`
+};

--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -145,6 +145,7 @@ export interface IJitsiConference {
     sendFeedback: Function;
     sendLobbyMessage: Function;
     sendMessage: Function;
+    sendOlmMessage: (participantId: string, type: string, payload: object) => void;
     sendPrivateTextMessage: Function;
     sendReaction: Function;
     sendTextMessage: Function;

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -54,6 +54,11 @@ interface IProps extends AbstractProps {
     _focusedTab?: ChatTabs;
 
     /**
+     * True if E2EE is enabled — used to show unencrypted-chat warning.
+     */
+    _isE2EEEnabled: boolean;
+
+    /**
      * True if the CC tab is enabled and false otherwise.
      */
     _isCCTabEnabled: boolean;
@@ -260,6 +265,7 @@ const Chat = ({
     _isCCTabEnabled,
     _isChatDisabled,
     _isFileSharingTabEnabled,
+    _isE2EEEnabled,
     _focusedTab,
     _isResizing,
     _messages,
@@ -482,6 +488,18 @@ const Chat = ({
                     id = { `${ChatTabs.CHAT}-panel` }
                     role = 'tabpanel'
                     tabIndex = { 0 }>
+                    {_isE2EEEnabled && (
+                        <div style = {{
+                            background: '#3d2e00',
+                            borderBottom: '1px solid #7a5c00',
+                            color: '#ffc107',
+                            fontSize: '11px',
+                            padding: '6px 12px',
+                            textAlign: 'center'
+                        }}>
+                            ⚠️ Chat messages are not end-to-end encrypted
+                        </div>
+                    )}
                     <MessageContainer
                         isVisible = { _focusedTab === ChatTabs.CHAT }
                         messages = { _messages } />
@@ -676,10 +694,12 @@ function _mapStateToProps(state: IReduxState, _ownProps: any) {
     const { unreadPollsCount } = state['features/polls'];
     const _localParticipant = getLocalParticipant(state);
     const { reducedUI } = state['features/base/responsive-ui'];
+    const _isE2EEEnabled = state['features/e2ee']?.enabled ?? false;
 
     return {
         _isModal: window.innerWidth <= SMALL_WIDTH_THRESHOLD,
         _isOpen: isOpen,
+        _isE2EEEnabled,
         _isPollsEnabled: !arePollsDisabled(state),
         _isCCTabEnabled: isCCTabEnabled(state),
         _isChatDisabled: isChatDisabled(state),

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -54,11 +54,6 @@ interface IProps extends AbstractProps {
     _focusedTab?: ChatTabs;
 
     /**
-     * True if E2EE is enabled — used to show unencrypted-chat warning.
-     */
-    _isE2EEEnabled: boolean;
-
-    /**
      * True if the CC tab is enabled and false otherwise.
      */
     _isCCTabEnabled: boolean;
@@ -265,7 +260,6 @@ const Chat = ({
     _isCCTabEnabled,
     _isChatDisabled,
     _isFileSharingTabEnabled,
-    _isE2EEEnabled,
     _focusedTab,
     _isResizing,
     _messages,
@@ -488,18 +482,6 @@ const Chat = ({
                     id = { `${ChatTabs.CHAT}-panel` }
                     role = 'tabpanel'
                     tabIndex = { 0 }>
-                    {_isE2EEEnabled && (
-                        <div style = {{
-                            background: '#3d2e00',
-                            borderBottom: '1px solid #7a5c00',
-                            color: '#ffc107',
-                            fontSize: '11px',
-                            padding: '6px 12px',
-                            textAlign: 'center'
-                        }}>
-                            ⚠️ Chat messages are not end-to-end encrypted
-                        </div>
-                    )}
                     <MessageContainer
                         isVisible = { _focusedTab === ChatTabs.CHAT }
                         messages = { _messages } />
@@ -694,12 +676,9 @@ function _mapStateToProps(state: IReduxState, _ownProps: any) {
     const { unreadPollsCount } = state['features/polls'];
     const _localParticipant = getLocalParticipant(state);
     const { reducedUI } = state['features/base/responsive-ui'];
-    const _isE2EEEnabled = state['features/e2ee']?.enabled ?? false;
-
     return {
         _isModal: window.innerWidth <= SMALL_WIDTH_THRESHOLD,
         _isOpen: isOpen,
-        _isE2EEEnabled,
         _isPollsEnabled: !arePollsDisabled(state),
         _isCCTabEnabled: isCCTabEnabled(state),
         _isChatDisabled: isChatDisabled(state),

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -300,6 +300,30 @@ MiddlewareRegistry.register(store => next => action => {
             } else if (privateMessageRecipient) {
                 conference.sendPrivateTextMessage(privateMessageRecipient.id, action.message, 'body', isVisitorChatParticipant(privateMessageRecipient));
                 _persistSentPrivateMessage(store, privateMessageRecipient, action.message);
+            } else if (state['features/e2ee']?.enabled) {
+                // E2EE is active — send via OLM (encrypted) instead of plain XMPP MUC.
+                const localParticipant2 = getLocalParticipant(state);
+                const displayName2 = getParticipantDisplayName(state, localParticipant?.id ?? '');
+
+                console.log('[encedo] encedo:chat OLM send');
+                conference.sendOlmMessage('', 'encedo:chat', {
+                    text: action.message,
+                    displayName: displayName2,
+                    ts: Date.now()
+                });
+
+                // OLM messages don't echo back — add own message to store directly.
+                dispatch(addMessage({
+                    displayName: displayName2,
+                    hasRead: true,
+                    participantId: localParticipant2?.id ?? '',
+                    messageType: MESSAGE_TYPE_LOCAL,
+                    message: action.message,
+                    privateMessage: false,
+                    lobbyChat: false,
+                    recipient: '',
+                    timestamp: Date.now()
+                }));
             } else {
                 conference.sendTextMessage(action.message);
             }
@@ -461,6 +485,25 @@ function _addChatMsgListener(conference: IJitsiConference, store: IStore) {
         JitsiConferenceEvents.CONFERENCE_ERROR, (errorType: string, error: Error) => {
             errorType === JitsiConferenceErrors.CHAT_ERROR && _handleChatError(store, error);
         });
+
+    // E2EE chat: receive encedo:chat OLM messages and inject into native chat UI.
+    conference.on(
+        JitsiConferenceEvents.OLM_MESSAGE_RECEIVED,
+        (from: string, type: string, payload: { text?: string; displayName?: string; ts?: number }) => {
+            if (type !== 'encedo:chat' || !payload?.text) {
+                return;
+            }
+            console.log('[encedo] encedo:chat OLM received from', from);
+            _handleReceivedMessage(store, {
+                participantId: from,
+                displayName: payload.displayName,
+                message: payload.text,
+                privateMessage: false,
+                lobbyChat: false,
+                timestamp: payload.ts ?? Date.now()
+            });
+        }
+    );
 }
 
 /**

--- a/react/features/e2ee/middleware.ts
+++ b/react/features/e2ee/middleware.ts
@@ -139,6 +139,11 @@ StateListenerRegistry.register(
         }
 
         if (conference) {
+            conference.on(JitsiConferenceEvents.OLM_MESSAGE_RECEIVED,
+                (from: string, type: string, payload: object) => {
+                    APP.API.notifyOlmMessageReceived(from, type, payload);
+                });
+
             conference.on(JitsiConferenceEvents.E2EE_VERIFICATION_AVAILABLE, (pId: string) => {
                 dispatch(participantUpdated({
                     e2eeVerificationAvailable: true,

--- a/react/features/e2ee/middleware.ts
+++ b/react/features/e2ee/middleware.ts
@@ -45,10 +45,16 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         unregisterE2eeAudioFiles(dispatch);
         break;
 
-    case CONFERENCE_JOINED:
-        _updateMaxMode(dispatch, getState);
+    case CONFERENCE_JOINED: {
+        const { e2ee = {} } = getState()['features/base/config'];
 
+        if (e2ee.externallyManagedKey) {
+            dispatch(toggleE2EE(true));
+        } else {
+            _updateMaxMode(dispatch, getState);
+        }
         break;
+    }
 
     case PARTICIPANT_JOINED: {
         const result = next(action);

--- a/react/features/e2ee/middleware.ts
+++ b/react/features/e2ee/middleware.ts
@@ -95,29 +95,17 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
     case SET_MEDIA_ENCRYPTION_KEY: {
         if (conference?.isE2EESupported()) {
-            const { exportedKey, index } = action.keyInfo;
+            const { exportedKey, index, participantId } = action.keyInfo;
 
-            if (exportedKey) {
-                window.crypto.subtle.importKey(
-                    'raw',
-                    new Uint8Array(exportedKey),
-                    'AES-GCM',
-                    false,
-                    [ 'encrypt', 'decrypt' ])
-                .then(
-                    encryptionKey => {
-                        conference.setMediaEncryptionKey({
-                            encryptionKey,
-                            index
-                        });
-                    })
-                .catch(error => logger.error('SET_MEDIA_ENCRYPTION_KEY error', error));
-            } else {
-                conference.setMediaEncryptionKey({
-                    encryptionKey: false,
-                    index
-                });
-            }
+            // Pass raw key bytes directly to the conference so that the E2EE worker can
+            // import them as HKDF material and derive the final AES-GCM key via deriveKeys().
+            // Importing here as AES-GCM would bypass the HKDF derivation step and produce
+            // the wrong key type for the worker's Context.setKey() pipeline.
+            conference.setMediaEncryptionKey({
+                encryptionKey: exportedKey ? new Uint8Array(exportedKey) : false,
+                index,
+                participantId
+            });
         }
 
         break;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -231,7 +231,8 @@ function getConfig(options = {}) {
                 'react-dom': resolve(__dirname, 'node_modules/react-dom'),
                 'roughjs/bin/rough': 'roughjs/bin/rough.js',
                 'roughjs/bin/generator': 'roughjs/bin/generator.js',
-                'roughjs/bin/math': 'roughjs/bin/math.js'
+                'roughjs/bin/math': 'roughjs/bin/math.js',
+                'lib-jitsi-meet': resolve(__dirname, '../lib-jitsi-meet')
             },
             aliasFields: [
                 'browser'
@@ -297,7 +298,12 @@ function getDevServerConfig() {
         static: {
             directory: process.cwd(),
             watch: {
-                ignored: file => file.endsWith('.log')
+                ignored: file => file.endsWith('.log') || file.includes('/node_modules/')
+            }
+        },
+        watchFiles: {
+            options: {
+                ignored: /node_modules/
             }
         }
     };


### PR DESCRIPTION
Companion to jitsi/lib-jitsi-meet#3028.

**Issue 1 — incorrect key type in middleware**

`middleware.ts` imported raw key bytes as an `AES-GCM` CryptoKey before
forwarding them to `conference.setMediaEncryptionKey()`.  However,
`ExternallyManagedKeyHandler` ultimately passes the value to the E2EE worker's
`Context.setKey(key: Uint8Array | ArrayBuffer)`, which calls:

```ts
const material = await importKey(keyBuffer);   // HKDF
const newKey   = await deriveKeys(material);   // HKDF-SHA-256 → AES-GCM-128
```

An already-derived AES-GCM key cannot serve as HKDF input.  The fix removes
the intermediate `importKey` call; raw `Uint8Array` bytes are passed directly
so the worker can perform the derivation itself.

**Issue 2 — participantId not propagated**

The `SET_MEDIA_ENCRYPTION_KEY` Redux action and the External API
`setMediaEncryptionKey()` method did not read or serialise a `participantId`
field.  This made per-sender key selection (enabled by
`e2ee.externallyManagedSharedKey: false` in lib-jitsi-meet) unreachable through
the public API.  `participantId` is now an optional field throughout the chain;
omitting it preserves the existing behaviour.

**Testing**

Unit tests are in the companion lib-jitsi-meet PR.  Manual verification:
1. Deploy Jitsi with `e2ee: { externallyManagedKey: true, externallyManagedSharedKey: false }`
2. From an embedding page call `api.setMediaEncryptionKey({ key, index, participantId })`
3. Confirm in the E2EE worker console that `setKey` is called with the correct
   `participantId` and non-empty key bytes.
