### PR TITLE
feat(chat): add money bag emoji to chat smileys

### DIFF
--- a/react/features/chat/smileys.ts
+++ b/react/features/chat/smileys.ts
@@ -18,5 +18,6 @@ export const smileys = {
     smiley17: ';(',
     smiley18: ':clap:',
     smiley19: ';)',
-    smiley20: ':beer:'
+    smiley20: ':beer:',
+    smiley21: ':moneybag:'
 };


### PR DESCRIPTION
Adds the `:moneybag:` 💰 emoji to the list of default emojis in chat. The alternative I tried, `:coin:` is not an alias supported by https://www.npmjs.com/package/react-emoji-render?activeTab=code.