### PR TITLE
fix(tests): bump knocking-participant notification timeout to 15s.

### DIFF
--- a/tests/pageobjects/Notifications.ts
+++ b/tests/pageobjects/Notifications.ts
@@ -166,7 +166,7 @@ export default class Notifications extends BasePageObject {
             = this.participant.driver.$('//div[@data-testid="notify.participantWantsToJoin"]/div/div/span');
 
         await knockingParticipantNotification.waitForDisplayed({
-            timeout: 3000,
+            timeout: 15000,
             timeoutMsg: 'Knocking participant notification not displayed'
         });
 


### PR DESCRIPTION
Sometimes network can be slow connecting to remote shards, add more tolerance in waiting — mirrors the precedent set by 0cb8f9dad for waitToJoinLobby.

