### PR TITLE
fix(tests): wait for desktop-sharing toggle to settle before returning

### DIFF
--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -196,17 +196,28 @@ export default class Toolbar extends BasePageObject {
     }
 
     /**
-     * Clicks on the desktop sharing button that starts desktop sharing.
+     * Clicks on the desktop sharing button that starts desktop sharing. Waits until the toggle takes effect
+     * (button flips to STOP_DESKTOP) so a subsequent call doesn't race a still-in-flight stop.
      */
-    clickDesktopSharingButton() {
-        return this.getButton(DESKTOP).click();
+    async clickDesktopSharingButton() {
+        await this.getButton(DESKTOP).click();
+        await this.getButton(STOP_DESKTOP).waitForExist({
+            timeout: 5_000,
+            timeoutMsg: `Desktop sharing did not start for ${this.participant.name}`
+        });
     }
 
     /**
-     * Clicks on the desktop sharing button to stop it.
+     * Clicks on the desktop sharing button to stop it. Waits until the toggle takes effect (button flips to
+     * DESKTOP) — clicks can be dropped during track-replace / P2P transitions, so without this the next caller
+     * sees a stale "still sharing" state.
      */
-    clickStopDesktopSharingButton() {
-        return this.getButton(STOP_DESKTOP).click();
+    async clickStopDesktopSharingButton() {
+        await this.getButton(STOP_DESKTOP).click();
+        await this.getButton(DESKTOP).waitForExist({
+            timeout: 5_000,
+            timeoutMsg: `Desktop sharing did not stop for ${this.participant.name}`
+        });
     }
 
     /**


### PR DESCRIPTION
clickDesktopSharingButton / clickStopDesktopSharingButton just clicked and returned, so a click that landed during a track-replace or P2P transition could be silently dropped (no presence update, no useVideoStream, local desktop track keeps encoding) and the next caller saw a stale "still sharing" / "still stopped" state. In desktopSharing.spec.ts the stop click on p2 fired 106ms after p1's stop while the conference was processing p1's screenshare removal, the handler dropped it, and the subsequent start click failed because the aria-label was still "Stop sharing your screen".

After-click wait for the opposite aria-label to appear converts a silently-dropped click into an immediate failure at the click site and resolves on the next React tick in the happy path.
