### PR TITLE
fix: prevent custom-panel iframe from shifting the page off-screen

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -22,6 +22,7 @@ html {
     height: 100%;
     width: 100%;
     overflow: hidden;
+    overflow: clip;
 }
 
 body {
@@ -30,7 +31,14 @@ body {
     height: 100%;
     font-size: 0.75rem;
     font-weight: 400;
+    // `clip` (vs. `hidden`) makes the element a non-scroll container so the
+    // engine cannot programmatically scroll it. Prevents Chrome's smooth
+    // cross-frame `scrollIntoView` from sliding `body` up by the off-screen
+    // toolbar's height when content inside an iframe (e.g. the custom panel)
+    // requests an auto-scroll. The `hidden` line is the fallback for browsers
+    // that do not understand `clip` (Chrome <90, Safari <16).
     overflow: hidden;
+    overflow: clip;
     color: #F1F1F1;
     background: #040404; // should match DEFAULT_BACKGROUND from interface_config
 }

--- a/react/features/custom-panel/subscriber.web.ts
+++ b/react/features/custom-panel/subscriber.web.ts
@@ -7,6 +7,21 @@ import { setCustomPanelWidth } from './actions.web';
 import { DEFAULT_CUSTOM_PANEL_WIDTH } from './constants';
 import { getCustomPanelMaxSize } from './functions';
 
+/**
+ * Listens for changes in the custom panel open state to recompute available
+ * video space width. Without this, opening or closing the panel does not
+ * refresh `videoSpaceWidth`, so tile dimensions stay sized for the previous
+ * layout until something else triggers a recalculation. Mirrors the pattern
+ * used by chat and the participants pane.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => state['features/custom-panel'].isOpen,
+    /* listener */ (_isOpen, store) => {
+        const { innerWidth, innerHeight } = window;
+
+        store.dispatch(clientResized(innerWidth, innerHeight));
+    });
+
 interface IListenerState {
     clientWidth: number;
     isOpen: boolean;

--- a/tests/pageobjects/Filmstrip.ts
+++ b/tests/pageobjects/Filmstrip.ts
@@ -58,9 +58,7 @@ export default class Filmstrip extends BasePageObject {
      * @param endpointId
      */
     async getRemoteVideoId(endpointId: string) {
-        const remoteDisplayName = this.participant.driver.$(`span[id="participant_${endpointId}"]`);
-
-        await remoteDisplayName.moveTo();
+        await this.participant.driver.$(`span[id="participant_${endpointId}"]`).waitForExist();
 
         return await this.participant.execute(eId =>
             document.evaluate(`//span[@id="participant_${eId}"]//video`,


### PR DESCRIPTION
## Summary

Two independent fixes that came out of debugging an intermittent layout glitch where the videoconference would shift up by ~96px after sending a message in the custom-panel iframe (and oscillate with toolbar visibility from then on).

### `fix(base): prevent body from being scrolled by cross-frame scrollIntoView`

Root cause: the custom-panel iframe's chat auto-scrolls on new content via `scrollIntoView({ behavior: 'smooth' })`. Per the [CSSOM View spec](https://drafts.csswg.org/cssom-view/#scroll-an-element-into-view), the algorithm walks up the frame tree and re-runs against the iframe element in the parent document. With `body { overflow: hidden }`, body is still a scroll container and the engine slides it up by exactly `body.scrollHeight - clientHeight`, which equals the off-screen toolbar's height (~96px because the hidden toolbar is parked at `bottom: -2 * toolbarSize`).

`overflow: clip` (CSS3) makes the element *not* a scroll container at all, so cross-frame `scrollIntoView` propagation has nowhere to land in the parent. `overflow: hidden` is kept as a fallback declaration for Chrome <90 and Safari <16.

### `fix(custom-panel): refresh videoSpaceWidth when the panel toggles open/closed`

Independent issue spotted in the same area: the custom-panel feature was missing the `isOpen` subscriber that chat and the participants pane have (`react/features/filmstrip/subscriber.web.ts:103-121`). Toggling the panel did not refresh `videoSpaceWidth`, so tile-view dimensions stayed sized for the previous layout until something else triggered a recalculation.

## Test plan

- [ ] Open custom panel, choose an agent, type a message, hit enter, move mouse — page no longer shifts up; toolbar shows/hides at the correct position.
- [ ] Verify `document.body.scrollTop` remains 0 throughout.
- [ ] Toggle custom panel open/closed multiple times — tile dimensions correctly account for the panel's width without needing an unrelated event to trigger recalculation.
- [ ] Smoke test on Safari 16+ (uses `clip`) and Safari 15 (falls back to `hidden`).