### PR TITLE
fix(mute-modal): restructure mute modal

### DIFF
--- a/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
+++ b/react/features/video-menu/components/web/MuteEveryoneDialog.tsx
@@ -28,7 +28,9 @@ class MuteEveryoneDialog extends AbstractMuteEveryoneDialog<IProps> {
                 onSubmit = { this._onSubmit }
                 title = { this.props.title }>
                 <div className = 'mute-dialog'>
-                    {this.state.content}
+                    <p>
+                        {this.state.content}
+                    </p>
                     {
                         this.props.isModerationSupported
                         && this.props.exclude.length === 0


### PR DESCRIPTION
Recreates #15674, which could not be reopened because the original fork branch (`joshuai96:fix/mute-modal-structure`) was force-pushed/rebased after it was closed and no longer points at the PR's head commit (`81a1b1a9`).

This cherry-picks the original change (authored by @joshuai96 / Joshua Irmer) onto current master.

## Change

Wraps the mute-dialog content in a `<p>` element so the modal body has proper paragraph structure.

Original PR: #15674
Co-authored-by: Joshua Irmer <irmer@gonicus.de>