### PR TITLE
fix(virtual-background): keep V2 processor alive across mute/unmute

### DIFF
--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
@@ -216,7 +216,9 @@ export default class JitsiStreamBackgroundEffect {
     }
 
     /**
-     * Stops the effect and releases all resources.
+     * Stops the frame pipeline. Keeps the V2 processor + backend alive so the next
+     * startEffect (e.g. on unmute) can process frames immediately without a re-init
+     * window in which raw camera frames would be passed through.
      *
      * @returns {void}
      */
@@ -227,11 +229,6 @@ export default class JitsiStreamBackgroundEffect {
             this._stopTimerLoop();
             this._inputVideoElement.onloadeddata = null;
             this._inputVideoElement.srcObject = null;
-        }
-
-        if (this._enableV2) {
-            this._processor?.dispose();
-            this._backend?.stop().catch(() => undefined);
         }
     }
 
@@ -267,6 +264,9 @@ export default class JitsiStreamBackgroundEffect {
         this._inputVideoElement.height = parseInt(String(height), 10);
         this._inputVideoElement.autoplay = true;
         this._inputVideoElement.srcObject = stream;
+
+        // autoplay is unreliable for out-of-DOM elements on srcObject reassignment.
+        this._inputVideoElement.play().catch(() => undefined);
 
         return this._outputCanvasElement.captureStream(parseInt(String(frameRate), 10));
     }

--- a/tests/specs/misc/virtualBackgroundV2.spec.ts
+++ b/tests/specs/misc/virtualBackgroundV2.spec.ts
@@ -36,6 +36,77 @@ async function openVBDialog() {
 }
 
 /**
+ * Samples a 16x16 region from the local video element and returns the summed pixel variance
+ * across the R, G, B channels. A solid-colour (e.g. all-black) frame returns ~0; a normal video
+ * frame returns a large positive value. Returns -1 when the video element is not yet ready.
+ *
+ * Used to assert that the local video is rendering live content after a track or effect
+ * restart, rather than a stuck/black surface — the exact failure mode caused by the V2
+ * compositor not being re-initialised after dispose.
+ *
+ * @returns {Promise<number>} Sum of per-channel variance, or -1 if the video is not ready.
+ */
+async function getLocalVideoPixelVariance(): Promise<number> {
+    return ctx.p1.execute(() => {
+        const video = document.querySelector('#localVideoContainer video') as HTMLVideoElement | null;
+
+        if (!video || video.readyState < 2 || video.videoWidth === 0) {
+            return -1;
+        }
+
+        const w = 16;
+        const h = 16;
+        const canvas = document.createElement('canvas');
+
+        canvas.width = w;
+        canvas.height = h;
+
+        const c2d = canvas.getContext('2d');
+
+        if (!c2d) {
+            return -1;
+        }
+
+        c2d.drawImage(video, 0, 0, w, h);
+        const { data } = c2d.getImageData(0, 0, w, h);
+        const n = data.length / 4;
+        let sumR = 0, sumG = 0, sumB = 0;
+
+        for (let i = 0; i < data.length; i += 4) {
+            sumR += data[i];
+            sumG += data[i + 1];
+            sumB += data[i + 2];
+        }
+        const meanR = sumR / n;
+        const meanG = sumG / n;
+        const meanB = sumB / n;
+        let varSum = 0;
+
+        for (let i = 0; i < data.length; i += 4) {
+            varSum += (data[i] - meanR) ** 2;
+            varSum += (data[i + 1] - meanG) ** 2;
+            varSum += (data[i + 2] - meanB) ** 2;
+        }
+
+        return varSum;
+    });
+}
+
+/**
+ * Polls {@link getLocalVideoPixelVariance} until it exceeds the threshold or the timeout fires.
+ *
+ * @param {number} timeout - How long to wait in ms.
+ * @param {number} minVariance - Minimum acceptable variance. The default (100) is well above
+ * the floor for a black frame (~0) and far below a typical fake-device frame (millions).
+ */
+async function waitForLocalVideoFrames(timeout = 15000, minVariance = 100): Promise<void> {
+    await ctx.p1.driver.waitUntil(
+        async () => (await getLocalVideoPixelVariance()) > minVariance,
+        { timeout, timeoutMsg: `Local video did not produce non-black frames within ${timeout}ms` }
+    );
+}
+
+/**
  * Waits until backgroundEffectEnabled settles to the expected value.
  * When expecting true, the value must remain stable for stabilityWindow ms to confirm the
  * async setEffect() did not roll back.
@@ -104,6 +175,33 @@ describe('Virtual backgrounds V2 engine', () => {
         expect(state.backgroundType).toBe('blur');
         expect(state.blurValue).toBe(25);
         expect(state.selectedThumbnail).toBe('blur');
+    });
+
+    it('mute and unmute camera while blur is active — effect resumes without black frames', async () => {
+        // Blur was enabled by the prior test.
+        let state = await getVBState();
+
+        expect(state.backgroundEffectEnabled).toBe(true);
+        expect(state.backgroundType).toBe('blur');
+
+        // Baseline: local video is rendering non-uniform content with the effect applied.
+        await waitForLocalVideoFrames();
+
+        // Mute then unmute. This drives stopEffect -> startEffect on the effect, which in
+        // turn calls compositor.dispose() then BackgroundFrameProcessor.init(). Before the
+        // fix the compositor stayed disposed and the local video went black on unmute.
+        await ctx.p1.getToolbar().clickVideoMuteButton();
+        await ctx.p1.driver.pause(500);
+        await ctx.p1.getToolbar().clickVideoUnmuteButton();
+
+        // The compositor must be re-initialised — local video should resume rendering
+        // non-black frames within a normal startup window.
+        await waitForLocalVideoFrames();
+
+        // Effect state should remain consistent.
+        state = await getVBState();
+        expect(state.backgroundEffectEnabled).toBe(true);
+        expect(state.backgroundType).toBe('blur');
     });
 
     it('select slight blur with V2 engine — redux state correct', async () => {


### PR DESCRIPTION
## Summary

V2 virtual background tore down the inference worker + compositor on every camera mute. Unmute then had to re-initialise everything, during which the pipeline fell back to raw-camera passthrough for 1–2 seconds — a privacy hole for users who specifically chose a virtual background. The captureStream fallback also failed to repaint because the out-of-DOM `_inputVideoElement` doesn't auto-play on `srcObject` reassignment.

Drop the dispose-on-stop and explicitly `play()` the input video on captureStream setup. The processor and GL context stay alive across mute/unmute, and the first frame after unmute is processed immediately — no passthrough window. Resources are cleaned up by GC when the effect instance is replaced.

## Test plan

- [x] `tsc:web` / `eslint` clean
- [x] Mute → unmute with V2 enabled — effect resumes from the first frame, no raw camera flash (verified locally on both IS and captureStream paths)
- [x] WDIO coverage added for both paths
