### PR TITLE
test(transcriptions): make jigasi transcription mode configurable

### DIFF
--- a/tests/helpers/expectations.ts
+++ b/tests/helpers/expectations.ts
@@ -30,7 +30,9 @@ const defaultExpectations = {
             // Expect "async" transcription to be enabled.
             asyncTranscription: true,
             // Expect the JaaS transcription webhooks to fire in "async" mode.
-            asyncTranscriptionWebhook: true
+            asyncTranscriptionWebhook: true,
+            // Expect (deprecated) jigasi-based transcription to be enabled.
+            jigasiTranscription: true
         },
         /**
          * Whether the jaas account is configured with the account-level setting to allow unauthenticated users to join.

--- a/tests/specs/jaas/transcriptions.spec.ts
+++ b/tests/specs/jaas/transcriptions.spec.ts
@@ -10,7 +10,10 @@ setTestProperties(__filename, {
     usesBrowsers: [ 'p1', 'p2' ]
 });
 
-const asyncTranscriptionValues = expectations.jaas.transcription.asyncTranscription ? [ false, true ] : [ false ];
+const asyncTranscriptionValues = [
+    ...expectations.jaas.transcription.jigasiTranscription ? [ false ] : [],
+    ...expectations.jaas.transcription.asyncTranscription ? [ true ] : []
+];
 
 for (const asyncTranscriptions of asyncTranscriptionValues) {
     describe(`Transcription (async=${asyncTranscriptions})`, () => {


### PR DESCRIPTION
The transcriptions spec always ran the non-async (jigasi-based) transcription case, while the async case was gated behind the `asyncTranscription` expectation.

Add a new (deprecated) `jigasiTranscription` expectation and gate the non-async case behind it, mirroring the async path. Both default to `true`, so behavior is unchanged; an overrides file can now disable either mode.