### PR TITLE
fix(popover): close hover menus on Escape

### DIFF
--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -192,9 +192,28 @@ class Popover extends Component<IProps, IState> {
      */
     override componentDidMount() {
         window.addEventListener('touchstart', this._onOutsideTouchStart);
+        if (this.props.visible) {
+            window.addEventListener('keydown', this._onEscKey);
+        }
         if (this.props.trigger === 'click') {
             // @ts-ignore
             window.addEventListener('click', this._onOutsideClick);
+        }
+    }
+
+    /**
+     * Attaches/removes the global Escape key listener as visibility changes.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    override componentDidUpdate(prevProps: IProps) {
+        if (prevProps.visible !== this.props.visible) {
+            if (this.props.visible) {
+                window.addEventListener('keydown', this._onEscKey);
+            } else {
+                window.removeEventListener('keydown', this._onEscKey);
+            }
         }
     }
 
@@ -206,6 +225,7 @@ class Popover extends Component<IProps, IState> {
      */
     override componentWillUnmount() {
         window.removeEventListener('touchstart', this._onOutsideTouchStart);
+        window.removeEventListener('keydown', this._onEscKey);
         if (this.props.trigger === 'click') {
             // @ts-ignore
             window.removeEventListener('click', this._onOutsideClick);
@@ -453,7 +473,7 @@ class Popover extends Component<IProps, IState> {
      *
      * @returns {void}
      */
-    _onEscKey(e: React.KeyboardEvent) {
+    _onEscKey(e: KeyboardEvent | React.KeyboardEvent) {
         if (e.key === 'Escape') {
             e.preventDefault();
             e.stopPropagation();


### PR DESCRIPTION
Fixes an accessibility issue where hover-opened popovers, such as the local video three-dot menu, could not be dismissed with Escape unless focus was inside the popover content.

This adds a global Escape key listener while the popover is visible and removes it when the popover closes or unmounts.