### PR TITLE
test(connectivity): add P2P and TURN connectivity tests

### DIFF
--- a/tests/helpers/expectations.ts
+++ b/tests/helpers/expectations.ts
@@ -53,6 +53,16 @@ const defaultExpectations = {
         // to set a room password unless they also happen to have a token (any valid token?))
         setPasswordAvailable: true
     },
+    connectivity: {
+        jvb: {
+            direct: true,
+            turn: true
+        },
+        p2p: {
+            direct: true,
+            turn: true
+        }
+    },
     // We can create conferences under any tenant.
     useTenant: true
 };

--- a/tests/helpers/types.ts
+++ b/tests/helpers/types.ts
@@ -7,6 +7,12 @@ import { IToken, ITokenOptions } from './token';
 
 export type IContext = {
     /**
+     * The name (describe block title) of the suite in which a test failed. Used to skip the remaining tests in that
+     * suite while still running tests in other describe blocks in the same file.
+     */
+    failedSuite?: string;
+
+    /**
      *  The up-to-six browser instances provided by the framework. These can be initialized using
      *  ensureOneParticipant, ensureTwoParticipants, etc. from participants.ts.
      **/

--- a/tests/specs/misc/connectivity.spec.ts
+++ b/tests/specs/misc/connectivity.spec.ts
@@ -1,54 +1,236 @@
 import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { config as testsConfig } from '../../helpers/TestsConfig';
+import { expectations } from '../../helpers/expectations';
 import { joinMuc, waitForMedia } from '../../helpers/joinMuc';
 
 setTestProperties(__filename, {
-    description: 'This test asserts that the connection to JVB is over UDP and using the same remote port. ',
+    description: 'Tests ICE connectivity for JVB, P2P, and TURN (relay) modes.',
     usesBrowsers: [ 'p1', 'p2' ]
 });
 
-describe('Connectivity', () => {
+describe('Connectivity - JVB', () => {
     let p1: Participant, p2: Participant;
 
+    before(async function() {
+        if (!expectations.connectivity.jvb.direct) {
+            // eslint-disable-next-line @typescript-eslint/no-invalid-this
+            this.skip();
+        }
+    });
+
     it('setup', async () => {
-        p1 = await joinMuc({ name: 'p1', token: testsConfig.jwt.preconfiguredToken });
-        p2 = await joinMuc({ name: 'p2', token: testsConfig.jwt.preconfiguredToken });
+        [ p1, p2 ] = await joinParticipants({ p2p: { enabled: false } });
         await waitForMedia([ p1, p2 ]);
     });
 
-    it('protocol', async () => {
-        expect(await getProtocol(p1)).toBe('udp');
-        expect(await getProtocol(p2)).toBe('udp');
+    it('uses UDP', async () => {
+        expect(await getProtocol(p1, false)).toBe('udp');
+        expect(await getProtocol(p2, false)).toBe('udp');
     });
 
-    it('port', async () => {
-        const port1 = await getRemotePort(p1);
-        const port2 = await getRemotePort(p2);
+    it('both clients connect to the same JVB port', async () => {
+        const [ t1, t2 ] = await getPairs([ p1, p2 ], false);
+        const port1 = parsePort(t1?.ip);
+        const port2 = parsePort(t2?.ip);
 
         expect(port1).toBeInteger('p1 remote port');
         expect(port2).toBeInteger('p2 remote port');
         expect(port1).toBe(port2);
     });
+
+    it('not using TURN', async () => assertTurn([ p1, p2 ], false, false));
+
+    it('not P2P', async () => {
+        expect(await isP2PActive(p1)).toBe(false);
+    });
 });
 
-/**
- * Get the remote port of the participant.
- * @param participant
- */
-async function getRemotePort(participant: Participant) {
-    const data = await participant.execute(() => APP?.conference?.getStats()?.transport[0]?.ip);
-    const parts = data.split(':');
+describe('Connectivity - P2P', () => {
+    let p1: Participant, p2: Participant;
 
-    return parts.length > 1 ? parseInt(parts[1], 10) : '';
+    before(async function() {
+        if (!expectations.connectivity.p2p.direct) {
+            // eslint-disable-next-line @typescript-eslint/no-invalid-this
+            this.skip();
+        }
+    });
+
+    it('setup', async () => {
+        [ p1, p2 ] = await joinParticipants({
+            p2p: { enabled: true, useStunTurn: false },
+            disable1On1Mode: false
+        });
+        await waitForP2P([ p1, p2 ]);
+        await waitForMedia([ p1, p2 ]);
+    });
+
+    it('is P2P active', async () => assertP2PActive([ p1, p2 ], true));
+
+    it('not using TURN', async () => assertTurn([ p1, p2 ], true, false));
+});
+
+describe('Connectivity - JVB + TURN', () => {
+    let p1: Participant, p2: Participant;
+    let t1: Record<string, any> | null, t2: Record<string, any> | null;
+
+    before(async function() {
+        if (!expectations.connectivity.jvb.turn) {
+            // eslint-disable-next-line @typescript-eslint/no-invalid-this
+            this.skip();
+        }
+    });
+
+    it('setup', async () => {
+        [ p1, p2 ] = await joinParticipants({ p2p: { enabled: false }, forceTurnRelay: true });
+        await waitForMedia([ p1, p2 ]);
+        [ t1, t2 ] = await getPairs([ p1, p2 ], false);
+        console.log('p1 active JVB pair:', JSON.stringify(t1));
+        console.log('p2 active JVB pair:', JSON.stringify(t2));
+    });
+
+    it('uses TURN', async () => {
+        expect(t1?.localCandidateUrl).toContain('turn:');
+        expect(t2?.localCandidateUrl).toContain('turn:');
+    });
+
+    it('both clients connect to the same JVB port', async () => {
+        const port1 = parsePort(t1?.ip);
+        const port2 = parsePort(t2?.ip);
+
+        expect(port1).toBeInteger('p1 remote port');
+        expect(port2).toBeInteger('p2 remote port');
+        expect(port1).toBe(port2);
+    });
+
+    it('not P2P', async () => {
+        expect(await isP2PActive(p1)).toBe(false);
+    });
+});
+
+describe('Connectivity - P2P + TURN', () => {
+    let p1: Participant, p2: Participant;
+
+    before(async function() {
+        if (!expectations.connectivity.p2p.turn) {
+            // eslint-disable-next-line @typescript-eslint/no-invalid-this
+            this.skip();
+        }
+    });
+
+    it('setup', async () => {
+        [ p1, p2 ] = await joinParticipants({
+            p2p: { enabled: true, useStunTurn: true },
+            disable1On1Mode: false,
+            forceTurnRelay: true
+        });
+        await waitForP2P([ p1, p2 ]);
+        await waitForMedia([ p1, p2 ]);
+    });
+
+    it('is P2P active', async () => assertP2PActive([ p1, p2 ], true));
+
+    it('uses TURN', async () => assertTurn([ p1, p2 ], true, true));
+});
+
+async function joinParticipants(configOverwrite: object): Promise<[ Participant, Participant ]> {
+    const joinOptions = { configOverwrite };
+    const p1 = await joinMuc({ name: 'p1', token: testsConfig.jwt.preconfiguredToken }, joinOptions);
+    const p2 = await joinMuc({ name: 'p2', token: testsConfig.jwt.preconfiguredToken }, joinOptions);
+
+    return [ p1, p2 ];
+}
+
+async function waitForP2P(participants: Participant[]): Promise<void> {
+    await Promise.all(participants.map(p => p.waitForP2PIceConnected()));
+}
+
+async function getPairs(
+        participants: Participant[], p2p: boolean): Promise<(Record<string, any> | null)[]> {
+    return Promise.all(participants.map(p => getActiveCandidatePair(p, p2p)));
+}
+
+async function assertTurn(participants: Participant[], p2p: boolean, expected: boolean): Promise<void> {
+    for (const p of participants) {
+        expect(await isUsingTurn(p, p2p)).toBe(expected);
+    }
+}
+
+async function assertP2PActive(participants: Participant[], expected: boolean): Promise<void> {
+    for (const p of participants) {
+        expect(await isP2PActive(p)).toBe(expected);
+    }
 }
 
 /**
- * Get the remote port of the participant.
- * @param participant
+ * Returns the active (currently nominated) candidate pair stats from the RTCPeerConnection for the given session.
+ * The cached transport array in getStats() accumulates all pairs ever used, so we query the PC directly instead.
  */
-async function getProtocol(participant: Participant) {
-    const data = await participant.execute(() => APP?.conference?.getStats()?.transport[0]?.type);
+async function getActiveCandidatePair(participant: Participant, p2p: boolean): Promise<Record<string, any> | null> {
+    return participant.execute(async (isP2P: boolean) => {
+        const room = APP?.conference?._room;
+        const session = isP2P ? room?.p2pJingleSession : room?.jvbJingleSession;
+        const pc = session?.peerconnection?.peerconnection;
 
-    return data.toLowerCase();
+        if (!pc) {
+            return null;
+        }
+
+        const stats = await pc.getStats();
+        let activePair: RTCIceCandidatePairStats | null = null;
+        const candidates: Map<string, any> = new Map();
+
+        stats.forEach((report: any) => {
+            if (report.type === 'local-candidate' || report.type === 'remote-candidate') {
+                candidates.set(report.id, report);
+            }
+        });
+        stats.forEach((report: any) => {
+            if (report.type === 'candidate-pair' && report.nominated && report.state === 'succeeded') {
+                if (!activePair || report.bytesSent > (activePair as any).bytesSent) {
+                    activePair = report;
+                }
+            }
+        });
+
+        if (!activePair) {
+            return null;
+        }
+
+        const local = candidates.get((activePair as any).localCandidateId);
+        const remote = candidates.get((activePair as any).remoteCandidateId);
+        const localIp = local?.ip ?? local?.address;
+        const remoteIp = remote?.ip ?? remote?.address;
+
+        return {
+            localip: `${localIp}:${local?.port}`,
+            ip: `${remoteIp}:${remote?.port}`,
+            localCandidateType: local?.candidateType,
+            localCandidateUrl: local?.url,
+            remoteCandidateType: remote?.candidateType,
+            type: remote?.protocol,
+            rtt: (activePair as any).currentRoundTripTime * 1000
+        };
+    }, p2p);
+}
+
+function parsePort(address: string): number {
+    const parts = address.split(':');
+
+    return parseInt(parts[parts.length - 1], 10);
+}
+
+async function getProtocol(participant: Participant, p2p: boolean): Promise<string> {
+    return (await getActiveCandidatePair(participant, p2p))?.type?.toLowerCase();
+}
+
+/** Returns true if the active candidate pair uses a TURN relay (url starts with "turn:"). */
+async function isUsingTurn(participant: Participant, p2p: boolean): Promise<boolean> {
+    const pair = await getActiveCandidatePair(participant, p2p);
+
+    return pair?.localCandidateUrl?.startsWith('turn:') === true;
+}
+
+async function isP2PActive(participant: Participant): Promise<boolean> {
+    return participant.execute(() => APP?.conference?._room?.isP2PActive());
 }

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -553,12 +553,18 @@ export const config: WebdriverIO.MultiremoteConfig = {
             AllureReporter.addSuite(test.parent);
         }
 
-        if (ctx.skipSuiteTests) {
-            if ((typeof ctx.skipSuiteTests) === 'string') {
+        // A failure in an earlier test skips the rest of that describe block, but not other describe blocks in the
+        // same file (ctx.failedSuite is scoped to the suite that failed, while ctx.skipSuiteTests is file-wide).
+        const failedSameSuite = Boolean(ctx.failedSuite) && ctx.failedSuite === test.parent;
+        const skipReason = ctx.skipSuiteTests
+            || (failedSameSuite ? `A previous test in suite "${test.parent}" has failed.` : false);
+
+        if (skipReason) {
+            if ((typeof skipReason) === 'string') {
                 AllureReporter.addDescription((ctx.testProperties.description || '')
-                    + '\n\nSkipped because: ' + ctx.skipSuiteTests, 'text');
+                    + '\n\nSkipped because: ' + skipReason, 'text');
             }
-            console.log(`Skipping because: ${ctx.skipSuiteTests}`);
+            console.log(`Skipping because: ${skipReason}`);
 
             context.skip();
 
@@ -584,8 +590,8 @@ export const config: WebdriverIO.MultiremoteConfig = {
 
         if (error) {
 
-            // skip all remaining tests in the suite
-            ctx.skipSuiteTests = `Test "${test.title}" has failed.`;
+            // Skip the remaining tests in the same describe block (but not other describe blocks in the file).
+            ctx.failedSuite = test.parent;
 
             // make sure all browsers are at the main app in iframe (if used), so we collect debug info
             await Promise.all(multiRemoteBrowser.instances.map(async (instance: string) => {


### PR DESCRIPTION
Extends the connectivity test suite with P2P and TURN cases:

- **JVB direct**: existing test, now uses active candidate pair from the raw PC stats instead of the cached transport array
- **P2P direct**: asserts P2P is active and no TURN is used
- **JVB + TURN**: asserts TURN relay is used (detected via candidate URL, handles `prflx` type) and both clients connect to the same JVB port
- **P2P + TURN**: asserts P2P is active and TURN relay is used

Each case is gated by a configurable expectation (`connectivity.jvb.{direct,turn}`, `connectivity.p2p.{direct,turn}`) so deployments without TURN or P2P can disable irrelevant cases via an expectations file.