### PR TITLE
fix(shared-video): do not prompt jibri to confirm playing shared video

### DIFF
--- a/react/features/shared-video/middleware.ts
+++ b/react/features/shared-video/middleware.ts
@@ -78,7 +78,10 @@ MiddlewareRegistry.register(store => next => action => {
 
                     if (isURLAllowedForSharedVideo(value, state['features/shared-video'].allowedUrlDomains, true)
                         || localParticipantId === from
-                        || state['features/shared-video'].confirmShowVideo) { // if confirmed skip asking again
+                        || state['features/shared-video'].confirmShowVideo // if confirmed skip asking again
+
+                        // jibri cannot confirm the dialog, just play
+                        || (state['features/base/config'].iAmRecorder && conference.isHidden())) {
                         handleSharingVideoStatus(store, value, {
                             ...attributes,
                             from


### PR DESCRIPTION
## Problem

The privacy control added for shared videos shows a `ShareVideoConfirmDialog` when a remote participant shares a video from a non-whitelisted URL. Jibri has no way to confirm the dialog, so the shared video is never played and therefore cannot be recorded or streamed.

Fixes jitsi/jibri#582

## Fix

Skip the confirmation and play the shared video directly when running as the recorder, restricted to a connection that actually joined via the hidden domain:

```ts
|| (state['features/base/config'].iAmRecorder && conference.isHidden())
```

Requiring both `iAmRecorder` and `JitsiConference.isHidden()` ensures only a genuine hidden-domain recorder (Jibri) bypasses the dialog, not any client that happens to set `iAmRecorder` in config. The dialog still protects regular participants from auto-played content.

## Testing

- `npm run tsc:web` passes.
- `eslint` passes on the changed file.