### PR TITLE
ci(rnsdk): add workflow to publish React Native SDK via npm trusted publishing

### DIFF
--- a/.github/workflows/release-rnsdk.yml
+++ b/.github/workflows/release-rnsdk.yml
@@ -1,0 +1,63 @@
+name: Release React Native SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.2.3). Leave empty to use the version already in package.json.'
+        required: false
+        type: string
+      dist-tag:
+        description: 'npm dist-tag'
+        required: true
+        default: 'latest'
+        type: choice
+        options:
+          - latest
+          - next
+          - beta
+      dry-run:
+        description: 'Dry run (do not actually publish)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - name: Ensure npm supports trusted publishing
+        run: npm install -g npm@latest
+      - name: Print versions
+        run: |
+          node -v
+          npm -v
+          echo "Ref:    ${{ github.ref }}"
+          echo "SHA:    ${{ github.sha }}"
+      - name: Install root dependencies
+        run: npm ci
+      - name: Set version
+        if: ${{ inputs.version != '' }}
+        working-directory: react-native-sdk
+        run: npm version --no-git-tag-version --allow-same-version "${{ inputs.version }}"
+      - name: Prepare SDK package
+        working-directory: react-native-sdk
+        run: npm run prepare
+      - name: Publish (dry run)
+        if: ${{ inputs.dry-run }}
+        working-directory: react-native-sdk
+        run: npm publish --tag "${{ inputs.dist-tag }}" --access public --dry-run
+      - name: Publish
+        if: ${{ !inputs.dry-run }}
+        working-directory: react-native-sdk
+        run: npm publish --tag "${{ inputs.dist-tag }}" --access public


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-rnsdk.yml`, a manually-dispatched workflow that publishes `@jitsi/react-native-sdk` to npm using OIDC trusted publishing (no `NPM_TOKEN` required, provenance attached automatically).
- Branch selection is via the standard `workflow_dispatch` ref picker. Inputs: optional `version` override, `dist-tag` (`latest`/`next`/`beta`), and `dry-run`.
- Designed to be dispatchable from Jenkins via `POST /repos/jitsi/jitsi-meet/actions/workflows/release-rnsdk.yml/dispatches` (or `gh workflow run`), passing the desired branch as `ref`.

## One-time setup required before first run
On npmjs.com, configure a Trusted Publisher on `@jitsi/react-native-sdk`:
- Owner: `jitsi`
- Repository: `jitsi-meet`
- Workflow filename: `release-rnsdk.yml`
- Environment: *(empty)*

The workflow file must exist on the default branch before `workflow_dispatch` becomes available — merging this PR enables it.

## Test plan
- [ ] Merge to master so `workflow_dispatch` is registered.
- [ ] Configure the npm trusted publisher entry for `@jitsi/react-native-sdk`.
- [ ] Run the workflow with `dry-run: true` from a release branch and verify `npm publish --dry-run` succeeds and OIDC token exchange works.
- [ ] Run a real release (e.g. with a `beta` dist-tag) and verify the package appears on npm with provenance.
- [ ] Trigger the workflow from Jenkins via the dispatches API and confirm the run is created against the chosen branch.