### PR TITLE
Disable colibri (JVB) WebSocket proxy in nginx/apache config by default

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.example
+++ b/doc/debian/jitsi-meet/jitsi-meet.example
@@ -10,11 +10,12 @@ upstream prosody {
     server 127.0.0.1:5280;
     keepalive 2;
 }
-upstream jvb1 {
-    zone upstreams 64K;
-    server 127.0.0.1:9090;
-    keepalive 2;
-}
+# Uncomment to enable colibri (JVB) WebSocket proxy (also requires websockets enabled in JVB config):
+# upstream jvb1 {
+#     zone upstreams 64K;
+#     server 127.0.0.1:9090;
+#     keepalive 2;
+# }
 map $arg_vnode $prosody_node {
     default prosody;
     v1 v1;
@@ -150,14 +151,14 @@ server {
         tcp_nodelay on;
     }
 
-    # colibri (JVB) websockets for jvb1
-    location ~ ^/colibri-ws/default-id/(.*) {
-        proxy_pass http://jvb1/colibri-ws/default-id/$1$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        tcp_nodelay on;
-    }
+    # Uncomment to enable colibri (JVB) WebSocket proxy (also requires websockets enabled in JVB config):
+    # location ~ ^/colibri-ws/default-id/(.*) {
+    #     proxy_pass http://jvb1/colibri-ws/default-id/$1$is_args$args;
+    #     proxy_http_version 1.1;
+    #     proxy_set_header Upgrade $http_upgrade;
+    #     proxy_set_header Connection "upgrade";
+    #     tcp_nodelay on;
+    # }
 
     # load test minimal client, uncomment when used
     #location ~ ^/_load-test/([^/?&:'"]+)$ {

--- a/doc/debian/jitsi-meet/jitsi-meet.example-apache
+++ b/doc/debian/jitsi-meet/jitsi-meet.example-apache
@@ -43,8 +43,9 @@
     ProxyPassReverse /http-bind http://localhost:5280/http-bind
     ProxyPass /xmpp-websocket ws://localhost:5280/xmpp-websocket
     ProxyPassReverse /xmpp-websocket ws://localhost:5280/xmpp-websocket
-    ProxyPass /colibri-ws/default-id ws://localhost:9090/colibri-ws/default-id
-    ProxyPassReverse /colibri-ws/default-id ws://localhost:9090/colibri-ws/default-id
+    # Uncomment to enable colibri (JVB) WebSocket proxy (also requires websockets enabled in JVB config):
+    # ProxyPass /colibri-ws/default-id ws://localhost:9090/colibri-ws/default-id
+    # ProxyPassReverse /colibri-ws/default-id ws://localhost:9090/colibri-ws/default-id
 
     RewriteEngine on
     RewriteRule ^/([a-zA-Z0-9]+)$ /index.html


### PR DESCRIPTION
Comment out the `upstream jvb1` block and the colibri-ws `location` (nginx) and `ProxyPass` (apache) entries to avoid a dangling upstream on port 9090 when JVB websockets are not enabled.

Each commented-out block includes instructions to uncomment when enabling.

See also: jitsi/jitsi-videobridge#2416 for the corresponding JVB config change.