### PR TITLE
fix(popover) Close popover on Esc when focus is outside content

### DIFF
--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -266,6 +266,7 @@ class Popover extends Component<IProps, IState> {
                 className = { className }
                 id = { id }
                 onClick = { this._onClick }
+                onKeyDown = { this._onEscKey }
                 onKeyPress = { this._onKeyPress }
                 onTouchStart = { this._onTouchStart }
                 { ...(trigger === 'hover' ? {
@@ -454,12 +455,10 @@ class Popover extends Component<IProps, IState> {
      * @returns {void}
      */
     _onEscKey(e: React.KeyboardEvent) {
-        if (e.key === 'Escape') {
+        if (e.key === 'Escape' && this.props.visible) {
             e.preventDefault();
             e.stopPropagation();
-            if (this.props.visible) {
-                this._onHideDialog();
-            }
+            this._onHideDialog();
         }
     }
 


### PR DESCRIPTION
## Summary

The `Popover` component declares an Esc-key handler (`_onEscKey`) but attaches it only to the inner `.popover-content` div. That div renders inside a `DialogPortal`, so for hover-triggered popovers — and for any case where focus remains on the trigger after the popover opens — the Esc `keydown` event never reaches the content handler and the popover cannot be closed by keyboard.

The fix attaches the same handler to the outer container so Esc bubbles up from the trigger (or anywhere inside the container) and closes the popover. The internal guard is tightened so `preventDefault` / `stopPropagation` only runs when the popover is actually visible — avoiding any chance of swallowing Esc for unrelated handlers when the popover is closed.

## Closes

- Closes #17374 — `[Accessibility] ESC doesn't close the reactions menu after hover`
- Closes #17373 — `[Accessibility] ESC doesn't close the three-dot menu after hover`

## Related (out of scope, but same cluster)

The same accessibility audit also reported four issues that need separate fixes in other components (`SettingsDialog`, `ParticipantsPane`, focus-into-menu on open). I'm happy to follow up with separate PRs if this one is acceptable.

- #17368 (participants pane focus on open) — needs work in `participants-pane/components/web/ParticipantsPane.tsx`
- #17367 (reactions menu focus on open) — focus-lock activation path in `react-focus-on` integration
- #17366 (settings dialog focus return) — `isElementInTheViewport` returns false when toolbox auto-hides
- #17365 (three-dot menu focus on open) — same root as #17367

## Test plan

- [x] `tsc --noEmit -p tsconfig.web.json` — clean
- [x] `eslint react/features/base/popover/components/Popover.web.tsx` — clean
- [ ] Manual on `meet.jit.si` build: hover reactions button → press Esc → menu closes (and triggering element retains focus, matching audit recommendation "closable without moving focus").
- [ ] Manual: tab to reactions button, Space to open via keyboard → Esc still closes (regression check).
- [ ] Manual: click three-dot menu (overflow) → Esc → menu closes.
- [ ] Manual: press Esc while no popover is open → other Esc handlers (e.g. dialog close) still fire as before.

## Disclosure

This patch was drafted with AI assistance and reviewed by me before submission.