### PR TITLE
fix(invite): react to dialinEnabled metadata changes in open invite dialog

### DIFF
--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -52,6 +52,7 @@ const DEFAULT_STATE = {
 };
 
 export interface IConferenceMetadata {
+    dialinEnabled?: boolean;
     files: {
         [fileId: string]: {
             authorParticipantJid: string;

--- a/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.tsx
+++ b/react/features/invite/components/add-people-dialog/web/AddPeopleDialog.tsx
@@ -18,6 +18,7 @@ import {
     getInviteText,
     getInviteTextiOS,
     isAddPeopleEnabled,
+    isDialInEnabled,
     isDialOutEnabled,
     isSharingEnabled,
     sharingFeatures
@@ -205,7 +206,7 @@ function mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
 
     return {
         _dialIn: dialIn,
-        _dialInVisible: isSharingEnabled(sharingFeatures.dialIn),
+        _dialInVisible: isSharingEnabled(sharingFeatures.dialIn) && isDialInEnabled(state),
         _urlSharingVisible: isDynamicBrandingDataLoaded(state) && isSharingEnabled(sharingFeatures.url),
         _emailSharingVisible: isSharingEnabled(sharingFeatures.email),
         _invitationText: getInviteText({ state,

--- a/react/features/invite/functions.ts
+++ b/react/features/invite/functions.ts
@@ -504,10 +504,9 @@ export function isDialOutEnabled(state: IReduxState): boolean {
  * @returns {boolean} Indication of whether dial out is currently enabled.
  */
 export function isDialInEnabled(state: IReduxState): boolean {
-    const dialInDisabled = state['features/base/conference']
-        .conference?.getMetadataHandler()?.getMetadata()?.dialinEnabled === false;
+    const { metadata } = state['features/base/conference'];
 
-    if (dialInDisabled) {
+    if (metadata?.dialinEnabled === false) {
         return false;
     }
 


### PR DESCRIPTION
Store dialinEnabled from conference metadata in Redux so the invite dialog re-renders and hides dial-in info when the server disables it after the dialog is already open. Defaults to enabled when metadata has not yet arrived.


