### PR TITLE
feat(ux): allow recording and transcription to be started and stopped independently

### DIFF
--- a/css/_recording.scss
+++ b/css/_recording.scss
@@ -112,7 +112,7 @@
         background-color: #FFD740;
         color: black;
         display: inline-flex;
-        margin: 32px 0;
+        margin: 16px 0 8px;
         width: 100%;
     }
 

--- a/lang/main.json
+++ b/lang/main.json
@@ -314,6 +314,7 @@
         "alreadySharedVideoMsg": "Another participant is already sharing a video. This conference allows only one shared video at a time.",
         "alreadySharedVideoTitle": "Only one shared video is allowed at a time",
         "applicationWindow": "Application window",
+        "applyChanges": "Apply changes",
         "authenticationRequired": "Authentication required",
         "cameraCaptureDialog": {
             "description": "Take and send a picture using your mobile camera",
@@ -449,6 +450,7 @@
         "permissionMicRequiredError": "Microphone permission is required to participate in conferences with audio. Please grant it in Settings",
         "readMore": "more",
         "recentlyUsedObjects": "Your recently used objects",
+        "recordAndTranscribe": "Record & Transcribe",
         "recording": "Recording",
         "recordingDisabledBecauseOfActiveLiveStreamingTooltip": "Not possible while a live stream is active",
         "recordingInProgressDescription": "This meeting is being recorded and analyzed by AI. Your audio and video have been muted. If you choose to unmute, you consent to being recorded.",
@@ -517,10 +519,13 @@
         "startLiveStreaming": "Start live stream",
         "startRecording": "Start recording",
         "startRemoteControlErrorMessage": "An error occurred while trying to start the remote control session!",
+        "startTranscription": "Start transcription",
         "stopLiveStreaming": "Stop live stream",
         "stopRecording": "Stop recording",
         "stopRecordingWarning": "Are you sure you would like to stop the recording?",
         "stopStreamingWarning": "Are you sure you would like to stop the live streaming?",
+        "stopTranscription": "Stop transcription",
+        "stopTranscriptionWarning": "Are you sure you would like to stop the transcription?",
         "streamKey": "Live stream key",
         "suggestedAccounts": "Suggested Accounts",
         "suggestedDeals": "Suggested Deals",
@@ -1135,6 +1140,7 @@
         }
     },
     "recording": {
+        "alsoTranscribe": "Also transcribe this meeting?",
         "authDropboxText": "Upload to Dropbox",
         "availableSpace": "Available space: {{spaceLeft}} MB (approximately {{duration}} minutes of recording)",
         "beta": "BETA",
@@ -1523,6 +1529,7 @@
         "reactionSilence": "Send silence reaction",
         "reactionSurprised": "Send surprised reaction",
         "reactions": "Reactions",
+        "recordAndTranscribe": "Record & Transcribe",
         "security": "Security options",
         "selectBackground": "Select background",
         "shareRoom": "Invite someone",
@@ -1549,6 +1556,7 @@
         "videounmute": "Start camera"
     },
     "transcribing": {
+        "alsoRecord": "Also record this meeting?",
         "ccButtonTooltip": "Start / Stop subtitles",
         "expandedLabel": "Transcribing is currently on",
         "failed": "Transcribing failed",

--- a/lang/main.json
+++ b/lang/main.json
@@ -519,6 +519,7 @@
         "startLiveStreaming": "Start live stream",
         "startRecording": "Start recording",
         "startRemoteControlErrorMessage": "An error occurred while trying to start the remote control session!",
+        "startTranscribing": "Start transcribing",
         "startTranscription": "Start transcription",
         "stopLiveStreaming": "Stop live stream",
         "stopRecording": "Stop recording",

--- a/lang/main.json
+++ b/lang/main.json
@@ -1530,6 +1530,7 @@
         "reactionSilence": "Send silence reaction",
         "reactionSurprised": "Send surprised reaction",
         "reactions": "Reactions",
+        "record": "Record",
         "recordAndTranscribe": "Record & Transcribe",
         "security": "Security options",
         "selectBackground": "Select background",

--- a/react/features/app/middlewares.native.ts
+++ b/react/features/app/middlewares.native.ts
@@ -12,6 +12,7 @@ import '../mobile/wake-lock/middleware';
 import '../mobile/react-native-sdk/middleware';
 import '../share-room/middleware';
 import '../shared-video/middleware';
+import '../recording/nudge.native';
 import '../toolbox/middleware.native';
 import '../whiteboard/middleware.native';
 

--- a/react/features/app/middlewares.native.ts
+++ b/react/features/app/middlewares.native.ts
@@ -12,7 +12,6 @@ import '../mobile/wake-lock/middleware';
 import '../mobile/react-native-sdk/middleware';
 import '../share-room/middleware';
 import '../shared-video/middleware';
-import '../recording/nudge.native';
 import '../toolbox/middleware.native';
 import '../whiteboard/middleware.native';
 

--- a/react/features/app/middlewares.web.ts
+++ b/react/features/app/middlewares.web.ts
@@ -26,6 +26,7 @@ import '../toolbox/middleware';
 import '../face-landmarks/middleware';
 import '../gifs/middleware';
 import '../time-timer/middleware.web';
+import '../recording/nudge.web';
 import '../whiteboard/middleware.web';
 import '../file-sharing/middleware.web';
 import '../custom-panel/middleware.web';

--- a/react/features/app/middlewares.web.ts
+++ b/react/features/app/middlewares.web.ts
@@ -26,7 +26,6 @@ import '../toolbox/middleware';
 import '../face-landmarks/middleware';
 import '../gifs/middleware';
 import '../time-timer/middleware.web';
-import '../recording/nudge.web';
 import '../whiteboard/middleware.web';
 import '../file-sharing/middleware.web';
 import '../custom-panel/middleware.web';

--- a/react/features/base/media/middleware.web.ts
+++ b/react/features/base/media/middleware.web.ts
@@ -26,7 +26,7 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: AnyA
     case SET_VIDEO_MUTED: {
         if (LocalRecordingManager.isRecordingLocally() && LocalRecordingManager.selfRecording.on) {
             if (action.muted && LocalRecordingManager.selfRecording.withVideo) {
-                dispatch(openDialog('StopRecordingDialog', StopRecordingDialog, { localRecordingVideoStop: true }));
+                dispatch(openDialog('StopRecordingDialog', StopRecordingDialog, { localRecordingVideoStop: true, stopMode: 'recording' }));
 
                 return;
             } else if (!action.muted && !LocalRecordingManager.selfRecording.withVideo) {

--- a/react/features/chat/components/AbstractClosedCaptions.tsx
+++ b/react/features/chat/components/AbstractClosedCaptions.tsx
@@ -6,7 +6,7 @@ import { openDialog } from '../../base/dialog/actions';
 import { MEET_FEATURES } from '../../base/jwt/constants';
 import { IMessageGroup, groupMessagesBySender } from '../../base/util/messageGrouping';
 import { maybeShowPremiumFeatureDialog } from '../../jaas/actions';
-import { StartRecordingDialog } from '../../recording/components/Recording';
+import { RecordingTranscriptionDialog } from '../../recording/components/Recording';
 import { setRequestingSubtitles } from '../../subtitles/actions.any';
 import { canStartSubtitles } from '../../subtitles/functions.any';
 import { ISubtitle } from '../../subtitles/types';
@@ -70,7 +70,7 @@ const AbstractClosedCaptions = (Component: ComponentType<AbstractProps>) => () =
         }
 
         if (isAsyncTranscriptionEnabled) {
-            dispatch(openDialog('StartRecordingDialog', StartRecordingDialog, {
+            dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
                 recordAudioAndVideo: false
             }));
         } else {

--- a/react/features/mobile/navigation/components/conference/components/ConferenceNavigationContainer.tsx
+++ b/react/features/mobile/navigation/components/conference/components/ConferenceNavigationContainer.tsx
@@ -151,7 +151,7 @@ const ConferenceNavigationContainer = () => {
                     name = { screen.conference.recording }
                     options = {{
                         ...recordingScreenOptions,
-                        title: t('recording.title')
+                        title: t('dialog.recordAndTranscribe')
                     }} />
                 <ConferenceStack.Screen
                     component = { StartLiveStreamDialog }

--- a/react/features/mobile/navigation/components/conference/components/ConferenceNavigationContainer.tsx
+++ b/react/features/mobile/navigation/components/conference/components/ConferenceNavigationContainer.tsx
@@ -28,9 +28,9 @@ import AddPeopleDialog
 import ParticipantsPane from '../../../../../participants-pane/components/native/ParticipantsPane';
 // @ts-ignore
 import StartLiveStreamDialog from '../../../../../recording/components/LiveStream/native/StartLiveStreamDialog';
-import StartRecordingDialog
+import RecordingTranscriptionDialog
 // @ts-ignore
-    from '../../../../../recording/components/Recording/native/StartRecordingDialog';
+    from '../../../../../recording/components/Recording/native/RecordingTranscriptionDialog';
 import SalesforceLinkDialog
 // @ts-ignore
     from '../../../../../salesforce/components/native/SalesforceLinkDialog';
@@ -147,7 +147,7 @@ const ConferenceNavigationContainer = () => {
                         title: t('security.title')
                     }} />
                 <ConferenceStack.Screen
-                    component = { StartRecordingDialog }
+                    component = { RecordingTranscriptionDialog }
                     name = { screen.conference.recording }
                     options = {{
                         ...recordingScreenOptions,

--- a/react/features/recording/actionTypes.ts
+++ b/react/features/recording/actionTypes.ts
@@ -125,3 +125,15 @@ export const SET_START_RECORDING_INTENT = 'SET_START_RECORDING_INTENT';
  * }
  */
 export const SET_STOP_RECORDING_INTENT = 'SET_STOP_RECORDING_INTENT';
+
+/**
+ * Tracks whether a local recording is currently active in Redux state so that
+ * selectors (isRecordingRunning, getSessionStatusToShow) can react to it
+ * without polling the LocalRecordingManager singleton directly.
+ *
+ * {
+ *     type: SET_LOCAL_RECORDING_RUNNING,
+ *     running: boolean
+ * }
+ */
+export const SET_LOCAL_RECORDING_RUNNING = 'SET_LOCAL_RECORDING_RUNNING';

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -253,11 +253,18 @@ export function showStoppedRecordingNotification(
  * the audio cue.
  * @returns {Function}
  */
+export interface INudge {
+    actionNameKey: string;
+    descriptionText: string;
+    handler: () => void;
+}
+
 export function showStartedRecordingNotification(
         mode: string,
         initiator: { getId: Function; } | string,
         sessionId: string,
-        willTranscribe?: boolean) {
+        willTranscribe?: boolean,
+        nudge?: INudge) {
     return async (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
         const state = getState();
         const initiatorId = getResourceId(initiator);
@@ -312,6 +319,17 @@ export function showStartedRecordingNotification(
                     descriptionArguments: { name: participantName },
                     titleKey: 'dialog.recording'
                 };
+            }
+
+            // Merge nudge action when only one service started.
+            if (nudge) {
+                notifyProps.dialogProps = {
+                    ...notifyProps.dialogProps,
+                    description: nudge.descriptionText,
+                    customActionNameKey: [ nudge.actionNameKey ],
+                    customActionHandler: [ nudge.handler ]
+                };
+                notifyProps.type = NOTIFICATION_TIMEOUT_TYPE.LONG;
             }
 
             // fetch the recording link from the server for recording initiators in jaas meetings

--- a/react/features/recording/actions.any.ts
+++ b/react/features/recording/actions.any.ts
@@ -22,6 +22,7 @@ import {
     CLEAR_RECORDING_SESSIONS,
     MARK_CONSENT_REQUESTED,
     RECORDING_SESSION_UPDATED,
+    SET_LOCAL_RECORDING_RUNNING,
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
     SET_SELECTED_RECORDING_SERVICE,
@@ -589,5 +590,19 @@ export function setStopRecordingIntent(intent: IStopRecordingIntent | null) {
     return {
         type: SET_STOP_RECORDING_INTENT,
         intent
+    };
+}
+
+/**
+ * Tracks whether a local recording is active in Redux state so that selectors
+ * can react to it without polling the LocalRecordingManager singleton directly.
+ *
+ * @param {boolean} running - Whether local recording is now running.
+ * @returns {Object}
+ */
+export function setLocalRecordingRunning(running: boolean) {
+    return {
+        type: SET_LOCAL_RECORDING_RUNNING,
+        running
     };
 }

--- a/react/features/recording/actions.web.tsx
+++ b/react/features/recording/actions.web.tsx
@@ -11,7 +11,7 @@ import {
 import { VIDEO_MUTISM_AUTHORITY } from '../base/media/constants';
 
 import { showStartRecordingNotificationWithCallback } from './actions.any';
-import { StartRecordingDialog } from './components/Recording';
+import { RecordingTranscriptionDialog } from './components/Recording';
 
 export * from './actions.any';
 
@@ -63,7 +63,7 @@ export function grantRecordingConsentAndUnmute() {
  */
 export function showStartRecordingNotification() {
     return (dispatch: IStore['dispatch']) => {
-        const openDialogCallback = () => dispatch(openDialog('StartRecordingDialog', StartRecordingDialog));
+        const openDialogCallback = () => dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
 
         dispatch(showStartRecordingNotificationWithCallback(openDialogCallback));
     };

--- a/react/features/recording/components/Recording/AbstractHighlightButton.ts
+++ b/react/features/recording/components/Recording/AbstractHighlightButton.ts
@@ -16,7 +16,7 @@ import {
     isHighlightMeetingMomentDisabled
 } from '../../functions';
 
-import { StartRecordingDialog } from './index';
+import { RecordingTranscriptionDialog } from './index';
 
 export interface IProps extends WithTranslation {
 
@@ -82,7 +82,7 @@ export default class AbstractHighlightButton<P extends IProps, S={}> extends Com
                     const dialogShown = dispatch(maybeShowPremiumFeatureDialog(MEET_FEATURES.RECORDING));
 
                     if (!dialogShown) {
-                        dispatch(openDialog('StartRecordingDialog', StartRecordingDialog));
+                        dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
                     }
                 } ],
                 appearance: NOTIFICATION_TYPE.NORMAL

--- a/react/features/recording/components/Recording/AbstractRecordButton.ts
+++ b/react/features/recording/components/Recording/AbstractRecordButton.ts
@@ -4,6 +4,7 @@ import { IReduxState } from '../../../app/types';
 import { IconRecord, IconStop } from '../../../base/icons/svg';
 import { MEET_FEATURES } from '../../../base/jwt/constants';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import { isLocalParticipantModerator } from '../../../base/participants/functions';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { maybeShowPremiumFeatureDialog } from '../../../jaas/actions';
 import { canStopRecording, getRecordButtonProps } from '../../functions';
@@ -37,8 +38,8 @@ export default class AbstractRecordButton<P extends IProps> extends AbstractButt
     override accessibilityLabel = 'dialog.startRecording';
     override toggledAccessibilityLabel = 'dialog.stopRecording';
     override icon = IconRecord;
-    override label = 'dialog.startRecording';
-    override toggledLabel = 'dialog.stopRecording';
+    override label = 'toolbar.recordAndTranscribe';
+    override toggledLabel = 'toolbar.recordAndTranscribe';
     override toggledIcon = IconStop;
 
     /**
@@ -133,6 +134,6 @@ export function _mapStateToProps(state: IReduxState) {
         _disabled,
         _isRecordingRunning: canStopRecording(state),
         _tooltip,
-        visible
+        visible: visible && isLocalParticipantModerator(state)
     };
 }

--- a/react/features/recording/components/Recording/AbstractRecordButton.ts
+++ b/react/features/recording/components/Recording/AbstractRecordButton.ts
@@ -3,11 +3,12 @@ import { sendAnalytics } from '../../../analytics/functions';
 import { IReduxState } from '../../../app/types';
 import { IconRecord, IconStop } from '../../../base/icons/svg';
 import { MEET_FEATURES } from '../../../base/jwt/constants';
+import { isJwtFeatureEnabled } from '../../../base/jwt/functions';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
 import { isLocalParticipantModerator } from '../../../base/participants/functions';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { maybeShowPremiumFeatureDialog } from '../../../jaas/actions';
-import { canStopRecording, getRecordButtonProps } from '../../functions';
+import { canStopRecording, getRecordButtonProps, supportsLocalRecording } from '../../functions';
 
 /**
  * The type of the React {@code Component} props of
@@ -19,6 +20,11 @@ export interface IProps extends AbstractButtonProps {
      * True if the button needs to be disabled.
      */
     _disabled: boolean;
+
+    /**
+     * True if the local participant is a moderator.
+     */
+    _isModerator: boolean;
 
     /**
      * True if there is a running active recording, false otherwise.
@@ -35,12 +41,20 @@ export interface IProps extends AbstractButtonProps {
  * An abstract implementation of a button for starting and stopping recording.
  */
 export default class AbstractRecordButton<P extends IProps> extends AbstractButton<P> {
-    override accessibilityLabel = 'dialog.startRecording';
-    override toggledAccessibilityLabel = 'dialog.stopRecording';
+    override accessibilityLabel = 'toolbar.recordAndTranscribe';
+    override toggledAccessibilityLabel = 'toolbar.recordAndTranscribe';
     override icon = IconRecord;
     override label = 'toolbar.recordAndTranscribe';
     override toggledLabel = 'toolbar.recordAndTranscribe';
     override toggledIcon = IconStop;
+
+    override _getLabel() {
+        return this.props._isModerator ? super._getLabel() : 'toolbar.record';
+    }
+
+    override _getAccessibilityLabel() {
+        return this.props._isModerator ? super._getAccessibilityLabel() : 'toolbar.record';
+    }
 
     /**
      * Returns the tooltip that should be displayed when the button is disabled.
@@ -129,11 +143,16 @@ export function _mapStateToProps(state: IReduxState) {
         tooltip: _tooltip,
         visible
     } = getRecordButtonProps(state);
+    const { localRecording } = state['features/base/config'];
+    const localRecordingEnabled = !localRecording?.disable && supportsLocalRecording();
+    const isModerator = isLocalParticipantModerator(state);
+    const hasRecordingJwt = isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false);
 
     return {
         _disabled,
+        _isModerator: isModerator,
         _isRecordingRunning: canStopRecording(state),
         _tooltip,
-        visible: visible && isLocalParticipantModerator(state)
+        visible: visible && (isModerator || localRecordingEnabled || hasRecordingJwt)
     };
 }

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -153,9 +153,8 @@ export interface IProps extends WithTranslation {
     navigation: any;
 
     /**
-     * Whether the record audio / video option is enabled by default.
-     * Optional — when omitted the dialog derives its initial state from the
-     * currently running services (_recordingRunning / _transcriptionRunning).
+     * Pre-selects the audio/video recording toggle when no session is active.
+     * Used by the nudge flow to open the dialog with recording already checked.
      */
     recordAudioAndVideo?: boolean;
 }

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -488,11 +488,19 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
 
         // === Stop transcription ===
         if (stopTranscription) {
-            dispatch(setRequestingSubtitles(false, _displaySubtitles, _subtitlesLanguage, true));
-            _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
-                isTranscribingEnabled: false,
-                ...(_recordingRunning && !stopRecording && { isRecordingRequested: true })
-            });
+            const recordingStillRunning = _recordingRunning && !stopRecording;
+
+            // When recording is still running, skip the subtitles-internal metadata write and do
+            // a single write ourselves. This prevents two consecutive metadata transitions
+            // (false→false on isRecordingRequested, then false→true) from firing spurious
+            // "recording stopped" and "recording started" sounds and notifications.
+            dispatch(setRequestingSubtitles(false, _displaySubtitles, _subtitlesLanguage, true, false, recordingStillRunning));
+            if (recordingStillRunning) {
+                _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                    isTranscribingEnabled: false,
+                    isRecordingRequested: true
+                });
+            }
         }
 
         // === Start recording ===

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -25,6 +25,7 @@ import {
 import { RECORDING_METADATA_ID, RECORDING_TYPES } from '../../constants';
 import {
     getActiveSession,
+    hasRecordingOrTranscriptionFeature,
     isRecordingRunning,
     isRecordingSharingEnabled,
     shouldAutoTranscribeOnRecord,
@@ -32,7 +33,6 @@ import {
 } from '../../functions';
 import { ISessionData } from '../../reducer';
 
-import LocalRecordingManager from './LocalRecordingManager';
 
 export interface IProps extends WithTranslation {
 
@@ -631,6 +631,12 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
         _language: _subtitlesLanguage
     } = state['features/subtitles'];
 
+    // Only treat cloud recordings as "running" for users who can actually control them.
+    // Non-mods without the recording/transcription JWT feature cannot stop cloud sessions,
+    // so from their perspective only their own local recording counts as "running".
+    const canControlCloud = isLocalParticipantModerator(state)
+        || hasRecordingOrTranscriptionFeature(state);
+
     return {
         _appKey: dropbox.appKey ?? '',
         _autoTranscribeOnRecord: shouldAutoTranscribeOnRecord(state),
@@ -641,11 +647,15 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
         _fileRecordingsServiceSharingEnabled: isRecordingSharingEnabled(state),
         _isModerator: isLocalParticipantModerator(state),
         _isDropboxEnabled: isDropboxEnabled(state),
-        _localRecording: LocalRecordingManager.isRecordingLocally(),
+        _localRecording: Boolean(state['features/recording'].localRecordingRunning),
         _localRecordingEnabled: !localRecording?.disable,
-        _recordingRunning: isRecordingRunning(state),
+        _recordingRunning: canControlCloud
+            ? isRecordingRunning(state)
+            : Boolean(state['features/recording'].localRecordingRunning),
         _rToken: state['features/dropbox'].rToken ?? '',
-        _transcriptionRunning: isRecorderTranscriptionsRunning(state),
+        _transcriptionRunning: canControlCloud
+            ? isRecorderTranscriptionsRunning(state)
+            : false,
         recordAudioAndVideo:
             isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false)
                 ? _ownProps.recordAudioAndVideo ?? recordings?.recordAudioAndVideo ?? true : false,

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -8,6 +8,7 @@ import { IJitsiConference } from '../../../base/conference/reducer';
 import { MEET_FEATURES } from '../../../base/jwt/constants';
 import { isJwtFeatureEnabled } from '../../../base/jwt/functions';
 import { JitsiRecordingConstants } from '../../../base/lib-jitsi-meet';
+import { isLocalParticipantModerator } from '../../../base/participants/functions';
 import { updateDropboxToken } from '../../../dropbox/actions';
 import { getNewAccessToken, isEnabled as isDropboxEnabled } from '../../../dropbox/functions';
 import { getDropboxData } from '../../../dropbox/functions.any';
@@ -76,6 +77,11 @@ export interface IProps extends WithTranslation {
      * If true the dropbox integration is enabled, otherwise - disabled.
      */
     _isDropboxEnabled: boolean;
+
+    /**
+     * Whether the local participant is a moderator.
+     */
+    _isModerator: boolean;
 
     /**
      * Whether a local recording is currently active.
@@ -295,7 +301,9 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
      * are enabled and false otherwise.
      */
     _areIntegrationsEnabled() {
-        return this.props._isDropboxEnabled;
+        return this.props._isDropboxEnabled
+            && !this.props._recordingRunning
+            && !this.props._transcriptionRunning;
     }
 
     /**
@@ -477,8 +485,8 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             } else if (_fileRecordingSession) {
                 _conference?.stopRecording(_fileRecordingSession.id);
                 this._toggleScreenshotCapture();
-                // Explicitly include both fields: some server implementations replace (not
-                // merge) the metadata object under this key, so omitting a field clears it.
+                // Keep isTranscribingEnabled in the metadata if transcription is still running,
+                // so the metadata listener does not see a false transition on that field.
                 _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
                     isRecordingRequested: false,
                     ...(_transcriptionRunning && !stopTranscription && { isTranscribingEnabled: true })
@@ -494,11 +502,16 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             // a single write ourselves. This prevents two consecutive metadata transitions
             // (false→false on isRecordingRequested, then false→true) from firing spurious
             // "recording stopped" and "recording started" sounds and notifications.
+            // Spread existing recording metadata so we only change isTranscribingEnabled —
+            // hardcoding isRecordingRequested: true would cause a spurious recordingStarting
+            // transition if that field was not previously set in the server metadata.
             dispatch(setRequestingSubtitles(false, _displaySubtitles, _subtitlesLanguage, true, false, recordingStillRunning));
             if (recordingStillRunning) {
+                const existingRecMeta = _conference?.getMetadataHandler()?.getMetadata()[RECORDING_METADATA_ID] ?? {};
+
                 _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
-                    isTranscribingEnabled: false,
-                    isRecordingRequested: true
+                    ...existingRecMeta,
+                    isTranscribingEnabled: false
                 });
             }
         }
@@ -626,6 +639,7 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
         _fileRecordingSession: getActiveSession(state, JitsiRecordingConstants.mode.FILE),
         _fileRecordingsServiceEnabled: recordingService?.enabled ?? false,
         _fileRecordingsServiceSharingEnabled: isRecordingSharingEnabled(state),
+        _isModerator: isLocalParticipantModerator(state),
         _isDropboxEnabled: isDropboxEnabled(state),
         _localRecording: LocalRecordingManager.isRecordingLocally(),
         _localRecordingEnabled: !localRecording?.disable,

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -13,9 +13,25 @@ import { getNewAccessToken, isEnabled as isDropboxEnabled } from '../../../dropb
 import { getDropboxData } from '../../../dropbox/functions.any';
 import { showErrorNotification } from '../../../notifications/actions';
 import { setRequestingSubtitles } from '../../../subtitles/actions.any';
-import { setSelectedRecordingService, setStartRecordingIntent, startLocalVideoRecording } from '../../actions.any';
+import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
+import {
+    setSelectedRecordingService,
+    setStartRecordingIntent,
+    setStopRecordingIntent,
+    startLocalVideoRecording,
+    stopLocalVideoRecording
+} from '../../actions.any';
 import { RECORDING_METADATA_ID, RECORDING_TYPES } from '../../constants';
-import { isRecordingSharingEnabled, shouldAutoTranscribeOnRecord, supportsLocalRecording } from '../../functions';
+import {
+    getActiveSession,
+    isRecordingRunning,
+    isRecordingSharingEnabled,
+    shouldAutoTranscribeOnRecord,
+    supportsLocalRecording
+} from '../../functions';
+import { ISessionData } from '../../reducer';
+
+import LocalRecordingManager from './LocalRecordingManager';
 
 export interface IProps extends WithTranslation {
 
@@ -40,6 +56,11 @@ export interface IProps extends WithTranslation {
     _displaySubtitles?: boolean;
 
     /**
+     * Active FILE recording session, needed to stop recording.
+     */
+    _fileRecordingSession?: ISessionData;
+
+    /**
      * Whether to show file recordings service, even if integrations
      * are enabled.
      */
@@ -57,6 +78,11 @@ export interface IProps extends WithTranslation {
     _isDropboxEnabled: boolean;
 
     /**
+     * Whether a local recording is currently active.
+     */
+    _localRecording?: boolean;
+
+    /**
      * Whether or not local recording is enabled.
      */
     _localRecordingEnabled: boolean;
@@ -65,6 +91,11 @@ export interface IProps extends WithTranslation {
      * The dropbox refresh token.
      */
     _rToken: string;
+
+    /**
+     * Whether file recording is currently running.
+     */
+    _recordingRunning?: boolean;
 
     /**
      * Whether or not the local participant is screensharing.
@@ -92,16 +123,35 @@ export interface IProps extends WithTranslation {
     _tokenExpireDate?: number;
 
     /**
+     * Whether transcription is currently running.
+     */
+    _transcriptionRunning?: boolean;
+
+    /**
      * The redux dispatch function.
      */
     dispatch: IStore['dispatch'];
+
+    /**
+     * Whether to pre-select recording when the dialog opens.
+     * Takes precedence over the running recording state when set.
+     */
+    initialRecording?: boolean;
+
+    /**
+     * Whether to pre-select transcription when the dialog opens.
+     * Overrides _autoTranscribeOnRecord when provided.
+     */
+    initialTranscription?: boolean;
 
     navigation: any;
 
     /**
      * Whether the record audio / video option is enabled by default.
+     * Optional — when omitted the dialog derives its initial state from the
+     * currently running services (_recordingRunning / _transcriptionRunning).
      */
-    recordAudioAndVideo: boolean;
+    recordAudioAndVideo?: boolean;
 }
 
 interface IState {
@@ -176,7 +226,6 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
 
         let selectedRecordingService = '';
 
-        // Select the default recording service based on what's actually available.
         if (this.props._fileRecordingsServiceEnabled) {
             selectedRecordingService = RECORDING_TYPES.JITSI_REC_SERVICE;
         } else if (this._areIntegrationsEnabled()) {
@@ -191,14 +240,23 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
         // If no service is available, selectedRecordingService stays '' and
         // the Start Recording button will be disabled.
 
+        const recordingRunning = props._recordingRunning ?? false;
+        const transcriptionRunning = props._transcriptionRunning ?? false;
+        const hasActiveSession = recordingRunning || transcriptionRunning;
 
         this.state = {
             isTokenValid: false,
             isValidating: false,
             userName: undefined,
             sharingEnabled: true,
-            shouldRecordAudioAndVideo: this.props.recordAudioAndVideo,
-            shouldRecordTranscription: this.props._autoTranscribeOnRecord,
+            // When a session is active derive initial toggles from running state.
+            // Explicit props (nudge flow) take priority.
+            shouldRecordAudioAndVideo: hasActiveSession
+                ? (props.initialRecording ?? recordingRunning)
+                : (props.recordAudioAndVideo ?? false),
+            shouldRecordTranscription: hasActiveSession
+                ? (props.initialTranscription ?? transcriptionRunning)
+                : (props.initialTranscription ?? props._autoTranscribeOnRecord ?? false),
             spaceLeft: undefined,
             selectedRecordingService,
             localRecordingOnlySelf: false
@@ -347,36 +405,102 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
     }
 
     /**
-     * Starts a file recording session.
+     * Returns true when the current toggle selection differs from what is
+     * already running — i.e. there is something to apply.
      *
-     * @private
-     * @returns {boolean} - True (to note that the modal should be closed).
+     * @returns {boolean}
+     */
+    _isChanged() {
+        const { _recordingRunning = false, _transcriptionRunning = false } = this.props;
+
+        return this.state.shouldRecordAudioAndVideo !== _recordingRunning
+            || this.state.shouldRecordTranscription !== _transcriptionRunning;
+    }
+
+    /**
+     * Applies recording/transcription changes by computing the delta between
+     * the current running state and the user's selection, then starting or
+     * stopping each service accordingly.
+     *
+     * @returns {boolean|undefined} - True to close the dialog, undefined to
+     *   keep it open (e.g. on validation failure).
      */
     _onSubmit() {
         const {
             _appKey,
             _conference,
             _displaySubtitles,
+            _fileRecordingSession,
             _isDropboxEnabled,
+            _localRecording,
+            _recordingRunning = false,
             _rToken,
             _subtitlesLanguage,
             _token,
+            _transcriptionRunning = false,
             dispatch
         } = this.props;
-        let appData;
-        const attributes: {
-            type?: string;
-        } = {};
 
-        // Dispatch intent synchronously before any async operations.
-        // This coordinates sound/notification timing between recording and transcription.
-        dispatch(setStartRecordingIntent({
-            recording: this.state.shouldRecordAudioAndVideo,
-            transcription: this.state.shouldRecordTranscription
-        }));
+        const {
+            localRecordingOnlySelf,
+            selectedRecordingService,
+            sharingEnabled,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription
+        } = this.state;
 
-        if (this.state.shouldRecordAudioAndVideo) {
-            switch (this.state.selectedRecordingService) {
+        const startRecording = !_recordingRunning && shouldRecordAudioAndVideo;
+        const stopRecording = _recordingRunning && !shouldRecordAudioAndVideo;
+        const startTranscription = !_transcriptionRunning && shouldRecordTranscription;
+        const stopTranscription = _transcriptionRunning && !shouldRecordTranscription;
+
+        // Pre-seed intents synchronously — must happen before any async operations
+        // so the sound/notification coordinator knows what to wait for.
+        if (startRecording || startTranscription) {
+            dispatch(setStartRecordingIntent({
+                recording: startRecording,
+                transcription: startTranscription
+            }));
+        }
+        if ((stopRecording || stopTranscription) && !_localRecording) {
+            dispatch(setStopRecordingIntent({
+                recording: stopRecording && Boolean(_fileRecordingSession),
+                transcription: stopTranscription
+            }));
+        }
+
+        // === Stop recording ===
+        if (stopRecording) {
+            sendAnalytics(createRecordingDialogEvent('stop', 'confirm.button'));
+            if (_localRecording) {
+                dispatch(stopLocalVideoRecording());
+            } else if (_fileRecordingSession) {
+                _conference?.stopRecording(_fileRecordingSession.id);
+                this._toggleScreenshotCapture();
+                // Explicitly include both fields: some server implementations replace (not
+                // merge) the metadata object under this key, so omitting a field clears it.
+                _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                    isRecordingRequested: false,
+                    ...(_transcriptionRunning && !stopTranscription && { isTranscribingEnabled: true })
+                });
+            }
+        }
+
+        // === Stop transcription ===
+        if (stopTranscription) {
+            dispatch(setRequestingSubtitles(false, _displaySubtitles, _subtitlesLanguage, true));
+            _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                isTranscribingEnabled: false,
+                ...(_recordingRunning && !stopRecording && { isRecordingRequested: true })
+            });
+        }
+
+        // === Start recording ===
+        if (startRecording) {
+            let appData;
+            const attributes: { type?: string; } = {};
+
+            switch (selectedRecordingService) {
             case RECORDING_TYPES.DROPBOX: {
                 if (_isDropboxEnabled && _token) {
                     appData = JSON.stringify({
@@ -391,9 +515,7 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
                     });
                     attributes.type = RECORDING_TYPES.DROPBOX;
                 } else {
-                    dispatch(showErrorNotification({
-                        titleKey: 'dialog.noDropboxToken'
-                    }));
+                    dispatch(showErrorNotification({ titleKey: 'dialog.noDropboxToken' }));
 
                     return;
                 }
@@ -402,26 +524,23 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             case RECORDING_TYPES.JITSI_REC_SERVICE: {
                 appData = JSON.stringify({
                     'file_recording_metadata': {
-                        'share': this.state.sharingEnabled
+                        'share': sharingEnabled
                     }
                 });
                 attributes.type = RECORDING_TYPES.JITSI_REC_SERVICE;
                 break;
             }
             case RECORDING_TYPES.LOCAL: {
-                dispatch(startLocalVideoRecording(this.state.localRecordingOnlySelf));
+                dispatch(startLocalVideoRecording(localRecordingOnlySelf));
                 _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
-                    isTranscribingEnabled: this.state.shouldRecordTranscription
+                    isTranscribingEnabled: shouldRecordTranscription
                 });
 
                 return true;
             }
             }
 
-            sendAnalytics(
-                createRecordingDialogEvent('start', 'confirm.button', attributes)
-            );
-
+            sendAnalytics(createRecordingDialogEvent('start', 'confirm.button', attributes));
             this._toggleScreenshotCapture();
             _conference?.startRecording({
                 mode: JitsiRecordingConstants.mode.FILE,
@@ -429,15 +548,23 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             });
         }
 
-        if (this.state.selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE
-                && this.state.shouldRecordTranscription) {
-            dispatch(setRequestingSubtitles(
-                true, _displaySubtitles, _subtitlesLanguage, true,
-                this.state.shouldRecordAudioAndVideo));
-        } else {
+        // === Handle transcription start ===
+        // JITSI_REC_SERVICE uses setRequestingSubtitles; other services update metadata directly.
+        if (startTranscription) {
+            if (selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE) {
+                dispatch(setRequestingSubtitles(
+                    true, _displaySubtitles, _subtitlesLanguage, true, startRecording || _recordingRunning));
+            } else {
+                _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                    isTranscribingEnabled: true
+                });
+            }
+        } else if (startRecording && shouldRecordTranscription
+                && selectedRecordingService !== RECORDING_TYPES.JITSI_REC_SERVICE) {
+            // Starting recording with transcription already on — ensure metadata is consistent.
             _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
-                isRecordingRequested: this.state.shouldRecordAudioAndVideo,
-                isTranscribingEnabled: this.state.shouldRecordTranscription
+                isRecordingRequested: true,
+                isTranscribingEnabled: true
             });
         }
 
@@ -488,11 +615,15 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
         _autoTranscribeOnRecord: shouldAutoTranscribeOnRecord(state),
         _conference: state['features/base/conference'].conference,
         _displaySubtitles,
+        _fileRecordingSession: getActiveSession(state, JitsiRecordingConstants.mode.FILE),
         _fileRecordingsServiceEnabled: recordingService?.enabled ?? false,
         _fileRecordingsServiceSharingEnabled: isRecordingSharingEnabled(state),
         _isDropboxEnabled: isDropboxEnabled(state),
+        _localRecording: LocalRecordingManager.isRecordingLocally(),
         _localRecordingEnabled: !localRecording?.disable,
+        _recordingRunning: isRecordingRunning(state),
         _rToken: state['features/dropbox'].rToken ?? '',
+        _transcriptionRunning: isRecorderTranscriptionsRunning(state),
         recordAudioAndVideo:
             isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false)
                 ? _ownProps.recordAudioAndVideo ?? recordings?.recordAudioAndVideo ?? true : false,

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -8,9 +8,10 @@ import ColorSchemeRegistry from '../../../base/color-scheme/ColorSchemeRegistry'
 import { _abstractMapStateToProps } from '../../../base/dialog/functions';
 import { MEET_FEATURES } from '../../../base/jwt/constants';
 import { isJwtFeatureEnabled } from '../../../base/jwt/functions';
+import { isLocalParticipantModerator } from '../../../base/participants/functions';
 import { authorizeDropbox, updateDropboxToken } from '../../../dropbox/actions';
 import { isVpaasMeeting } from '../../../jaas/functions';
-import { canAddTranscriber } from '../../../transcribing/functions';
+import { canAddTranscriber, isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { RECORDING_TYPES } from '../../constants';
 import { supportsLocalRecording } from '../../functions';
 
@@ -34,6 +35,11 @@ export interface IProps extends WithTranslation {
      * Whether to hide the storage warning or not.
      */
     _hideStorageWarning: boolean;
+
+    /**
+     * Whether the local participant is a moderator.
+     */
+    _isModerator: boolean;
 
     /**
      * Whether local recording is available or not.
@@ -64,6 +70,11 @@ export interface IProps extends WithTranslation {
      * The color-schemed stylesheet of this component.
      */
     _styles: any;
+
+    /**
+     * Whether transcription is currently running.
+     */
+    _transcriptionRunning: boolean;
 
     /**
      * The redux dispatch function.
@@ -149,7 +160,7 @@ export interface IProps extends WithTranslation {
      * Used to bypass the _canStartTranscribing guard so the transcription toggle
      * remains visible for stopping.
      */
-    sessionActive?: boolean;
+    servicesRunning?: boolean;
 
     /**
      * Boolean to set file recording sharing on or off.
@@ -337,15 +348,32 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
     _onRecordingServiceSwitchChange() {
         const {
             onChange,
-            selectedRecordingService
+            onRecordAudioAndVideoChange,
+            onTranscriptionChange,
+            selectedRecordingService,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription
         } = this.props;
 
-        // act like group, cannot toggle off
         if (selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE) {
+            // Cloud is selected but both options are off (switch visually OFF) —
+            // clicking re-enables both advanced options.
+            if (!shouldRecordAudioAndVideo && !shouldRecordTranscription) {
+                onRecordAudioAndVideoChange(true);
+                onTranscriptionChange(true);
+            }
+
             return;
         }
 
         onChange(RECORDING_TYPES.JITSI_REC_SERVICE);
+
+        // If both options are off, re-enable them in the same click so the switch turns ON
+        // immediately — without this, checked stays false until a second click.
+        if (!shouldRecordAudioAndVideo && !shouldRecordTranscription) {
+            onRecordAudioAndVideoChange(true);
+            onTranscriptionChange(true);
+        }
     }
 
     /**
@@ -433,7 +461,9 @@ export function mapStateToProps(state: IReduxState) {
         isVpaas: isVpaasMeeting(state),
         _canStartTranscribing: canAddTranscriber(state),
         _hideStorageWarning: Boolean(recordingService?.hideStorageWarning),
+        _isModerator: isLocalParticipantModerator(state),
         _renderRecording: isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false),
+        _transcriptionRunning: isRecorderTranscriptionsRunning(state),
         _localRecordingAvailable,
         _localRecordingEnabled: !localRecording?.disable,
         _localRecordingSelfEnabled: !localRecording?.disableSelfRecording,

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -13,7 +13,7 @@ import { authorizeDropbox, updateDropboxToken } from '../../../dropbox/actions';
 import { isVpaasMeeting } from '../../../jaas/functions';
 import { canAddTranscriber, isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { RECORDING_TYPES } from '../../constants';
-import { supportsLocalRecording } from '../../functions';
+import { hasRecordingOrTranscriptionFeature, supportsLocalRecording } from '../../functions';
 
 /**
  * The type of the React {@code Component} props of
@@ -409,7 +409,9 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
         const {
             _localRecordingAvailable,
             onChange,
-            selectedRecordingService
+            onRecordAudioAndVideoChange,
+            selectedRecordingService,
+            shouldRecordAudioAndVideo
         } = this.props;
 
         if (!_localRecordingAvailable) {
@@ -417,12 +419,17 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
         }
 
         // act like group, cannot toggle off
-        if (selectedRecordingService
-            === RECORDING_TYPES.LOCAL) {
+        if (selectedRecordingService === RECORDING_TYPES.LOCAL) {
             return;
         }
 
         onChange(RECORDING_TYPES.LOCAL);
+
+        // Selecting local recording implies audio+video — ensure the flag is on
+        // so _isChanged() reflects the selection and the Apply button enables.
+        if (!shouldRecordAudioAndVideo) {
+            onRecordAudioAndVideoChange(true);
+        }
     }
 
     /**
@@ -455,6 +462,7 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
 export function mapStateToProps(state: IReduxState) {
     const { localRecording, recordingService } = state['features/base/config'];
     const _localRecordingAvailable = !localRecording?.disable && supportsLocalRecording();
+    const canControlCloud = isLocalParticipantModerator(state) || hasRecordingOrTranscriptionFeature(state);
 
     return {
         ..._abstractMapStateToProps(state),
@@ -463,7 +471,7 @@ export function mapStateToProps(state: IReduxState) {
         _hideStorageWarning: Boolean(recordingService?.hideStorageWarning),
         _isModerator: isLocalParticipantModerator(state),
         _renderRecording: isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false),
-        _transcriptionRunning: isRecorderTranscriptionsRunning(state),
+        _transcriptionRunning: canControlCloud ? isRecorderTranscriptionsRunning(state) : false,
         _localRecordingAvailable,
         _localRecordingEnabled: !localRecording?.disable,
         _localRecordingSelfEnabled: !localRecording?.disableSelfRecording,

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -134,9 +134,22 @@ export interface IProps extends WithTranslation {
     onTranscriptionChange: Function;
 
     /**
+     * When true, audio/video recording is specifically in progress.
+     * The service selector is hidden since the destination cannot change mid-session.
+     */
+    recordingRunning?: boolean;
+
+    /**
      * The currently selected recording service of type: RECORDING_TYPES.
      */
     selectedRecordingService: string | null;
+
+    /**
+     * When true, at least one service (recording or transcription) is active.
+     * Used to bypass the _canStartTranscribing guard so the transcription toggle
+     * remains visible for stopping.
+     */
+    sessionActive?: boolean;
 
     /**
      * Boolean to set file recording sharing on or off.

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -63,12 +63,11 @@ export interface IProps extends WithTranslation {
     localRecordingVideoStop?: boolean;
 
     /**
-     * Controls which service is stopped. Defaults to 'recording' for
-     * backwards compatibility. Use 'transcription' when opening from the
-     * transcription button to stop only transcription and leave recording
+     * Controls which service is stopped: 'recording' stops the file recording
+     * session, 'transcription' stops only transcription and leaves recording
      * running.
      */
-    stopMode?: 'recording' | 'transcription';
+    stopMode: 'recording' | 'transcription';
 }
 
 /**
@@ -110,7 +109,7 @@ export default class AbstractStopRecordingDialog<P extends IProps>
             _transcriptionRunning,
             dispatch,
             localRecordingVideoStop,
-            stopMode = 'recording'
+            stopMode
         } = this.props;
 
         const stoppingRecording = stopMode === 'recording';

--- a/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStopRecordingDialog.ts
@@ -61,6 +61,14 @@ export interface IProps extends WithTranslation {
      * The user trying to stop the video while local recording is running.
      */
     localRecordingVideoStop?: boolean;
+
+    /**
+     * Controls which service is stopped. Defaults to 'recording' for
+     * backwards compatibility. Use 'transcription' when opening from the
+     * transcription button to stop only transcription and leave recording
+     * running.
+     */
+    stopMode?: 'recording' | 'transcription';
 }
 
 /**
@@ -101,42 +109,53 @@ export default class AbstractStopRecordingDialog<P extends IProps>
             _subtitlesLanguage,
             _transcriptionRunning,
             dispatch,
-            localRecordingVideoStop
+            localRecordingVideoStop,
+            stopMode = 'recording'
         } = this.props;
 
-        // Pre-seed stopRecordingIntent from current running state so the
-        // off-sound/notification coordinator (maybeNotifyRecordingStop) knows
-        // what to wait for. Local recording has its own inline sound path and
-        // does not flow through this coordinator.
-        if (!_localRecording) {
-            const recordingRunning = Boolean(_fileRecordingSession);
+        const stoppingRecording = stopMode === 'recording';
+        const stoppingTranscription = stopMode === 'transcription';
 
-            if (recordingRunning || _transcriptionRunning) {
+        // Pre-seed stopRecordingIntent so the off-sound/notification coordinator
+        // (maybeNotifyRecordingStop) knows what to wait for. Each button only
+        // signals the service it is responsible for stopping.
+        if (!_localRecording) {
+            const recordingRunning = stoppingRecording && Boolean(_fileRecordingSession);
+            const transcriptionRunning = stoppingTranscription && _transcriptionRunning;
+
+            if (recordingRunning || transcriptionRunning) {
                 dispatch(setStopRecordingIntent({
                     recording: recordingRunning,
-                    transcription: _transcriptionRunning
+                    transcription: transcriptionRunning
                 }));
             }
         }
 
-        if (_localRecording) {
-            dispatch(stopLocalVideoRecording());
-            if (localRecordingVideoStop) {
-                dispatch(setVideoMuted(true));
+        if (stoppingRecording) {
+            if (_localRecording) {
+                dispatch(stopLocalVideoRecording());
+                if (localRecordingVideoStop) {
+                    dispatch(setVideoMuted(true));
+                }
+            } else if (_fileRecordingSession) {
+                _conference?.stopRecording(_fileRecordingSession.id);
+                this._toggleScreenshotCapture();
             }
-        } else if (_fileRecordingSession) {
-            _conference?.stopRecording(_fileRecordingSession.id);
-            this._toggleScreenshotCapture();
+
+            _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                isRecordingRequested: false
+            });
         }
 
-        // TODO: this should be an action in transcribing. -saghul
-        this.props.dispatch(
-            setRequestingSubtitles(Boolean(_displaySubtitles), _displaySubtitles, _subtitlesLanguage, true));
+        if (stoppingTranscription) {
+            // TODO: this should be an action in transcribing. -saghul
+            dispatch(
+                setRequestingSubtitles(Boolean(_displaySubtitles), _displaySubtitles, _subtitlesLanguage, true));
 
-        this.props._conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
-            isRecordingRequested: false,
-            isTranscribingEnabled: false
-        });
+            _conference?.getMetadataHandler().setMetadata(RECORDING_METADATA_ID, {
+                isTranscribingEnabled: false
+            });
+        }
 
         return true;
     }

--- a/react/features/recording/components/Recording/LocalRecordingManager.web.ts
+++ b/react/features/recording/components/Recording/LocalRecordingManager.web.ts
@@ -254,15 +254,25 @@ const LocalRecordingManager: ILocalRecordingManager = {
             videoBitsPerSecond: VIDEO_BIT_RATE
         });
 
-        this.recorder.addEventListener('dataavailable', async e => {
-            if (this.recorder && e.data && e.data.size > 0) {
-                let data = e.data;
+        // Serialize all chunk writes so the stop handler can await them before closing the
+        // stream. Without this, the stop event fires concurrently with the last dataavailable
+        // callback's async fixDuration call, and close() races the write — leaving an empty
+        // file for recordings shorter than the 5-second timeslice.
+        let writeQueue: Promise<void> = Promise.resolve();
 
-                if (!this.firstChunk) {
-                    this.firstChunk = data = await fixDuration(data, 864000000); // Reserve 24h.
-                }
+        this.recorder.addEventListener('dataavailable', e => {
+            if (e.data && e.data.size > 0) {
+                const chunk = e.data;
 
-                await this.writableStream?.write(data);
+                writeQueue = writeQueue.then(async () => {
+                    let data = chunk;
+
+                    if (!this.firstChunk) {
+                        this.firstChunk = data = await fixDuration(chunk, 864000000); // Reserve 24h.
+                    }
+
+                    await this.writableStream?.write(data);
+                });
             }
         });
 
@@ -276,8 +286,6 @@ const LocalRecordingManager: ILocalRecordingManager = {
             this.stream?.getTracks().forEach((track: MediaStreamTrack) => track.stop());
             gdmStream?.getTracks().forEach((track: MediaStreamTrack) => track.stop());
 
-            // The stop event is emitted when the recorder is done, and _after_ the last buffered
-            // data has been handed over to the dataavailable event.
             this.recorder = undefined;
             this.audioContext?.close();
             this.audioContext = undefined;
@@ -286,6 +294,9 @@ const LocalRecordingManager: ILocalRecordingManager = {
             this.stream = undefined;
             this.selfRecording.on = false;
             this.selfRecording.withVideo = false;
+
+            // Wait for all pending dataavailable writes before closing the stream.
+            await writeQueue;
 
             if (this.writableStream) {
                 try {

--- a/react/features/recording/components/Recording/index.native.ts
+++ b/react/features/recording/components/Recording/index.native.ts
@@ -1,2 +1,2 @@
-export { default as StartRecordingDialog } from './native/StartRecordingDialog';
+export { default as RecordingTranscriptionDialog } from './native/RecordingTranscriptionDialog';
 export { default as RecordingConsentDialog } from './native/RecordingConsentDialog';

--- a/react/features/recording/components/Recording/index.web.ts
+++ b/react/features/recording/components/Recording/index.web.ts
@@ -1,2 +1,2 @@
-export { default as StartRecordingDialog } from './web/StartRecordingDialog';
+export { default as RecordingTranscriptionDialog } from './web/RecordingTranscriptionDialog';
 export { default as RecordingConsentDialog } from './web/RecordingConsentDialog';

--- a/react/features/recording/components/Recording/native/RecordButton.ts
+++ b/react/features/recording/components/Recording/native/RecordButton.ts
@@ -2,7 +2,6 @@ import { Platform } from 'react-native';
 import { connect } from 'react-redux';
 
 import { IReduxState } from '../../../../app/types';
-import { openDialog } from '../../../../base/dialog/actions';
 import { IOS_RECORDING_ENABLED, RECORDING_ENABLED } from '../../../../base/flags/constants';
 import { getFeatureFlag } from '../../../../base/flags/functions';
 import { translate } from '../../../../base/i18n/functions';
@@ -17,12 +16,11 @@ import AbstractRecordButton, {
     _mapStateToProps as _abstractMapStateToProps
 } from '../AbstractRecordButton';
 
-import StopRecordingDialog from './StopRecordingDialog';
-
 type Props = IProps & AbstractProps;
 
 /**
- * Button for opening a screen where a recording session can be started.
+ * Button for opening the recording/transcription management screen.
+ * The screen handles both starting a new session and managing a running one.
  */
 class RecordButton extends AbstractRecordButton<Props> {
 
@@ -34,13 +32,7 @@ class RecordButton extends AbstractRecordButton<Props> {
      * @returns {void}
      */
     _onHandleClick() {
-        const { _isRecordingRunning, dispatch } = this.props;
-
-        if (_isRecordingRunning) {
-            dispatch(openDialog('StopRecordingDialog', StopRecordingDialog));
-        } else {
-            navigate(screen.conference.recording);
-        }
+        navigate(screen.conference.recording);
     }
 }
 

--- a/react/features/recording/components/Recording/native/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/native/RecordingTranscriptionDialog.tsx
@@ -68,14 +68,14 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
      */
     _updateNavigationOptions() {
         const { _localRecording, _recordingRunning, _transcriptionRunning, navigation, t } = this.props;
-        const sessionActive = Boolean(_recordingRunning || _transcriptionRunning || _localRecording);
+        const servicesRunning = Boolean(_recordingRunning || _transcriptionRunning || _localRecording);
 
         navigation.setOptions({
             // eslint-disable-next-line react/no-multi-comp
             headerRight: () => (
                 <HeaderNavigationButton
-                    disabled = { sessionActive ? !this._isChanged() : this.isStartRecordingDisabled() }
-                    label = { sessionActive ? t('dialog.applyChanges') : t('dialog.start') }
+                    disabled = { servicesRunning ? !this._isChanged() : this.isStartRecordingDisabled() }
+                    label = { servicesRunning ? t('dialog.applyChanges') : t('dialog.start') }
                     onPress = { this._onStartPress }
                     twoActions = { true } />
             )
@@ -129,7 +129,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
             _recordingRunning,
             _transcriptionRunning
         } = this.props;
-        const sessionActive = Boolean(_recordingRunning || _transcriptionRunning);
+        const servicesRunning = Boolean(_recordingRunning || _transcriptionRunning);
         const {
             isTokenValid,
             isValidating,
@@ -158,7 +158,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
                     onTranscriptionChange = { this._onTranscriptionChange }
                     recordingRunning = { Boolean(_recordingRunning) }
                     selectedRecordingService = { selectedRecordingService }
-                    sessionActive = { sessionActive }
+                    servicesRunning = { servicesRunning }
                     sharingSetting = { sharingEnabled }
                     shouldRecordAudioAndVideo = { shouldRecordAudioAndVideo }
                     shouldRecordTranscription = { shouldRecordTranscription }

--- a/react/features/recording/components/Recording/native/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/native/RecordingTranscriptionDialog.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { translate } from '../../../../base/i18n/functions';
+import JitsiScreen from '../../../../base/modal/components/JitsiScreen';
+import HeaderNavigationButton
+    from '../../../../mobile/navigation/components/HeaderNavigationButton';
+import { goBack } from
+    '../../../../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
+import { RECORDING_TYPES } from '../../../constants';
+import AbstractStartRecordingDialog, {
+    IProps,
+    mapStateToProps
+} from '../AbstractStartRecordingDialog';
+import styles from '../styles.native';
+
+import StartRecordingDialogContent from './StartRecordingDialogContent';
+
+
+/**
+ * React Component for managing a recording/transcription session on native.
+ * Handles both starting (when nothing is active) and managing toggles
+ * (when a session is already running).
+ *
+ * @augments Component
+ */
+class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
+
+    /**
+     * Constructor of the component.
+     *
+     * @inheritdoc
+     */
+    constructor(props: IProps) {
+        super(props);
+
+        this._onStartPress = this._onStartPress.bind(this);
+    }
+
+    /**
+     * Implements React's {@link Component#componentDidMount()}.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    override componentDidMount() {
+        super.componentDidMount();
+
+        this._updateNavigationOptions();
+    }
+
+    /**
+     * Implements React's {@link Component#componentDidUpdate()}.
+     *
+     * @inheritdoc
+     * @returns {void}
+     */
+    override componentDidUpdate(prevProps: IProps) {
+        super.componentDidUpdate(prevProps);
+
+        this._updateNavigationOptions();
+    }
+
+    /**
+     * Sets the header right button based on whether a session is active.
+     *
+     * @returns {void}
+     */
+    _updateNavigationOptions() {
+        const { _localRecording, _recordingRunning, _transcriptionRunning, navigation, t } = this.props;
+        const sessionActive = Boolean(_recordingRunning || _transcriptionRunning || _localRecording);
+
+        navigation.setOptions({
+            // eslint-disable-next-line react/no-multi-comp
+            headerRight: () => (
+                <HeaderNavigationButton
+                    disabled = { sessionActive ? !this._isChanged() : this.isStartRecordingDisabled() }
+                    label = { sessionActive ? t('dialog.applyChanges') : t('dialog.start') }
+                    onPress = { this._onStartPress }
+                    twoActions = { true } />
+            )
+        });
+    }
+
+    /**
+     * Applies changes and navigates back.
+     *
+     * @returns {void}
+     */
+    _onStartPress() {
+        this._onSubmit() && goBack();
+    }
+
+    /**
+     * Returns true when the start button should be disabled (no-session case).
+     *
+     * @returns {boolean}
+     */
+    isStartRecordingDisabled() {
+        const {
+            isTokenValid,
+            selectedRecordingService,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription
+        } = this.state;
+
+        if (!shouldRecordAudioAndVideo && !shouldRecordTranscription) {
+            return true;
+        }
+
+        if (selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE) {
+            return false;
+        } else if (selectedRecordingService === RECORDING_TYPES.DROPBOX) {
+            return !isTokenValid;
+        }
+
+        return true;
+    }
+
+    /**
+     * Implements React's {@link Component#render()}.
+     *
+     * @inheritdoc
+     */
+    override render() {
+        const {
+            _fileRecordingsServiceEnabled,
+            _fileRecordingsServiceSharingEnabled,
+            _recordingRunning,
+            _transcriptionRunning
+        } = this.props;
+        const sessionActive = Boolean(_recordingRunning || _transcriptionRunning);
+        const {
+            isTokenValid,
+            isValidating,
+            localRecordingOnlySelf,
+            selectedRecordingService,
+            sharingEnabled,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription,
+            spaceLeft,
+            userName
+        } = this.state;
+
+        return (
+            <JitsiScreen style = { styles.startRecodingContainer }>
+                <StartRecordingDialogContent
+                    fileRecordingsServiceEnabled = { _fileRecordingsServiceEnabled }
+                    fileRecordingsServiceSharingEnabled = { _fileRecordingsServiceSharingEnabled }
+                    integrationsEnabled = { this._areIntegrationsEnabled() }
+                    isTokenValid = { isTokenValid }
+                    isValidating = { isValidating }
+                    localRecordingOnlySelf = { localRecordingOnlySelf }
+                    onChange = { this._onSelectedRecordingServiceChanged }
+                    onLocalRecordingSelfChange = { this._onLocalRecordingSelfChange }
+                    onRecordAudioAndVideoChange = { this._onRecordAudioAndVideoChange }
+                    onSharingSettingChanged = { this._onSharingSettingChanged }
+                    onTranscriptionChange = { this._onTranscriptionChange }
+                    recordingRunning = { Boolean(_recordingRunning) }
+                    selectedRecordingService = { selectedRecordingService }
+                    sessionActive = { sessionActive }
+                    sharingSetting = { sharingEnabled }
+                    shouldRecordAudioAndVideo = { shouldRecordAudioAndVideo }
+                    shouldRecordTranscription = { shouldRecordTranscription }
+                    spaceLeft = { spaceLeft }
+                    userName = { userName } />
+            </JitsiScreen>
+        );
+    }
+}
+
+export default translate(connect(mapStateToProps)(RecordingTranscriptionDialog));

--- a/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
@@ -26,13 +26,73 @@ import {
  */
 class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
     /**
+     * Renders the two service toggles (recording + transcription) directly,
+     * without the collapsible wrapper — used in manage mode when a session
+     * is already active.
+     *
+     * @returns {React$Component}
+     */
+    _renderSessionToggles() {
+        const {
+            _dialogStyles,
+            _styles: styles,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription,
+            t
+        } = this.props;
+
+        return (
+            <>
+                <View
+                    key = 'audioVideoSetting'
+                    style = { styles.header }>
+                    <Text
+                        style = {{
+                            ..._dialogStyles.text,
+                            ...styles.title
+                        }}>
+                        { t('recording.recordAudioAndVideo') }
+                    </Text>
+                    <Switch
+                        checked = { shouldRecordAudioAndVideo }
+                        onChange = { this._onRecordAudioAndVideoSwitchChange }
+                        style = { styles.switch } />
+                </View>
+                <View
+                    key = 'transcriptionSetting'
+                    style = { styles.header }>
+                    <Text
+                        style = {{
+                            ..._dialogStyles.text,
+                            ...styles.title
+                        }}>
+                        { t('recording.recordTranscription') }
+                    </Text>
+                    <Switch
+                        checked = { shouldRecordTranscription }
+                        onChange = { this._onTranscriptionSwitchChange }
+                        style = { styles.switch } />
+                </View>
+            </>
+        );
+    }
+
+    /**
      * Renders the component.
      *
      * @protected
      * @returns {React$Component}
      */
     override render() {
-        const { _styles: styles } = this.props;
+        const { _styles: styles, sessionActive } = this.props;
+
+        if (sessionActive) {
+            return (
+                <View style = { styles.container }>
+                    { this._renderSessionToggles() }
+                </View>
+            );
+        }
 
         return (
             <View style = { styles.container }>

--- a/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
@@ -84,9 +84,9 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     override render() {
-        const { _styles: styles, sessionActive } = this.props;
+        const { _styles: styles, servicesRunning } = this.props;
 
-        if (sessionActive) {
+        if (servicesRunning) {
             return (
                 <View style = { styles.container }>
                     { this._renderSessionToggles() }

--- a/react/features/recording/components/Recording/web/HighlightButton.tsx
+++ b/react/features/recording/components/Recording/web/HighlightButton.tsx
@@ -11,7 +11,7 @@ import Label from '../../../../base/label/components/web/Label';
 import Tooltip from '../../../../base/tooltip/components/Tooltip';
 import BaseTheme from '../../../../base/ui/components/BaseTheme.web';
 import { maybeShowPremiumFeatureDialog } from '../../../../jaas/actions';
-import StartRecordingDialog from '../../Recording/web/StartRecordingDialog';
+import RecordingTranscriptionDialog from '../../Recording/web/RecordingTranscriptionDialog';
 import AbstractHighlightButton, {
     IProps as AbstractProps,
     _abstractMapStateToProps
@@ -138,7 +138,7 @@ export class HighlightButton extends AbstractHighlightButton<IProps, IState> {
         const dialogShown = dispatch(maybeShowPremiumFeatureDialog(MEET_FEATURES.RECORDING));
 
         if (!dialogShown) {
-            dispatch(openDialog('StartRecordingDialog', StartRecordingDialog));
+            dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
         }
     }
 

--- a/react/features/recording/components/Recording/web/RecordButton.ts
+++ b/react/features/recording/components/Recording/web/RecordButton.ts
@@ -3,17 +3,17 @@ import { connect } from 'react-redux';
 import { IReduxState } from '../../../../app/types';
 import { openDialog } from '../../../../base/dialog/actions';
 import { translate } from '../../../../base/i18n/functions';
+import { isRecordingRunning } from '../../../functions';
 import AbstractRecordButton, {
     IProps,
     _mapStateToProps as _abstractMapStateToProps
 } from '../AbstractRecordButton';
 
-import StartRecordingDialog from './StartRecordingDialog';
-import StopRecordingDialog from './StopRecordingDialog';
+import RecordingTranscriptionDialog from './RecordingTranscriptionDialog';
 
 
 /**
- * Button for opening a dialog where a recording session can be started.
+ * Button for opening the unified recording & transcription management dialog.
  */
 class RecordingButton extends AbstractRecordButton<IProps> {
 
@@ -25,11 +25,9 @@ class RecordingButton extends AbstractRecordButton<IProps> {
      * @returns {void}
      */
     override _onHandleClick() {
-        const { _isRecordingRunning, dispatch } = this.props;
-        const dialogComponent = _isRecordingRunning ? StopRecordingDialog : StartRecordingDialog;
-        const dialogName = _isRecordingRunning ? 'StopRecordingDialog' : 'StartRecordingDialog';
+        const { dispatch } = this.props;
 
-        dispatch(openDialog(dialogName, dialogComponent));
+        dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
     }
 }
 
@@ -53,6 +51,7 @@ export function _mapStateToProps(state: IReduxState) {
 
     return {
         ...abstractProps,
+        _isRecordingRunning: isRecordingRunning(state),
         visible
     };
 }

--- a/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
@@ -20,39 +20,34 @@ import StartRecordingDialogContent from './StartRecordingDialogContent';
  *
  * @augments Component
  */
-class StartRecordingDialog extends AbstractStartRecordingDialog {
+class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
 
     /**
-     * Disables start recording button.
+     * Returns true when the primary button should be disabled.
+     *
+     * Disabled when nothing has changed (no-op), or when starting recording
+     * but the recording service selection is invalid.
      *
      * @returns {boolean}
      */
     isStartRecordingDisabled() {
-        const {
-            isTokenValid,
-            selectedRecordingService,
-            shouldRecordAudioAndVideo,
-            shouldRecordTranscription
-        } = this.state;
-
-        if (!shouldRecordAudioAndVideo && !shouldRecordTranscription) {
+        if (!this._isChanged()) {
             return true;
         }
 
-        // Start button is disabled if recording service is only shown;
-        // When validating dropbox token, if that is not enabled, we either always
-        // show the start button or, if just dropbox is enabled, start button
-        // is available when there is token.
+        const { _recordingRunning } = this.props;
+        const { isTokenValid, selectedRecordingService, shouldRecordAudioAndVideo } = this.state;
+        const startingRecording = !_recordingRunning && shouldRecordAudioAndVideo;
+
+        if (!startingRecording) {
+            return false;
+        }
+
         if (selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE) {
             return false;
         } else if (selectedRecordingService === RECORDING_TYPES.DROPBOX) {
             return !isTokenValid;
         } else if (selectedRecordingService === RECORDING_TYPES.LOCAL) {
-            return false;
-        }
-
-        // Allow transcription-only start even without a recording service selected.
-        if (!selectedRecordingService && shouldRecordTranscription) {
             return false;
         }
 
@@ -78,17 +73,19 @@ class StartRecordingDialog extends AbstractStartRecordingDialog {
         } = this.state;
         const {
             _fileRecordingsServiceEnabled,
-            _fileRecordingsServiceSharingEnabled
+            _fileRecordingsServiceSharingEnabled,
+            _recordingRunning,
+            _transcriptionRunning
         } = this.props;
 
         return (
             <Dialog
                 ok = {{
-                    translationKey: 'dialog.startRecording',
+                    translationKey: 'dialog.applyChanges',
                     disabled: this.isStartRecordingDisabled()
                 }}
                 onSubmit = { this._onSubmit }
-                titleKey = 'dialog.startRecording'>
+                titleKey = 'dialog.recordAndTranscribe'>
                 <StartRecordingDialogContent
                     fileRecordingsServiceEnabled = { _fileRecordingsServiceEnabled }
                     fileRecordingsServiceSharingEnabled = { _fileRecordingsServiceSharingEnabled }
@@ -101,7 +98,9 @@ class StartRecordingDialog extends AbstractStartRecordingDialog {
                     onRecordAudioAndVideoChange = { this._onRecordAudioAndVideoChange }
                     onSharingSettingChanged = { this._onSharingSettingChanged }
                     onTranscriptionChange = { this._onTranscriptionChange }
+                    recordingRunning = { Boolean(_recordingRunning) }
                     selectedRecordingService = { selectedRecordingService }
+                    sessionActive = { Boolean(_recordingRunning || _transcriptionRunning) }
                     sharingSetting = { sharingEnabled }
                     shouldRecordAudioAndVideo = { shouldRecordAudioAndVideo }
                     shouldRecordTranscription = { shouldRecordTranscription }
@@ -139,4 +138,4 @@ function mapStateToProps(state: IReduxState, ownProps: any) {
     };
 }
 
-export default translate(connect(mapStateToProps)(StartRecordingDialog));
+export default translate(connect(mapStateToProps)(RecordingTranscriptionDialog));

--- a/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
@@ -74,6 +74,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
         const {
             _fileRecordingsServiceEnabled,
             _fileRecordingsServiceSharingEnabled,
+            _isModerator,
             _recordingRunning,
             _transcriptionRunning
         } = this.props;
@@ -85,7 +86,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
                     disabled: this.isStartRecordingDisabled()
                 }}
                 onSubmit = { this._onSubmit }
-                titleKey = 'dialog.recordAndTranscribe'>
+                titleKey = { _isModerator ? 'dialog.recordAndTranscribe' : 'toolbar.record' }>
                 <StartRecordingDialogContent
                     fileRecordingsServiceEnabled = { _fileRecordingsServiceEnabled }
                     fileRecordingsServiceSharingEnabled = { _fileRecordingsServiceSharingEnabled }
@@ -100,7 +101,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
                     onTranscriptionChange = { this._onTranscriptionChange }
                     recordingRunning = { Boolean(_recordingRunning) }
                     selectedRecordingService = { selectedRecordingService }
-                    sessionActive = { Boolean(_recordingRunning || _transcriptionRunning) }
+                    servicesRunning = { Boolean(_recordingRunning || _transcriptionRunning) }
                     sharingSetting = { sharingEnabled }
                     shouldRecordAudioAndVideo = { shouldRecordAudioAndVideo }
                     shouldRecordTranscription = { shouldRecordTranscription }

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -90,10 +90,9 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
             );
         }
 
-        // Transcription is running but recording has not started yet.
-        const transcriptionRunning = Boolean(_transcriptionRunning) && !recordingRunning;
+        const isTranscriptionOnlySession = Boolean(_transcriptionRunning) && !recordingRunning;
 
-        if (transcriptionRunning) {
+        if (isTranscriptionOnlySession) {
             // Transcription-only session: show the share-link toggle and
             // interactive service toggles so the user can start recording
             // and/or stop transcription independently.
@@ -176,7 +175,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
         return (
             <>
                 <div
-                    className = 'recording-header'
+                    className = 'recording-header space-top'
                     onClick = { this._onToggleShowOptions }>
                     <label className = 'recording-title-no-space'>
                         {t('recording.showAdvancedOptions')}

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -36,13 +36,63 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @protected
      * @returns {React$Component}
      */
+    /**
+     * Renders the two service toggles (recording + transcription) directly,
+     * without the collapsible wrapper — used in manage mode when a session
+     * is already active.
+     *
+     * @returns {React$Component}
+     */
+    _renderSessionToggles() {
+        const { shouldRecordAudioAndVideo, shouldRecordTranscription, t } = this.props;
+
+        return (
+            <>
+                <div className = 'recording-header space-top'>
+                    <label
+                        className = 'recording-title'
+                        htmlFor = 'recording-switch-audio-video'>
+                        { t('recording.recordAudioAndVideo') }
+                    </label>
+                    <Switch
+                        checked = { shouldRecordAudioAndVideo }
+                        className = 'recording-switch'
+                        id = 'recording-switch-audio-video'
+                        onChange = { this._onRecordAudioAndVideoSwitchChange } />
+                </div>
+                <div className = 'recording-header space-top'>
+                    <label
+                        className = 'recording-title'
+                        htmlFor = 'recording-switch-transcription'>
+                        { t('recording.recordTranscription') }
+                    </label>
+                    <Switch
+                        checked = { shouldRecordTranscription }
+                        className = 'recording-switch'
+                        id = 'recording-switch-transcription'
+                        onChange = { this._onTranscriptionSwitchChange } />
+                </div>
+            </>
+        );
+    }
+
     override render() {
         const {
             _canStartTranscribing,
             _localRecordingAvailable,
             _renderRecording,
-            integrationsEnabled
+            integrationsEnabled,
+            recordingRunning
         } = this.props;
+
+        if (recordingRunning) {
+            return (
+                <Container className = 'recording-dialog'>
+                    { this._renderSessionToggles() }
+                </Container>
+            );
+        }
+
         const hasRecordingService = _renderRecording || _localRecordingAvailable || integrationsEnabled;
         const transcriptionOnly = !hasRecordingService && _canStartTranscribing;
 
@@ -94,7 +144,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     _renderAdvancedOptions() {
-        if (!this._canStartTranscribing()) {
+        if (!this._canStartTranscribing() && !this.props.sessionActive) {
             return null;
         }
         const { selectedRecordingService } = this.props;

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -31,12 +31,6 @@ const EMPTY_FUNCTION = () => {
  */
 class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
     /**
-     * Renders the component.
-     *
-     * @protected
-     * @returns {React$Component}
-     */
-    /**
      * Renders the two service toggles (recording + transcription) directly,
      * without the collapsible wrapper — used in manage mode when a session
      * is already active.
@@ -44,7 +38,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     _renderSessionToggles() {
-        const { shouldRecordAudioAndVideo, shouldRecordTranscription, t } = this.props;
+        const { _isModerator, shouldRecordAudioAndVideo, shouldRecordTranscription, t } = this.props;
 
         return (
             <>
@@ -60,18 +54,20 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                         id = 'recording-switch-audio-video'
                         onChange = { this._onRecordAudioAndVideoSwitchChange } />
                 </div>
-                <div className = 'recording-header space-top'>
-                    <label
-                        className = 'recording-title'
-                        htmlFor = 'recording-switch-transcription'>
-                        { t('recording.recordTranscription') }
-                    </label>
-                    <Switch
-                        checked = { shouldRecordTranscription }
-                        className = 'recording-switch'
-                        id = 'recording-switch-transcription'
-                        onChange = { this._onTranscriptionSwitchChange } />
-                </div>
+                { _isModerator && (
+                    <div className = 'recording-header space-top'>
+                        <label
+                            className = 'recording-title'
+                            htmlFor = 'recording-switch-transcription'>
+                            { t('recording.recordTranscription') }
+                        </label>
+                        <Switch
+                            checked = { shouldRecordTranscription }
+                            className = 'recording-switch'
+                            id = 'recording-switch-transcription'
+                            onChange = { this._onTranscriptionSwitchChange } />
+                    </div>
+                ) }
             </>
         );
     }
@@ -81,6 +77,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
             _canStartTranscribing,
             _localRecordingAvailable,
             _renderRecording,
+            _transcriptionRunning,
             integrationsEnabled,
             recordingRunning
         } = this.props;
@@ -88,6 +85,21 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
         if (recordingRunning) {
             return (
                 <Container className = 'recording-dialog'>
+                    { this._renderSessionToggles() }
+                </Container>
+            );
+        }
+
+        // Transcription is running but recording has not started yet.
+        const transcriptionRunning = Boolean(_transcriptionRunning) && !recordingRunning;
+
+        if (transcriptionRunning) {
+            // Transcription-only session: show the share-link toggle and
+            // interactive service toggles so the user can start recording
+            // and/or stop transcription independently.
+            return (
+                <Container className = 'recording-dialog'>
+                    { this._renderFileSharingContent() }
                     { this._renderSessionToggles() }
                 </Container>
             );
@@ -102,13 +114,13 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                     <>
                         { this._renderNoIntegrationsContent() }
                         { this._renderFileSharingContent() }
+                        { this._renderAdvancedOptions() }
                         { this._renderUploadToTheCloudInfo() }
                         { this._renderIntegrationsContent() }
                     </>
                 )}
                 { this._renderLocalRecordingContent() }
                 { transcriptionOnly && this._renderTranscriptionOnly() }
-                { hasRecordingService && <> { this._renderAdvancedOptions() } </> }
             </Container>
         );
     }
@@ -144,12 +156,14 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     _renderAdvancedOptions() {
-        if (!this._canStartTranscribing() && !this.props.sessionActive) {
+        if (!this.props._isModerator) {
+            return null;
+        }
+        if (!this._canStartTranscribing() && !this.props.servicesRunning) {
             return null;
         }
         const { selectedRecordingService } = this.props;
         const validService = selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE
-            || selectedRecordingService === RECORDING_TYPES.LOCAL
             || !selectedRecordingService;
 
         if (!validService) {
@@ -161,7 +175,6 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
 
         return (
             <>
-                <div className = 'recording-header-line' />
                 <div
                     className = 'recording-header'
                     onClick = { this._onToggleShowOptions }>
@@ -225,6 +238,8 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
             isValidating,
             isVpaas,
             selectedRecordingService,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription,
             t
         } = this.props;
 
@@ -232,9 +247,10 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
             = integrationsEnabled || _localRecordingAvailable
                 ? (
                     <Switch
-                        checked = { selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE }
+                        checked = { selectedRecordingService === RECORDING_TYPES.JITSI_REC_SERVICE
+                            && (shouldRecordAudioAndVideo || shouldRecordTranscription) }
                         className = 'recording-switch'
-                        disabled = { isValidating || !this.props.shouldRecordAudioAndVideo }
+                        disabled = { isValidating }
                         id = 'recording-switch-jitsi'
                         onChange = { this._onRecordingServiceSwitchChange } />
                 ) : null;
@@ -450,7 +466,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                     checked = { selectedRecordingService
                         === RECORDING_TYPES.DROPBOX }
                     className = 'recording-switch'
-                    disabled = { isValidating || !this.props.shouldRecordAudioAndVideo }
+                    disabled = { isValidating }
                     id = 'recording-switch-integration'
                     onChange = { this._onDropboxSwitchChange } />
             );
@@ -528,7 +544,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                             checked = { selectedRecordingService
                                 === RECORDING_TYPES.LOCAL }
                             className = 'recording-switch'
-                            disabled = { isValidating || !this.props.shouldRecordAudioAndVideo }
+                            disabled = { isValidating }
                             id = 'recording-switch-local'
                             onChange = { this._onLocalRecordingSwitchChange } />
                     </Container>
@@ -552,7 +568,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                                     <Switch
                                         checked = { Boolean(localRecordingOnlySelf) }
                                         className = 'recording-switch'
-                                        disabled = { isValidating || !this.props.shouldRecordAudioAndVideo }
+                                        disabled = { isValidating }
                                         id = 'recording-switch-myself'
                                         onChange = { onLocalRecordingSelfChange ?? EMPTY_FUNCTION } />
                                 </Container>

--- a/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
+++ b/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
@@ -23,14 +23,19 @@ class StopRecordingDialog extends AbstractStopRecordingDialog<IProps> {
      * @returns {ReactElement}
      */
     override render() {
-        const { t, localRecordingVideoStop } = this.props;
+        const { localRecordingVideoStop, stopMode = 'recording', t } = this.props;
+
+        const titleKey = stopMode === 'transcription' ? 'dialog.stopTranscription' : 'dialog.recording';
+        const bodyKey = stopMode === 'transcription'
+            ? 'dialog.stopTranscriptionWarning'
+            : (localRecordingVideoStop ? 'recording.localRecordingVideoStop' : 'dialog.stopRecordingWarning');
 
         return (
             <Dialog
                 ok = {{ translationKey: 'dialog.confirm' }}
                 onSubmit = { this._onSubmit }
-                titleKey = 'dialog.recording'>
-                {t(localRecordingVideoStop ? 'recording.localRecordingVideoStop' : 'dialog.stopRecordingWarning') }
+                titleKey = { titleKey }>
+                { t(bodyKey) }
             </Dialog>
         );
     }

--- a/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
+++ b/react/features/recording/components/Recording/web/StopRecordingDialog.tsx
@@ -23,7 +23,7 @@ class StopRecordingDialog extends AbstractStopRecordingDialog<IProps> {
      * @returns {ReactElement}
      */
     override render() {
-        const { localRecordingVideoStop, stopMode = 'recording', t } = this.props;
+        const { localRecordingVideoStop, stopMode, t } = this.props;
 
         const titleKey = stopMode === 'transcription' ? 'dialog.stopTranscription' : 'dialog.recording';
         const bodyKey = stopMode === 'transcription'

--- a/react/features/recording/components/web/RecordingLabel.tsx
+++ b/react/features/recording/components/web/RecordingLabel.tsx
@@ -15,7 +15,7 @@ import AbstractRecordingLabel, {
     IProps as AbstractProps,
     _mapStateToProps as _abstractMapStateToProps
 } from '../AbstractRecordingLabel';
-import StopRecordingDialog from '../Recording/web/StopRecordingDialog';
+import RecordingTranscriptionDialog from '../Recording/web/RecordingTranscriptionDialog';
 
 interface IProps extends AbstractProps {
 
@@ -76,7 +76,7 @@ class RecordingLabel extends AbstractRecordingLabel<IProps> {
      */
     _onClick() {
         if (this.props._canControlRecording) {
-            this.props.dispatch(openDialog('StopRecordingDialog', StopRecordingDialog));
+            this.props.dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
         }
     }
 

--- a/react/features/recording/components/web/TranscribingLabel.tsx
+++ b/react/features/recording/components/web/TranscribingLabel.tsx
@@ -14,7 +14,7 @@ import { hasRecordingOrTranscriptionFeature } from '../../functions';
 import AbstractRecordingLabel, {
     IProps as AbstractProps
 } from '../AbstractRecordingLabel';
-import StopRecordingDialog from '../Recording/web/StopRecordingDialog';
+import RecordingTranscriptionDialog from '../Recording/web/RecordingTranscriptionDialog';
 
 interface IProps extends AbstractProps {
 
@@ -75,7 +75,7 @@ class TranscribingLabel extends AbstractRecordingLabel<IProps> {
      */
     _onClick() {
         if (this.props._canControlRecording) {
-            this.props.dispatch(openDialog('StopRecordingDialog', StopRecordingDialog));
+            this.props.dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog));
         }
     }
 

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -148,7 +148,7 @@ export function getSessionStatusToShow(state: IReduxState, mode: string): string
             }
         }
     }
-    if (!status && mode === JitsiRecordingConstants.mode.FILE
+    if (mode === JitsiRecordingConstants.mode.FILE
             && (state['features/recording'].localRecordingRunning || isRemoteParticipantRecordingLocally(state))) {
         status = JitsiRecordingConstants.status.ON;
     }

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -148,7 +148,7 @@ export function getSessionStatusToShow(state: IReduxState, mode: string): string
         }
     }
     if (!status && mode === JitsiRecordingConstants.mode.FILE
-            && (LocalRecordingManager.isRecordingLocally() || isRemoteParticipantRecordingLocally(state))) {
+            && (state['features/recording'].localRecordingRunning || isRemoteParticipantRecordingLocally(state))) {
         status = JitsiRecordingConstants.status.ON;
     }
 
@@ -193,7 +193,7 @@ export function isLiveStreamingRunning(state: IReduxState) {
 export function isRecordingRunning(state: IReduxState) {
     return (
         isCloudRecordingRunning(state)
-        || LocalRecordingManager.isRecordingLocally()
+        || Boolean(state['features/recording'].localRecordingRunning)
     );
 }
 
@@ -216,7 +216,7 @@ export function hasRecordingOrTranscriptionFeature(state: IReduxState) {
  * @returns {boolean}
  */
 export function canStopRecording(state: IReduxState) {
-    if (LocalRecordingManager.isRecordingLocally()) {
+    if (state['features/recording'].localRecordingRunning) {
         return true;
     }
 

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -12,6 +12,7 @@ import { isSpotTV } from '../base/util/spot';
 import { isInBreakoutRoom as isInBreakoutRoomF } from '../breakout-rooms/functions';
 import { isEnabled as isDropboxEnabled } from '../dropbox/functions';
 import { extractFqnFromPath } from '../dynamic-branding/functions.any';
+import { isVpaasMeeting } from '../jaas/functions';
 import { canAddTranscriber, isRecorderTranscriptionsRunning } from '../transcribing/functions';
 import { iAmVisitor } from '../visitors/functions';
 
@@ -290,6 +291,10 @@ export function getRecordButtonProps(state: IReduxState) {
         visible = recordingEnabled;
     } else if (isJwtFeatureEnabled(state, MEET_FEATURES.TRANSCRIPTION, false)) {
         visible = transcriptionEnabled;
+    } else if (!isVpaasMeeting(state)) {
+        // Self-hosted without JWT: fall back to server config so moderators
+        // see the button when recordingService.enabled or transcription.enabled.
+        visible = recordingEnabled || transcriptionEnabled;
     }
 
     // disable the button if the livestreaming is running.

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -85,7 +85,7 @@ let _nudgeProvider: NudgeProvider | null = null;
 
 /**
  * Registers a platform-specific provider for nudge notification actions.
- * Called by web-only code (recordingNudge.web.ts) at startup.
+ * Called by platform-specific code (nudge.web.ts / nudge.native.ts) at startup.
  *
  * @param {NudgeProvider} fn - Provider function.
  * @returns {void}

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -43,6 +43,7 @@ import {
     clearRecordingSessions,
     hidePendingRecordingNotification,
     markConsentRequested,
+    setLocalRecordingRunning,
     setStartRecordingIntent,
     setStopRecordingIntent,
     showPendingRecordingNotification,
@@ -444,6 +445,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
                 titleKey: 'recording.localRecordingStartWarningTitle',
                 descriptionKey: 'recording.localRecordingStartWarning'
             }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
+            dispatch(setLocalRecordingRunning(true));
             dispatch(updateLocalRecordingStatus(true, onlySelf));
             sendAnalytics(createRecordingEvent('started', `local${onlySelf ? '.self' : ''}`));
             if (typeof APP !== 'undefined') {
@@ -484,6 +486,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
 
         if (LocalRecordingManager.isRecordingLocally()) {
             LocalRecordingManager.stopLocalRecording();
+            dispatch(setLocalRecordingRunning(false));
             dispatch(updateLocalRecordingStatus(false));
             if (localRecording?.notifyAllParticipants && !LocalRecordingManager.selfRecording) {
                 dispatch(playSound(RECORDING_OFF_SOUND_ID));

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -21,7 +21,11 @@ import { MEDIA_TYPE } from '../base/media/constants';
 import { PARTICIPANT_UPDATED } from '../base/participants/actionTypes';
 import { updateLocalRecordingStatus } from '../base/participants/actions';
 import { PARTICIPANT_ROLE } from '../base/participants/constants';
-import { getLocalParticipant, getParticipantDisplayName } from '../base/participants/functions';
+import {
+    getLocalParticipant,
+    getParticipantDisplayName,
+    isLocalParticipantModerator
+} from '../base/participants/functions';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 import StateListenerRegistry from '../base/redux/StateListenerRegistry';
 import {
@@ -35,6 +39,7 @@ import { isRecorderTranscriptionsRunning, isTranscribing } from '../transcribing
 
 import { RECORDING_SESSION_UPDATED, START_LOCAL_RECORDING, STOP_LOCAL_RECORDING } from './actionTypes';
 import {
+    INudge,
     clearRecordingSessions,
     hidePendingRecordingNotification,
     markConsentRequested,
@@ -70,6 +75,24 @@ import {
 } from './functions';
 import logger from './logger';
 import { ISessionData } from './reducer';
+
+type NudgeProvider = (
+    scenario: 'recording' | 'transcription',
+    dispatch: IStore['dispatch']
+) => INudge | null;
+
+let _nudgeProvider: NudgeProvider | null = null;
+
+/**
+ * Registers a platform-specific provider for nudge notification actions.
+ * Called by web-only code (recordingNudge.web.ts) at startup.
+ *
+ * @param {NudgeProvider} fn - Provider function.
+ * @returns {void}
+ */
+export function registerNudgeProvider(fn: NudgeProvider): void {
+    _nudgeProvider = fn;
+}
 
 /**
  * Evaluates whether all intended services (recording and/or transcription) have
@@ -161,18 +184,33 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
         dispatch(playSound(soundID));
     }
 
+    // Nudge when only one service was just started AND the other is not already running.
+    // Only moderators can start the complementary service, so skip the nudge for non-mods.
+    const nudgeNeeded = Boolean(_nudgeProvider) && isLocalParticipantModerator(state)
+        && (wantsRecording !== wantsTranscription)
+        && (wantsRecording ? !transcriptionOn : !recordingOn);
+    const nudge = nudgeNeeded && _nudgeProvider
+        ? _nudgeProvider(wantsRecording ? 'recording' : 'transcription', dispatch)
+        : null;
+
     if (recordingOn && fileSession?.initiator && fileSession.id) {
         dispatch(showStartedRecordingNotification(
             modeConstants.FILE,
             fileSession.initiator,
             fileSession.id,
-            recordingOn && transcriptionOn));
+            recordingOn && transcriptionOn,
+            nudge ?? undefined));
     } else if (transcriptionOn && !recordingOn) {
         // Transcription-only case (recording failed or wasn't requested).
         dispatch(showNotification({
             descriptionKey: 'transcribing.on',
-            titleKey: 'dialog.recording'
-        }, NOTIFICATION_TIMEOUT_TYPE.SHORT));
+            titleKey: 'dialog.recording',
+            ...(nudge ? {
+                description: nudge.descriptionText,
+                customActionNameKey: [ nudge.actionNameKey ],
+                customActionHandler: [ nudge.handler ]
+            } : {})
+        }, nudge ? NOTIFICATION_TIMEOUT_TYPE.LONG : NOTIFICATION_TIMEOUT_TYPE.SHORT));
     }
 }
 
@@ -243,7 +281,9 @@ export function maybeNotifyRecordingStop(dispatch: IStore['dispatch'], getState:
     dispatch(setStopRecordingIntent(null));
 
     if (offSoundID) {
-        if (onSoundID) {
+        // Always stop the combined sound in case both services were started together.
+        dispatch(stopSound(RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID));
+        if (onSoundID && onSoundID !== RECORDING_AND_TRANSCRIPTION_ON_SOUND_ID) {
             dispatch(stopSound(onSoundID));
         }
         dispatch(playSound(offSoundID));

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -39,7 +39,6 @@ import { isRecorderTranscriptionsRunning, isTranscribing } from '../transcribing
 
 import { RECORDING_SESSION_UPDATED, START_LOCAL_RECORDING, STOP_LOCAL_RECORDING } from './actionTypes';
 import {
-    INudge,
     clearRecordingSessions,
     hidePendingRecordingNotification,
     markConsentRequested,
@@ -75,25 +74,8 @@ import {
     unregisterRecordingAudioFiles
 } from './functions';
 import logger from './logger';
+import { getNudge } from './nudge';
 import { ISessionData } from './reducer';
-
-type NudgeProvider = (
-    scenario: 'recording' | 'transcription',
-    dispatch: IStore['dispatch']
-) => INudge | null;
-
-let _nudgeProvider: NudgeProvider | null = null;
-
-/**
- * Registers a platform-specific provider for nudge notification actions.
- * Called by platform-specific code (nudge.web.ts / nudge.native.ts) at startup.
- *
- * @param {NudgeProvider} fn - Provider function.
- * @returns {void}
- */
-export function registerNudgeProvider(fn: NudgeProvider): void {
-    _nudgeProvider = fn;
-}
 
 /**
  * Evaluates whether all intended services (recording and/or transcription) have
@@ -187,11 +169,11 @@ export function maybeNotifyRecordingStart(dispatch: IStore['dispatch'], getState
 
     // Nudge when only one service was just started AND the other is not already running.
     // Only moderators can start the complementary service, so skip the nudge for non-mods.
-    const nudgeNeeded = Boolean(_nudgeProvider) && isLocalParticipantModerator(state)
+    const nudgeNeeded = isLocalParticipantModerator(state)
         && (wantsRecording !== wantsTranscription)
         && (wantsRecording ? !transcriptionOn : !recordingOn);
-    const nudge = nudgeNeeded && _nudgeProvider
-        ? _nudgeProvider(wantsRecording ? 'recording' : 'transcription', dispatch)
+    const nudge = nudgeNeeded
+        ? getNudge(wantsRecording ? 'recording' : 'transcription', dispatch)
         : null;
 
     if (recordingOn && fileSession?.initiator && fileSession.id) {

--- a/react/features/recording/nudge.native.ts
+++ b/react/features/recording/nudge.native.ts
@@ -1,11 +1,19 @@
+import { IStore } from '../app/types';
 import i18next from '../base/i18n/i18next';
 import { navigate }
     from '../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
 import { screen } from '../mobile/navigation/routes';
 
-import { registerNudgeProvider } from './middleware';
+import { INudge } from './actions.any';
 
-registerNudgeProvider((scenario: 'recording' | 'transcription') => {
+/**
+ * Returns the nudge notification payload for the given scenario.
+ *
+ * @param {string} scenario - Which service just started.
+ * @param {Function} _dispatch - Unused on native (navigation handles the action).
+ * @returns {Object}
+ */
+export function getNudge(scenario: 'recording' | 'transcription', _dispatch: IStore['dispatch']): INudge {
     if (scenario === 'recording') {
         return {
             descriptionText: `· ${i18next.t('recording.alsoTranscribe')}`,
@@ -19,4 +27,4 @@ registerNudgeProvider((scenario: 'recording' | 'transcription') => {
         actionNameKey: 'dialog.startRecording',
         handler: () => navigate(screen.conference.recording)
     };
-});
+}

--- a/react/features/recording/nudge.native.ts
+++ b/react/features/recording/nudge.native.ts
@@ -1,0 +1,22 @@
+import i18next from '../base/i18n/i18next';
+import { navigate }
+    from '../mobile/navigation/components/conference/ConferenceNavigationContainerRef';
+import { screen } from '../mobile/navigation/routes';
+
+import { registerNudgeProvider } from './middleware';
+
+registerNudgeProvider((scenario: 'recording' | 'transcription') => {
+    if (scenario === 'recording') {
+        return {
+            descriptionText: `· ${i18next.t('recording.alsoTranscribe')}`,
+            actionNameKey: 'dialog.startTranscribing',
+            handler: () => navigate(screen.conference.recording)
+        };
+    }
+
+    return {
+        descriptionText: `· ${i18next.t('transcribing.alsoRecord')}`,
+        actionNameKey: 'dialog.startRecording',
+        handler: () => navigate(screen.conference.recording)
+    };
+});

--- a/react/features/recording/nudge.web.ts
+++ b/react/features/recording/nudge.web.ts
@@ -5,12 +5,6 @@ import i18next from '../base/i18n/i18next';
 import RecordingTranscriptionDialog from './components/Recording/web/RecordingTranscriptionDialog';
 import { registerNudgeProvider } from './middleware';
 
-/**
- * Registers the web-specific nudge provider.
- *
- * When only recording or only transcription starts, the "started" notification
- * will include a description and action button offering to start the other service.
- */
 registerNudgeProvider((scenario: 'recording' | 'transcription', dispatch: IStore['dispatch']) => {
     if (scenario === 'recording') {
         return {

--- a/react/features/recording/nudge.web.ts
+++ b/react/features/recording/nudge.web.ts
@@ -2,10 +2,17 @@ import { IStore } from '../app/types';
 import { openDialog } from '../base/dialog/actions';
 import i18next from '../base/i18n/i18next';
 
+import { INudge } from './actions.any';
 import RecordingTranscriptionDialog from './components/Recording/web/RecordingTranscriptionDialog';
-import { registerNudgeProvider } from './middleware';
 
-registerNudgeProvider((scenario: 'recording' | 'transcription', dispatch: IStore['dispatch']) => {
+/**
+ * Returns the nudge notification payload for the given scenario.
+ *
+ * @param {string} scenario - Which service just started.
+ * @param {Function} dispatch - The Redux dispatch function.
+ * @returns {Object}
+ */
+export function getNudge(scenario: 'recording' | 'transcription', dispatch: IStore['dispatch']): INudge {
     if (scenario === 'recording') {
         return {
             descriptionText: `· ${i18next.t('recording.alsoTranscribe')}`,
@@ -24,4 +31,4 @@ registerNudgeProvider((scenario: 'recording' | 'transcription', dispatch: IStore
             initialRecording: true
         }))
     };
-});
+}

--- a/react/features/recording/recordingNudge.web.ts
+++ b/react/features/recording/recordingNudge.web.ts
@@ -15,7 +15,7 @@ registerNudgeProvider((scenario: 'recording' | 'transcription', dispatch: IStore
     if (scenario === 'recording') {
         return {
             descriptionText: `· ${i18next.t('recording.alsoTranscribe')}`,
-            actionNameKey: 'dialog.startTranscription',
+            actionNameKey: 'dialog.startTranscribing',
             handler: () => dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
                 recordAudioAndVideo: false,
                 initialTranscription: true

--- a/react/features/recording/recordingNudge.web.ts
+++ b/react/features/recording/recordingNudge.web.ts
@@ -1,0 +1,33 @@
+import { IStore } from '../app/types';
+import { openDialog } from '../base/dialog/actions';
+import i18next from '../base/i18n/i18next';
+
+import RecordingTranscriptionDialog from './components/Recording/web/RecordingTranscriptionDialog';
+import { registerNudgeProvider } from './middleware';
+
+/**
+ * Registers the web-specific nudge provider.
+ *
+ * When only recording or only transcription starts, the "started" notification
+ * will include a description and action button offering to start the other service.
+ */
+registerNudgeProvider((scenario: 'recording' | 'transcription', dispatch: IStore['dispatch']) => {
+    if (scenario === 'recording') {
+        return {
+            descriptionText: `· ${i18next.t('recording.alsoTranscribe')}`,
+            actionNameKey: 'dialog.startTranscription',
+            handler: () => dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
+                recordAudioAndVideo: false,
+                initialTranscription: true
+            }))
+        };
+    }
+
+    return {
+        descriptionText: `· ${i18next.t('transcribing.alsoRecord')}`,
+        actionNameKey: 'dialog.startRecording',
+        handler: () => dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
+            initialRecording: true
+        }))
+    };
+});

--- a/react/features/recording/reducer.ts
+++ b/react/features/recording/reducer.ts
@@ -4,6 +4,7 @@ import {
     CLEAR_RECORDING_SESSIONS,
     MARK_CONSENT_REQUESTED,
     RECORDING_SESSION_UPDATED,
+    SET_LOCAL_RECORDING_RUNNING,
     SET_MEETING_HIGHLIGHT_BUTTON_STATE,
     SET_PENDING_RECORDING_NOTIFICATION_UID,
     SET_SELECTED_RECORDING_SERVICE,
@@ -54,6 +55,7 @@ export interface IStopRecordingIntent {
 export interface IRecordingState {
     consentRequested: Set<any>;
     disableHighlightMeetingMoment: boolean;
+    localRecordingRunning?: boolean;
     pendingNotificationUids: {
         [key: string]: string | undefined;
     };
@@ -157,6 +159,12 @@ ReducerRegistry.register<IRecordingState>(STORE_NAME,
             return {
                 ...state,
                 wasStartRecordingSuggested: true
+            };
+
+        case SET_LOCAL_RECORDING_RUNNING:
+            return {
+                ...state,
+                localRecordingRunning: action.running
             };
 
         default:

--- a/react/features/subtitles/components/web/LanguageSelectorDialog.tsx
+++ b/react/features/subtitles/components/web/LanguageSelectorDialog.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from 'tss-react/mui';
 import { openDialog } from '../../../base/dialog/actions';
 import { translate, translateToHTML } from '../../../base/i18n/functions';
 import Dialog from '../../../base/ui/components/web/Dialog';
-import { StartRecordingDialog } from '../../../recording/components/Recording';
+import { RecordingTranscriptionDialog } from '../../../recording/components/Recording';
 import { openSettingsDialog } from '../../../settings/actions.web';
 import { SETTINGS_TABS } from '../../../settings/constants';
 import { toggleLanguageSelectorDialog } from '../../actions.web';
@@ -43,7 +43,7 @@ const LanguageSelectorDialog = (props: IAbstractLanguageSelectorDialogProps) => 
 
     const onSelected = useCallback((e: string) => {
         if (asyncTranscription) {
-            dispatch(openDialog('StartRecordingDialog', StartRecordingDialog, {
+            dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
                 recordAudioAndVideo: false
             }));
         } else {

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -436,7 +436,7 @@ function _requestingSubtitlesChange(
             language.replace('translation-languages:', ''));
     }
 
-    if (!enabled && (backendRecordingOn || forceBackendRecordingOn)
+    if (!enabled && !skipMetadataUpdate && (backendRecordingOn || forceBackendRecordingOn)
         && conference?.getMetadataHandler()?.getMetadata()[RECORDING_METADATA_ID]?.isTranscribingEnabled) {
         conference?.getMetadataHandler()?.setMetadata(RECORDING_METADATA_ID, {
             isRecordingRequested: false,

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -21,6 +21,7 @@ import Notifications, {
 import ParticipantsPane from '../pageobjects/ParticipantsPane';
 import PasswordDialog from '../pageobjects/PasswordDialog';
 import PreJoinScreen from '../pageobjects/PreJoinScreen';
+import RecordingTranscriptionDialog from '../pageobjects/RecordingTranscriptionDialog';
 import SecurityDialog from '../pageobjects/SecurityDialog';
 import SettingsDialog from '../pageobjects/SettingsDialog';
 import Toolbar from '../pageobjects/Toolbar';
@@ -664,6 +665,13 @@ export class Participant {
      */
     getVirtualBackgroundDialog(): VirtualBackgroundDialog {
         return new VirtualBackgroundDialog(this);
+    }
+
+    /**
+     * Returns the unified recording & transcription dialog.
+     */
+    getRecordingTranscriptionDialog(): RecordingTranscriptionDialog {
+        return new RecordingTranscriptionDialog(this);
     }
 
     /**

--- a/tests/pageobjects/RecordingTranscriptionDialog.ts
+++ b/tests/pageobjects/RecordingTranscriptionDialog.ts
@@ -1,0 +1,112 @@
+import BasePageObject from './BasePageObject';
+
+const DIALOG_TITLE = '#dialog-title';
+const OK_BUTTON = '#modal-dialog-ok-button';
+const CLOSE_BUTTON = '#modal-header-close-button';
+const RECORDING_SWITCH = '#recording-switch-audio-video';
+const TRANSCRIPTION_SWITCH = '#recording-switch-transcription';
+const RECORDING_SWITCH_LABEL = '[for="recording-switch-audio-video"]';
+const TRANSCRIPTION_SWITCH_LABEL = '[for="recording-switch-transcription"]';
+
+/**
+ * Page object for the unified Recording & Transcription dialog.
+ */
+export default class RecordingTranscriptionDialog extends BasePageObject {
+    /**
+     * Waits for the dialog to be displayed.
+     */
+    async waitForDisplay(): Promise<void> {
+        await this.participant.driver.$(DIALOG_TITLE).waitForExist({
+            timeout: 5000,
+            timeoutMsg: 'Recording & Transcription dialog did not appear'
+        });
+    }
+
+    /**
+     * Returns whether the dialog is currently open.
+     */
+    async isDisplayed(): Promise<boolean> {
+        return this.participant.driver.$(DIALOG_TITLE).isExisting();
+    }
+
+    /**
+     * Returns the dialog title text.
+     */
+    getTitle(): Promise<string> {
+        return this.participant.driver.$(DIALOG_TITLE).getText();
+    }
+
+    /**
+     * Returns the OK button text.
+     */
+    getOkButtonText(): Promise<string> {
+        return this.participant.driver.$(OK_BUTTON).getText();
+    }
+
+    /**
+     * Returns whether the OK button is enabled (not disabled).
+     */
+    async isOkButtonEnabled(): Promise<boolean> {
+        return this.participant.driver.$(OK_BUTTON).isEnabled();
+    }
+
+    /**
+     * Returns whether the recording (audio/video) toggle exists in the dialog.
+     */
+    hasRecordingToggle(): Promise<boolean> {
+        return this.participant.driver.$(RECORDING_SWITCH).isExisting();
+    }
+
+    /**
+     * Returns whether the transcription toggle exists in the dialog.
+     */
+    hasTranscriptionToggle(): Promise<boolean> {
+        return this.participant.driver.$(TRANSCRIPTION_SWITCH).isExisting();
+    }
+
+    /**
+     * Returns whether the recording (audio/video) toggle is checked.
+     */
+    isRecordingToggleChecked(): Promise<boolean> {
+        return this.participant.driver.$(RECORDING_SWITCH).isSelected();
+    }
+
+    /**
+     * Returns whether the transcription toggle is checked.
+     */
+    isTranscriptionToggleChecked(): Promise<boolean> {
+        return this.participant.driver.$(TRANSCRIPTION_SWITCH).isSelected();
+    }
+
+    /**
+     * Clicks the recording (audio/video) toggle by clicking its associated label.
+     */
+    async clickRecordingToggle(): Promise<void> {
+        await this.participant.log('RecordingTranscriptionDialog: clicking recording toggle');
+
+        return this.participant.driver.$(RECORDING_SWITCH_LABEL).click();
+    }
+
+    /**
+     * Clicks the transcription toggle by clicking its associated label.
+     */
+    async clickTranscriptionToggle(): Promise<void> {
+        await this.participant.log('RecordingTranscriptionDialog: clicking transcription toggle');
+
+        return this.participant.driver.$(TRANSCRIPTION_SWITCH_LABEL).click();
+    }
+
+    /**
+     * Clicks the OK / "Apply changes" button to confirm.
+     */
+    confirm(): Promise<void> {
+        return this.participant.driver.$(OK_BUTTON).click();
+    }
+
+    /**
+     * Clicks the close (X) button to dismiss the dialog without applying changes.
+     */
+    cancel(): Promise<void> {
+        return this.participant.driver.$(CLOSE_BUTTON).click();
+    }
+}

--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -1,6 +1,7 @@
 import BasePageObject from './BasePageObject';
 
 const AUDIO_MUTE = 'Mute microphone';
+const RECORDING = 'Record & Transcribe';
 const AUDIO_UNMUTE = 'Unmute microphone';
 const CHAT = 'Open chat';
 const CLOSE_CHAT = 'Close chat';
@@ -49,6 +50,26 @@ export default class Toolbar extends BasePageObject {
      */
     get audioUnMuteBtn() {
         return this.getButton(AUDIO_UNMUTE);
+    }
+
+    /**
+     * Returns whether the recording button exists in the DOM for this participant.
+     *
+     * @returns {Promise<boolean>}
+     */
+    async hasRecordingButton(): Promise<boolean> {
+        return this.getButton(RECORDING).isExisting();
+    }
+
+    /**
+     * Clicks the recording button to open the recording/transcription dialog.
+     *
+     * @returns {Promise<void>}
+     */
+    async clickRecordingButton(): Promise<void> {
+        await this.participant.log('Clicking on: Recording Button');
+
+        return this.getButton(RECORDING).click();
     }
 
     /**

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -1,0 +1,389 @@
+import { Participant } from '../../helpers/Participant';
+import { setTestProperties } from '../../helpers/TestProperties';
+import { expectations } from '../../helpers/expectations';
+import { joinJaasMuc, generateJaasToken as t } from '../../helpers/jaas';
+
+setTestProperties(__filename, {
+    useJaas: true
+});
+
+/**
+ * Joins a JaaS meeting as a moderator using the iFrame API wrapper.
+ */
+async function joinAsModerator(): Promise<Participant> {
+    return joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+}
+
+/**
+ * Waits for the "dialog.recording" notification to appear inside the current iframe context.
+ * The notification fires whenever recording or transcription starts (or both).
+ */
+async function waitForRecordingNotification(p: Participant, timeoutMsg: string): Promise<void> {
+    await p.driver.$('[data-testid="dialog.recording"]').waitForExist({
+        timeout: 30_000,
+        timeoutMsg
+    });
+}
+
+/**
+ * Dismisses the current "dialog.recording" notification (if it is showing) and waits for it
+ * to disappear, so subsequent assertions start from a clean slate.
+ */
+async function dismissRecordingNotification(p: Participant): Promise<void> {
+    const dismissButton = p.driver.$('[data-testid="dialog.recording-dismiss"]');
+
+    if (await dismissButton.isExisting()) {
+        await dismissButton.moveTo();
+        await dismissButton.click();
+        await p.driver.$('[data-testid="dialog.recording"]')
+            .waitForExist({ reverse: true, timeout: 3_000 });
+    }
+}
+
+/**
+ * Waits until the recording feature state reports that a FILE-mode session is active.
+ */
+async function waitForRecordingRunning(p: Participant): Promise<void> {
+    await p.driver.waitUntil(
+        () => p.execute(() => Boolean(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            APP.store.getState()['features/recording'].sessionDatas.some(
+                (s: any) => s.mode === 'file' && s.status !== 'off'))),
+        { timeout: 30_000, timeoutMsg: 'Recording session did not become active' }
+    );
+}
+
+/**
+ * Waits until the transcription feature state reports that transcription is active.
+ */
+async function waitForTranscriptionRunning(p: Participant): Promise<void> {
+    await p.driver.waitUntil(
+        () => p.execute(() => Boolean(APP.store.getState()['features/transcribing'].isTranscribing)),
+        { timeout: 30_000, timeoutMsg: 'Transcription did not become active' }
+    );
+}
+
+/**
+ * Waits until the transcription feature state reports that transcription is no longer active.
+ */
+async function waitForTranscriptionStopped(p: Participant): Promise<void> {
+    await p.driver.waitUntil(
+        () => p.execute(() => !APP.store.getState()['features/transcribing'].isTranscribing),
+        { timeout: 20_000, timeoutMsg: 'Transcription did not stop' }
+    );
+}
+
+/**
+ * Waits until the recording feature state reports that no FILE session is active.
+ */
+async function waitForRecordingStopped(p: Participant): Promise<void> {
+    await p.driver.waitUntil(
+        () => p.execute(() => Boolean(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            APP.store.getState()['features/recording'].sessionDatas.every(
+                (s: any) => s.mode !== 'file' || s.status === 'off'))),
+        { timeout: 20_000, timeoutMsg: 'Recording session did not stop' }
+    );
+}
+
+// ─── Nudge notification tests ────────────────────────────────────────────────
+
+describe('Recording & transcription nudge notifications', () => {
+    it('nudge shows "Start transcribing" action when only recording starts', async () => {
+        if (!expectations.jaas.recordingEnabled || !expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', { mode: 'file' });
+            await p.switchToIFrame();
+
+            await waitForRecordingNotification(p, 'Recording-started notification did not appear');
+
+            const nudgeButton = p.driver.$('[data-testid="dialog.startTranscribing"]');
+
+            expect(await nudgeButton.isExisting()).toBe(true);
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('nudge shows "Start recording" action when only transcription starts', async () => {
+        if (!expectations.jaas.transcriptionEnabled || !expectations.jaas.recordingEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', { transcription: true });
+            await p.switchToIFrame();
+
+            await waitForRecordingNotification(p, 'Transcription-started notification did not appear');
+
+            const nudgeButton = p.driver.$('[data-testid="dialog.startRecording"]');
+
+            expect(await nudgeButton.isExisting()).toBe(true);
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('no spurious "recording started" notification when stopping transcription while recording runs', async () => {
+        if (!expectations.jaas.recordingEnabled || !expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', {
+                mode: 'file',
+                transcription: true
+            });
+
+            await p.switchToIFrame();
+            await waitForRecordingNotification(p, 'Recording+transcription start notification did not appear');
+            await dismissRecordingNotification(p);
+            await p.switchToMainFrame();
+
+            // Stop only transcription while recording keeps running.
+            await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+
+            await p.switchToIFrame();
+
+            // Give the UI time to settle — a spurious notification would appear within ~3 s.
+            await p.driver.pause(4_000);
+
+            // The description keys used on a new "recording started" notification —
+            // neither must appear after a transcription-only stop.
+            expect(await p.driver.$('[data-testid="recording.on"]').isExisting()).toBe(false);
+            expect(await p.driver.$('[data-testid="recording.onWithTranscription"]').isExisting()).toBe(false);
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+});
+
+// ─── Manage-mode (session active) dialog tests ───────────────────────────────
+
+describe('Recording & transcription dialog — manage mode', () => {
+    it('dialog opens with recording toggle ON when recording is running', async () => {
+        if (!expectations.jaas.recordingEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', { mode: 'file' });
+            await p.switchToIFrame();
+
+            await waitForRecordingRunning(p);
+
+            await p.getToolbar().clickRecordingButton();
+
+            const dialog = p.getRecordingTranscriptionDialog();
+
+            await dialog.waitForDisplay();
+
+            expect(await dialog.isRecordingToggleChecked()).toBe(true);
+            expect(await dialog.isTranscriptionToggleChecked()).toBe(false);
+
+            await dialog.cancel();
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('dialog opens with transcription toggle ON when transcription is running', async () => {
+        if (!expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', { transcription: true });
+            await p.switchToIFrame();
+
+            await waitForTranscriptionRunning(p);
+
+            await p.getToolbar().clickRecordingButton();
+
+            const dialog = p.getRecordingTranscriptionDialog();
+
+            await dialog.waitForDisplay();
+
+            expect(await dialog.isTranscriptionToggleChecked()).toBe(true);
+            expect(await dialog.isRecordingToggleChecked()).toBe(false);
+
+            await dialog.cancel();
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('dialog opens with both toggles ON when both services are running', async () => {
+        if (!expectations.jaas.recordingEnabled || !expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', {
+                mode: 'file',
+                transcription: true
+            });
+            await p.switchToIFrame();
+
+            await waitForRecordingRunning(p);
+            await waitForTranscriptionRunning(p);
+
+            await p.getToolbar().clickRecordingButton();
+
+            const dialog = p.getRecordingTranscriptionDialog();
+
+            await dialog.waitForDisplay();
+
+            expect(await dialog.isRecordingToggleChecked()).toBe(true);
+            expect(await dialog.isTranscriptionToggleChecked()).toBe(true);
+
+            // Nothing changed yet — OK must be disabled.
+            expect(await dialog.isOkButtonEnabled()).toBe(false);
+
+            await dialog.cancel();
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('can stop transcription independently while recording keeps running', async () => {
+        if (!expectations.jaas.recordingEnabled || !expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', {
+                mode: 'file',
+                transcription: true
+            });
+            await p.switchToIFrame();
+
+            await waitForRecordingRunning(p);
+            await waitForTranscriptionRunning(p);
+
+            // Open dialog: both toggles on.
+            await p.getToolbar().clickRecordingButton();
+
+            const dialog = p.getRecordingTranscriptionDialog();
+
+            await dialog.waitForDisplay();
+
+            // Turn transcription off, leave recording on.
+            await dialog.clickTranscriptionToggle();
+            expect(await dialog.isTranscriptionToggleChecked()).toBe(false);
+            expect(await dialog.isRecordingToggleChecked()).toBe(true);
+            expect(await dialog.isOkButtonEnabled()).toBe(true);
+
+            await dialog.confirm();
+
+            // Transcription should stop.
+            await waitForTranscriptionStopped(p);
+
+            // Recording should still be running.
+            const recordingStillOn = await p.execute(() => Boolean(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                APP.store.getState()['features/recording'].sessionDatas.some(
+                    (s: any) => s.mode === 'file' && s.status !== 'off')
+            ));
+
+            expect(recordingStillOn).toBe(true);
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+
+    it('can stop recording independently while transcription keeps running', async () => {
+        if (!expectations.jaas.recordingEnabled || !expectations.jaas.transcriptionEnabled) {
+            return;
+        }
+
+        const p = await joinAsModerator();
+
+        try {
+            await p.getIframeAPI().executeCommand('startRecording', {
+                mode: 'file',
+                transcription: true
+            });
+            await p.switchToIFrame();
+
+            await waitForRecordingRunning(p);
+            await waitForTranscriptionRunning(p);
+
+            // Open dialog: both toggles on.
+            await p.getToolbar().clickRecordingButton();
+
+            const dialog = p.getRecordingTranscriptionDialog();
+
+            await dialog.waitForDisplay();
+
+            // Turn recording off, leave transcription on.
+            await dialog.clickRecordingToggle();
+            expect(await dialog.isRecordingToggleChecked()).toBe(false);
+            expect(await dialog.isTranscriptionToggleChecked()).toBe(true);
+            expect(await dialog.isOkButtonEnabled()).toBe(true);
+
+            await dialog.confirm();
+
+            // Recording should stop.
+            await waitForRecordingStopped(p);
+
+            // Transcription should still be running.
+            const transcriptionStillOn = await p.execute(
+                () => Boolean(APP.store.getState()['features/transcribing'].isTranscribing)
+            );
+
+            expect(transcriptionStillOn).toBe(true);
+        } finally {
+            await p.switchToMainFrame();
+            await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await p.getIframeAPI().executeCommand('hangup');
+        }
+    });
+});
+
+// ─── Button visibility ────────────────────────────────────────────────────────
+
+describe('Recording button visibility', () => {
+    it('moderator button has aria-label "Record & Transcribe"', async () => {
+        if (!expectations.jaas.recordingEnabled) {
+            return;
+        }
+
+        const p = await joinJaasMuc({ token: t({ moderator: true }) });
+
+        expect(await p.getToolbar().hasRecordingButton()).toBe(true);
+
+        await p.getIframeAPI().executeCommand('hangup');
+    });
+});

--- a/tests/specs/misc/recordingButtonVisibility.spec.ts
+++ b/tests/specs/misc/recordingButtonVisibility.spec.ts
@@ -1,0 +1,43 @@
+import { Participant } from '../../helpers/Participant';
+import { setTestProperties } from '../../helpers/TestProperties';
+import { expectations } from '../../helpers/expectations';
+import { ensureOneParticipant, ensureTwoParticipants } from '../../helpers/participants';
+
+setTestProperties(__filename, {
+    description: 'Recording button is shown to moderators and hidden from non-moderators',
+    usesBrowsers: [ 'p1', 'p2' ]
+});
+
+describe('Recording button visibility', () => {
+    let p1: Participant, p2: Participant;
+
+    it('setup', async () => {
+        if (!expectations.jaas.recordingEnabled) {
+            ctx.skipSuiteTests = 'Recording is not enabled in this environment';
+
+            return;
+        }
+
+        if (expectations.moderation.allModerators) {
+            ctx.skipSuiteTests = 'Cannot test non-moderator visibility when all participants are moderators';
+
+            return;
+        }
+
+        await ensureOneParticipant();
+        p1 = ctx.p1;
+        expect(await p1.isModerator()).toBe(true);
+
+        await ensureTwoParticipants();
+        p2 = ctx.p2;
+        expect(await p2.isModerator()).toBe(false);
+    });
+
+    it('moderator sees the recording button', async () => {
+        expect(await p1.getToolbar().hasRecordingButton()).toBe(true);
+    });
+
+    it('non-moderator does not see the recording button', async () => {
+        expect(await p2.getToolbar().hasRecordingButton()).toBe(false);
+    });
+});

--- a/tests/specs/misc/recordingButtonVisibility.spec.ts
+++ b/tests/specs/misc/recordingButtonVisibility.spec.ts
@@ -5,11 +5,13 @@ import { ensureOneParticipant, ensureTwoParticipants } from '../../helpers/parti
 
 setTestProperties(__filename, {
     description: 'Recording button is shown to moderators and hidden from non-moderators',
-    usesBrowsers: [ 'p1', 'p2' ]
+    usesBrowsers: [ 'p1', 'p2' ],
+    useJaas: true
 });
 
 describe('Recording button visibility', () => {
     let p1: Participant, p2: Participant;
+    let localRecordingAvailable: boolean;
 
     it('setup', async () => {
         if (!expectations.jaas.recordingEnabled) {
@@ -31,13 +33,30 @@ describe('Recording button visibility', () => {
         await ensureTwoParticipants();
         p2 = ctx.p2;
         expect(await p2.isModerator()).toBe(false);
+
+        localRecordingAvailable = await p2.execute(() => {
+            const state = APP.store.getState();
+            const { localRecording } = state['features/base/config'];
+
+            return localRecording?.disable !== true && Boolean(window.MediaRecorder);
+        });
     });
 
     it('moderator sees the recording button', async () => {
         expect(await p1.getToolbar().hasRecordingButton()).toBe(true);
     });
 
-    it('non-moderator does not see the recording button', async () => {
+    it('non-moderator does not see the recording button when local recording is disabled', async () => {
+        if (localRecordingAvailable) {
+            return;
+        }
         expect(await p2.getToolbar().hasRecordingButton()).toBe(false);
+    });
+
+    it('non-moderator sees the recording button when local recording is enabled', async () => {
+        if (!localRecordingAvailable) {
+            return;
+        }
+        expect(await p2.getToolbar().hasRecordingButton()).toBe(true);
     });
 });

--- a/tests/specs/misc/recordingTranscriptionDialog.spec.ts
+++ b/tests/specs/misc/recordingTranscriptionDialog.spec.ts
@@ -1,0 +1,163 @@
+import { setTestProperties } from '../../helpers/TestProperties';
+import { expectations } from '../../helpers/expectations';
+import { ensureOneParticipant } from '../../helpers/participants';
+
+setTestProperties(__filename, {
+    description: 'Unified Recording & Transcription dialog structure',
+    usesBrowsers: [ 'p1' ]
+});
+
+describe('Recording & Transcription dialog', () => {
+    it('setup', async () => {
+        if (!expectations.jaas.recordingEnabled) {
+            ctx.skipSuiteTests = 'Recording is not enabled in this environment';
+
+            return;
+        }
+
+        if (!expectations.moderation.firstModerator) {
+            ctx.skipSuiteTests = 'First participant must be a moderator for these tests';
+
+            return;
+        }
+
+        await ensureOneParticipant();
+        expect(await ctx.p1.isModerator()).toBe(true);
+    });
+
+    it('dialog title is "Record & Transcribe"', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        expect(await dialog.getTitle()).toBe('Record & Transcribe');
+
+        await dialog.cancel();
+    });
+
+    it('OK button reads "Apply changes"', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        expect(await dialog.getOkButtonText()).toBe('Apply changes');
+
+        await dialog.cancel();
+    });
+
+    it('dialog contains recording and transcription toggles', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        expect(await dialog.hasRecordingToggle()).toBe(true);
+        expect(await dialog.hasTranscriptionToggle()).toBe(true);
+
+        await dialog.cancel();
+    });
+
+    it('OK button is disabled when nothing has changed from initial state', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        // No session is running and no toggles have been changed — nothing to apply.
+        expect(await dialog.isOkButtonEnabled()).toBe(false);
+
+        await dialog.cancel();
+    });
+
+    it('OK button enables after toggling recording on', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        const wasEnabled = await dialog.isOkButtonEnabled();
+
+        await dialog.clickRecordingToggle();
+
+        // If the toggle moved us away from the initial state the button must be enabled.
+        // If it was already enabled (e.g. autoTranscribeOnRecord pre-checked transcription)
+        // it should stay enabled.
+        expect(await dialog.isOkButtonEnabled()).toBe(true);
+
+        // Verify the button was NOT enabled before the toggle (catches regressions).
+        expect(wasEnabled).toBe(false);
+
+        await dialog.cancel();
+    });
+
+    it('OK button enables after toggling transcription on', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        // Snapshot state before any interaction.
+        const initiallyEnabled = await dialog.isOkButtonEnabled();
+
+        await dialog.clickTranscriptionToggle();
+
+        expect(await dialog.isOkButtonEnabled()).toBe(true);
+        expect(initiallyEnabled).toBe(false);
+
+        await dialog.cancel();
+    });
+
+    it('toggling and then toggling back disables OK again', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        await dialog.clickRecordingToggle();
+        expect(await dialog.isOkButtonEnabled()).toBe(true);
+
+        // Toggle back to original state — should no longer differ from running state.
+        await dialog.clickRecordingToggle();
+        expect(await dialog.isOkButtonEnabled()).toBe(false);
+
+        await dialog.cancel();
+    });
+
+    it('cancel closes the dialog without errors', async () => {
+        const p1 = ctx.p1;
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+        await dialog.cancel();
+
+        await p1.driver.$(
+            '#dialog-title'
+        ).waitForExist({ reverse: true, timeout: 3000, timeoutMsg: 'Dialog did not close after cancel' });
+    });
+
+    it('dialog reopens cleanly after cancel — button is still in toolbar', async () => {
+        const p1 = ctx.p1;
+
+        // Verify the button is still accessible and the dialog can be opened again.
+        expect(await p1.getToolbar().hasRecordingButton()).toBe(true);
+
+        const dialog = p1.getRecordingTranscriptionDialog();
+
+        await p1.getToolbar().clickRecordingButton();
+        await dialog.waitForDisplay();
+
+        expect(await dialog.getTitle()).toBe('Record & Transcribe');
+
+        await dialog.cancel();
+    });
+});

--- a/tests/specs/misc/recordingTranscriptionDialog.spec.ts
+++ b/tests/specs/misc/recordingTranscriptionDialog.spec.ts
@@ -4,7 +4,8 @@ import { ensureOneParticipant } from '../../helpers/participants';
 
 setTestProperties(__filename, {
     description: 'Unified Recording & Transcription dialog structure',
-    usesBrowsers: [ 'p1' ]
+    usesBrowsers: [ 'p1' ],
+    useJaas: true
 });
 
 describe('Recording & Transcription dialog', () => {


### PR DESCRIPTION
Replace the separate start/stop recording dialogs on web and native with a single unified dialog where recording and transcription can be toggled independently, including while a session is already active.