### PR TITLE
fix(mobile) clamp computed avatar sizes to positive values

### DIFF
--- a/react/features/base/avatar/components/native/styles.ts
+++ b/react/features/base/avatar/components/native/styles.ts
@@ -70,7 +70,7 @@ export default {
     initialsText: (size: number = DEFAULT_SIZE) => {
         return {
             color: 'white',
-            fontSize: size * 0.45,
+            fontSize: Math.max(size * 0.45, 1),
             fontWeight: '100'
         };
     },

--- a/react/features/large-video/components/LargeVideo.native.tsx
+++ b/react/features/large-video/components/LargeVideo.native.tsx
@@ -108,7 +108,7 @@ class LargeVideo extends PureComponent<IProps, IState> {
 
         if (size < AVATAR_SIZE * 1.5) {
             return {
-                avatarSize: size - 15, // Leave some margin.
+                avatarSize: Math.max(size - 15, 0), // Leave some margin.
                 useConnectivityInfoLabel: false
             };
         }


### PR DESCRIPTION
## Summary

On Android with the New Architecture, `LargeVideo` can compute a **negative** avatar size on the first render, which propagates into a negative `fontSize` on the avatar initials `<Text>` and hard-crashes the app inside React Native's Fabric text measurement:

```
java.lang.IllegalArgumentException: FontSize should be a positive value. Current value: -20
    at com.facebook.react.views.text.TextAttributeProps.getLetterSpacing(TextAttributeProps.kt:150)
    at com.facebook.react.views.text.TextLayoutManager.buildSpannableFromFragments(TextLayoutManager.kt:292)
    at com.facebook.react.views.text.TextLayoutManager.createSpannableFromAttributedString(TextLayoutManager.kt:584)
    at com.facebook.react.views.text.TextLayoutManager.getOrCreateSpannableForText(TextLayoutManager.kt:554)
    at com.facebook.react.views.text.TextLayoutManager.createLayoutForMeasurement(TextLayoutManager.kt:772)
    at com.facebook.react.views.text.TextLayoutManager.measureText(TextLayoutManager.kt:1060)
    at com.facebook.react.fabric.FabricUIManager.measureText(FabricUIManager.java:633)
```

This PR clamps the two computed values so they can never go non-positive.

## Problem

`LargeVideo.native.tsx` derives the avatar size from the viewport dimensions stored in `features/base/responsive-ui`:

```ts
static getDerivedStateFromProps(props: IProps) {
    const { _height, _width } = props;

    // Get the size, rounded to the nearest even number.
    const size = 2 * Math.round(Math.min(_height, _width) / 2);

    if (size < AVATAR_SIZE * 1.5) {
        return {
            avatarSize: size - 15, // Leave some margin.
            ...
```

`clientWidth`/`clientHeight` initialize to `0` in the Redux store (`window.innerWidth/innerHeight` are undefined in React Native) and are only corrected after the first `onLayout` of `DimensionsDetector`. Under the New Architecture the initial render commonly happens **before** that layout event lands, so `LargeVideo` renders with `_width = _height = 0`:

- `size = 0` → `avatarSize = 0 - 15 = -15`
- avatar initials style: `fontSize: size * 0.45` → `-15 * 0.45 = -6.75`
- Fabric converts to pixels (`-6.75` dp × 3.0 density → `-20` px) and `TextAttributeProps` throws the `IllegalArgumentException` above during `measureText`, crashing the surface before the user sees anything.

On the old architecture / older RN versions the dimensions usually arrived before the first `LargeVideo` render, so the bug was latent. It is reliably reproducible with the SDK embedded in a React Native 0.86 host app on Android.

## Fix

Two one-line clamps:

1. `react/features/large-video/components/LargeVideo.native.tsx` — never produce a negative avatar size:

   ```ts
   avatarSize: Math.max(size - 15, 0), // Leave some margin.
   ```

2. `react/features/base/avatar/components/native/styles.ts` — never produce a non-positive font size, regardless of caller (Fabric also rejects `fontSize: 0`):

   ```ts
   initialsText: (size: number = DEFAULT_SIZE) => {
       return {
           color: 'white',
           fontSize: Math.max(size * 0.45, 1),
           fontWeight: '100'
       };
   },
   ```

Once the real dimensions arrive a moment later, `getDerivedStateFromProps` re-runs and the avatar takes its proper size, so there is no visual regression — the clamp only covers the transient (or erroneous) zero/negative-size window instead of crashing.

## Testing

- Reproduced the crash with `@jitsi/react-native-sdk` 12.1.4 embedded in a host app on React Native 0.86.0, Android (New Architecture, Hermes, emulator API 36): launching a meeting crashed during the first commit with the stack trace above. A dev-time instrumentation of `<Text>` confirmed the offending style was the avatar initials (`{"color":"white","fontSize":-6.75,"fontWeight":"100"}` with content `" J "`).
- With the clamps applied, the meeting renders and joins normally; avatars display at their normal size once layout settles.
- No behavior change for any caller passing a positive size.
