### PR TITLE
Add webpack entry for the embedded API bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -374,6 +374,20 @@ module.exports = (_env, argv) => {
                 ...getBundleAnalyzerPlugin(analyzeBundle, 'external_api')
             ],
             performance: getPerformanceHints(perfHintOptions, 100 * 1024) },
+
+        { ...config,
+            entry: {
+                'embedded_api': './modules/API/external/embedded_index.js'
+            },
+            output: { ...config.output,
+                library: 'JitsiMeetEmbeddedAPI',
+                libraryTarget: 'umd' },
+            plugins: [
+                ...config.plugins,
+                ...getBundleAnalyzerPlugin(analyzeBundle, 'embedded_api')
+            ],
+            performance: getPerformanceHints(perfHintOptions, 95 * 1024) },
+
         { ...config,
             entry: {
                 'face-landmarks-worker': './react/features/face-landmarks/faceLandmarksWorker.ts'


### PR DESCRIPTION
**Description**

This adds a webpack entry so the embedded API gets built into its own bundle.
It's the same setup as the existing `external_api `  bundle, it just points at `embedded_index.js` and and builds it as a global called `JitsiMeetEmbeddedAPI`, so a host page can load `embedded_api.min.js` and use the API directly without an iframe.

The files it points at come from - [jitsi-meet #17477](https://github.com/jitsi/jitsi-meet/pull/17477)