### PR TITLE
ios: fix screen-sharing

### DIFF
--- a/ios/sdk/src/JitsiMeet+Private.h
+++ b/ios/sdk/src/JitsiMeet+Private.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <React/RCTBridge.h>
 #import <RCTReactNativeFactory.h>
 
 #import "ExternalAPI.h"

--- a/ios/sdk/src/JitsiMeet.m
+++ b/ios/sdk/src/JitsiMeet.m
@@ -274,8 +274,10 @@
 }
 
 - (ExternalAPI *)getExternalAPI {
-    ExternalAPI *api = [ExternalAPI sharedInstance];
-    return api;
+    // The live RCTBridgeProxy is injected into every
+    // RCTEventEmitter module by the interop layer, so source it from a there.
+    RCTBridge *bridge = [ExternalAPI sharedInstance].bridge;
+    return (ExternalAPI *)[bridge moduleForClass:ExternalAPI.class];
 }
 
 @end

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "react-native-tab-view": "3.5.2",
         "react-native-url-polyfill": "2.0.0",
         "react-native-video": "6.18.0",
-        "react-native-webrtc": "124.0.7",
+        "react-native-webrtc": "https://github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
         "react-native-webview": "13.16.0",
         "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
         "react-native-youtube-iframe": "2.3.0",
@@ -22869,27 +22869,15 @@
     },
     "node_modules/react-native-webrtc": {
       "version": "124.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
-      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
+      "resolved": "git+ssh://git@github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
+      "integrity": "sha512-7hdwf7FJbtsomLYIfFHiWHHMNVoGonWSD/cKzzQZIksL3yZYGQGJpHUj/nHQUrcvEIkmXULcnp3LU1vIGyHo9g==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",
-        "debug": "4.3.4",
-        "event-target-shim": "6.0.2"
+        "debug": "4.3.4"
       },
       "peerDependencies": {
         "react-native": ">=0.60.0"
-      }
-    },
-    "node_modules/react-native-webrtc/node_modules/event-target-shim": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/react-native-webview": {
@@ -42870,20 +42858,12 @@
       "integrity": "sha512-9BjAtAh1uGq6h/GNCCh5yzb/iI9qJHuflwNGExyhoUxbhPD1s+15h+CdpJ2MKKJTXw6J7w+nQOp1Ywa54R8w7Q=="
     },
     "react-native-webrtc": {
-      "version": "124.0.7",
-      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
-      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
+      "version": "git+ssh://git@github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
+      "integrity": "sha512-7hdwf7FJbtsomLYIfFHiWHHMNVoGonWSD/cKzzQZIksL3yZYGQGJpHUj/nHQUrcvEIkmXULcnp3LU1vIGyHo9g==",
+      "from": "react-native-webrtc@https://github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
       "requires": {
         "base64-js": "1.5.1",
-        "debug": "4.3.4",
-        "event-target-shim": "6.0.2"
-      },
-      "dependencies": {
-        "event-target-shim": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
-          "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-        }
+        "debug": "4.3.4"
       }
     },
     "react-native-webview": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-native-tab-view": "3.5.2",
     "react-native-url-polyfill": "2.0.0",
     "react-native-video": "6.18.0",
-    "react-native-webrtc": "124.0.7",
+    "react-native-webrtc": "https://github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
     "react-native-webview": "13.16.0",
     "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
     "react-native-youtube-iframe": "2.3.0",

--- a/react/features/base/connection/actions.native.ts
+++ b/react/features/base/connection/actions.native.ts
@@ -4,7 +4,6 @@ import { getCustomerDetails } from '../../jaas/actions.any';
 import { getJaasJWT, isVpaasMeeting } from '../../jaas/functions';
 import { replaceRoot } from '../../mobile/navigation/rootNavigationContainerRef';
 import { screen } from '../../mobile/navigation/routes';
-import { conferenceLeft } from '../conference/actions.native';
 import { setJWT } from '../jwt/actions';
 import { JitsiConnectionErrors } from '../lib-jitsi-meet';
 
@@ -59,8 +58,5 @@ export function connect(id?: string, password?: string) {
  * @returns {Function}
  */
 export function hangup(_requestFeedback = false) {
-    return (dispatch: IStore['dispatch']) => {
-        dispatch(appNavigate(undefined));
-        dispatch(conferenceLeft());
-    };
+    return (dispatch: IStore['dispatch']) => dispatch(appNavigate(undefined));
 }

--- a/react/features/mobile/call-integration/middleware.ts
+++ b/react/features/mobile/call-integration/middleware.ts
@@ -229,7 +229,7 @@ function _conferenceJoined({ getState }: IStore, next: Function, action: AnyActi
 function _conferenceLeft({ getState }: IStore, next: Function, action: AnyAction) {
     const result = next(action);
 
-    if (!isCallIntegrationEnabled(getState) || !action.conference) {
+    if (!isCallIntegrationEnabled(getState)) {
         return result;
     }
 

--- a/react/features/toolbox/components/native/ScreenSharingIosButton.tsx
+++ b/react/features/toolbox/components/native/ScreenSharingIosButton.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { IReduxState } from '../../../app/types';
 import { IOS_SCREENSHARING_ENABLED } from '../../../base/flags/constants';
 import { getFeatureFlag } from '../../../base/flags/functions';
-import { translate } from '../../../base/i18n/functions';
+import { translate } from '../../../base/i18n/functions.native';
 import { IconScreenshare } from '../../../base/icons/svg';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { isLocalVideoTrackDesktop } from '../../../base/tracks/functions.native';
@@ -29,7 +29,9 @@ interface IProps extends AbstractButtonProps {
 
 const styles = {
     screenCapturePickerView: {
-        display: 'none'
+        position: 'absolute',
+        width: 0,
+        height: 0
     }
 };
 


### PR DESCRIPTION
ScreenCapturePickerView is mounted via the Fabric interop layer in new arch and is absent from the legacy RCTUIManager view registry. 