### PR TITLE
fix(tracks): resubscribe streaming status on p2p<->jvb track swap

### DIFF
--- a/react/features/base/tracks/hooks.any.ts
+++ b/react/features/base/tracks/hooks.any.ts
@@ -14,10 +14,10 @@ import { ITrack } from './types';
  */
 export function useTrackStreamingStatus(track: ITrack | undefined) {
     const dispatch = useDispatch();
-    const sourceName = track?.jitsiTrack?.getSourceName();
+    const jitsiTrack = track?.jitsiTrack;
 
-    const handleStreamingStatusChanged = (jitsiTrack: any, streamingStatus: string) => {
-        dispatch(trackStreamingStatusChanged(jitsiTrack, streamingStatus));
+    const handleStreamingStatusChanged = (changedTrack: any, streamingStatus: string) => {
+        dispatch(trackStreamingStatusChanged(changedTrack, streamingStatus));
     };
 
     useEffect(() => {
@@ -32,5 +32,11 @@ export function useTrackStreamingStatus(track: ITrack | undefined) {
             track.jitsiTrack.off(JitsiTrackEvents.TRACK_STREAMING_STATUS_CHANGED, handleStreamingStatusChanged);
             dispatch(trackStreamingStatusChanged(track.jitsiTrack, track.jitsiTrack.getTrackStreamingStatus?.()));
         };
-    }, [ sourceName ]);
+
+        // The dependency must be the track OBJECT, not its source name: on a P2P<->JVB switch the remote track is
+        // replaced by a new JitsiRemoteTrack with the SAME source name. Keying on the source name leaves the
+        // listener on the old (removed) track and nobody subscribed to the new one, so once its streaming status
+        // tracker is disposed the status is stuck as null in redux and the tile falls back to the avatar while
+        // video is in fact flowing.
+    }, [ jitsiTrack ]);
 }

--- a/react/features/base/tracks/hooks.any.ts
+++ b/react/features/base/tracks/hooks.any.ts
@@ -39,5 +39,5 @@ export function useTrackStreamingStatus(track: ITrack | undefined) {
         // listener on the old (removed) track and nobody subscribed to the new one, so once its streaming status
         // tracker is disposed the status is stuck as null in redux and the tile falls back to the avatar while
         // video is in fact flowing.
-    }, [ jitsiTrack ]);
+    }, [ jitsiTrack, sourceName ]);
 }

--- a/react/features/base/tracks/hooks.any.ts
+++ b/react/features/base/tracks/hooks.any.ts
@@ -15,6 +15,7 @@ import { ITrack } from './types';
 export function useTrackStreamingStatus(track: ITrack | undefined) {
     const dispatch = useDispatch();
     const jitsiTrack = track?.jitsiTrack;
+    const sourceName = jitsiTrack?.getSourceName();
 
     const handleStreamingStatusChanged = (changedTrack: any, streamingStatus: string) => {
         dispatch(trackStreamingStatusChanged(changedTrack, streamingStatus));


### PR DESCRIPTION
On a p2p<->jvb switch the remote track is replaced by a new JitsiRemoteTrack with the same source name. useTrackStreamingStatus keyed its effect on the source name, so the listener stayed on the old (removed) track and nobody subscribed to the new one. Once the new track's streaming status tracker was disposed (last transient listener removed), the status was stuck as null in redux and the participant's tile fell back to the avatar while video was in fact flowing and decoding.

Key the effect on the track object instead. Any source-name change also changes the object, so the only new behavior is the resubscribe on the swap that was previously missed.

