### PR TITLE
feat(input): improve error message association

### DIFF
--- a/react/features/base/ui/components/web/Input.tsx
+++ b/react/features/base/ui/components/web/Input.tsx
@@ -15,6 +15,7 @@ interface IProps extends IInputProps {
     autoFocus?: boolean;
     bottomLabel?: string;
     className?: string;
+    describedBy?: string;
     hiddenDescription?: string; // Text that will be announced by screen readers but not displayed visually.
     iconClick?: () => void;
 
@@ -24,6 +25,7 @@ interface IProps extends IInputProps {
      * info (label, error) so that screen reader users don't get lost.
      */
     id: string;
+    invalidReason?: 'grammar' | 'spelling' | boolean;
     maxLength?: number;
     maxRows?: number;
     maxValue?: number;
@@ -164,11 +166,13 @@ const Input = React.forwardRef<any, IProps>(({
     className,
     clearable = false,
     disabled,
+    describedBy,
     error,
     hiddenDescription,
     icon,
     iconClick,
     id,
+    invalidReason,
     label,
     maxValue,
     maxLength,
@@ -201,12 +205,24 @@ const Input = React.forwardRef<any, IProps>(({
     const hiddenDescriptionId = `${id}-hidden-description`;
     let ariaDescribedById: string | undefined;
 
-    if (bottomLabel) {
+    if (describedBy) {
+        ariaDescribedById = describedBy;
+    } else if (bottomLabel) {
         ariaDescribedById = `${id}-description`;
     } else if (hiddenDescription) {
         ariaDescribedById = hiddenDescriptionId;
     } else {
         ariaDescribedById = undefined;
+    }
+
+    let ariaInvalid: 'grammar' | 'spelling' | boolean | undefined;
+
+    if (invalidReason) {
+        ariaInvalid = invalidReason;
+    } else if (error) {
+        ariaInvalid = error;
+    } else {
+        ariaInvalid = undefined;
     }
 
     return (
@@ -226,6 +242,7 @@ const Input = React.forwardRef<any, IProps>(({
                 {textarea ? (
                     <TextareaAutosize
                         aria-describedby = { ariaDescribedById }
+                        aria-invalid = { ariaInvalid }
                         aria-label = { accessibilityLabel }
                         autoComplete = { autoComplete }
                         autoFocus = { autoFocus }
@@ -247,6 +264,7 @@ const Input = React.forwardRef<any, IProps>(({
                 ) : (
                     <input
                         aria-describedby = { ariaDescribedById }
+                        aria-invalid = { ariaInvalid }
                         aria-label = { accessibilityLabel }
                         autoComplete = { autoComplete }
                         autoFocus = { autoFocus }
@@ -280,11 +298,12 @@ const Input = React.forwardRef<any, IProps>(({
                 </button>}
             </div>
             {bottomLabel && (
-                <span
+                <p
+                    aria-live = 'polite'
                     className = { cx(styles.bottomLabel, isMobile && 'is-mobile', error && 'error') }
-                    id = { `${id}-description` }>
-                    {bottomLabel}
-                </span>
+                    id = { `${id}-description` } >
+                    { bottomLabel }
+                </p>
             )}
             {!bottomLabel && hiddenDescription && <HiddenDescription id = { hiddenDescriptionId }>{ hiddenDescription }</HiddenDescription>}
         </div>

--- a/react/features/prejoin/components/web/Prejoin.tsx
+++ b/react/features/prejoin/components/web/Prejoin.tsx
@@ -417,12 +417,14 @@ const Prejoin = ({
                     autoComplete = { 'name' }
                     autoFocus = { true }
                     className = { classes.input }
+                    describedBy = { showErrorOnField ? 'prejoin-error-missing-name' : undefined }
                     error = { showErrorOnField }
                     id = 'premeeting-name-input'
                     onChange = { setName }
                     onKeyPress = { showUnsafeRoomWarning && !unsafeRoomConsent ? undefined : onInputKeyPress }
                     placeholder = { t('dialog.enterDisplayName') }
                     readOnly = { readOnlyName }
+                    required = { true }
                     value = { name } />
                 ) : (
                     <div className = { classes.avatarContainer }>
@@ -438,7 +440,9 @@ const Prejoin = ({
                 {showErrorOnField && <div
                     className = { classes.error }
                     data-testid = 'prejoin.errorMessage'>
-                    <p aria-live = 'polite' >
+                    <p
+                        aria-live = 'polite'
+                        id = 'prejoin-error-missing-name' >
                         {t('prejoin.errorMissingName')}
                     </p>
                 </div>}


### PR DESCRIPTION
This is related to [WCAG Success Criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).

The input gets a `describedBy` attribute to link an external description. This takes priority over the `bottomLabel` and `hiddenLabel`. 
This is used on the prejoin message `Please enter your name to join the meeting` which was unlinked to the name input.

Furthermore the input got the `invalidReason` attribute according to [mdn reference for `aria-invalid`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-invalid#values). This takes priority over the `error` attribute, but can fall back to it.

The prejoin name input is now set as required, as entering without a name is not allowed.