### PR TITLE
test(wdio): treat worker killed mid-teardown as benign

### DIFF
--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -211,10 +211,21 @@ const keepAlive: Array<any> = [];
 const CONCURRENCY_LOG_PATH = path.join(TEST_RESULTS_DIR, 'concurrency.jsonl');
 
 /**
- * Detects the "tests completed but session DELETE timed out" signature in a worker's wdio log.
+ * Detects the "tests completed but session teardown crashed" signature in a worker's wdio log.
  * Selenium Grid (especially with Firefox) sometimes takes longer than `connectionRetryTimeout`
  * to acknowledge session deletion; the runner exits non-zero even though the test ran fine.
- * Returns true when afterSuite finished AND a DELETE-method timeout follows in the same log.
+ *
+ * Two variants of the same benign pattern are recognised, both gated on the suite having run to
+ * completion (the `afterSuite` hook finished):
+ *  1. An explicit DELETE-method WebDriverError timeout in the log tail.
+ *  2. The worker was killed mid-teardown: the framework `after` hook finished and a session
+ *     `deleteSession()`/`[DELETE] .../session/` was issued, then the log simply truncates with no
+ *     error line ever written. This is what happens when the grid drops the worker during DELETE.
+ *
+ * Both require `afterSuite` to have finished, so every test body and hook executed; the only thing
+ * left was tearing the session(s) down. A genuine test failure that managed to write results is
+ * already handled earlier by the `xmlHasNamedTests` early-return in `onWorkerEnd`, so it never
+ * reaches here.
  *
  * @param specFile - The worker's first spec file (path or URL); used to locate its wdio log.
  * @param cid - The worker (capability) id.
@@ -250,9 +261,17 @@ function isPostTestSessionDeleteTimeout(specFile: string | undefined, cid: strin
 
         const tail = buf.toString('utf8');
         const afterSuiteFinished = tail.includes('Finished to run "afterSuite" hook');
+
+        // Variant 1: the grid was slow to ack the DELETE and the runner logged an explicit timeout.
         const deleteTimeout = /WebDriverError:[^\n]*timeout[^\n]*method "DELETE"/i.test(tail);
 
-        return afterSuiteFinished && deleteTimeout;
+        // Variant 2: the worker was killed during teardown. The framework `after` hook finished and
+        // a session DELETE was issued, but the log truncates before any error is written.
+        const afterHookFinished = tail.includes('Finished to run "after" hook');
+        const deleteIssued = tail.includes('COMMAND deleteSession()')
+            || /\[DELETE\][^\n]*\/session\//.test(tail);
+
+        return afterSuiteFinished && (deleteTimeout || (afterHookFinished && deleteIssued));
     } catch {
         return false;
     }
@@ -651,11 +670,11 @@ export const config: WebdriverIO.MultiremoteConfig = {
     /**
      * Gets executed after a worker process has exited.
      * Handles three crash scenarios:
-     * 1. Session DELETE timeout AFTER tests completed (common with Firefox on Selenium Grid):
-     *    afterSuite ran, then the grid was slow to acknowledge the DELETE, the runner timed out
-     *    and exited non-zero. Tests actually passed. We skip the misleading "crashed" synthesis;
-     *    allure already has accurate per-test results, and we summarise the teardown anomaly in
-     *    a passing JUnit entry.
+     * 1. Session teardown crash AFTER tests completed (common with Firefox on Selenium Grid):
+     *    afterSuite ran, then the session DELETE either timed out or the worker was killed
+     *    mid-teardown, so the runner exited non-zero. Tests actually passed. We skip the misleading
+     *    "crashed" synthesis; allure already has accurate per-test results, and we summarise the
+     *    teardown anomaly in a passing JUnit entry. See isPostTestSessionDeleteTimeout.
      * 2. Session DELETE timeout BEFORE tests completed: JUnit reporter never flushes,
      *    leaving a zero-byte XML. Synthesise a failure entry.
      * 3. Session INIT timeout: JUnit reporter writes a non-empty XML but with empty name/classname,
@@ -692,22 +711,48 @@ export const config: WebdriverIO.MultiremoteConfig = {
             return;
         }
 
-        // Detect the "tests passed but session DELETE timed out" pattern from the worker's wdio
+        // Detect the "tests passed but session teardown crashed" pattern from the worker's wdio
         // log. Pass the raw spec path so the log file name is derived the same way
         // @wdio/local-runner derives it (only the final extension is stripped).
         if (isPostTestSessionDeleteTimeout(workerSpecs?.[0], cid)) {
+            const teardownName = 'Session teardown crashed after tests completed';
             const teardownMessage
-                = `Session DELETE timed out after tests completed (worker exit ${exitCode}). `
-                + 'Allure has the per-test results; this entry just records the teardown anomaly.';
+                = `Session teardown crashed after tests completed (worker exit ${exitCode}). `
+                + 'The suite ran to completion; this entry just records the teardown anomaly.';
             const b = junitReportBuilder.newBuilder();
 
             b.testSuite().name(specName).testCase()
-                .name('Session DELETE timed out during teardown')
+                .name(teardownName)
                 .className(specName)
                 .standardOutput(teardownMessage);
             b.writeTo(xmlPath);
-            console.log(`[onWorkerEnd] Worker ${cid} (${specName}): session DELETE timed out after `
-                + 'afterSuite — synthesising passing JUnit summary, leaving allure per-test results untouched.');
+
+            // When the worker is killed mid-teardown the reporters never flush, so allure has no
+            // per-test results for this spec and it would otherwise vanish from the report. Write a
+            // passing entry so the spec stays visible with the teardown anomaly recorded. If allure
+            // already captured the per-test results (e.g. a slow-DELETE timeout after a clean
+            // flush), this is just an extra informational passing entry alongside them.
+            const allureResult = {
+                uuid: randomUUID(),
+                name: teardownName,
+                status: 'passed',
+                statusDetails: { message: teardownMessage },
+                stage: 'finished',
+                steps: [],
+                attachments: [],
+                parameters: [],
+                labels: [
+                    { name: 'parentSuite', value: dir },
+                    { name: 'suite', value: specName }
+                ],
+                links: []
+            };
+            const allurePath
+                = path.join(TEST_RESULTS_DIR, 'allure-results', `${allureResult.uuid}-result.json`);
+
+            fs.writeFileSync(allurePath, JSON.stringify(allureResult));
+            console.log(`[onWorkerEnd] Worker ${cid} (${specName}): session teardown crashed after `
+                + 'afterSuite — synthesising passing JUnit + allure entry; suite ran to completion.');
 
             return;
         }


### PR DESCRIPTION
The onWorkerEnd handler already ignores the Firefox/grid post-test session-DELETE crash when the worker logs an explicit "WebDriverError ... timeout ... method DELETE" line. But the grid can also kill the worker mid-DELETE, truncating the log before that line is ever written, which fell through to a synthesized "Test runner crashed" broken result even though the suite ran to completion.

Recognize that second variant in isPostTestSessionDeleteTimeout (afterSuite finished + after hook finished + a session DELETE was issued) and, in the benign branch, also write a passing allure entry so the spec stays visible in the report instead of vanishing when no reporter flushed.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
