### PR TITLE
GSoC: feat(recording): add config for recording dialog advanced options

### DIFF
--- a/config.js
+++ b/config.js
@@ -405,6 +405,11 @@ var config = {
     // recordings: {
     //    // IF true (default) recording audio and video is selected by default in the recording dialog.
     //    // recordAudioAndVideo: true,
+    //    // If true, the transcription and audio/video toggles in the recording dialog are hidden.
+    //    // Use with transcription.autoTranscribeOnRecord to keep transcription enabled.
+    //    // hideAdvancedOptions: false,
+    //    // If true, the transcription and audio/video toggles are collapsed by default.
+    //    // collapseAdvancedOptionsByDefault: false,
     //    // If true, shows a notification at the start of the meeting with a call to action button
     //    // to start recording (for users who can do so).
     //    // suggestRecording: true,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -627,7 +627,9 @@ export interface IConfig {
     };
     recordingSharingUrl?: string;
     recordings?: {
+        collapseAdvancedOptionsByDefault?: boolean;
         consentLearnMoreLink?: string;
+        hideAdvancedOptions?: boolean;
         recordAudioAndVideo?: boolean;
         requireConsent?: boolean;
         showPrejoinWarning?: boolean;

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -12,6 +12,7 @@ import { updateDropboxToken } from '../../../dropbox/actions';
 import { getDropboxData, getNewAccessToken, isEnabled as isDropboxEnabled } from '../../../dropbox/functions.any';
 import { showErrorNotification } from '../../../notifications/actions';
 import { setRequestingSubtitles } from '../../../subtitles/actions.any';
+import { canAddTranscriber } from '../../../transcribing/functions';
 import { setSelectedRecordingService, setStartRecordingIntent, startLocalVideoRecording } from '../../actions';
 import { RECORDING_METADATA_ID, RECORDING_TYPES } from '../../constants';
 import { isRecordingSharingEnabled, shouldAutoTranscribeOnRecord, supportsLocalRecording } from '../../functions';
@@ -27,6 +28,16 @@ export interface IProps extends WithTranslation {
      * Requests transcribing when recording is turned on.
      */
     _autoTranscribeOnRecord: boolean;
+
+    /**
+     * Whether the local participant can start transcribing.
+     */
+    _canStartTranscribing: boolean;
+
+    /**
+     * Whether to hide the transcription and audio/video toggles in the dialog.
+     */
+    _hideAdvancedOptions: boolean;
 
     /**
      * The {@code JitsiConference} for the current conference.
@@ -197,7 +208,9 @@ class AbstractStartRecordingDialog extends Component<IProps, IState> {
             userName: undefined,
             sharingEnabled: true,
             shouldRecordAudioAndVideo: this.props.recordAudioAndVideo,
-            shouldRecordTranscription: this.props._autoTranscribeOnRecord,
+            shouldRecordTranscription: props._hideAdvancedOptions && props._canStartTranscribing
+                ? true
+                : props._autoTranscribeOnRecord,
             spaceLeft: undefined,
             selectedRecordingService,
             localRecordingOnlySelf: false
@@ -485,10 +498,12 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
     return {
         _appKey: dropbox.appKey ?? '',
         _autoTranscribeOnRecord: shouldAutoTranscribeOnRecord(state),
+        _canStartTranscribing: canAddTranscriber(state),
         _conference: state['features/base/conference'].conference,
         _displaySubtitles,
         _fileRecordingsServiceEnabled: recordingService?.enabled ?? false,
         _fileRecordingsServiceSharingEnabled: isRecordingSharingEnabled(state),
+        _hideAdvancedOptions: Boolean(recordings.hideAdvancedOptions),
         _isDropboxEnabled: isDropboxEnabled(state),
         _localRecordingEnabled: !localRecording?.disable,
         _rToken: state['features/dropbox'].rToken ?? '',

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -26,6 +26,16 @@ export interface IProps extends WithTranslation {
     _canStartTranscribing: boolean;
 
     /**
+     * Whether to collapse the advanced options section by default.
+     */
+    _collapseAdvancedOptionsByDefault: boolean;
+
+    /**
+     * Whether to hide the transcription and audio/video toggles in the dialog.
+     */
+    _hideAdvancedOptions: boolean;
+
+    /**
      * Style of the dialogs feature.
      */
     _dialogStyles: any;
@@ -197,7 +207,7 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
         this._onToggleShowOptions = this._onToggleShowOptions.bind(this);
 
         this.state = {
-            showAdvancedOptions: true
+            showAdvancedOptions: !props._collapseAdvancedOptionsByDefault
         };
     }
 
@@ -207,6 +217,10 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
      * @inheritdoc
      */
     override componentDidMount() {
+        if (this.props._hideAdvancedOptions && this._canStartTranscribing()) {
+            this._onTranscriptionSwitchChange(true);
+        }
+
         if (!this._shouldRenderNoIntegrationsContent()
             && !this._shouldRenderIntegrationsContent()
             && !this._shouldRenderFileSharingContent()) {
@@ -412,13 +426,15 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
  * @returns {IProps}
  */
 export function mapStateToProps(state: IReduxState) {
-    const { localRecording, recordingService } = state['features/base/config'];
+    const { localRecording, recordingService, recordings = {} } = state['features/base/config'];
     const _localRecordingAvailable = !localRecording?.disable && supportsLocalRecording();
 
     return {
         ..._abstractMapStateToProps(state),
         isVpaas: isVpaasMeeting(state),
         _canStartTranscribing: canAddTranscriber(state),
+        _collapseAdvancedOptionsByDefault: Boolean(recordings.collapseAdvancedOptionsByDefault),
+        _hideAdvancedOptions: Boolean(recordings.hideAdvancedOptions),
         _hideStorageWarning: Boolean(recordingService?.hideStorageWarning),
         _renderRecording: isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false),
         _localRecordingAvailable,

--- a/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/native/StartRecordingDialogContent.tsx
@@ -32,7 +32,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     override render() {
-        const { _styles: styles } = this.props;
+        const { _hideAdvancedOptions, _styles: styles } = this.props;
 
         return (
             <View style = { styles.container }>
@@ -40,7 +40,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                 { this._renderFileSharingContent() }
                 { this._renderUploadToTheCloudInfo() }
                 { this._renderIntegrationsContent() }
-                { this._renderAdvancedOptions() }
+                { !_hideAdvancedOptions && this._renderAdvancedOptions() }
             </View>
         );
     }

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -39,6 +39,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
     override render() {
         const {
             _canStartTranscribing,
+            _hideAdvancedOptions,
             _localRecordingAvailable,
             _renderRecording,
             integrationsEnabled
@@ -58,7 +59,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                 )}
                 { this._renderLocalRecordingContent() }
                 { transcriptionOnly && this._renderTranscriptionOnly() }
-                { hasRecordingService && <> { this._renderAdvancedOptions() } </> }
+                { hasRecordingService && !_hideAdvancedOptions && <> { this._renderAdvancedOptions() } </> }
             </Container>
         );
     }
@@ -70,6 +71,10 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     _renderTranscriptionOnly() {
+        if (this.props._hideAdvancedOptions) {
+            return null;
+        }
+
         const { shouldRecordTranscription, t } = this.props;
 
         return (


### PR DESCRIPTION
## Summary
- Add `recordings.hideAdvancedOptions` — hides transcription and audio/video toggles in the start recording dialog (transcription stays enabled when available)
- Add `recordings.collapseAdvancedOptionsByDefault` — the advanced options section starts collapsed instead of expanded
- Works on web and native recording dialog

## Config example
``` js
recordings: {
    hideAdvancedOptions: true,
    // pair with transcription.autoTranscribeOnRecord: true to keep transcription on
},
transcription: {
    autoTranscribeOnRecord: true,
}