### PR TITLE
feat(mobile/navigation): improvements

### DIFF
--- a/react/features/app/actions.native.ts
+++ b/react/features/app/actions.native.ts
@@ -23,7 +23,8 @@ import {
 import { isPrejoinPageEnabled } from '../mobile/navigation/functions';
 import {
     goBackToRoot,
-    navigateRoot
+    navigateRoot,
+    replaceRoot
 } from '../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../mobile/navigation/routes';
 import { clearNotifications } from '../notifications/actions';
@@ -156,13 +157,13 @@ export function appNavigate(uri?: string, options: IReloadNowOptions = {}) {
 
         if (!options.hidePrejoin && isPrejoinPageEnabled(getState())) {
             if (isUnsafeRoomWarningEnabled(getState()) && isInsecureRoomName(room)) {
-                navigateRoot(screen.unsafeRoomWarning);
+                replaceRoot(screen.unsafeRoomWarning);
             } else {
-                navigateRoot(screen.preJoin);
+                replaceRoot(screen.preJoin);
             }
         } else {
             dispatch(connect());
-            navigateRoot(screen.conference.root);
+            replaceRoot(screen.conference.root);
         }
     };
 }

--- a/react/features/base/connection/actions.native.ts
+++ b/react/features/base/connection/actions.native.ts
@@ -2,7 +2,7 @@ import { appNavigate } from '../../app/actions.native';
 import { IStore } from '../../app/types';
 import { getCustomerDetails } from '../../jaas/actions.any';
 import { getJaasJWT, isVpaasMeeting } from '../../jaas/functions';
-import { navigateRoot } from '../../mobile/navigation/rootNavigationContainerRef';
+import { replaceRoot } from '../../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../../mobile/navigation/routes';
 import { conferenceLeft } from '../conference/actions.native';
 import { setJWT } from '../jwt/actions';
@@ -45,7 +45,7 @@ export function connect(id?: string, password?: string) {
 
         .catch(error => {
             if (error === JitsiConnectionErrors.NOT_LIVE_ERROR) {
-                navigateRoot(screen.visitorsQueue);
+                replaceRoot(screen.visitorsQueue);
             }
         });
     };

--- a/react/features/conference/components/native/Conference.tsx
+++ b/react/features/conference/components/native/Conference.tsx
@@ -33,7 +33,6 @@ import { isFilmstripVisible } from '../../../filmstrip/functions.native';
 import CalleeInfoContainer from '../../../invite/components/callee-info/CalleeInfoContainer';
 import LargeVideo from '../../../large-video/components/LargeVideo.native';
 import { getIsLobbyVisible } from '../../../lobby/functions';
-import { navigate } from '../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../../../mobile/navigation/routes';
 import { isPipEnabled, setPictureInPictureEnabled } from '../../../mobile/picture-in-picture/functions';
 import Captions from '../../../subtitles/components/native/Captions';
@@ -233,14 +232,14 @@ class Conference extends AbstractConference<IProps, State> {
         } = this.props;
 
         if (!prevProps._showLobby && _showLobby) {
-            navigate(screen.lobby.root);
+            navigation.navigate(screen.lobby.root);
         }
 
         if (prevProps._showLobby && !_showLobby) {
             if (_audioOnlyEnabled && _startCarMode) {
                 navigation.navigate(screen.conference.carmode);
             } else {
-                navigate(screen.conference.main);
+                navigation.navigate(screen.conference.main);
             }
         }
     }

--- a/react/features/mobile/navigation/rootNavigationContainerRef.ts
+++ b/react/features/mobile/navigation/rootNavigationContainerRef.ts
@@ -1,4 +1,4 @@
-import { NavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainerRef, StackActions } from '@react-navigation/native';
 import React from 'react';
 
 import { IStore } from '../../app/types';
@@ -21,6 +21,17 @@ export const rootNavigationRef = React.createRef<NavigationContainerRef<any>>();
  */
 export function navigateRoot(name: string, params?: Object) {
     return rootNavigationRef.current?.navigate(name, params);
+}
+
+/**
+ * Replaces the currently focused screen in the root navigation stack.
+ *
+ * @param {string} name - Destination route name.
+ * @param {Object} params - Params to pass to the destination route.
+ * @returns {void}
+ */
+export function replaceRoot(name: string, params?: Object) {
+    return rootNavigationRef.current?.dispatch(StackActions.replace(name, params));
 }
 
 /**

--- a/react/features/prejoin/actions.native.ts
+++ b/react/features/prejoin/actions.native.ts
@@ -1,6 +1,6 @@
 import { IStore } from '../app/types';
 import { connect } from '../base/connection/actions.native';
-import { navigateRoot } from '../mobile/navigation/rootNavigationContainerRef';
+import { replaceRoot } from '../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../mobile/navigation/routes';
 import { showVisitorsQueue } from '../visitors/functions';
 
@@ -17,7 +17,7 @@ export function joinConference(options?: Object, _ignoreJoiningInProgress = fals
 
         if (_showVisitorsQueue) {
             dispatch(connect());
-            navigateRoot(screen.conference.root);
+            replaceRoot(screen.conference.root);
         }
     };
 }

--- a/react/features/prejoin/components/native/Prejoin.tsx
+++ b/react/features/prejoin/components/native/Prejoin.tsx
@@ -34,7 +34,7 @@ import { openDisplayNamePrompt } from '../../../display-name/actions';
 import BrandingImageBackground from '../../../dynamic-branding/components/native/BrandingImageBackground';
 import LargeVideo from '../../../large-video/components/LargeVideo.native';
 import HeaderNavigationButton from '../../../mobile/navigation/components/HeaderNavigationButton';
-import { navigateRoot } from '../../../mobile/navigation/rootNavigationContainerRef';
+import { replaceRoot } from '../../../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../../../mobile/navigation/routes';
 import AudioMuteButton from '../../../toolbox/components/native/AudioMuteButton';
 import VideoMuteButton from '../../../toolbox/components/native/VideoMuteButton';
@@ -82,7 +82,7 @@ const Prejoin: React.FC<IPrejoinProps> = ({ navigation }: IPrejoinProps) => {
 
     const onJoin = useCallback(() => {
         dispatch(connect());
-        navigateRoot(screen.conference.root);
+        replaceRoot(screen.conference.root);
     }, [ dispatch ]);
 
     const maybeJoin = useCallback(() => {

--- a/react/features/prejoin/components/native/UnsafeRoomWarning.tsx
+++ b/react/features/prejoin/components/native/UnsafeRoomWarning.tsx
@@ -21,7 +21,7 @@ import Button from '../../../base/ui/components/native/Button';
 import { BUTTON_TYPES } from '../../../base/ui/constants.native';
 import getUnsafeRoomText from '../../../base/util/getUnsafeRoomText.native';
 import HeaderNavigationButton from '../../../mobile/navigation/components/HeaderNavigationButton';
-import { navigateRoot } from '../../../mobile/navigation/rootNavigationContainerRef';
+import { replaceRoot } from '../../../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../../../mobile/navigation/routes';
 import { IPrejoinProps } from '../../types';
 
@@ -44,7 +44,7 @@ const UnsafeRoomWarning: React.FC<IPrejoinProps> = ({ navigation }: IPrejoinProp
     }, [ dispatch ]);
 
     const onProceed = useCallback(() => {
-        navigateRoot(screen.preJoin);
+        replaceRoot(screen.preJoin);
 
         return true;
     }, [ dispatch ]);


### PR DESCRIPTION
1. Fix lobby screen getting stuck by using navigation prop instead of global ref.
2. Created helper that replaces current active screen with next active screen in the navigation stack.
