### PR TITLE
chore(deps): upgrade @jitsi/js-utils to 6.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@giphy/react-components": "6.9.4",
         "@giphy/react-native-sdk": "5.0.1",
         "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.5/jitsi-excalidraw-v0.18.5.tgz",
-        "@jitsi/js-utils": "2.6.7",
+        "@jitsi/js-utils": "6.3.2",
         "@jitsi/logger": "2.1.1",
         "@jitsi/rnnoise-wasm": "0.2.1",
         "@matrix-org/olm": "3.2.15",
@@ -4743,12 +4743,12 @@
       }
     },
     "node_modules/@jitsi/js-utils": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.6.7.tgz",
-      "integrity": "sha512-r16J3CjYt325CFIpfHznND4O3b9BE7CZ7cu+Xx0uk1C+ZY6/bDPZFM/0d4t0VH+1/rmfG4I7i18qxXct3xmPrw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-6.3.2.tgz",
+      "integrity": "sha512-nGF24WVADFQF2OfdlJWbel2MvwTRbxxZdNDzIqUBKGtRYd10CukgrcydB2WRPRLtn4Q97KrpdqrcAuH0Idi3yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@hapi/bourne": "^3.0.0",
+        "@hapi/bourne": "3.0.0",
         "js-md5": "0.7.3",
         "ua-parser-js": "1.0.35"
       }
@@ -4756,7 +4756,8 @@
     "node_modules/@jitsi/js-utils/node_modules/js-md5": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
-      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ=="
+      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==",
+      "license": "MIT"
     },
     "node_modules/@jitsi/logger": {
       "version": "2.1.1",
@@ -4785,10 +4786,27 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/@jitsi/rtcstats/node_modules/@jitsi/js-utils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.8.2.tgz",
+      "integrity": "sha512-tMFuci2lPmbQIFF/f3b5QdkL1vzY6sii9nj0e+K0EEJcFUJiX/QVkv5GbI6pMZ74BYAQXGFZqeASo8hKItniUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hapi/bourne": "3.0.0",
+        "js-md5": "0.7.3",
+        "ua-parser-js": "1.0.35"
+      }
+    },
     "node_modules/@jitsi/rtcstats/node_modules/@jitsi/logger": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
       "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg=="
+    },
+    "node_modules/@jitsi/rtcstats/node_modules/js-md5": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
+      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==",
+      "license": "MIT"
     },
     "node_modules/@jitsi/rtcstats/node_modules/uuid": {
       "version": "8.3.2",
@@ -32867,11 +32885,11 @@
       }
     },
     "@jitsi/js-utils": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.6.7.tgz",
-      "integrity": "sha512-r16J3CjYt325CFIpfHznND4O3b9BE7CZ7cu+Xx0uk1C+ZY6/bDPZFM/0d4t0VH+1/rmfG4I7i18qxXct3xmPrw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-6.3.2.tgz",
+      "integrity": "sha512-nGF24WVADFQF2OfdlJWbel2MvwTRbxxZdNDzIqUBKGtRYd10CukgrcydB2WRPRLtn4Q97KrpdqrcAuH0Idi3yg==",
       "requires": {
-        "@hapi/bourne": "^3.0.0",
+        "@hapi/bourne": "3.0.0",
         "js-md5": "0.7.3",
         "ua-parser-js": "1.0.35"
       },
@@ -32909,10 +32927,25 @@
         "uuid": "^8.3.2"
       },
       "dependencies": {
+        "@jitsi/js-utils": {
+          "version": "2.8.2",
+          "resolved": "https://registry.npmjs.org/@jitsi/js-utils/-/js-utils-2.8.2.tgz",
+          "integrity": "sha512-tMFuci2lPmbQIFF/f3b5QdkL1vzY6sii9nj0e+K0EEJcFUJiX/QVkv5GbI6pMZ74BYAQXGFZqeASo8hKItniUA==",
+          "requires": {
+            "@hapi/bourne": "3.0.0",
+            "js-md5": "0.7.3",
+            "ua-parser-js": "1.0.35"
+          }
+        },
         "@jitsi/logger": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/@jitsi/logger/-/logger-2.0.2.tgz",
           "integrity": "sha512-qwbpRwuwkBFgh0F5jivq/5fAm46yVoXURc5LCklEs8lAShYVangFEXKW7RLpZuZ5nQnrHrlvU8MswQNREmvahg=="
+        },
+        "js-md5": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
+          "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ=="
         },
         "uuid": {
           "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@giphy/react-components": "6.9.4",
     "@giphy/react-native-sdk": "5.0.1",
     "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.5/jitsi-excalidraw-v0.18.5.tgz",
-    "@jitsi/js-utils": "2.6.7",
+    "@jitsi/js-utils": "6.3.2",
     "@jitsi/logger": "2.1.1",
     "@jitsi/rnnoise-wasm": "0.2.1",
     "@matrix-org/olm": "3.2.15",

--- a/react/features/app/getRouteToRender.web.ts
+++ b/react/features/app/getRouteToRender.web.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { generateRoomWithoutSeparator } from '@jitsi/js-utils/random';
 
 import { IStateful } from '../base/app/types';

--- a/react/features/base/app/components/BaseApp.tsx
+++ b/react/features/base/app/components/BaseApp.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 import { isEqual } from 'lodash-es';
 import React, { Component, ComponentType, Fragment } from 'react';
@@ -133,7 +132,18 @@ export default class BaseApp<P> extends Component<P, IState> {
      * @returns {Promise}
      */
     _initStorage(): Promise<any> {
-        const _initializing = jitsiLocalStorage.getItem('_initializing');
+        // On react-native, global.localStorage is replaced at startup with the
+        // Storage polyfill in react/features/mobile/polyfills/Storage.js, which
+        // stores its AsyncStorage-loading Promise as an instance property named
+        // `_initializing`. Its getItem() returns own-property values, so
+        // getItem('_initializing') surfaces that Promise and lets us wait for
+        // AsyncStorage to finish loading persisted state. On web this is always
+        // null (no such key in window.localStorage) and the cast is a no-op.
+        // The new @jitsi/js-utils types declare getItem as `string | null`,
+        // which is accurate for the standard Web Storage shape but doesn't
+        // capture this RN-only side channel — hence the cast.
+        const _initializing = jitsiLocalStorage.getItem('_initializing') as
+            Promise<unknown> | null;
 
         return _initializing || Promise.resolve();
     }

--- a/react/features/base/config/actions.ts
+++ b/react/features/base/config/actions.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 
 import { IStore } from '../../app/types';

--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -1,7 +1,4 @@
-// @ts-ignore
 import { jitsiLocalStorage } from '@jitsi/js-utils';
-// eslint-disable-next-line lines-around-comment
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import { isEmpty, mergeWith, pick } from 'lodash-es';
 

--- a/react/features/base/connection/actions.web.ts
+++ b/react/features/base/connection/actions.web.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 
 import { IStore } from '../../app/types';

--- a/react/features/base/dialog/components/native/PageReloadDialog.tsx
+++ b/react/features/base/dialog/components/native/PageReloadDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { randomInt } from '@jitsi/js-utils/random';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';

--- a/react/features/base/jitsi-local-storage/setup.web.ts
+++ b/react/features/base/jitsi-local-storage/setup.web.ts
@@ -1,7 +1,4 @@
-// @ts-ignore
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
-// eslint-disable-next-line lines-around-comment
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import { pick } from 'lodash-es';
 

--- a/react/features/base/lib-jitsi-meet/actions.ts
+++ b/react/features/base/lib-jitsi-meet/actions.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 
 import { IStore } from '../../app/types';

--- a/react/features/base/lib-jitsi-meet/functions.native.ts
+++ b/react/features/base/lib-jitsi-meet/functions.native.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 // @ts-ignore
 import { Worklets } from 'react-native-worklets-core';

--- a/react/features/base/participants/functions.ts
+++ b/react/features/base/participants/functions.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { getGravatarURL } from '@jitsi/js-utils/avatar';
 
 import { IReduxState, IStore } from '../../app/types';

--- a/react/features/base/redux/PersistenceRegistry.ts
+++ b/react/features/base/redux/PersistenceRegistry.ts
@@ -1,7 +1,4 @@
-// @ts-ignore
 import { jitsiLocalStorage } from '@jitsi/js-utils';
-// eslint-disable-next-line lines-around-comment
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import md5 from 'js-md5';
 

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 import { escape } from 'lodash-es';
 

--- a/react/features/base/util/parseURLParams.ts
+++ b/react/features/base/util/parseURLParams.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 
 import { reportError } from './helpers';

--- a/react/features/calendar-sync/actions.native.ts
+++ b/react/features/calendar-sync/actions.native.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { generateRoomWithoutSeparator } from '@jitsi/js-utils/random';
 
 import { getDefaultURL } from '../app/functions';

--- a/react/features/calendar-sync/actions.web.ts
+++ b/react/features/calendar-sync/actions.web.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { generateRoomWithoutSeparator } from '@jitsi/js-utils/random';
 
 import { createCalendarConnectedEvent } from '../analytics/AnalyticsEvents';

--- a/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.tsx
+++ b/react/features/chrome-extension-banner/components/ChromeExtensionBanner.web.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 import React, { PureComponent } from 'react';
 import { WithTranslation } from 'react-i18next';

--- a/react/features/invite/functions.ts
+++ b/react/features/invite/functions.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 
 import { IReduxState } from '../app/types';

--- a/react/features/overlay/components/web/AbstractPageReloadOverlay.tsx
+++ b/react/features/overlay/components/web/AbstractPageReloadOverlay.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { randomInt } from '@jitsi/js-utils/random';
 import React, { Component } from 'react';
 import { WithTranslation } from 'react-i18next';

--- a/react/features/remote-control/middleware.ts
+++ b/react/features/remote-control/middleware.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { PostMessageTransportBackend, Transport } from '@jitsi/js-utils/transport';
 
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../base/app/actionTypes';

--- a/react/features/virtual-background/components/VirtualBackgrounds.tsx
+++ b/react/features/virtual-background/components/VirtualBackgrounds.tsx
@@ -1,7 +1,4 @@
-// @ts-ignore
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
-// eslint-disable-next-line lines-around-comment
-// @ts-ignore
 import { safeJsonParse } from '@jitsi/js-utils/json';
 import React, { useCallback, useEffect, useState } from 'react';
 import { WithTranslation } from 'react-i18next';

--- a/react/features/welcome/components/AbstractWelcomePage.ts
+++ b/react/features/welcome/components/AbstractWelcomePage.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import { generateRoomWithoutSeparator } from '@jitsi/js-utils/random';
 import { Component } from 'react';
 import { WithTranslation } from 'react-i18next';

--- a/tsconfig.native.json
+++ b/tsconfig.native.json
@@ -8,7 +8,7 @@
         "lib": [ "ES2020", "ES2024.Promise" ],
         "types": [ "react-native" ],
         "skipLibCheck": true,
-        "moduleResolution": "Node",
+        "moduleResolution": "Bundler",
         "strict": true,
         "noImplicitAny": true,
         "strictPropertyInitialization": false,

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -7,7 +7,7 @@
         "jsx": "react",
         "lib": [ "ES2024", "DOM" ],
         "skipLibCheck": true,
-        "moduleResolution": "Node",
+        "moduleResolution": "Bundler",
         "strict": true,
         "noImplicitAny": true,
         "noImplicitOverride": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -373,7 +373,7 @@ module.exports = (_env, argv) => {
                 ...config.plugins,
                 ...getBundleAnalyzerPlugin(analyzeBundle, 'external_api')
             ],
-            performance: getPerformanceHints(perfHintOptions, 95 * 1024) },
+            performance: getPerformanceHints(perfHintOptions, 100 * 1024) },
         { ...config,
             entry: {
                 'face-landmarks-worker': './react/features/face-landmarks/faceLandmarksWorker.ts'


### PR DESCRIPTION
## Summary

- Upgrades `@jitsi/js-utils` from `2.6.7` to `6.3.2`. The new release ships its own TypeScript types and a modern `exports` map, so the long-standing `@ts-ignore`/`@ts-expect-error` suppressions on every `@jitsi/js-utils` import line are no longer needed.
- Switches `tsconfig.{web,native}.json` from `moduleResolution: "Node"` to `"Bundler"` so TypeScript honors the package's `exports` field. Legacy Node resolution ignores `exports` entirely, which is why all the subpath imports needed `@ts-ignore` to begin with.
- Removes 7 unused root-import `@ts-expect-error` directives (`BaseApp.tsx`, `base/config/actions.ts`, `base/connection/actions.web.ts`, `base/lib-jitsi-meet/actions.ts`, `base/settings/reducer.ts`, `ChromeExtensionBanner.web.tsx`, `invite/functions.ts`) plus 14 subpath-import `@ts-ignore`/`@ts-expect-error` suppressions across web and native files. Drops the paired `// eslint-disable-next-line lines-around-comment` lines that only existed to silence the directive clutter.
- `BaseApp._initStorage`: narrow type assertion (with comment) to preserve the react-native polyfill side channel — `jitsiLocalStorage.getItem('_initializing')` on RN returns the AsyncStorage-loading Promise from `react/features/mobile/polyfills/Storage.js`, which the new package's `string | null` types don't (and shouldn't) describe.
- Bumps the `external_api` bundle size budget from 95 KiB to 100 KiB to accommodate the small per-file TS-compilation overhead introduced by the new package layout.

## Test plan

- [ ] `npm run tsc:ci` passes on web and native.
- [ ] `npm run lint:ci` passes.
- [ ] `make compile` produces all bundles successfully and `external_api.min.js` stays under the new 100 KiB budget.
- [ ] WebDriverIO suite runs cleanly against a deployment that has the upgraded code.
- [ ] Manual: join a meeting on web; verify settings/persistence survive reload (exercises the `jitsiLocalStorage` paths).
- [ ] Manual: iframe API embed — confirm the parent ↔ iframe localStorage sync still works (touches the rewritten `JitsiLocalStorage` and the `Transport` backend).
- [ ] Manual on mobile (RN): confirm the app starts cleanly (touches the `_initStorage` cast on the RN side, which relies on the polyfilled `window.localStorage._initializing` Promise).