### PR TITLE
test(jaas/dial-in): mute p1 before waitForMedia so dial-in stays forwarded

### DIFF
--- a/tests/specs/jaas/dial/dialin.spec.ts
+++ b/tests/specs/jaas/dial/dialin.spec.ts
@@ -63,6 +63,13 @@ describe('Dial-in', () => {
         expect(dialInPin.length).toBeGreaterThanOrEqual(8);
 
         await dialIn(dialInPin);
+
+        // Mute p1 so the dial-in remains the dominant speaker; otherwise the JVB audio-source
+        // forwarding can evict the dial-in source and waitForReceiveMedia times out.
+        await p1.waitForParticipants(1);
+        await p1.driver.pause(1000);
+        await p1.getToolbar().clickAudioMuteButton();
+
         await waitForMedia(p1);
 
         let startedPayload: any;
@@ -74,6 +81,7 @@ describe('Dial-in', () => {
 
         const endpointId = await p1.execute(() => APP?.conference?.listMembers()[0].getId());
 
+        await p1.getToolbar().clickAudioUnmuteButton();
         await p1.getFilmstrip().kickParticipant(endpointId);
 
         if (webhooksProxy) {


### PR DESCRIPTION
Without muting, p1's fakeAudioStream.wav playback competes for dominant speaker and the bridge stops forwarding the dial-in audio source after the initial burst, causing waitForReceiveMedia to time out.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
