### PR TITLE
feat(participants-pane): add config flag to disable automatic participant resorting (#16249)

### DIFF
--- a/config.js
+++ b/config.js
@@ -154,6 +154,12 @@ var config = {
     // Shows/hides the moderator setting for chat permissions.
     // showChatPermissionsModeratorSetting: false,
 
+    // When true, the participants list will NOT automatically resort
+    // when someone speaks or becomes dominant speaker.
+    // Participants will appear in the order they joined.
+    // Default: false (current behavior - list reorders dynamically).
+    // disableAutoResortParticipants: false,
+
     // screenshotCapture : {
     //      Enables the screensharing capture feature.
     //      enabled: false,

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -309,12 +309,13 @@ export interface IConfig {
     disableAEC?: boolean;
     disableAGC?: boolean;
     disableAP?: boolean;
-
     /**
      * @deprecated Use `virtualBackground.disableAddingImages` instead.
      */
     disableAddingBackgroundImages?: boolean;
+
     disableAudioLevels?: boolean;
+    disableAutoResortParticipants?: boolean;
     disableBeforeUnloadHandlers?: boolean;
     disableCameraTintForeground?: boolean;
     disableChat?: boolean;

--- a/react/features/filmstrip/functions.any.ts
+++ b/react/features/filmstrip/functions.any.ts
@@ -18,6 +18,37 @@ export function updateRemoteParticipants(store: IStore, force?: boolean, partici
     let reorderedParticipants = [];
     const { sortedRemoteVirtualScreenshareParticipants } = state['features/base/participants'];
 
+    if (state['features/base/config']?.disableAutoResortParticipants) {
+        const { fakeParticipants, remote } = state['features/base/participants'];
+        const remoteMap = new Map(remote);
+        const sharedVideos = fakeParticipants ? Array.from(fakeParticipants.keys()) : [];
+        const screenShareVirtualIds = sortedRemoteVirtualScreenshareParticipants
+            ? Array.from(sortedRemoteVirtualScreenshareParticipants.keys())
+            : [];
+        const participantsWithScreenShare = screenShareVirtualIds.reduce<string[]>((acc, screenshare) => {
+            const ownerId = getVirtualScreenshareParticipantOwnerId(screenshare);
+
+            acc.push(ownerId);
+            acc.push(screenshare);
+            remoteMap.delete(ownerId);
+            remoteMap.delete(screenshare);
+
+            return acc;
+        }, []);
+
+        for (const sharedVideo of sharedVideos) {
+            remoteMap.delete(sharedVideo);
+        }
+
+        store.dispatch(setRemoteParticipants([
+            ...participantsWithScreenShare,
+            ...sharedVideos,
+            ...Array.from(remoteMap.keys())
+        ]));
+
+        return;
+    }
+
     if (!isFilmstripScrollVisible(state) && !sortedRemoteVirtualScreenshareParticipants.size && !force) {
         if (participantId) {
             const { remoteParticipants } = state['features/filmstrip'];

--- a/react/features/participants-pane/functions.ts
+++ b/react/features/participants-pane/functions.ts
@@ -189,6 +189,18 @@ export const shouldRenderInviteButton = (state: IReduxState) => {
  * @returns {Array<string>}
  */
 export function getSortedParticipantIds(stateful: IStateful) {
+    const state = toState(stateful);
+
+    if (state['features/base/config']?.disableAutoResortParticipants) {
+        const filmstripOrder = getRemoteParticipantsSorted(stateful);
+        const raisedHandParticipants = getRaiseHandsQueue(stateful).map(({ id: particId }) => particId);
+
+        return [
+            ...raisedHandParticipants,
+            ...filmstripOrder.filter(id => !raisedHandParticipants.includes(id))
+        ];
+    }
+
     const id = getLocalParticipant(stateful)?.id;
     const remoteParticipants = getRemoteParticipantsSorted(stateful);
     const reorderedParticipants = new Set(remoteParticipants);


### PR DESCRIPTION
## Summary

Adds a new `disableAutoResortParticipants` config option that prevents the participant list from automatically reordering when someone speaks or becomes dominant speaker. When enabled, participants appear in the order they joined the meeting.

## Problem

The "Meeting Participants" list automatically reorders itself whenever someone speaks — dominant speaker jumps to the top, recent speakers are promoted, and the rest are sorted alphabetically. This makes it difficult for moderators to find specific participants, especially when assigning breakout rooms or managing large meetings. (See issue #16249.)

## Solution

Introduces `disableAutoResortParticipants` (default: `false`) — a deployer-controlled config flag.

When set to `true`:

### What changes:
- ❌ Dominant speaker no longer jumps to the top of the list
- ❌ Recent speakers are no longer promoted
- ❌ Alphabetical sorting on participant join is skipped
- ❌ Participant list no longer re-sorts when names change

### What stays the same (essential functionality preserved):
- ✅ Screenshare participants and their owners are still promoted to the top of the filmstrip
- ✅ Shared video participants (fake participants) are still grouped together
- ✅ Raised hand participants still appear at the top of the participants pane (in timestamp order)
- ✅ All other moderator controls (mute, kick, pin, etc.) remain unaffected

## Implementation

**4 files changed (51 insertions, 1 deletion):**

| File | Change |
|------|--------|
| `config.js` | Added `disableAutoResortParticipants` config option (commented out, default `false`) |
| `react/features/base/config/configType.ts` | Added TypeScript type definition for `disableAutoResortParticipants` |
| `react/features/filmstrip/functions.any.ts` | When flag is true, returns participants in join order — screenshares and shared videos are still extracted and promoted to the front |
| `react/features/participants-pane/functions.ts` | When flag is true, raised hands are still moved to the top, remaining participants stay in filmstrip order (join order) |

## How It Works

### 1. Filmstrip (`updateRemoteParticipants`)

When the flag is true, the function builds the participant order from the raw `remote` Map (which preserves insertion order). Screenshare owners and virtual participants, as well as shared video participants, are still pulled to the front. No speaker promotion, dominant speaker handling, or alphabetical sorting is applied.

### 2. Participants pane (`getSortedParticipantIds`)

When the flag is true, the function takes the filmstrip's order and only moves raised-hand participants to the top (preserving their timestamp order). No dominant speaker or alphabetical reordering is applied.

### 3. Config

The flag is read directly from `state['features/base/config']` in both selectors. The base participant reducer is not modified (reducers don't have access to the full state tree), so `sortedRemoteParticipants` continues to be sorted alphabetically — but both the filmstrip and participants pane bypass it when the flag is true.

## Testing

- Set `disableAutoResortParticipants: true` in `config.js`
- Join a meeting with 3+ participants
- Verify participants appear in join order in both the filmstrip and participants pane
- Verify screenshares still appear at the top of the filmstrip
- Verify raised hands still appear at the top of the participants pane
- Verify speaking/becoming dominant speaker does NOT change the order
- Run `npm run lint:ci` — passes with 0 warnings

## Related

- Closes #16249
- Supersedes PR #16757 (which was stale and did not preserve screenshare/raised-hand behavior)

## Checklist

- [x] Code follows project coding conventions
- [x] TypeScript types added/updated
- [x] Config option documented in `config.js`
- [x] Lint passes with 0 warnings

## Contributor Checklist

- [x] I have read and followed the Contributing Guidelines
- [x] I have signed the Individual Contributor License Agreement (ICLA)
- [x] I understand that my contribution will be licensed under the Apache License 2.0

Signed CLA: ✅ https://jitsi.org/icla (girishpavan985@gmail.com)
