### PR TITLE
feat(speaker-stats): Allow selecting & copying participant names from Participant Status list

### DIFF
--- a/react/features/speaker-stats/components/web/SpeakerStatsList.tsx
+++ b/react/features/speaker-stats/components/web/SpeakerStatsList.tsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles()(theme => {
                     backgroundColor: theme.palette.speakerStatsRowBackground
                 },
                 '& .display-name': {
+                    userSelect: 'text',
                     ...theme.typography.bodyShortRegular,
                     [theme.breakpoints.down(MOBILE_BREAKPOINT)]: {
                         ...theme.typography.bodyShortRegularLarge


### PR DESCRIPTION
- Jitsi css by default sets all fields except input & text-area as not user selectable.
- Allow to select and copy speaker/participants names from the Participant Stats list. This serves as a simple 'attendance register' for moderators.

I've signed the CLA.
