### PR TITLE
fix(time-timer): anchor elapsed to scheduled start, not join time

### DIFF
--- a/react/features/time-timer/actions.ts
+++ b/react/features/time-timer/actions.ts
@@ -69,8 +69,10 @@ export function tickTimeTimer() {
  *
  * @param {Object} options - Timer parameters from the embedder.
  * @param {number} options.duration - Scheduled duration in seconds.
- * @param {number} [options.elapsed] - Seconds since the scheduled start
- * (may exceed duration for a late joiner). Defaults to 0.
+ * @param {number} [options.elapsed] - Seconds since the scheduled start.
+ * May be negative (the meeting hasn't started yet — the timer sits at the
+ * full duration until the start arrives) or exceed the duration (a late
+ * joiner, landing directly in the overrun state). Defaults to 0.
  * @returns {Function}
  */
 export function setMeetingTimer({ duration, elapsed = 0 }: { duration?: number; elapsed?: number; } = {}) {
@@ -80,7 +82,7 @@ export function setMeetingTimer({ duration, elapsed = 0 }: { duration?: number; 
         }
 
         if (typeof duration === 'number' && duration > 0) {
-            dispatch(startTimeTimer(duration, Math.max(0, elapsed)));
+            dispatch(startTimeTimer(duration, elapsed));
         } else {
             dispatch(stopTimeTimer());
         }

--- a/react/features/time-timer/middleware.web.ts
+++ b/react/features/time-timer/middleware.web.ts
@@ -104,13 +104,19 @@ MiddlewareRegistry.register((store: IStore) => (next: Function) => (action: any)
 
             if (calendarMatchesRoom
                     && typeof calendarDurationSeconds === 'number' && calendarDurationSeconds > 0) {
-                // Elapsed-since-scheduled-start is the single source of truth
-                // and may exceed the duration (joined after the scheduled
-                // end). Compute it live from the calendar start time so late
-                // joiners land directly in the correct (possibly overrun)
-                // state; otherwise start from 0.
+                // Elapsed-since-SCHEDULED-START is the single source of truth,
+                // anchored to the calendar event's absolute start time — never
+                // to when this particular participant joined. That keeps the
+                // displayed time identical for everyone at a given wall-clock
+                // moment, regardless of who joins early (including the
+                // organizer). It MAY be negative (joined before the scheduled
+                // start) or exceed the duration (joined after the scheduled
+                // end); the reducer pins the scheduled end from it and derives
+                // the rest. A negative value naturally shows 00:00 / full
+                // duration until the start arrives, then counts up. With no
+                // start time we fall back to 0 (start counting from now).
                 const elapsed = typeof calendarStartTimeUnix === 'number'
-                    ? Math.max(0, Math.round((Date.now() - calendarStartTimeUnix) / 1000))
+                    ? Math.round((Date.now() - calendarStartTimeUnix) / 1000)
                     : 0;
 
                 dispatch(startTimeTimer(calendarDurationSeconds, elapsed));

--- a/react/features/time-timer/reducer.ts
+++ b/react/features/time-timer/reducer.ts
@@ -88,13 +88,17 @@ ReducerRegistry.register<ITimeTimerState>('features/time-timer', (state = DEFAUL
     case START_TIME_TIMER: {
         const { durationSeconds, nowUnix } = action;
 
-        // `elapsedSeconds` is seconds since the scheduled start and may exceed
-        // the duration (joining after the scheduled end). From it and the
-        // current wall-clock time we pin the scheduled end as an absolute
-        // timestamp; everything else is derived from that timestamp, both here
-        // and on every subsequent tick. This is what lets a late joiner land
-        // directly in the correct overrun / lap state.
-        const elapsedSeconds = Math.max(0, action.elapsedSeconds);
+        // `elapsedSeconds` is seconds since the SCHEDULED start. It may be
+        // negative (joined before the scheduled start) or exceed the duration
+        // (joined after the scheduled end). We deliberately do NOT clamp it:
+        // from it and the current wall-clock time we pin the scheduled end as
+        // an absolute timestamp, and everything else is derived from that
+        // timestamp here and on every tick. A negative value pushes the end
+        // out to the true scheduled end, so an early joiner sees 00:00 / full
+        // duration until the start arrives, then the counter climbs — landing
+        // on the limit exactly at the scheduled end. A value past the duration
+        // lands a late joiner directly in the correct overrun / lap state.
+        const { elapsedSeconds } = action;
         const scheduledEndUnix = nowUnix + ((durationSeconds - elapsedSeconds) * 1000);
         const counters = _deriveCounters(durationSeconds, scheduledEndUnix, nowUnix);
 

--- a/tests/specs/iframe/setMeetingTimer.spec.ts
+++ b/tests/specs/iframe/setMeetingTimer.spec.ts
@@ -43,6 +43,28 @@ describe('setMeetingTimer iframe API command', () => {
         await expect(await p1.driver.$(PILL_SELECTOR)).toBeDisplayed();
     });
 
+    it('shows a running (not expired) timer when joining before the scheduled start', async () => {
+        const { p1 } = ctx;
+
+        // Negative elapsed === the meeting starts in 10 minutes. The timer must
+        // show as running (anchored to the scheduled start), NOT expired — an
+        // early joiner should never see the red over-schedule state.
+        await p1.switchToMainFrame();
+        await p1.getIframeAPI().executeCommand('setMeetingTimer', {
+            duration: 1800, // 30 min
+            elapsed: -600 // joined 10 min before the scheduled start
+        });
+
+        await p1.switchToIFrame();
+
+        await expect(await p1.driver.$(PILL_SELECTOR)).toBeDisplayed();
+
+        // No expired border and no ended notification while still before / within
+        // the scheduled window.
+        await expect(await p1.driver.$(EXPIRED_BORDER_SELECTOR)).not.toExist();
+        await expect(await p1.driver.$(ENDED_NOTIFICATION_SELECTOR)).not.toExist();
+    });
+
     it('flips to the expired state when an over-schedule timer is pushed', async () => {
         const { p1 } = ctx;
 


### PR DESCRIPTION
## What this fixes

Follow-up to #17468. The meeting-pace timer must reflect the meeting's **fixed schedule** — the same value for every participant at a given moment — regardless of when anyone joins (including the organizer joining early).

The calendar path clamped elapsed-since-scheduled-start to `0` at join (`Math.max(0, now - start)`), and the reducer clamped it again. So a participant who joined **before** the scheduled start had their timer anchored to their **join moment** instead of the schedule.

### Symptom

30-minute meeting scheduled 14:00–14:30, organizer joins at 13:50 (10 min early):

| Real time | Before (buggy) | After (fixed) |
|---|---|---|
| 13:50 (join, early) | `00:00 (30:00)` | `00:00 (30:00)` |
| **14:00 (scheduled start)** | `10:00 (30:00)` ❌ | `00:00 (30:00)` ✅ |
| 14:15 | `25:00 (30:00)` ❌ | `15:00 (30:00)` ✅ |
| **14:30 (scheduled end)** | `40:00` — **red/over** ❌ | `30:00` — turns red exactly on time ✅ |

The early joiner's elapsed was inflated by however early they joined, and the timer flipped to the red over-schedule state before the meeting actually ended.

## The fix

Stop clamping. Elapsed-since-scheduled-start may now be **negative** (joined before the start) or **exceed the duration** (joined after the end). The reducer pins the absolute scheduled end from it and derives `remaining`/`over`/`elapsed` from that timestamp on every tick. An early joiner sees the full duration (`00:00` elapsed) until the scheduled start arrives, then the counter climbs and lands on the limit exactly at the scheduled end.

The `setMeetingTimer` iframe-API command accepts a negative `elapsed` for the same reason (embedders can express "starts in N seconds").

## Tests

Adds an e2e case to `tests/specs/iframe/setMeetingTimer.spec.ts` for the early-join (negative `elapsed`) path: the pill shows a running, non-expired timer.