### PR TITLE
GSoC: fix(toolbox): improve disabled button contrast for WCAG AA

### DIFF
--- a/css/_base.scss
+++ b/css/_base.scss
@@ -58,7 +58,7 @@ body {
 }
 
 .disabled .jitsi-icon svg {
-    fill: #929292;
+    fill: $disabledToolbarIconColor;
 }
 
 .jitsi-icon.gray svg {

--- a/css/_settings-button.scss
+++ b/css/_settings-button.scss
@@ -10,11 +10,11 @@
 
         &.disabled, .disabled & {
             cursor: initial;
-            color: #929292;
-            background-color: #36383c;
+            color: $disabledToolbarIconColor;
+            background-color: $disabledToolbarBackgroundColor;
 
             &:hover {
-                background-color: #36383c;
+                background-color: $disabledToolbarBackgroundColor;
             }
         }
     }
@@ -39,10 +39,10 @@
         }
 
         &.settings-button-small-icon--disabled {
-            background: #36383C;
+            background: $disabledToolbarBackgroundColor;
 
             & svg {
-                fill: #929292;
+                fill: $disabledToolbarIconColor;
             }
         }
     }
@@ -52,11 +52,11 @@
     }
 
     &--disabled {
-        background-color: #36383c;
+        background-color: $disabledToolbarBackgroundColor;
         cursor: default;
 
         & svg {
-            fill: #929292;
+            fill: $disabledToolbarIconColor;
         }
     }
 }

--- a/css/_variables.scss
+++ b/css/_variables.scss
@@ -14,6 +14,8 @@ $thumbnailsBorder: 2px;
  * Toolbar
  */
 $newToolbarBackgroundColor: #131519;
+$disabledToolbarBackgroundColor: #292929;
+$disabledToolbarIconColor: #C2C2C2;
 $newToolbarSize: 48px;
 $newToolbarSizeMobile: 60px;
 $newToolbarSizeWithPadding: calc(#{$newToolbarSize} + 24px);

--- a/react/features/base/ui/constants.web.ts
+++ b/react/features/base/ui/constants.web.ts
@@ -260,10 +260,10 @@ export const commonStyles = (theme: Theme) => {
 
             '&.disabled': {
                 cursor: 'initial !important',
-                backgroundColor: `${theme.palette.disabled01} !important`,
+                backgroundColor: `${theme.palette.ui02} !important`,
 
                 '& svg': {
-                    fill: `${theme.palette.icon03} !important`
+                    fill: `${theme.palette.textColor02} !important`
                 }
             }
         },


### PR DESCRIPTION
## Summary
- Update disabled toolbar icon colors to use design tokens (`surface03` / `textColor02`) instead of low-contrast `#929292` on `#36383c`
- Align legacy SCSS and React theme styles for consistent WCAG 2.1 AA contrast on pre-join and in-meeting toolbars

## Reproduction steps (before fix)
1. Open https://meet.jit.si (or local dev pre-join screen)
2. Observe disabled mic/camera toolbar buttons before granting permissions
3. Disabled icons appear as dim gray on dark gray background with insufficient contrast

## Expected behavior
Disabled toolbar icons remain clearly visible with at least 3:1 contrast ratio (WCAG 2.1 AA)

## Test plan
- [ ] Open pre-join screen — disabled mic/camera buttons have visible icons
- [ ] Verify in-meeting disabled toolbox buttons (if applicable)
- [ ] `npm run lint-fix` and `npm run tsc:ci` pass locally

Fixes #17216