### PR TITLE
fix(ui): guard createRoot/isVisible against missing DOM containers

### DIFF
--- a/modules/UI/util/UIUtil.js
+++ b/modules/UI/util/UIUtil.js
@@ -52,7 +52,7 @@ const UIUtil = {
      * @param {el} The DOM element we'd like to check for visibility
      */
     isVisible(el) {
-        return el.offsetParent !== null;
+        return Boolean(el) && el.offsetParent !== null;
     }
 };
 

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -152,9 +152,6 @@ export default class LargeVideoManager {
             = this._onVideoResolutionUpdate.bind(this);
 
         this.videoContainer.addResizeListener(this._onVideoResolutionUpdate);
-
-        this._dominantSpeakerAvatarContainer
-            = document.getElementById('dominantSpeakerAvatarContainer');
     }
 
     /**
@@ -533,8 +530,17 @@ export default class LargeVideoManager {
      * Updates the src of the dominant speaker avatar
      */
     updateAvatar() {
+        // Re-fetch the container each call rather than caching it in the constructor:
+        // LargeVideo's React subtree can unmount/remount and a cached reference becomes
+        // a detached node. Bail out if the container is not currently in the DOM.
+        const container = document.getElementById('dominantSpeakerAvatarContainer');
+
+        if (!container) {
+            return;
+        }
+
         if (!this._avatarRoot) {
-            this._avatarRoot = createRoot(this._dominantSpeakerAvatarContainer);
+            this._avatarRoot = createRoot(container);
         }
         this._avatarRoot.render(
             <Provider store = { APP.store }>

--- a/modules/UI/videolayout/LargeVideoManager.js
+++ b/modules/UI/videolayout/LargeVideoManager.js
@@ -539,8 +539,17 @@ export default class LargeVideoManager {
             return;
         }
 
+        // If the LargeVideo subtree remounted, the cached root is bound to a now-detached
+        // node — subsequent renders would be invisible and leak. Drop the stale root so
+        // we re-create one against the live container.
+        if (this._avatarRoot && this._avatarContainer !== container) {
+            this._avatarRoot.unmount();
+            this._avatarRoot = null;
+        }
+
         if (!this._avatarRoot) {
             this._avatarRoot = createRoot(container);
+            this._avatarContainer = container;
         }
         this._avatarRoot.render(
             <Provider store = { APP.store }>

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -675,8 +675,17 @@ export class VideoContainer extends LargeContainer {
             return;
         }
 
+        // If the LargeVideo subtree remounted, the cached root is bound to a now-detached
+        // node — subsequent renders would be invisible and leak. Drop the stale root so
+        // we re-create one against the live container.
+        if (this._backgroundRoot && this._backgroundContainer !== container) {
+            this._backgroundRoot.unmount();
+            this._backgroundRoot = null;
+        }
+
         if (!this._backgroundRoot) {
             this._backgroundRoot = createRoot(container);
+            this._backgroundContainer = container;
         }
         this._backgroundRoot.render(
             <LargeVideoBackground

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -666,8 +666,17 @@ export class VideoContainer extends LargeContainer {
             return;
         }
 
+        const container = document.getElementById('largeVideoBackgroundContainer');
+
+        // LargeVideo's React subtree may not be mounted (e.g. between fade-out and
+        // fade-in, or during reduced-UI transitions). createRoot(null) would throw
+        // React error #200; bail out instead.
+        if (!container) {
+            return;
+        }
+
         if (!this._backgroundRoot) {
-            this._backgroundRoot = createRoot(document.getElementById('largeVideoBackgroundContainer'));
+            this._backgroundRoot = createRoot(container);
         }
         this._backgroundRoot.render(
             <LargeVideoBackground


### PR DESCRIPTION
## Summary

`23a65fbf2` ([#16960](https://github.com/jitsi/jitsi-meet/pull/16960)) migrated `ReactDOM.render` → `createRoot` but dropped null-tolerance on three imperative-React call sites:

- `VideoContainer._updateBackground` runs `createRoot(getElementById('largeVideoBackgroundContainer'))` with no null guard. Triggered from `setTimeout` inside `hide()`/`show()` — if `LargeVideo`'s subtree isn't currently mounted when the timeout fires, `createRoot(null)` throws React error #200.
- `LargeVideoManager.updateAvatar` uses a container captured once in the constructor. Surviving a `LargeVideo` remount leaves it pointing at a detached node.
- `UIUtil.isVisible(el)` dereferences `el.offsetParent` without a null check. `AudioLevels.updateLargeVideoAudioLevel` calls it with `document.getElementById(...)` which can be null in the same conditions.

This surfaced as a frontend crash on `api.executeCommand("toggleVirtualBackgroundDialog")` ([community report](https://community.jitsi.org/t/jitsi-meet-frontend-is-crashing-when-toggle-background/142305)):

```
TypeError: Cannot read properties of null (reading 'offsetParent')
    at UIUtil.isVisible
    at AudioLevels.updateLargeVideoAudioLevel
    at LargeVideoManager.updateLargeVideoAudioLevel
Uncaught Error: Minified React error #200
    at VideoContainer._updateBackground
```

This PR adds three defensive null guards. No behavior change in the happy path.

## Test plan

- [x] `tsc:web` clean (pre-existing native-style errors only)
- [x] `eslint` clean on the 3 modified files
- [ ] Manual: open VB dialog via external API, confirm no console errors
