### PR TITLE
fix(tests): wake auto-hidden toolbar before opening overflow menu

### DIFF
--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -331,6 +331,10 @@ export default class Toolbar extends BasePageObject {
             return;
         }
 
+        // Wake the auto-hidden toolbar by hovering the local video tile; otherwise the overflow
+        // button click can fire on an invisible element and the menu never appears.
+        await this.participant.driver.$('span[id="localVideoContainer"]').moveTo();
+
         await this.clickOverflowButton();
 
         await this.waitForOverFlowMenu(true);

--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -332,8 +332,16 @@ export default class Toolbar extends BasePageObject {
         }
 
         // Wake the auto-hidden toolbar by hovering the local video tile; otherwise the overflow
-        // button click can fire on an invisible element and the menu never appears.
-        await this.participant.driver.$('span[id="localVideoContainer"]').moveTo();
+        // button click can fire on an invisible element and the menu never appears. When the
+        // self-view is hidden (e.g. via settings), localVideoContainer is not in the DOM, so fall
+        // back to the large video container which is always present while in conference.
+        const localVideoContainer = this.participant.driver.$('span[id="localVideoContainer"]');
+
+        if (await localVideoContainer.isExisting()) {
+            await localVideoContainer.moveTo();
+        } else {
+            await this.participant.driver.$('#largeVideoContainer').moveTo();
+        }
 
         await this.clickOverflowButton();
 


### PR DESCRIPTION
clickButtonInOverflowMenu() was failing on beta shards with 'Overflow menu is not visible' whenever it ran soon after a hangup + rejoin. The Jitsi toolbar auto-hides when the cursor isn't over the local video tile, so the overflow-button click was firing on an invisible element and the menu never opened.

Hover the local video tile inside openOverflowMenu() to wake the toolbar before clicking. Every spec that touches the overflow menu benefits, not just the virtual-background V2 tests that exposed this.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
