### PR TITLE
 feat(api): add EMBEDDED_MODE flag to enable External API without iframe

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -140,6 +140,7 @@ import { getJitsiMeetTransport } from '../transport';
 
 import {
     API_ID,
+    EMBEDDED_MODE,
     ENDPOINT_TEXT_MESSAGE_NAME
 } from './constants';
 
@@ -886,7 +887,7 @@ function initCommands() {
                 APP.store.dispatch(setRequestingSubtitles(false, false, null, true));
             }
 
-            // Mirror AbstractStopRecordingDialog — clear both fields atomically so
+            // Mirror AbstractStopRecordingDialog â€” clear both fields atomically so
             // remote clients see the end of the recording/transcription intent.
             // Covers recording-only, transcription-only, and combined stops.
             if (wantsStopRecording || wantsStopTranscription) {
@@ -1203,6 +1204,11 @@ function initCommands() {
 function shouldBeEnabled() {
     return (
         typeof API_ID === 'number'
+
+            // Enable the API when running in embedded mode (without iframe).
+            // In this mode, JitsiMeetEmbeddedAPI sets the _embeddedMode flag
+            // on the global namespace before the app bundle loads.
+            || EMBEDDED_MODE
 
             // XXX Enable the API when a JSON Web Token (JWT) is specified in
             // the location/URL because then it is very likely that the Jitsi

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1,4 +1,4 @@
-/* global APP */
+﻿/* global APP */
 import Logger from '@jitsi/logger';
 
 import { createApiEvent } from '../../react/features/analytics/AnalyticsEvents';
@@ -887,7 +887,7 @@ function initCommands() {
                 APP.store.dispatch(setRequestingSubtitles(false, false, null, true));
             }
 
-            // Mirror AbstractStopRecordingDialog â€” clear both fields atomically so
+            // Mirror AbstractStopRecordingDialog — clear both fields atomically so
             // remote clients see the end of the recording/transcription intent.
             // Covers recording-only, transcription-only, and combined stops.
             if (wantsStopRecording || wantsStopTranscription) {

--- a/modules/API/constants.js
+++ b/modules/API/constants.js
@@ -19,6 +19,20 @@ try {
 export const API_ID = _apiID;
 
 /**
+ * Whether the app is running in embedded mode (without iframe).
+ * This flag is set by JitsiMeetEmbeddedAPI before the app bundle loads.
+ *
+ * @type {boolean}
+ */
+let _embeddedMode = false;
+
+try {
+    _embeddedMode = Boolean(window.JitsiMeetJS?.app?._embeddedMode);
+} catch (_) { /* Ignore. */ }
+
+export const EMBEDDED_MODE = _embeddedMode;
+
+/**
  * The payload name for the datachannel/endpoint text message event.
  */
 export const ENDPOINT_TEXT_MESSAGE_NAME = 'endpoint-text-message';

--- a/modules/transport/index.js
+++ b/modules/transport/index.js
@@ -1,12 +1,12 @@
 // FIXME: change to '../API' when we update to webpack2. If we do this now all
 // files from API modules will be included in external_api.js.
-import { PostMessageTransportBackend, Transport } from '@jitsi/js-utils/transport';
+import { EmbeddedTransportBackend, PostMessageTransportBackend, Transport } from '@jitsi/js-utils/transport';
 
 import { getJitsiMeetGlobalNS } from '../../react/features/base/util/helpers';
 import { API_ID } from '../API/constants';
 
-
 export {
+    EmbeddedTransportBackend,
     PostMessageTransportBackend,
     Transport
 };
@@ -43,10 +43,19 @@ export function getJitsiMeetTransport() {
 }
 
 /**
- * Sets the transport to passed transport.
+ * Sets the transport to passed transport. Ensures the transport instance
+ * is initialized before attempting to swap the backend.
  *
- * @param {Object} externalTransportBackend - The new transport.
+ * @param {Object} externalTransportBackend - The new transport backend.
  * @returns {void}
  */
-getJitsiMeetGlobalNS().setExternalTransportBackend = externalTransportBackend =>
+getJitsiMeetGlobalNS().setExternalTransportBackend = externalTransportBackend => {
+    // Ensure transport is initialized before swapping the backend.
+    // This is important for embedded mode where setExternalTransportBackend
+    // may be called before getJitsiMeetTransport().
+    if (!transport) {
+        getJitsiMeetTransport();
+    }
+
     transport.setBackend(externalTransportBackend);
+};


### PR DESCRIPTION
**Description**
The External API currently only works when Jitsi Meet is loaded inside  an iframe. This PR is a step toward making it work without one, loading Jitsi directly into a host page div instead.

 **Changes**
 - constants.js - adds `EMBEDDED_MODE`, which checks if the host page set the _embeddedMode flag before the app loaded.
 - API.js - `shouldBeEnabled`() now also returns true when `EMBEDDED_MODE `is set, not just in iframe mode.
 - transport/index.js - exports EmbeddedTransportBackend and adds `setExternalTransportBackend`() so the host page can plug                 in the direct-call backend. (depends on[ jitsi/js-utils#130](https://github.com/jitsi/js-utils/pull/130), open PR)
 
 This is part of the **"External API without iframe**" project. I proposed this as a GSoC 2026 project and although I wasn't selected, I want to keep working on it and contribute it to the community. Follow-up PRs will add JitsiMeetEmbeddedAPI.