### PR TITLE
fix(config): fetch config.js on web when window.config is missing.

### DIFF
--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -5,7 +5,9 @@ import {
     configWillLoad,
     setConfig
 } from '../base/config/actions';
+import { buildConfigURL } from '../base/config/functions.any';
 import { setLocationURL } from '../base/connection/actions.web';
+import { loadConfig } from '../base/lib-jitsi-meet/functions.web';
 import { isEmbedded } from '../base/util/embedUtils';
 import { parseURIString } from '../base/util/uri';
 import { isVpaasMeeting } from '../jaas/functions';
@@ -70,7 +72,24 @@ export function appNavigate(uri?: string) {
 
         dispatch(configWillLoad(locationURL));
         dispatch(setLocationURL(locationURL));
-        dispatch(setConfig(window.config));
+
+        let config = window.config;
+
+        if (!config) {
+            const url = buildConfigURL(locationURL, room);
+
+            try {
+                config = await loadConfig(url);
+
+                // Mirror to window.config so legacy bare `config` global
+                // references (UI.js, etc.) resolve when SSI did not inject it.
+                window.config = config;
+            } catch (err) {
+                logger.error(`Failed to load config from ${url}`, err);
+            }
+        }
+
+        dispatch(setConfig(config));
         dispatch(setRoom(room));
     };
 }

--- a/react/features/base/i18n/configLanguageDetector.ts
+++ b/react/features/base/i18n/configLanguageDetector.ts
@@ -1,9 +1,12 @@
 import { noop } from 'lodash-es';
 
-declare let config: any;
-
 /**
  * Custom language detection, just returns the config property if any.
+ *
+ * When config.js has not yet been loaded (e.g. SSI did not inject it and we
+ * are fetching it asynchronously via appNavigate), this returns undefined so
+ * other detectors in the chain take over. Once SET_CONFIG dispatches, the
+ * i18n middleware applies defaultLanguage from the store via changeLanguage.
  */
 export default {
     cacheUserLanguage: noop,
@@ -11,10 +14,10 @@ export default {
     /**
      * Looks the language up in the config.
      *
-     * @returns {string} The default language if any.
+     * @returns {string | undefined} The default language if available.
      */
     lookup() {
-        return config.defaultLanguage;
+        return window.config?.defaultLanguage;
     },
 
     /**

--- a/react/features/base/i18n/middleware.ts
+++ b/react/features/base/i18n/middleware.ts
@@ -1,5 +1,6 @@
 import { SET_DYNAMIC_BRANDING_DATA } from '../../dynamic-branding/actionTypes';
 import { getConferenceState } from '../conference/functions';
+import { SET_CONFIG } from '../config/actionTypes';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 
 import { I18NEXT_INITIALIZED, LANGUAGE_CHANGED } from './actionTypes';
@@ -15,6 +16,20 @@ import logger from './logger';
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
+    case SET_CONFIG: {
+        // When config.js is fetched asynchronously (no window.config at boot),
+        // configLanguageDetector returns undefined and i18next falls back. Once
+        // the store has the config, apply its defaultLanguage if it differs
+        // from what i18next picked.
+        const defaultLanguage = action.config?.defaultLanguage;
+
+        if (defaultLanguage && defaultLanguage !== i18next.language) {
+            i18next.changeLanguage(defaultLanguage).catch(err => {
+                logger.log('Error applying defaultLanguage from config', err);
+            });
+        }
+        break;
+    }
     case I18NEXT_INITIALIZED:
     case LANGUAGE_CHANGED:
     case SET_DYNAMIC_BRANDING_DATA: {

--- a/react/features/dynamic-branding/functions.any.ts
+++ b/react/features/dynamic-branding/functions.any.ts
@@ -39,10 +39,7 @@ export function extractFqnFromPath(state?: IReduxState) {
 export async function getDynamicBrandingUrl(stateful: IStateful) {
     const state = toState(stateful);
 
-    // NB: On web this is dispatched really early, before the config has been stored in the
-    // state. Thus, fetch it from the window global.
-    const config
-        = navigator.product === 'ReactNative' ? state['features/base/config'] : window.config;
+    const config = state['features/base/config'];
     const { dynamicBrandingUrl } = config;
 
     if (dynamicBrandingUrl) {

--- a/react/features/dynamic-branding/middleware.web.ts
+++ b/react/features/dynamic-branding/middleware.web.ts
@@ -1,4 +1,4 @@
-import { APP_WILL_MOUNT } from '../base/app/actionTypes';
+import { SET_CONFIG } from '../base/config/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 
 import { SET_DYNAMIC_BRANDING_DATA } from './actionTypes';
@@ -9,10 +9,12 @@ import './middleware.any';
 
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-    case APP_WILL_MOUNT: {
+    case SET_CONFIG: {
+        const result = next(action);
 
         store.dispatch(fetchCustomBrandingData());
-        break;
+
+        return result;
     }
     case SET_DYNAMIC_BRANDING_DATA: {
         const { customTheme } = action.value;


### PR DESCRIPTION
Mirrors the native flow: if SSI did not inject config.js, build the config URL (with tenant via contextRoot, room, release) and fetch it asynchronously, then mirror to window.config so legacy bare `config` global references keep resolving.

Also reacts to SET_CONFIG to apply defaultLanguage via i18next changeLanguage (configLanguageDetector returns undefined at boot when config is not yet present) and defers dynamic branding fetch to SET_CONFIG so it reads from the store rather than window.config.
