### PR TITLE
feat(multi-screen): complete multi-screen feature (approach before pivot)

### DIFF
--- a/config.js
+++ b/config.js
@@ -1938,6 +1938,21 @@ var config = {
     //     storageBackendUrl: 'https://excalidraw-s3-storage-backend.example.com',
     // },
 
+    // Settings for the multi-screen feature, which opens a secondary browser
+    // window rendering the conference in an independent layout (e.g. gallery on
+    // one monitor, active speaker on another). On browsers that expose the
+    // Window Management API (Chrome/Edge) the window is placed on another screen
+    // automatically; elsewhere it opens at an offset the user can drag over.
+    // multiScreen: {
+    //     // Whether the feature is enabled. It is experimental and disabled by
+    //     // default; set to true to show the toolbar button and allow opening
+    //     // the secondary window (on browsers that support it).
+    //     enabled: true,
+    //     // The layout the secondary window opens with: 'gallery' (default) or
+    //     // 'active-speaker'.
+    //     defaultLayout: 'gallery',
+    // },
+
     // The watchRTC initialize config params as described :
     // https://testrtc.com/docs/installing-the-watchrtc-javascript-sdk/#h-set-up-the-sdk
     // https://www.npmjs.com/package/@testrtc/watchrtc-sdk

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -26,6 +26,23 @@ declare global {
         requestAdapterInfo?(): Promise<{ device: string }>;
     }
 
+    // Window Management API (https://www.w3.org/TR/window-management/) — not yet
+    // part of lib.dom.d.ts. Declared minimally here for multi-screen placement.
+    interface ScreenDetailed extends Screen {
+        availLeft: number;
+        availTop: number;
+        isInternal: boolean;
+        isPrimary: boolean;
+        label: string;
+        left: number;
+        top: number;
+    }
+
+    interface ScreenDetails {
+        currentScreen: ScreenDetailed;
+        screens: ScreenDetailed[];
+    }
+
     interface Window {
         config: IConfig;
         JITSI_MEET_LITE_SDK?: boolean;
@@ -47,6 +64,7 @@ declare global {
         // selenium tests handler
         _sharedVideoPlayer: any;
         alwaysOnTop: { api: any };
+        getScreenDetails(): Promise<ScreenDetails>;
     }
 
     interface Document {

--- a/lang/main.json
+++ b/lang/main.json
@@ -824,11 +824,15 @@
     "me": "me",
     "multiScreen": {
         "close": "Close",
+        "dragHint": "Your browser can't place this window on another screen automatically. Drag it to your second monitor if needed.",
+        "dragHintTitle": "Multi-screen window opened",
         "galleryView": "Gallery",
         "layoutLabel": "Secondary window layout",
         "noParticipants": "No participants",
         "permissionDenied": "Grant the window-management permission to automatically place this window on another screen.",
         "permissionDeniedTitle": "Couldn't move window to another screen",
+        "popupBlocked": "Your browser blocked the pop-up. Allow pop-ups for this site, then try again.",
+        "popupBlockedTitle": "Couldn't open multi-screen window",
         "speakerView": "Speaker",
         "windowTitle": "Jitsi Meet — Multi-Screen"
     },

--- a/lang/main.json
+++ b/lang/main.json
@@ -822,6 +822,16 @@
         "youAreAlone": "You are the only one in the meeting"
     },
     "me": "me",
+    "multiScreen": {
+        "close": "Close",
+        "galleryView": "Gallery",
+        "layoutLabel": "Secondary window layout",
+        "noParticipants": "No participants",
+        "permissionDenied": "Grant the window-management permission to automatically place this window on another screen.",
+        "permissionDeniedTitle": "Couldn't move window to another screen",
+        "speakerView": "Speaker",
+        "windowTitle": "Jitsi Meet — Multi-Screen"
+    },
     "notify": {
         "OldElectronAPPTitle": "Security vulnerability!",
         "allowAll": "Allow All",
@@ -1346,6 +1356,7 @@
             "closeChat": "Close chat",
             "closeCustomPanel": "Close",
             "closeMoreActions": "Close more actions menu",
+            "closeMultiScreen": "Close multi-screen window",
             "closeParticipantsPane": "Close participants pane",
             "closedCaptions": "Closed captions",
             "collapse": "Collapse",
@@ -1382,6 +1393,7 @@
             "moreActions": "More actions",
             "moreActionsMenu": "More actions menu",
             "moreOptions": "Show more options",
+            "multiScreen": "Open multi-screen window",
             "mute": "Mute microphone",
             "muteEveryone": "Mute everyone",
             "muteEveryoneElse": "Mute everyone else",
@@ -1451,6 +1463,7 @@
         "clap": "Clap",
         "closeChat": "Close chat",
         "closeCustomPanel": "Close",
+        "closeMultiScreen": "Close multi-screen window",
         "closeParticipantsPane": "Close participants pane",
         "closeReactionsMenu": "Close reactions menu",
         "closedCaptions": "Closed captions",
@@ -1489,6 +1502,7 @@
         "lowerYourHand": "Lower your hand",
         "moreActions": "More actions",
         "moreOptions": "More options",
+        "multiScreen": "Multi-screen view",
         "mute": "Mute microphone",
         "muteEveryone": "Mute everyone",
         "muteEveryonesVideo": "Disable everyone's camera",

--- a/react/features/app/components/App.web.tsx
+++ b/react/features/app/components/App.web.tsx
@@ -4,6 +4,7 @@ import GlobalStyles from '../../base/ui/components/GlobalStyles.web';
 import JitsiThemeProvider from '../../base/ui/components/JitsiThemeProvider.web';
 import DialogContainer from '../../base/ui/components/web/DialogContainer';
 import ChromeExtensionBanner from '../../chrome-extension-banner/components/ChromeExtensionBanner.web';
+import MultiScreenWindow from '../../multi-screen/components/MultiScreenWindow';
 import OverlayContainer from '../../overlay/components/web/OverlayContainer';
 import PiP from '../../pip/components/PiP';
 
@@ -49,6 +50,7 @@ export class App extends AbstractApp {
                 <GlobalStyles />
                 <ChromeExtensionBanner />
                 <PiP />
+                <MultiScreenWindow />
                 { super._createMainElement(component, props) }
             </JitsiThemeProvider>
         );

--- a/react/features/app/middlewares.web.ts
+++ b/react/features/app/middlewares.web.ts
@@ -9,6 +9,7 @@ import '../dynamic-branding/middleware';
 import '../e2ee/middleware';
 import '../external-api/middleware';
 import '../keyboard-shortcuts/middleware';
+import '../multi-screen/middleware';
 import '../no-audio-signal/middleware';
 import '../notifications/middleware';
 import '../noise-detection/middleware';

--- a/react/features/app/reducers.any.ts
+++ b/react/features/app/reducers.any.ts
@@ -37,6 +37,7 @@ import '../invite/reducer';
 import '../jaas/reducer';
 import '../large-video/reducer';
 import '../lobby/reducer';
+import '../multi-screen/reducer';
 import '../notifications/reducer';
 import '../participants-pane/reducer';
 import '../polls/reducer';

--- a/react/features/app/types.ts
+++ b/react/features/app/types.ts
@@ -53,6 +53,7 @@ import { IMobileAudioModeState } from '../mobile/audio-mode/reducer';
 import { IMobileBackgroundState } from '../mobile/background/reducer';
 import { ICallIntegrationState } from '../mobile/call-integration/reducer';
 import { IMobileExternalApiState } from '../mobile/external-api/reducer';
+import { IMultiScreenState } from '../multi-screen/reducer';
 import { INoAudioSignalState } from '../no-audio-signal/reducer';
 import { INoiseDetectionState } from '../noise-detection/reducer';
 import { INoiseSuppressionState } from '../noise-suppression/reducer';
@@ -143,6 +144,7 @@ export interface IReduxState {
     'features/mobile/audio-mode': IMobileAudioModeState;
     'features/mobile/background': IMobileBackgroundState;
     'features/mobile/external-api': IMobileExternalApiState;
+    'features/multi-screen': IMultiScreenState;
     'features/no-audio-signal': INoAudioSignalState;
     'features/noise-detection': INoiseDetectionState;
     'features/noise-suppression': INoiseSuppressionState;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -142,6 +142,9 @@ export interface INoiseSuppressionConfig {
 }
 
 export interface IMultiScreenConfig {
+    // Keep this union in sync with SecondaryLayout in features/multi-screen/constants
+    // (inlined rather than imported to avoid coupling base/config to a feature).
+    defaultLayout?: 'active-speaker' | 'gallery';
     enabled?: boolean;
 }
 

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -141,6 +141,10 @@ export interface INoiseSuppressionConfig {
     };
 }
 
+export interface IMultiScreenConfig {
+    enabled?: boolean;
+}
+
 export interface IWhiteboardConfig {
     collabServerBaseUrl?: string;
     enabled?: boolean;
@@ -560,6 +564,7 @@ export interface IConfig {
     microsoftApiApplicationClientID?: string;
     moderatedRoomServiceUrl?: string;
     mouseMoveCallbackInterval?: number;
+    multiScreen?: IMultiScreenConfig;
     noiseSuppression?: INoiseSuppressionConfig;
     noticeMessage?: string;
     notificationTimeouts?: {

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -185,6 +185,7 @@ export default [
     'mainToolbarButtons',
     'maxFullResolutionParticipants',
     'mouseMoveCallbackInterval',
+    'multiScreen.enabled',
     'notifications',
     'notificationTimeouts',
     'notifyOnConferenceDestruction',

--- a/react/features/base/settings/reducer.ts
+++ b/react/features/base/settings/reducer.ts
@@ -26,6 +26,7 @@ const DEFAULT_STATE: ISettingsState = {
     localFlipX: true,
     maxStageParticipants: 1,
     micDeviceId: undefined,
+    multiScreenLayout: undefined,
     serverURL: undefined,
     hideShareAudioHelper: false,
     showSubtitlesOnStage: false,
@@ -72,6 +73,7 @@ export interface ISettingsState {
     localFlipX?: boolean;
     maxStageParticipants?: number;
     micDeviceId?: string | boolean;
+    multiScreenLayout?: string;
     previewAudioTrack?: any | null;
     serverURL?: string;
     showSubtitlesOnStage?: boolean;

--- a/react/features/multi-screen/actionTypes.ts
+++ b/react/features/multi-screen/actionTypes.ts
@@ -1,0 +1,19 @@
+/**
+ * The type of (redux) action which sets the multi-screen active state.
+ *
+ * {
+ *     type: SET_MULTI_SCREEN_ACTIVE,
+ *     isActive: boolean
+ * }
+ */
+export const SET_MULTI_SCREEN_ACTIVE = 'SET_MULTI_SCREEN_ACTIVE';
+
+/**
+ * The type of (redux) action which sets the layout mode of the secondary window.
+ *
+ * {
+ *     type: SET_SECONDARY_LAYOUT,
+ *     layout: SecondaryLayout
+ * }
+ */
+export const SET_SECONDARY_LAYOUT = 'SET_SECONDARY_LAYOUT';

--- a/react/features/multi-screen/actions.web.ts
+++ b/react/features/multi-screen/actions.web.ts
@@ -1,0 +1,347 @@
+import { IStore } from '../app/types';
+import i18next from '../base/i18n/i18next';
+import BaseTheme from '../base/ui/components/BaseTheme.web';
+import { showWarningNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
+
+import { SET_MULTI_SCREEN_ACTIVE, SET_SECONDARY_LAYOUT } from './actionTypes';
+import { SECONDARY_WINDOW_NAME, SECONDARY_WINDOW_ROOT_ID, SecondaryLayout } from './constants';
+import { getSecondaryWindowPlacement, isMultiScreenSupported } from './functions';
+import logger from './logger';
+
+/**
+ * Module-level reference to the secondary window.
+ * Stored at module scope so it persists across renders and can be
+ * accessed by the portal component without going through Redux.
+ */
+let secondaryWindow: Window | null = null;
+
+/**
+ * Synchronous in-flight guard for openSecondaryWindow(). Flipped before the
+ * first await so two rapid toggles can't both pass the "already open" check and
+ * race to window.open() with the same named target.
+ */
+let isOpening = false;
+
+/**
+ * Set while we are closing the window ourselves, so the window's beforeunload
+ * listener can tell a programmatic close from a user-initiated one and avoid
+ * dispatching a duplicate closeSecondaryWindow(). Reset on the next open.
+ */
+let isClosingProgrammatically = false;
+
+/**
+ * Observer that mirrors stylesheets added to the main document's <head> after
+ * the window opened (CSS-in-JS, lazily-loaded feature CSS) into the popup.
+ */
+let styleObserver: MutationObserver | null = null;
+
+/**
+ * Returns the current secondary window reference, or null if not open.
+ *
+ * @returns {Window|null} The secondary window.
+ */
+export function getSecondaryWindow(): Window | null {
+    return secondaryWindow;
+}
+
+/**
+ * Copies all stylesheets from the main document into a target window document.
+ *
+ * Uses a two-tier approach:
+ * 1. Same-origin stylesheets: inline the CSS rules as style elements.
+ * 2. Cross-origin stylesheets: link to the external stylesheet via link element.
+ *
+ * @param {Window} targetWindow - The window to copy styles into.
+ * @returns {void}
+ */
+export function copyStylesToWindow(targetWindow: Window): void {
+    const targetDoc = targetWindow.document;
+
+    Array.from(document.styleSheets).forEach(styleSheet => {
+        try {
+            // Tier 1: Same-origin — inline the CSS rules directly.
+            const cssRules = Array.from(styleSheet.cssRules)
+                .map(rule => rule.cssText)
+                .join('\n');
+            const style = targetDoc.createElement('style');
+
+            style.textContent = cssRules;
+            targetDoc.head.appendChild(style);
+        } catch {
+            // Tier 2: Cross-origin — link to the external stylesheet.
+            if (styleSheet.href) {
+                const link = targetDoc.createElement('link');
+
+                link.rel = 'stylesheet';
+                link.href = styleSheet.href;
+                targetDoc.head.appendChild(link);
+            }
+        }
+    });
+}
+
+/**
+ * Copies a single <style>/<link rel="stylesheet"> node that was added to the
+ * main document into the target window, mirroring copyStylesToWindow()'s
+ * two-tier approach for one node. Non-stylesheet nodes are ignored.
+ *
+ * @param {Node} node - The node that was added to the main document's <head>.
+ * @param {Window} targetWindow - The window to copy the style into.
+ * @returns {void}
+ */
+function copyStyleNodeToWindow(node: Node, targetWindow: Window): void {
+    const targetDoc = targetWindow.document;
+
+    if (node instanceof HTMLStyleElement) {
+        const style = targetDoc.createElement('style');
+
+        try {
+            // Prefer the parsed rules so CSS-in-JS (rules inserted via the CSSOM
+            // with empty textContent) is captured; fall back to textContent.
+            style.textContent = Array.from(node.sheet?.cssRules ?? [])
+                .map(rule => rule.cssText)
+                .join('\n') || node.textContent || '';
+        } catch {
+            style.textContent = node.textContent ?? '';
+        }
+        targetDoc.head.appendChild(style);
+    } else if (node instanceof HTMLLinkElement && node.rel === 'stylesheet' && node.href) {
+        const link = targetDoc.createElement('link');
+
+        link.rel = 'stylesheet';
+        link.href = node.href;
+        targetDoc.head.appendChild(link);
+    }
+}
+
+/**
+ * Watches the main document's <head> and copies any stylesheet nodes added
+ * after the window opened into the popup, so content rendered into it later
+ * (e.g. lazily-loaded features) is not left unstyled.
+ *
+ * @param {Window} targetWindow - The window to keep in sync.
+ * @returns {MutationObserver} The observer, so the caller can disconnect it.
+ */
+function observeStyleChanges(targetWindow: Window): MutationObserver {
+    const observer = new MutationObserver(mutations => {
+        if (targetWindow.closed) {
+            return;
+        }
+
+        mutations.forEach(mutation =>
+            mutation.addedNodes.forEach(node => copyStyleNodeToWindow(node, targetWindow)));
+    });
+
+    observer.observe(document.head, { childList: true });
+
+    return observer;
+}
+
+/**
+ * Resolves once the freshly-opened window's document is ready to be mutated.
+ *
+ * A window.open('about:blank') call can hand back an initial empty document
+ * that Chromium asynchronously replaces, wiping synchronous DOM changes; waiting
+ * for DOMContentLoaded (when the document is still loading) avoids that race.
+ *
+ * @param {Window} win - The newly-opened window.
+ * @returns {Promise<void>}
+ */
+function whenDocumentReady(win: Window): Promise<void> {
+    return new Promise(resolve => {
+        if (win.document.readyState !== 'loading') {
+            resolve();
+
+            return;
+        }
+
+        win.addEventListener('DOMContentLoaded', () => resolve(), { once: true });
+    });
+}
+
+/**
+ * Initialises the secondary window's document: title, themed background and the
+ * root element the conference is portaled into.
+ *
+ * @param {Window} win - The secondary window.
+ * @returns {void}
+ */
+function setupSecondaryDocument(win: Window): void {
+    const { uiBackground } = BaseTheme.palette;
+    const doc = win.document;
+
+    doc.title = i18next.t('multiScreen.windowTitle');
+
+    // Match the conference background using the theme token so it stays
+    // consistent if branding changes.
+    doc.documentElement.style.backgroundColor = uiBackground;
+    doc.body.style.backgroundColor = uiBackground;
+    doc.body.style.margin = '0';
+    doc.body.style.padding = '0';
+    doc.body.style.overflow = 'hidden';
+
+    // Create the root element for React portal rendering.
+    const rootDiv = doc.createElement('div');
+
+    rootDiv.id = SECONDARY_WINDOW_ROOT_ID;
+    rootDiv.style.width = '100%';
+    rootDiv.style.height = '100%';
+    doc.body.appendChild(rootDiv);
+}
+
+/**
+ * Opens a secondary browser window for multi-screen conferencing.
+ *
+ * Uses the Window Management API (getScreenDetails) to detect connected
+ * monitors and position the window on a non-primary screen when available.
+ * Falls back to a default offset position if the API is unavailable.
+ *
+ * @returns {Function}
+ */
+export function openSecondaryWindow() {
+    return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const state = getState();
+
+        if (!isMultiScreenSupported(state)) {
+            logger.warn('Multi-screen is not supported or not enabled');
+
+            return;
+        }
+
+        // Synchronous in-flight guard: don't open a second window if one is
+        // already open or another open is mid-flight (before the await below).
+        if (isOpening || (secondaryWindow && !secondaryWindow.closed)) {
+            logger.warn('Secondary window is already open or opening');
+            secondaryWindow?.focus();
+
+            return;
+        }
+        isOpening = true;
+
+        try {
+            // Resolve where to place the secondary window (smart multi-monitor
+            // placement when available, otherwise a sensible fallback).
+            const { placement, permissionDenied } = await getSecondaryWindowPlacement();
+
+            if (permissionDenied) {
+                dispatch(showWarningNotification({
+                    titleKey: 'multiScreen.permissionDeniedTitle',
+                    descriptionKey: 'multiScreen.permissionDenied'
+                }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+            }
+
+            const { left, top, width, height } = placement;
+            const features = `left=${left},top=${top},width=${width},height=${height}`;
+            const newWindow = window.open('about:blank', SECONDARY_WINDOW_NAME, features);
+
+            if (!newWindow) {
+                logger.error('Popup was blocked by the browser');
+
+                return;
+            }
+
+            // Wait for the document to settle before mutating it (about:blank race).
+            await whenDocumentReady(newWindow);
+
+            // The window could have been closed while we were awaiting.
+            if (newWindow.closed) {
+                logger.warn('Secondary window was closed before it could be initialised');
+
+                return;
+            }
+
+            setupSecondaryDocument(newWindow);
+
+            // Copy current stylesheets, then keep them in sync with later additions.
+            copyStylesToWindow(newWindow);
+            styleObserver = observeStyleChanges(newWindow);
+
+            secondaryWindow = newWindow;
+            isClosingProgrammatically = false;
+
+            // Mirror the window going away (user closes it, navigates, etc.) back
+            // into Redux — unless we initiated the close ourselves.
+            newWindow.addEventListener('beforeunload', () => {
+                if (isClosingProgrammatically) {
+                    return;
+                }
+
+                dispatch(closeSecondaryWindow());
+            });
+
+            // Update Redux state.
+            dispatch({
+                type: SET_MULTI_SCREEN_ACTIVE,
+                isActive: true
+            });
+
+            logger.info('Secondary window opened successfully');
+        } catch (error) {
+            logger.error('Failed to open secondary window', error);
+        } finally {
+            isOpening = false;
+        }
+    };
+}
+
+/**
+ * Closes the secondary browser window and cleans up state.
+ *
+ * @returns {Function}
+ */
+export function closeSecondaryWindow() {
+    return (dispatch: IStore['dispatch']) => {
+        // Stop mirroring styles into a window that's going away.
+        styleObserver?.disconnect();
+        styleObserver = null;
+
+        if (secondaryWindow && !secondaryWindow.closed) {
+            // Flag this as our own close so the beforeunload listener doesn't
+            // dispatch a second closeSecondaryWindow(). Left set until the next
+            // open, in case beforeunload fires asynchronously after close().
+            isClosingProgrammatically = true;
+            secondaryWindow.close();
+        }
+
+        secondaryWindow = null;
+
+        dispatch({
+            type: SET_MULTI_SCREEN_ACTIVE,
+            isActive: false
+        });
+
+        logger.info('Secondary window closed');
+    };
+}
+
+/**
+ * Toggles the secondary multi-screen window open or closed.
+ *
+ * @returns {Function}
+ */
+export function toggleMultiScreen() {
+    return (dispatch: IStore['dispatch']) => {
+        if (secondaryWindow && !secondaryWindow.closed) {
+            dispatch(closeSecondaryWindow());
+        } else {
+            dispatch(openSecondaryWindow());
+        }
+    };
+}
+
+/**
+ * Sets the layout mode of the secondary window.
+ *
+ * @param {SecondaryLayout} layout - The layout to set (from SECONDARY_LAYOUTS).
+ * @returns {{
+ *     type: SET_SECONDARY_LAYOUT,
+ *     layout: SecondaryLayout
+ * }}
+ */
+export function setSecondaryLayout(layout: SecondaryLayout) {
+    return {
+        type: SET_SECONDARY_LAYOUT,
+        layout
+    };
+}

--- a/react/features/multi-screen/actions.web.ts
+++ b/react/features/multi-screen/actions.web.ts
@@ -1,12 +1,13 @@
 import { IStore } from '../app/types';
 import i18next from '../base/i18n/i18next';
+import { updateSettings } from '../base/settings/actions';
 import BaseTheme from '../base/ui/components/BaseTheme.web';
-import { showWarningNotification } from '../notifications/actions';
+import { showNotification, showWarningNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 
 import { SET_MULTI_SCREEN_ACTIVE, SET_SECONDARY_LAYOUT } from './actionTypes';
 import { SECONDARY_WINDOW_NAME, SECONDARY_WINDOW_ROOT_ID, SecondaryLayout } from './constants';
-import { getSecondaryWindowPlacement, isMultiScreenSupported } from './functions';
+import { getEffectiveSecondaryLayout, getSecondaryWindowPlacement, isMultiScreenSupported } from './functions';
 import logger from './logger';
 
 /**
@@ -35,6 +36,12 @@ let isClosingProgrammatically = false;
  * the window opened (CSS-in-JS, lazily-loaded feature CSS) into the popup.
  */
 let styleObserver: MutationObserver | null = null;
+
+/**
+ * Set once we've shown the "drag the window to your other screen" hint on the
+ * no-Window-Management-API fallback path, so it isn't repeated on every open.
+ */
+let hasShownPlacementHint = false;
 
 /**
  * Returns the current secondary window reference, or null if not open.
@@ -222,14 +229,8 @@ export function openSecondaryWindow() {
         try {
             // Resolve where to place the secondary window (smart multi-monitor
             // placement when available, otherwise a sensible fallback).
-            const { placement, permissionDenied } = await getSecondaryWindowPlacement();
-
-            if (permissionDenied) {
-                dispatch(showWarningNotification({
-                    titleKey: 'multiScreen.permissionDeniedTitle',
-                    descriptionKey: 'multiScreen.permissionDenied'
-                }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
-            }
+            const { placement, permissionDenied, windowManagementUnavailable }
+                = await getSecondaryWindowPlacement();
 
             const { left, top, width, height } = placement;
             const features = `left=${left},top=${top},width=${width},height=${height}`;
@@ -237,6 +238,10 @@ export function openSecondaryWindow() {
 
             if (!newWindow) {
                 logger.error('Popup was blocked by the browser');
+                dispatch(showWarningNotification({
+                    titleKey: 'multiScreen.popupBlockedTitle',
+                    descriptionKey: 'multiScreen.popupBlocked'
+                }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
 
                 return;
             }
@@ -249,6 +254,25 @@ export function openSecondaryWindow() {
                 logger.warn('Secondary window was closed before it could be initialised');
 
                 return;
+            }
+
+            // The window is genuinely open now, so surface any placement caveats:
+            // a denied window-management permission, or a browser that couldn't
+            // place the popup on another screen (hinted once per session). Doing
+            // this only after a successful open avoids contradicting the
+            // "pop-up blocked" warning and avoids burning the one-time hint when
+            // no window actually opened.
+            if (permissionDenied) {
+                dispatch(showWarningNotification({
+                    titleKey: 'multiScreen.permissionDeniedTitle',
+                    descriptionKey: 'multiScreen.permissionDenied'
+                }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+            } else if (windowManagementUnavailable && !hasShownPlacementHint) {
+                hasShownPlacementHint = true;
+                dispatch(showNotification({
+                    titleKey: 'multiScreen.dragHintTitle',
+                    descriptionKey: 'multiScreen.dragHint'
+                }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
             }
 
             setupSecondaryDocument(newWindow);
@@ -269,6 +293,11 @@ export function openSecondaryWindow() {
 
                 dispatch(closeSecondaryWindow());
             });
+
+            // Open in the user's last-used layout when they have one, otherwise
+            // the deployment-configured default, otherwise the gallery fallback
+            // (resolved and validated in the selector).
+            dispatch(setSecondaryLayout(getEffectiveSecondaryLayout(state)));
 
             // Update Redux state.
             dispatch({
@@ -343,5 +372,20 @@ export function setSecondaryLayout(layout: SecondaryLayout) {
     return {
         type: SET_SECONDARY_LAYOUT,
         layout
+    };
+}
+
+/**
+ * Switches the secondary-window layout in response to a user action and
+ * remembers it as the user's preference (persisted via {@code base/settings}),
+ * so the window reopens in the same layout next time.
+ *
+ * @param {SecondaryLayout} layout - The layout to switch to.
+ * @returns {Function}
+ */
+export function selectSecondaryLayout(layout: SecondaryLayout) {
+    return (dispatch: IStore['dispatch']) => {
+        dispatch(setSecondaryLayout(layout));
+        dispatch(updateSettings({ multiScreenLayout: layout }));
     };
 }

--- a/react/features/multi-screen/components/ActiveSpeakerView.tsx
+++ b/react/features/multi-screen/components/ActiveSpeakerView.tsx
@@ -1,0 +1,70 @@
+import React, { useRef } from 'react';
+import { useSelector } from 'react-redux';
+
+import { IReduxState } from '../../app/types';
+import Avatar from '../../base/avatar/components/Avatar';
+import { getParticipantDisplayName } from '../../base/participants/functions';
+import { getVideoTrackByParticipant } from '../../base/tracks/functions.any';
+import { getLargeVideoParticipant } from '../../large-video/functions';
+
+import { useAttachTrack } from './useAttachTrack';
+
+/**
+ * Active Speaker (stage) layout for the secondary window.
+ *
+ * Mirrors the main window's large video: it shows whichever participant the
+ * shared large-video state currently elects — the dominant speaker, a pinned
+ * participant, or an auto-pinned screenshare — so the stage stays in sync with
+ * the regular stage view (and follows screenshares) with zero extra logic. The
+ * large-video participant is maintained globally by the large-video middleware.
+ *
+ * Mounted only while the Active Speaker layout is selected, so its {@code <video>}
+ * is recreated on a layout switch and re-attaches the track on its own.
+ *
+ * @returns {React.ReactElement}
+ */
+const ActiveSpeakerView: React.FC = () => {
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    const participant = useSelector(getLargeVideoParticipant);
+
+    // getVideoTrackByParticipant resolves a screenshare track for virtual
+    // screenshare participants and the camera track otherwise.
+    const videoTrack = useSelector(
+        (state: IReduxState) => getVideoTrackByParticipant(state, participant)
+    );
+    const hasVideo = Boolean(videoTrack?.jitsiTrack && !videoTrack.muted);
+
+    // The deployment's localized fallback name is used when the participant has
+    // no display name yet.
+    const participantName = useSelector((state: IReduxState) =>
+        (participant ? getParticipantDisplayName(state, participant.id) : ''));
+
+    // Attach only a live, unmuted track; the avatar is shown otherwise.
+    useAttachTrack(videoRef, hasVideo ? videoTrack : undefined);
+
+    return (
+        <div className = 'multi-screen-active-speaker'>
+            <div className = 'multi-screen-video-wrapper'>
+                <video
+                    autoPlay = { true }
+                    className = { `multi-screen-video ${hasVideo ? '' : 'hidden'}` }
+                    id = 'multiScreenActiveSpeakerVideo'
+                    playsInline = { true }
+                    ref = { videoRef } />
+                { !hasVideo && (
+                    <div className = 'multi-screen-avatar'>
+                        <Avatar
+                            participantId = { participant?.id }
+                            size = { 160 } />
+                    </div>
+                ) }
+            </div>
+            <div className = 'multi-screen-name-overlay'>
+                { participantName }
+            </div>
+        </div>
+    );
+};
+
+export default ActiveSpeakerView;

--- a/react/features/multi-screen/components/GalleryTile.tsx
+++ b/react/features/multi-screen/components/GalleryTile.tsx
@@ -1,0 +1,103 @@
+import React, { useRef } from 'react';
+import { useSelector } from 'react-redux';
+
+import { IReduxState } from '../../app/types';
+import Avatar from '../../base/avatar/components/Avatar';
+import { MEDIA_TYPE } from '../../base/media/constants';
+import { getParticipantDisplayName } from '../../base/participants/functions';
+import { getTrackByMediaTypeAndParticipant } from '../../base/tracks/functions.any';
+
+import { useAttachTrack } from './useAttachTrack';
+
+interface IProps {
+
+    /**
+     * The height of the tile in pixels.
+     */
+    height: number;
+
+    /**
+     * Whether this participant is the active/dominant speaker and should get
+     * the speaking-indicator border.
+     */
+    isActiveSpeaker: boolean;
+
+    /**
+     * The participant ID to display.
+     */
+    participantId: string;
+
+    /**
+     * The width of the tile in pixels.
+     */
+    width: number;
+}
+
+/**
+ * Individual participant tile for the gallery view in the secondary window.
+ *
+ * Each tile manages its own video track attach/detach lifecycle; the speaking
+ * indicator border is driven by the {@code isActiveSpeaker} prop.
+ *
+ * @param {IProps} props - Component props.
+ * @returns {React.ReactElement}
+ */
+const GalleryTile: React.FC<IProps> = ({
+    height,
+    isActiveSpeaker,
+    participantId,
+    width
+}) => {
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    // Resolve the name reactively from the store so renames update the label.
+    // getParticipantDisplayName supplies the deployment's localized fallback
+    // (defaultRemoteDisplayName) when a participant has no name yet.
+    const participantName = useSelector(
+        (state: IReduxState) => getParticipantDisplayName(state, participantId)
+    );
+
+    // Select this participant's specific video track rather than the whole
+    // tracks slice, so the tile only re-renders when its own track changes
+    // (not on every track mutation anywhere in the conference).
+    const videoTrack = useSelector((state: IReduxState) =>
+        getTrackByMediaTypeAndParticipant(state['features/base/tracks'], MEDIA_TYPE.VIDEO, participantId));
+
+    const hasVideo = Boolean(videoTrack?.jitsiTrack && !videoTrack.muted);
+
+    // Attach only when there is a live, unmuted track; muted/camera-off tiles
+    // show the avatar instead.
+    useAttachTrack(videoRef, hasVideo ? videoTrack : undefined);
+
+    const tileStyle = {
+        width: `${width}px`,
+        height: `${height}px`
+    };
+
+    // Mirror Jitsi's thumbnail avatar sizing: half the tile height, capped.
+    const avatarSize = Math.floor(Math.min(height / 2, width - 30, 150));
+
+    return (
+        <div
+            className = { `multi-screen-tile ${isActiveSpeaker ? 'speaking' : ''}` }
+            style = { tileStyle }>
+            <video
+                autoPlay = { true }
+                className = { `multi-screen-tile-video ${hasVideo ? '' : 'hidden'}` }
+                playsInline = { true }
+                ref = { videoRef } />
+            { !hasVideo && (
+                <div className = 'multi-screen-tile-avatar'>
+                    <Avatar
+                        participantId = { participantId }
+                        size = { avatarSize } />
+                </div>
+            ) }
+            <div className = 'multi-screen-tile-name'>
+                { participantName }
+            </div>
+        </div>
+    );
+};
+
+export default GalleryTile;

--- a/react/features/multi-screen/components/GalleryView.tsx
+++ b/react/features/multi-screen/components/GalleryView.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { getGalleryGridDimensions } from '../functions';
+
+import GalleryTile from './GalleryTile';
+
+/**
+ * Maximum number of columns in the gallery grid.
+ */
+const MAX_GALLERY_COLUMNS = 5;
+
+/**
+ * Gap between gallery tiles in pixels.
+ */
+const GALLERY_GAP = 4;
+
+interface IProps {
+
+    /**
+     * The participant currently shown with the dominant-speaker ring, if any.
+     */
+    dominantSpeakerId: string | null;
+
+    /**
+     * Ordered participant IDs to render as tiles (local first, then remotes).
+     */
+    participantIds: string[];
+}
+
+/**
+ * Gallery layout for the secondary window: every participant in a responsive
+ * grid sized to the container.
+ *
+ * @param {IProps} props - Component props.
+ * @returns {React.ReactElement}
+ */
+const GalleryView: React.FC<IProps> = ({ dominantSpeakerId, participantIds }) => {
+    const { t } = useTranslation();
+
+    // Container dimensions, tracked via a ResizeObserver bound through a callback
+    // ref. The callback (re)attaches the observer whenever the grid mounts —
+    // including when participants arrive after the window opened empty — and
+    // tears it down when the grid unmounts (React calls it with null), so
+    // nothing lingers on a detached node.
+    //
+    // The grid lives in the SECONDARY window's document while this React code
+    // runs in the main window's realm, so the observer, rAF and resize listener
+    // are all taken from that owner window. Otherwise the main window's
+    // ResizeObserver never sees the popup's own layout changes — most visibly
+    // browser page-zoom, which reflows only the popup and would otherwise leave
+    // the tiles sized for the zoom level the window first opened at.
+    const [ dimensions, setDimensions ] = useState<{ height: number; width: number; } | null>(null);
+    const cleanupRef = useRef<(() => void) | null>(null);
+
+    const attachGridRef = useCallback((element: HTMLDivElement | null) => {
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+
+        if (!element) {
+            return;
+        }
+
+        const ownerWindow = element.ownerDocument.defaultView ?? window;
+        const ResizeObserverCtor = ownerWindow.ResizeObserver ?? ResizeObserver;
+        let frame = 0;
+
+        const measure = () => {
+            const width = element.clientWidth;
+            const height = element.clientHeight;
+
+            // Bail out when the size is unchanged so a no-op measurement never
+            // triggers a re-render (which would re-enter the observer).
+            setDimensions(prev =>
+                (prev && prev.width === width && prev.height === height)
+                    ? prev
+                    : { height,
+                        width });
+        };
+
+        // Defer the measurement out of the observer/resize callback: updating
+        // state there resizes the tiles synchronously, which is what raises the
+        // benign "ResizeObserver loop … undelivered notifications" overlay error.
+        const schedule = () => {
+            ownerWindow.cancelAnimationFrame(frame);
+            frame = ownerWindow.requestAnimationFrame(measure);
+        };
+
+        const observer = new ResizeObserverCtor(schedule);
+
+        observer.observe(element);
+
+        // Page-zoom fires resize on the popup window but does not always reach a
+        // cross-document ResizeObserver, so re-measure on it explicitly too.
+        ownerWindow.addEventListener('resize', schedule);
+
+        cleanupRef.current = () => {
+            ownerWindow.cancelAnimationFrame(frame);
+            ownerWindow.removeEventListener('resize', schedule);
+            observer.disconnect();
+        };
+
+        measure();
+    }, []);
+
+    const count = participantIds.length;
+
+    if (count === 0) {
+        return (
+            <div className = 'multi-screen-gallery-placeholder'>
+                <div className = 'multi-screen-gallery-message'>
+                    { t('multiScreen.noParticipants') }
+                </div>
+            </div>
+        );
+    }
+
+    // The grid is always rendered so attachGridRef can measure it; the tiles
+    // themselves wait until the first measurement lands, avoiding a frame of
+    // mis-sized tiles from a guessed default size.
+    let tiles: React.ReactNode = null;
+
+    if (dimensions) {
+        const { columns, rows } = getGalleryGridDimensions(count, MAX_GALLERY_COLUMNS);
+
+        // Calculate tile dimensions based on the gallery container size.
+        const availableWidth = dimensions.width - ((columns - 1) * GALLERY_GAP) - 16;
+        const availableHeight = dimensions.height - ((rows - 1) * GALLERY_GAP) - 16;
+        const tileWidth = Math.floor(availableWidth / columns);
+        const tileHeight = Math.floor(availableHeight / rows);
+
+        // Build rows of participant IDs.
+        const galleryRows: string[][] = [];
+
+        for (let i = 0; i < count; i += columns) {
+            galleryRows.push(participantIds.slice(i, i + columns));
+        }
+
+        tiles = galleryRows.map((row, rowIndex) => (
+            <div
+                className = 'multi-screen-gallery-row'
+                key = { `row-${rowIndex}` }>
+                { row.map(id => (
+                    <GalleryTile
+                        height = { tileHeight }
+                        isActiveSpeaker = { id === dominantSpeakerId }
+                        key = { id }
+                        participantId = { id }
+                        width = { tileWidth } />
+                )) }
+            </div>
+        ));
+    }
+
+    return (
+        <div
+            className = 'multi-screen-gallery'
+            ref = { attachGridRef }>
+            { tiles }
+        </div>
+    );
+};
+
+export default GalleryView;

--- a/react/features/multi-screen/components/MultiScreenButton.ts
+++ b/react/features/multi-screen/components/MultiScreenButton.ts
@@ -1,0 +1,76 @@
+import { connect } from 'react-redux';
+
+import { createToolbarEvent } from '../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../analytics/functions';
+import { IReduxState } from '../../app/types';
+import { translate } from '../../base/i18n/functions';
+import { IconEnlarge } from '../../base/icons/svg';
+import AbstractButton, { IProps as AbstractButtonProps } from '../../base/toolbox/components/AbstractButton';
+import { toggleMultiScreen } from '../actions';
+import { isMultiScreenActive } from '../functions';
+
+interface IProps extends AbstractButtonProps {
+
+    /**
+     * Whether or not multi-screen is currently active.
+     */
+    _isActive: boolean;
+}
+
+/**
+ * Implementation of a button for toggling multi-screen mode.
+ * Opens/closes a secondary browser window for displaying an
+ * independent conference layout.
+ */
+class MultiScreenButton extends AbstractButton<IProps> {
+    override accessibilityLabel = 'toolbar.accessibilityLabel.multiScreen';
+    override toggledAccessibilityLabel = 'toolbar.accessibilityLabel.closeMultiScreen';
+    override label = 'toolbar.multiScreen';
+    override toggledLabel = 'toolbar.closeMultiScreen';
+    override tooltip = 'toolbar.multiScreen';
+    override toggledTooltip = 'toolbar.closeMultiScreen';
+    override icon = IconEnlarge;
+
+    /**
+     * Indicates whether this button is in toggled state or not.
+     *
+     * @override
+     * @protected
+     * @returns {boolean}
+     */
+    override _isToggled() {
+        return this.props._isActive;
+    }
+
+    /**
+     * Handles clicking the button, toggling the secondary window.
+     *
+     * @private
+     * @returns {void}
+     */
+    override _handleClick() {
+        const { dispatch, _isActive } = this.props;
+
+        sendAnalytics(createToolbarEvent(
+            'toggle.multi-screen',
+            {
+                enable: !_isActive
+            }));
+
+        dispatch(toggleMultiScreen());
+    }
+}
+
+/**
+ * Function that maps parts of Redux state tree into component props.
+ *
+ * @param {Object} state - Redux state.
+ * @returns {Object}
+ */
+const mapStateToProps = (state: IReduxState) => {
+    return {
+        _isActive: isMultiScreenActive(state)
+    };
+};
+
+export default translate(connect(mapStateToProps)(MultiScreenButton));

--- a/react/features/multi-screen/components/MultiScreenWindow.tsx
+++ b/react/features/multi-screen/components/MultiScreenWindow.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { useSelector } from 'react-redux';
+
+import { getSecondaryWindow } from '../actions';
+import { SECONDARY_WINDOW_ROOT_ID } from '../constants';
+import { isMultiScreenActive } from '../functions';
+
+import SecondaryConference from './SecondaryConference';
+
+// Side-effect import: style-loader injects these rules into the main document's
+// <head>, which copyStylesToWindow() then copies into the secondary window.
+import '../multi-screen.css';
+
+/**
+ * Component that bridges the main React tree to the secondary browser window
+ * via React's createPortal(). This allows the SecondaryConference to render
+ * into the secondary window's DOM while sharing the same Redux store, React
+ * context, and WebRTC tracks as the main window.
+ *
+ * @returns {React.ReactPortal | null}
+ */
+const MultiScreenWindow: React.FC = () => {
+    const isActive = useSelector(isMultiScreenActive);
+
+    if (!isActive) {
+        return null;
+    }
+
+    const secondaryWindow = getSecondaryWindow();
+
+    // The user may have closed the window externally before Redux flips
+    // isActive to false; reading .document on a closed window can throw or
+    // behave inconsistently across browsers, so bail out on a missing or
+    // already-closed window first.
+    if (!secondaryWindow || secondaryWindow.closed) {
+        return null;
+    }
+
+    const rootElement = secondaryWindow.document?.getElementById(SECONDARY_WINDOW_ROOT_ID);
+
+    if (!rootElement) {
+        return null;
+    }
+
+    // createPortal renders SecondaryConference into the secondary window's DOM
+    // but keeps it in the same React tree — Redux access is automatic.
+    return createPortal(<SecondaryConference />, rootElement);
+};
+
+export default MultiScreenWindow;

--- a/react/features/multi-screen/components/SecondaryConference.tsx
+++ b/react/features/multi-screen/components/SecondaryConference.tsx
@@ -1,0 +1,67 @@
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { IReduxState } from '../../app/types';
+import { getDominantSpeakerParticipant, getLocalParticipant } from '../../base/participants/functions';
+import { SECONDARY_LAYOUTS } from '../constants';
+import { getSecondaryLayout } from '../functions';
+
+import ActiveSpeakerView from './ActiveSpeakerView';
+import GalleryView from './GalleryView';
+import SecondaryToolbar from './SecondaryToolbar';
+
+/**
+ * The main UI component rendered inside the secondary browser window.
+ *
+ * Renders either the Active Speaker (stage) view — which mirrors the main
+ * window's large video — or the Gallery view, plus the toolbar. Each view is
+ * mounted only while its layout is active.
+ *
+ * @returns {React.ReactElement}
+ */
+const SecondaryConference: React.FC = () => {
+    const currentLayout = useSelector(
+        (state: IReduxState) => getSecondaryLayout(state)
+    );
+
+    // Participant membership is driven by the filmstrip's remoteParticipants
+    // array, which is reassigned immutably on join/leave. The base participants
+    // Map is mutated in place, so selecting it directly would never trigger a
+    // re-render when someone joins or leaves.
+    const localParticipant = useSelector(
+        (state: IReduxState) => getLocalParticipant(state)
+    );
+    const remoteParticipantIds = useSelector(
+        (state: IReduxState) => state['features/filmstrip'].remoteParticipants
+    );
+
+    // The conference dominant speaker drives the gallery's speaking ring,
+    // mirroring the main window's thumbnail indicator (one tile at a time).
+    const dominantSpeakerId = useSelector(
+        (state: IReduxState) => getDominantSpeakerParticipant(state)?.id ?? null
+    );
+
+    // Ordered list of participant IDs to display (local first, then remotes).
+    const participantIds = useMemo(() => {
+        const ids: string[] = [];
+
+        if (localParticipant?.id) {
+            ids.push(localParticipant.id);
+        }
+
+        return ids.concat(remoteParticipantIds);
+    }, [ localParticipant?.id, remoteParticipantIds ]);
+
+    return (
+        <div className = 'multi-screen-container'>
+            { currentLayout === SECONDARY_LAYOUTS.ACTIVE_SPEAKER
+                ? <ActiveSpeakerView />
+                : <GalleryView
+                    dominantSpeakerId = { dominantSpeakerId }
+                    participantIds = { participantIds } /> }
+            <SecondaryToolbar />
+        </div>
+    );
+};
+
+export default SecondaryConference;

--- a/react/features/multi-screen/components/SecondaryToolbar.tsx
+++ b/react/features/multi-screen/components/SecondaryToolbar.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { IReduxState } from '../../app/types';
+import { closeSecondaryWindow, setSecondaryLayout } from '../actions';
+import { SECONDARY_LAYOUTS } from '../constants';
+import { getSecondaryLayout } from '../functions';
+
+/**
+ * Toolbar displayed inside the secondary browser window.
+ *
+ * The two layout buttons form a WAI-ARIA radiogroup: only the selected one is
+ * in the tab order (roving tabindex) and the arrow/Home/End keys move the
+ * selection between them. The close button sits outside the group. All state
+ * changes go through the shared Redux store.
+ *
+ * @returns {React.ReactElement}
+ */
+const SecondaryToolbar: React.FC = () => {
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+    const currentLayout = useSelector(
+        (state: IReduxState) => getSecondaryLayout(state)
+    );
+    const activeSpeakerRef = useRef<HTMLButtonElement>(null);
+    const galleryRef = useRef<HTMLButtonElement>(null);
+
+    const isActiveSpeaker = currentLayout === SECONDARY_LAYOUTS.ACTIVE_SPEAKER;
+    const isGallery = currentLayout === SECONDARY_LAYOUTS.GALLERY;
+
+    /**
+     * Handles switching to active speaker layout.
+     *
+     * @returns {void}
+     */
+    const onActiveSpeaker = useCallback(() => {
+        dispatch(setSecondaryLayout(SECONDARY_LAYOUTS.ACTIVE_SPEAKER));
+    }, [ dispatch ]);
+
+    /**
+     * Handles switching to gallery layout.
+     *
+     * @returns {void}
+     */
+    const onGallery = useCallback(() => {
+        dispatch(setSecondaryLayout(SECONDARY_LAYOUTS.GALLERY));
+    }, [ dispatch ]);
+
+    /**
+     * Handles closing the secondary window.
+     *
+     * @returns {void}
+     */
+    const onClose = useCallback(() => {
+        dispatch(closeSecondaryWindow());
+    }, [ dispatch ]);
+
+    /**
+     * Moves the radiogroup selection with the keyboard, following the WAI-ARIA
+     * radio pattern: arrows toggle between the two options, Home selects the
+     * first and End the last.
+     *
+     * @param {React.KeyboardEvent} event - The keydown event.
+     * @returns {void}
+     */
+    const onLayoutKeyDown = useCallback((event: React.KeyboardEvent) => {
+        switch (event.key) {
+        case 'ArrowLeft':
+        case 'ArrowUp':
+        case 'ArrowRight':
+        case 'ArrowDown':
+            event.preventDefault();
+            if (isActiveSpeaker) {
+                onGallery();
+                galleryRef.current?.focus();
+            } else {
+                onActiveSpeaker();
+                activeSpeakerRef.current?.focus();
+            }
+            break;
+        case 'Home':
+            event.preventDefault();
+            onActiveSpeaker();
+            activeSpeakerRef.current?.focus();
+            break;
+        case 'End':
+            event.preventDefault();
+            onGallery();
+            galleryRef.current?.focus();
+            break;
+        }
+    }, [ isActiveSpeaker, onActiveSpeaker, onGallery ]);
+
+    return (
+        <div className = 'multi-screen-toolbar'>
+            <div
+                aria-label = { t('multiScreen.layoutLabel') }
+                className = 'multi-screen-toolbar-buttons'
+                onKeyDown = { onLayoutKeyDown }
+                role = 'radiogroup'>
+                <button
+                    aria-checked = { isActiveSpeaker }
+                    className = { `multi-screen-toolbar-btn ${isActiveSpeaker ? 'active' : ''}` }
+                    id = 'multiScreenActiveSpeakerBtn'
+                    onClick = { onActiveSpeaker }
+                    ref = { activeSpeakerRef }
+                    role = 'radio'
+                    tabIndex = { isActiveSpeaker ? 0 : -1 }
+                    type = 'button'>
+                    { t('multiScreen.speakerView') }
+                </button>
+                <button
+                    aria-checked = { isGallery }
+                    className = { `multi-screen-toolbar-btn ${isGallery ? 'active' : ''}` }
+                    id = 'multiScreenGalleryBtn'
+                    onClick = { onGallery }
+                    ref = { galleryRef }
+                    role = 'radio'
+                    tabIndex = { isGallery ? 0 : -1 }
+                    type = 'button'>
+                    { t('multiScreen.galleryView') }
+                </button>
+            </div>
+            <button
+                className = 'multi-screen-toolbar-btn multi-screen-close-btn'
+                id = 'multiScreenCloseBtn'
+                onClick = { onClose }
+                type = 'button'>
+                { t('multiScreen.close') }
+            </button>
+        </div>
+    );
+};
+
+export default SecondaryToolbar;

--- a/react/features/multi-screen/components/SecondaryToolbar.tsx
+++ b/react/features/multi-screen/components/SecondaryToolbar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { IReduxState } from '../../app/types';
-import { closeSecondaryWindow, setSecondaryLayout } from '../actions';
+import { closeSecondaryWindow, selectSecondaryLayout } from '../actions';
 import { SECONDARY_LAYOUTS } from '../constants';
 import { getSecondaryLayout } from '../functions';
 
@@ -35,7 +35,7 @@ const SecondaryToolbar: React.FC = () => {
      * @returns {void}
      */
     const onActiveSpeaker = useCallback(() => {
-        dispatch(setSecondaryLayout(SECONDARY_LAYOUTS.ACTIVE_SPEAKER));
+        dispatch(selectSecondaryLayout(SECONDARY_LAYOUTS.ACTIVE_SPEAKER));
     }, [ dispatch ]);
 
     /**
@@ -44,7 +44,7 @@ const SecondaryToolbar: React.FC = () => {
      * @returns {void}
      */
     const onGallery = useCallback(() => {
-        dispatch(setSecondaryLayout(SECONDARY_LAYOUTS.GALLERY));
+        dispatch(selectSecondaryLayout(SECONDARY_LAYOUTS.GALLERY));
     }, [ dispatch ]);
 
     /**

--- a/react/features/multi-screen/components/useAttachTrack.ts
+++ b/react/features/multi-screen/components/useAttachTrack.ts
@@ -1,0 +1,50 @@
+import { RefObject, useEffect } from 'react';
+
+import { ITrack } from '../../base/tracks/types';
+
+/**
+ * Attaches a video track to a {@code <video>} element and keeps it in sync:
+ * detaches the previous track when it changes and on unmount, and clears the
+ * element ({@code srcObject = null}) when there is no track so a stale frame is
+ * never left on screen.
+ *
+ * Shared by the active-speaker stage and each gallery tile so the attach/detach
+ * lifecycle lives in one place. The Active Speaker and Gallery views mount fresh
+ * on a layout switch, so a remounted element re-runs this effect and re-attaches
+ * on its own — no explicit reset key is needed.
+ *
+ * @param {RefObject<HTMLVideoElement>} videoRef - Ref to the target video element.
+ * @param {ITrack} [videoTrack] - The track to display, if any.
+ * @returns {void}
+ */
+export function useAttachTrack(
+        videoRef: RefObject<HTMLVideoElement>,
+        videoTrack?: ITrack
+): void {
+    useEffect(() => {
+        const videoElement = videoRef.current;
+
+        if (!videoElement) {
+            return;
+        }
+
+        const jitsiTrack = videoTrack?.jitsiTrack;
+
+        if (jitsiTrack) {
+            jitsiTrack.attach(videoElement);
+        } else {
+            // Prevent stale frames when there is nothing to show.
+            videoElement.srcObject = null;
+        }
+
+        // Detaching lives only here: React runs this cleanup before the next
+        // effect (on a videoTrack change) and on unmount, so the element is
+        // detached exactly once before any re-attach — detaching in the effect
+        // body too would detach the same track twice.
+        return () => {
+            if (jitsiTrack) {
+                jitsiTrack.detach(videoElement);
+            }
+        };
+    }, [ videoTrack ]);
+}

--- a/react/features/multi-screen/constants.ts
+++ b/react/features/multi-screen/constants.ts
@@ -1,0 +1,76 @@
+/**
+ * Layout modes available for the secondary window.
+ *
+ * These are intentionally separate from the main window's LAYOUTS
+ * (in features/video-layout/constants.ts) so that each window
+ * can independently choose its own layout.
+ */
+export const SECONDARY_LAYOUTS = {
+
+    /**
+     * Active speaker view — shows the dominant/speaking participant
+     * in a large video display.
+     */
+    ACTIVE_SPEAKER: 'active-speaker',
+
+    /**
+     * Gallery view — shows all participants in a responsive grid.
+     */
+    GALLERY: 'gallery'
+} as const;
+
+export type SecondaryLayout = typeof SECONDARY_LAYOUTS[keyof typeof SECONDARY_LAYOUTS];
+
+/**
+ * The DOM id of the root element inside the secondary window into which the
+ * SecondaryConference is rendered (via React portal).
+ *
+ * Shared between the action that creates the element and the portal component
+ * that targets it, so the two cannot drift.
+ */
+export const SECONDARY_WINDOW_ROOT_ID = 'multi-screen-root';
+
+/**
+ * The window name (target) used when opening the secondary window.
+ *
+ * Reusing the same name means a repeated open() references the existing window
+ * instead of spawning a duplicate.
+ */
+export const SECONDARY_WINDOW_NAME = 'jitsi-multi-screen';
+
+/**
+ * Fallback geometry for the secondary window, used when the Window Management
+ * API is unavailable, permission is denied, or only a single screen is present.
+ *
+ * The window is offset from the top-left corner and sized to a fraction of the
+ * available screen real estate so it scales with the display (e.g. 960×540 on a
+ * 1080p screen). The fixed WIDTH/HEIGHT are used only when the `screen` metrics
+ * cannot be read.
+ */
+export const SECONDARY_WINDOW_FALLBACK = {
+
+    /**
+     * Horizontal offset, in pixels, from the left edge of the primary screen.
+     */
+    LEFT: 100,
+
+    /**
+     * Vertical offset, in pixels, from the top edge of the primary screen.
+     */
+    TOP: 100,
+
+    /**
+     * Fraction of the available screen size used for the window dimensions.
+     */
+    SIZE_RATIO: 0.5,
+
+    /**
+     * Width, in pixels, used when screen metrics are unavailable.
+     */
+    WIDTH: 960,
+
+    /**
+     * Height, in pixels, used when screen metrics are unavailable.
+     */
+    HEIGHT: 540
+} as const;

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -1,0 +1,202 @@
+import { IReduxState } from '../app/types';
+
+import { SECONDARY_WINDOW_FALLBACK, SecondaryLayout } from './constants';
+import logger from './logger';
+
+/**
+ * The on-screen placement (position and size, in pixels) of the secondary
+ * multi-screen window.
+ */
+export interface ISecondaryWindowPlacement {
+
+    /**
+     * The height of the window.
+     */
+    height: number;
+
+    /**
+     * The distance from the left edge of the (virtual) screen.
+     */
+    left: number;
+
+    /**
+     * The distance from the top edge of the (virtual) screen.
+     */
+    top: number;
+
+    /**
+     * The width of the window.
+     */
+    width: number;
+}
+
+/**
+ * The result of resolving a secondary-window placement: the geometry plus
+ * whether the Window Management permission was denied (so the caller can
+ * surface that to the user).
+ */
+export interface ISecondaryWindowPlacementResult {
+
+    /**
+     * Whether window-management permission was denied, causing placement to
+     * fall back instead of targeting a specific monitor.
+     */
+    permissionDenied: boolean;
+
+    /**
+     * The computed window geometry.
+     */
+    placement: ISecondaryWindowPlacement;
+}
+
+/**
+ * Returns whether multi-screen support is available in the current browser.
+ *
+ * The feature only needs {@code window.open()} to work; the Window Management
+ * API ({@code getScreenDetails}) is used for smart multi-monitor placement when
+ * present (Chrome/Edge 100+) and otherwise the window opens at a fallback offset
+ * the user can drag to another screen. Gating on {@code window.open} (rather than
+ * the placement API) keeps that fallback path reachable on Firefox/Safari.
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {boolean} Whether multi-screen is supported.
+ */
+export function isMultiScreenSupported(state: IReduxState): boolean {
+    return typeof window !== 'undefined'
+        && typeof window.open === 'function'
+        && state['features/base/config'].multiScreen?.enabled !== false;
+}
+
+/**
+ * Returns whether the secondary multi-screen window is currently active.
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {boolean} Whether multi-screen is active.
+ */
+export function isMultiScreenActive(state: IReduxState): boolean {
+    return state['features/multi-screen'].isActive;
+}
+
+/**
+ * Returns the current layout mode of the secondary window.
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {SecondaryLayout} The current secondary layout.
+ */
+export function getSecondaryLayout(state: IReduxState): SecondaryLayout {
+    return state['features/multi-screen'].secondaryLayout;
+}
+
+/**
+ * Computes the gallery grid dimensions (columns and rows) for a given number of
+ * participants, using a Jitsi-style heuristic:
+ * {@code columns = min(ceil(sqrt(n)), maxColumns, n)}.
+ *
+ * Kept pure and side-effect free so it can be unit-tested in isolation.
+ *
+ * @param {number} numberOfParticipants - The number of participants to lay out.
+ * @param {number} maxColumns - The maximum number of columns allowed.
+ * @returns {Object} The grid dimensions, as { columns, rows }.
+ */
+export function getGalleryGridDimensions(
+        numberOfParticipants: number,
+        maxColumns: number
+): { columns: number; rows: number; } {
+    if (numberOfParticipants <= 0) {
+        return { columns: 1,
+            rows: 1 };
+    }
+
+    const columns = Math.min(
+        Math.ceil(Math.sqrt(numberOfParticipants)),
+        maxColumns,
+        numberOfParticipants
+    );
+    const rows = Math.ceil(numberOfParticipants / columns);
+
+    return { columns,
+        rows };
+}
+
+/**
+ * Computes the placement (position and size) for the secondary multi-screen
+ * window.
+ *
+ * Uses the Window Management API (getScreenDetails) to detect connected
+ * monitors and, when more than one is present, fills whichever screen the main
+ * meeting window is not currently on. When only a single screen is available —
+ * or the API is unsupported or its permission is denied — it falls back to an
+ * offset window sized relative to the available screen real estate (see
+ * {@link SECONDARY_WINDOW_FALLBACK}).
+ *
+ * @returns {Promise<ISecondaryWindowPlacementResult>} The placement geometry
+ * and whether window-management permission was denied.
+ */
+export async function getSecondaryWindowPlacement(): Promise<ISecondaryWindowPlacementResult> {
+    const placement = getFallbackPlacement();
+
+    if (typeof window === 'undefined' || !('getScreenDetails' in window)) {
+        return { permissionDenied: false, placement };
+    }
+
+    try {
+        const { currentScreen, screens } = await window.getScreenDetails();
+
+        if (screens.length <= 1) {
+            logger.info('Only one screen detected, using offset position');
+
+            return { permissionDenied: false, placement };
+        }
+
+        // Fill whichever screen the main meeting window is NOT currently on, so
+        // the secondary always lands on the other monitor regardless of which
+        // display the meeting occupies. Screens are matched by their position in
+        // the virtual desktop (object identity is not guaranteed across the API);
+        // fall back to a non-primary screen, then to any other screen.
+        const isSameScreen = (a: ScreenDetailed, b: ScreenDetailed) => a.left === b.left && a.top === b.top;
+        const secondary = screens.find(s => !isSameScreen(s, currentScreen))
+            ?? screens.find(s => !s.isPrimary)
+            ?? screens[1];
+        const targeted: ISecondaryWindowPlacement = {
+            height: secondary.availHeight,
+            left: secondary.availLeft,
+            top: secondary.availTop,
+            width: secondary.availWidth
+        };
+
+        logger.info(`Targeting secondary screen: ${targeted.width}x${targeted.height} `
+            + `at (${targeted.left}, ${targeted.top})`);
+
+        return { permissionDenied: false, placement: targeted };
+    } catch (error) {
+        // getScreenDetails rejects with a NotAllowedError DOMException when the
+        // window-management permission is denied; distinguish that so the caller
+        // can prompt the user, versus other (transient) failures.
+        const permissionDenied = error instanceof DOMException && error.name === 'NotAllowedError';
+
+        logger.warn('Window Management API failed, using fallback position', error);
+
+        return { permissionDenied, placement };
+    }
+}
+
+/**
+ * Builds the fallback placement used when the secondary window cannot be
+ * targeted to a specific monitor. The window is sized to a fraction of the
+ * available screen real estate, degrading to fixed dimensions when the screen
+ * metrics cannot be read.
+ *
+ * @returns {ISecondaryWindowPlacement} The fallback window placement geometry.
+ */
+function getFallbackPlacement(): ISecondaryWindowPlacement {
+    const { HEIGHT, LEFT, SIZE_RATIO, TOP, WIDTH } = SECONDARY_WINDOW_FALLBACK;
+    const availWidth = typeof window === 'undefined' ? 0 : window.screen.availWidth;
+    const availHeight = typeof window === 'undefined' ? 0 : window.screen.availHeight;
+
+    return {
+        height: Math.round(availHeight * SIZE_RATIO) || HEIGHT,
+        left: LEFT,
+        top: TOP,
+        width: Math.round(availWidth * SIZE_RATIO) || WIDTH
+    };
+}

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -1,6 +1,6 @@
 import { IReduxState } from '../app/types';
 
-import { SECONDARY_WINDOW_FALLBACK, SecondaryLayout } from './constants';
+import { SECONDARY_LAYOUTS, SECONDARY_WINDOW_FALLBACK, SecondaryLayout } from './constants';
 import logger from './logger';
 
 /**
@@ -31,9 +31,9 @@ export interface ISecondaryWindowPlacement {
 }
 
 /**
- * The result of resolving a secondary-window placement: the geometry plus
- * whether the Window Management permission was denied (so the caller can
- * surface that to the user).
+ * The result of resolving a secondary-window placement: the geometry plus flags
+ * for why it may have fallen back (permission denied, or window management
+ * unavailable) so the caller can surface that to the user.
  */
 export interface ISecondaryWindowPlacementResult {
 
@@ -47,24 +47,34 @@ export interface ISecondaryWindowPlacementResult {
      * The computed window geometry.
      */
     placement: ISecondaryWindowPlacement;
+
+    /**
+     * Whether the Window Management API is unavailable in this browser (e.g.
+     * Firefox/Safari), so the window opened at a fallback offset the user may
+     * need to drag to another screen rather than being placed there
+     * automatically.
+     */
+    windowManagementUnavailable: boolean;
 }
 
 /**
- * Returns whether multi-screen support is available in the current browser.
+ * Returns whether multi-screen is available and enabled.
  *
- * The feature only needs {@code window.open()} to work; the Window Management
- * API ({@code getScreenDetails}) is used for smart multi-monitor placement when
+ * The feature is experimental, so it is opt-in: it is enabled only when
+ * {@code config.multiScreen.enabled} is explicitly {@code true}. Beyond that it
+ * only needs {@code window.open()} to work; the Window Management API
+ * ({@code getScreenDetails}) is used for smart multi-monitor placement when
  * present (Chrome/Edge 100+) and otherwise the window opens at a fallback offset
  * the user can drag to another screen. Gating on {@code window.open} (rather than
  * the placement API) keeps that fallback path reachable on Firefox/Safari.
  *
  * @param {IReduxState} state - The Redux state.
- * @returns {boolean} Whether multi-screen is supported.
+ * @returns {boolean} Whether multi-screen is supported and enabled.
  */
 export function isMultiScreenSupported(state: IReduxState): boolean {
     return typeof window !== 'undefined'
         && typeof window.open === 'function'
-        && state['features/base/config'].multiScreen?.enabled !== false;
+        && state['features/base/config'].multiScreen?.enabled === true;
 }
 
 /**
@@ -85,6 +95,54 @@ export function isMultiScreenActive(state: IReduxState): boolean {
  */
 export function getSecondaryLayout(state: IReduxState): SecondaryLayout {
     return state['features/multi-screen'].secondaryLayout;
+}
+
+/**
+ * Type guard for whether a string is one of the known secondary layouts.
+ *
+ * @param {string} [value] - The candidate layout value.
+ * @returns {boolean} Whether it is a valid {@link SecondaryLayout}.
+ */
+function isValidLayout(value?: string): value is SecondaryLayout {
+    return (Object.values(SECONDARY_LAYOUTS) as string[]).includes(value ?? '');
+}
+
+/**
+ * Returns the secondary layout the window should open with, as configured by the
+ * deployment via {@code config.multiScreen.defaultLayout}, or {@code undefined}
+ * when nothing valid is configured (in which case the user preference or reducer
+ * default applies).
+ *
+ * The configured value is validated against {@link SECONDARY_LAYOUTS} so an
+ * unrecognised string in config can't put the secondary window into an invalid
+ * layout.
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {SecondaryLayout|undefined} The configured default layout, if valid.
+ */
+export function getConfiguredDefaultLayout(state: IReduxState): SecondaryLayout | undefined {
+    const configured = state['features/base/config'].multiScreen?.defaultLayout;
+
+    return isValidLayout(configured) ? configured : undefined;
+}
+
+/**
+ * Resolves the layout the secondary window should open in, in priority order:
+ * the user's last-used layout (persisted in {@code base/settings}), then the
+ * deployment-configured default, then the gallery fallback. Each candidate is
+ * validated against {@link SECONDARY_LAYOUTS}.
+ *
+ * @param {IReduxState} state - The Redux state.
+ * @returns {SecondaryLayout} The layout to open with.
+ */
+export function getEffectiveSecondaryLayout(state: IReduxState): SecondaryLayout {
+    const saved = state['features/base/settings'].multiScreenLayout;
+
+    if (isValidLayout(saved)) {
+        return saved;
+    }
+
+    return getConfiguredDefaultLayout(state) ?? SECONDARY_LAYOUTS.GALLERY;
 }
 
 /**
@@ -129,14 +187,15 @@ export function getGalleryGridDimensions(
  * offset window sized relative to the available screen real estate (see
  * {@link SECONDARY_WINDOW_FALLBACK}).
  *
- * @returns {Promise<ISecondaryWindowPlacementResult>} The placement geometry
- * and whether window-management permission was denied.
+ * @returns {Promise<ISecondaryWindowPlacementResult>} The placement geometry,
+ * whether window-management permission was denied, and whether the window had to
+ * fall back to an offset (because the API is unavailable or otherwise failed).
  */
 export async function getSecondaryWindowPlacement(): Promise<ISecondaryWindowPlacementResult> {
     const placement = getFallbackPlacement();
 
     if (typeof window === 'undefined' || !('getScreenDetails' in window)) {
-        return { permissionDenied: false, placement };
+        return { permissionDenied: false, placement, windowManagementUnavailable: true };
     }
 
     try {
@@ -145,7 +204,7 @@ export async function getSecondaryWindowPlacement(): Promise<ISecondaryWindowPla
         if (screens.length <= 1) {
             logger.info('Only one screen detected, using offset position');
 
-            return { permissionDenied: false, placement };
+            return { permissionDenied: false, placement, windowManagementUnavailable: false };
         }
 
         // Fill whichever screen the main meeting window is NOT currently on, so
@@ -167,16 +226,19 @@ export async function getSecondaryWindowPlacement(): Promise<ISecondaryWindowPla
         logger.info(`Targeting secondary screen: ${targeted.width}x${targeted.height} `
             + `at (${targeted.left}, ${targeted.top})`);
 
-        return { permissionDenied: false, placement: targeted };
+        return { permissionDenied: false, placement: targeted, windowManagementUnavailable: false };
     } catch (error) {
         // getScreenDetails rejects with a NotAllowedError DOMException when the
         // window-management permission is denied; distinguish that so the caller
-        // can prompt the user, versus other (transient) failures.
+        // can prompt the user. Any other failure (SecurityError in a restricted
+        // iframe, NotSupportedError, transient errors) also leaves the window at
+        // the fallback offset, so flag it as unavailable too — otherwise the
+        // caller would surface nothing and the user wouldn't know to drag it.
         const permissionDenied = error instanceof DOMException && error.name === 'NotAllowedError';
 
         logger.warn('Window Management API failed, using fallback position', error);
 
-        return { permissionDenied, placement };
+        return { permissionDenied, placement, windowManagementUnavailable: !permissionDenied };
     }
 }
 

--- a/react/features/multi-screen/hooks.web.ts
+++ b/react/features/multi-screen/hooks.web.ts
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+
+import MultiScreenButton from './components/MultiScreenButton';
+import { isMultiScreenSupported } from './functions';
+
+const multiScreen = {
+    key: 'multi-screen',
+    Content: MultiScreenButton,
+    group: 2
+};
+
+/**
+ * A hook that returns the multi-screen toolbar button descriptor when the
+ * feature is supported, and undefined otherwise (so the toolbox omits it
+ * entirely), mirroring the other conditional toolbar-button hooks.
+ *
+ * @returns {Object | undefined}
+ */
+export function useMultiScreenButton() {
+    const supported = useSelector(isMultiScreenSupported);
+
+    if (supported) {
+        return multiScreen;
+    }
+}

--- a/react/features/multi-screen/logger.ts
+++ b/react/features/multi-screen/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('app:multi-screen');

--- a/react/features/multi-screen/middleware.web.ts
+++ b/react/features/multi-screen/middleware.web.ts
@@ -1,0 +1,33 @@
+import { CONFERENCE_FAILED, CONFERENCE_LEFT } from '../base/conference/actionTypes';
+import { CONNECTION_DISCONNECTED } from '../base/connection/actionTypes';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+
+import { closeSecondaryWindow, getSecondaryWindow } from './actions.web';
+import logger from './logger';
+
+/**
+ * Middleware for the multi-screen feature.
+ *
+ * Handles automatic cleanup of the secondary window whenever the user leaves
+ * the conference — by leaving, on failure, or on disconnect — preventing stale
+ * orphaned popup windows.
+ */
+MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case CONFERENCE_LEFT:
+    case CONFERENCE_FAILED:
+    case CONNECTION_DISCONNECTED: {
+        const secondaryWindow = getSecondaryWindow();
+
+        if (secondaryWindow && !secondaryWindow.closed) {
+            logger.info(`${action.type} — auto-closing secondary window`);
+            store.dispatch(closeSecondaryWindow());
+        }
+        break;
+    }
+    }
+
+    return result;
+});

--- a/react/features/multi-screen/multi-screen.css
+++ b/react/features/multi-screen/multi-screen.css
@@ -1,0 +1,249 @@
+/**
+ * Styles for the multi-screen secondary window.
+ *
+ * These styles are copied into the secondary window's document via the
+ * two-tier stylesheet copy system in actions.web.ts. Colors are kept in
+ * sync with Jitsi's design tokens (jitsiTokens.json):
+ *   surface01 #040404 — app background
+ *   surface02 #141414 — toolbar / overlays
+ *   surface03 #292929 — tile / large-video background
+ */
+
+/* Safety net for Jitsi's <Avatar> rendered inside the popped-out document.
+ * The per-participant background color and size are applied via inline styles
+ * (so they always work), but the circle shape and initials centering come from
+ * emotion-generated classes. The literal `avatar` class is always present on
+ * the StatelessAvatar root, so we re-assert the essentials here in case those
+ * generated rules are not copied across to the secondary window. */
+.multi-screen-container .avatar {
+    border-radius: 50%;
+    overflow: hidden;
+    text-align: center;
+    color: #fff;
+}
+
+.multi-screen-container .avatar > div {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+}
+
+/* Container — fills the entire secondary window viewport */
+.multi-screen-container {
+    width: 100%;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: #040404;
+    color: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    overflow: hidden;
+}
+
+/* ---------------------------------------------------------------------------
+ * Active Speaker layout
+ * ------------------------------------------------------------------------- */
+.multi-screen-active-speaker {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    min-height: 0;
+    background-color: #292929;
+}
+
+.multi-screen-video-wrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    min-height: 0;
+}
+
+.multi-screen-video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background-color: #040404;
+}
+
+.multi-screen-video.hidden {
+    display: none;
+}
+
+/* Avatar fallback when video is off — centered over the stage */
+.multi-screen-avatar {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Name pill — matches Jitsi's DisplayNameBadge */
+.multi-screen-name-overlay {
+    position: absolute;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 6px 16px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 3px;
+    font-size: 13px;
+    line-height: 18px;
+    font-weight: 600;
+    max-width: 50%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ---------------------------------------------------------------------------
+ * Gallery layout
+ * ------------------------------------------------------------------------- */
+.multi-screen-gallery {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    gap: 8px;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.multi-screen-gallery-row {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+}
+
+.multi-screen-gallery-placeholder {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.multi-screen-gallery-message {
+    font-size: 16px;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+/* Individual gallery tile — matches Jitsi's thumbnail look.
+ * A transparent 3px border is always reserved so the speaking ring doesn't
+ * shift the layout when it appears. */
+.multi-screen-tile {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #292929;
+    border-radius: 4px;
+    overflow: hidden;
+    box-sizing: border-box;
+    border: 3px solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+/* Dominant-speaker ring — mirrors the main window's blue thumbnail indicator.
+ * Color is Jitsi's action01Hover / hover01 token (#4687ED). */
+.multi-screen-tile.speaking {
+    border-color: #4687ED;
+}
+
+.multi-screen-tile-video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.multi-screen-tile-video.hidden {
+    display: none;
+}
+
+.multi-screen-tile-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Tile name pill — bottom-left, matches main window thumbnails */
+.multi-screen-tile-name {
+    position: absolute;
+    bottom: 8px;
+    left: 8px;
+    padding: 3px 8px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 3px;
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+    max-width: calc(100% - 16px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ---------------------------------------------------------------------------
+ * Secondary window toolbar
+ * ------------------------------------------------------------------------- */
+.multi-screen-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background-color: #141414;
+    flex-shrink: 0;
+}
+
+.multi-screen-toolbar-buttons {
+    display: flex;
+    gap: 8px;
+}
+
+.multi-screen-toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    padding: 0 16px;
+    border: none;
+    border-radius: 6px;
+    background-color: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.multi-screen-toolbar-btn:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
+/* Selected layout — Jitsi's action01 / hover01 token (#4687ED), matching the
+ * dominant-speaker ring. */
+.multi-screen-toolbar-btn.active {
+    background-color: #4687ED;
+}
+
+.multi-screen-toolbar-btn.active:hover {
+    background-color: #2f6fd6;
+}
+
+.multi-screen-close-btn {
+    background-color: #cb2233;
+}
+
+.multi-screen-close-btn:hover {
+    background-color: #a91b29;
+}

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -1,0 +1,54 @@
+import ReducerRegistry from '../base/redux/ReducerRegistry';
+
+import { SET_MULTI_SCREEN_ACTIVE, SET_SECONDARY_LAYOUT } from './actionTypes';
+import { SECONDARY_LAYOUTS, SecondaryLayout } from './constants';
+
+/**
+ * The Redux state shape for the multi-screen feature.
+ */
+export interface IMultiScreenState {
+
+    /**
+     * Whether the secondary window is currently open and active.
+     */
+    isActive: boolean;
+
+    /**
+     * The current layout mode of the secondary window.
+     * One of the values from SECONDARY_LAYOUTS.
+     */
+    secondaryLayout: SecondaryLayout;
+}
+
+/**
+ * The default state for the multi-screen feature.
+ */
+const DEFAULT_STATE: IMultiScreenState = {
+    isActive: false,
+    secondaryLayout: SECONDARY_LAYOUTS.GALLERY
+};
+
+/**
+ * Reduces the Redux actions of the multi-screen feature.
+ */
+ReducerRegistry.register<IMultiScreenState>(
+    'features/multi-screen',
+    (state = DEFAULT_STATE, action): IMultiScreenState => {
+        switch (action.type) {
+        case SET_MULTI_SCREEN_ACTIVE:
+            return {
+                ...state,
+                isActive: action.isActive
+            };
+
+        case SET_SECONDARY_LAYOUT:
+            return {
+                ...state,
+                secondaryLayout: action.layout
+            };
+
+        default:
+            return state;
+        }
+    }
+);

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -165,6 +165,7 @@ export const TOOLBAR_BUTTONS: ToolbarButton[] = [
     'linktosalesforce',
     'livestreaming',
     'microphone',
+    'multi-screen',
     'mute-everyone',
     'mute-video-everyone',
     'participants-pane',

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -26,6 +26,7 @@ import { isGifEnabled } from '../gifs/function.any';
 import InviteButton from '../invite/components/add-people-dialog/web/InviteButton';
 import { registerShortcut, unregisterShortcut } from '../keyboard-shortcuts/actions';
 import { useKeyboardShortcutsButton } from '../keyboard-shortcuts/hooks';
+import { useMultiScreenButton } from '../multi-screen/hooks.web';
 import NoiseSuppressionButton from '../noise-suppression/components/NoiseSuppressionButton';
 import {
     close as closeParticipantsPane,
@@ -289,6 +290,7 @@ export function useToolboxButtons(
     const reactions = useReactionsButton();
     const participants = useParticipantPaneButton();
     const tileview = useTileViewButton();
+    const multiScreen = useMultiScreenButton();
     const chat = useChatButton();
     const cc = useClosedCaptionButton();
     const polls = usePollsButton();
@@ -321,6 +323,7 @@ export function useToolboxButtons(
         'participants-pane': participants,
         invite: _invite,
         tileview,
+        'multi-screen': multiScreen,
         'toggle-camera': toggleCameraButton,
         videoquality: videoQuality,
         fullscreen: _fullscreen,

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -35,6 +35,7 @@ export type ToolbarButton = 'camera' |
     'linktosalesforce' |
     'livestreaming' |
     'microphone' |
+    'multi-screen' |
     'mute-everyone' |
     'mute-video-everyone' |
     'noisesuppression' |

--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -17,6 +17,7 @@ const SETTINGS = 'Open settings';
 const STOP_DESKTOP = 'Stop sharing your screen';
 const ENTER_TILE_VIEW_BUTTON = 'Enter tile view';
 const EXIT_TILE_VIEW_BUTTON = 'Exit tile view';
+const MULTI_SCREEN_BUTTON = 'Open multi-screen window';
 const VIDEO_QUALITY = 'Manage video quality';
 const VIRTUAL_BACKGROUND = 'Select Background';
 const VIDEO_MUTE = 'Stop camera';
@@ -256,6 +257,13 @@ export default class Toolbar extends BasePageObject {
      */
     clickExitTileViewButton() {
         return this.getButton(EXIT_TILE_VIEW_BUTTON).click();
+    }
+
+    /**
+     * Clicks on the multi-screen button which opens the secondary window.
+     */
+    clickMultiScreenButton() {
+        return this.getButton(MULTI_SCREEN_BUTTON).click();
     }
 
     /**

--- a/tests/specs/ui/multiScreen.spec.ts
+++ b/tests/specs/ui/multiScreen.spec.ts
@@ -1,0 +1,71 @@
+import { Participant } from '../../helpers/Participant';
+import { setTestProperties } from '../../helpers/TestProperties';
+import { joinMuc } from '../../helpers/joinMuc';
+
+/**
+ * Selectors for the controls rendered inside the secondary multi-screen window.
+ */
+const GALLERY_BUTTON = '#multiScreenGalleryBtn';
+const SPEAKER_BUTTON = '#multiScreenActiveSpeakerBtn';
+const CLOSE_BUTTON = '#multiScreenCloseBtn';
+const GALLERY_GRID = '.multi-screen-gallery';
+const ACTIVE_SPEAKER_VIDEO = '#multiScreenActiveSpeakerVideo';
+
+setTestProperties(__filename, {
+    usesBrowsers: [ 'p1', 'p2' ]
+});
+
+describe('Multi-screen', () => {
+    let p1: Participant;
+    let mainWindow: string;
+
+    before('join the meeting', async () => {
+        p1 = await joinMuc({ name: 'p1' });
+
+        // A second participant so the gallery has a remote tile to render.
+        await joinMuc({ name: 'p2' });
+    });
+
+    it('opens the secondary window', async () => {
+        mainWindow = await p1.driver.getWindowHandle();
+
+        await p1.getToolbar().clickMultiScreenButton();
+
+        // The secondary view opens as a separate browser window; wait for it and
+        // switch into it.
+        await p1.driver.waitUntil(
+            async () => (await p1.driver.getWindowHandles()).length > 1,
+            {
+                timeout: 5000,
+                timeoutMsg: 'Secondary window did not open'
+            });
+
+        const secondary = (await p1.driver.getWindowHandles()).find(handle => handle !== mainWindow);
+
+        await p1.driver.switchToWindow(secondary as string);
+
+        await p1.driver.$(SPEAKER_BUTTON).waitForDisplayed({ timeout: 5000 });
+        await p1.driver.$(GALLERY_BUTTON).waitForDisplayed({ timeout: 5000 });
+    });
+
+    it('switches to gallery and back to speaker', async () => {
+        await p1.driver.$(GALLERY_BUTTON).click();
+        await p1.driver.$(GALLERY_GRID).waitForExist({ timeout: 5000 });
+
+        await p1.driver.$(SPEAKER_BUTTON).click();
+        await p1.driver.$(ACTIVE_SPEAKER_VIDEO).waitForExist({ timeout: 5000 });
+    });
+
+    it('closes the secondary window', async () => {
+        await p1.driver.$(CLOSE_BUTTON).click();
+
+        await p1.driver.switchToWindow(mainWindow);
+
+        await p1.driver.waitUntil(
+            async () => (await p1.driver.getWindowHandles()).length === 1,
+            {
+                timeout: 5000,
+                timeoutMsg: 'Secondary window did not close'
+            });
+    });
+});

--- a/tsconfig.native.json
+++ b/tsconfig.native.json
@@ -26,6 +26,7 @@
         "react/features/embed-meeting",
         "react/features/face-landmarks",
         "react/features/keyboard-shortcuts",
+        "react/features/multi-screen",
         "react/features/no-audio-signal",
         "react/features/pip",
         "react/features/noise-suppression",


### PR DESCRIPTION
## Multi-Screen Support (GSoC 2026)

Hi @quitrk @cosmintimis — this adds Multi-Screen support: a secondary browser window
that shows an independent conference layout (Active Speaker or Gallery) on another
monitor, under `react/features/multi-screen/` (web-only).

It renders into a `window.open()` popup via React `createPortal()`, so the secondary
window stays in the **same React tree** and shares the **same Redux store and WebRTC
tracks** as the main window -- no duplicate connection, no IPC, no extra state-sync layer.
The secondary window keeps its **own** layout state (separate from `features/video-layout`),
so the two windows can show different layouts at the same time.

The PR is organised as 3 commits:

### 1. `feat(multi-screen): add Redux foundation`
- `actionTypes.ts` — `SET_MULTI_SCREEN_ACTIVE`, `SET_SECONDARY_LAYOUT`
- `constants.ts` — `SECONDARY_LAYOUTS` (`active-speaker` / `gallery`) as `const … as const`
  with a derived `SecondaryLayout` type used wherever a layout is accepted; window root
  id/name; fallback geometry
- `reducer.ts` — `{ isActive, secondaryLayout: SecondaryLayout }`, registered via
  `ReducerRegistry`; wired into `IReduxState` and `app/reducers.any`
- off-by-default `multiScreen` config flag (`configType` + `configWhitelist`)

###  2. `feat(multi-screen): add secondary-window management`
- `actions.web.ts` — open/place/close/toggle the popup, copy app stylesheets into it,
  single-handle focus, robust against the user closing it externally
- `functions.web.ts` — `getSecondaryWindowPlacement()` uses the Window Management API
  (`getScreenDetails`) to open on the monitor the meeting is **not** on (via `currentScreen`),
  with an offset fallback when there's one screen / no API / permission denied;
  `isMultiScreenSupported()` gates on `window.open` so the fallback works on Firefox/Safari
- `middleware.web.ts`, `logger.ts`; Window Management API types in `globals.d.ts` (no `@ts-ignore`)

### 3. `feat(multi-screen): add active-speaker and gallery secondary views`
- **Active Speaker** view mirrors the main window's large video (`getLargeVideoParticipant`) —
  follows the dominant speaker, pins, and auto-pinned screenshares; track via
  `getVideoTrackByParticipant`
- **Gallery** view — responsive grid with the conference dominant speaker highlighted portal bridge, 
   in-window toolbar as a WAI-ARIA radiogroup, gated toolbar button, shared
  `useAttachTrack`, styles, i18n, `tsconfig.native` exclude, and a WebDriver smoke test

### Review history
Built and reviewed in stages on my fork; all feedback is incorporated here:
- Secondary-window management (commit 2) -
https://github.com/codewithabhay10/jitsi-meet/pull/3
- Active-speaker & gallery views (commit 3) -
https://github.com/codewithabhay10/jitsi-meet/pull/4
- Config integration + browser fallback (commit 4) -
https://github.com/codewithabhay10/jitsi-meet/pull/5

Commit 1 (Redux foundation) was reviewed directly on this PR.

Happy to iterate further on any of it.