### PR TITLE
fix(tests): tolerate transient Firefox ICE disconnect in waitForIceConnected

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -451,7 +451,25 @@ export class Participant {
      */
     waitForIceConnected(): Promise<boolean> {
         return this.driver.waitUntil(() =>
-            this.execute(() => APP?.conference?.getConnectionState() === 'connected'), {
+            this.execute(() => {
+                const state = APP?.conference?.getConnectionState();
+
+                if (state === 'connected') {
+                    return true;
+                }
+
+                // Firefox can leave the JVB PeerConnection reporting a transient ICE
+                // 'disconnected' state (a brief consent-check blip) while the selected
+                // candidate pair keeps carrying media, and it does not always transition
+                // back to 'connected' the way Chrome does. Treat that as connected when
+                // stats show we are actually receiving media from the bridge, so a momentary
+                // disconnect does not fail the whole spec. Terminal 'failed'/'closed' keep waiting.
+                if (state === 'disconnected') {
+                    return APP?.conference?.getStats()?.bitrate?.download > 0;
+                }
+
+                return false;
+            }), {
             timeout: 15_000,
             timeoutMsg: `expected ICE to be connected for 15s for ${this.name}`
         });


### PR DESCRIPTION
## Problem

A torture-test run flaked on the **ff-chrome** grid: `media/stopVideo.spec.ts` failed in `ensureTwoParticipants` with:

```
Error: expected ICE to be connected for 15s for p1
    at async ensureTwoParticipants (tests/helpers/participants.ts:190:5)
```

Cross-referencing the per-browser WebRTC debug log, JVB log, and TURN log, the failure was **not** a real connectivity problem:

- p1 (Firefox) ICE **connected cleanly** at `19:25:07.139` (JVB confirms `Completed` at `.138`).
- At `19:25:17.077` Firefox's PeerConnection reported a transient **`ICE disconnected`** — a brief consent-check blip. **JVB never saw any disconnect** and kept the endpoint until the participant left.
- Media **recovered and kept flowing** (p1 rendered the rejoined peer's video at `19:25:19`, bridge channel delivered stats at `19:25:26`), but Firefox's `iceConnectionState` **never transitioned back to `connected`** — unlike Chrome.
- The next test started ~1s after the drop, so `waitForIceConnected` saw `disconnected` and timed out after 15s, failing an otherwise healthy spec.

## Fix

`waitForIceConnected` now accepts a transient `disconnected` state as connected **when stats show we are actually receiving media from the bridge** (`getStats().bitrate.download > 0`).

The change is purely **additive**:
- `connected` still passes immediately (unchanged behavior).
- Terminal `failed` / `closed` (and `checking`) still wait out the timeout.
- It can only let a genuinely-working-but-Firefox-flaky connection pass; it cannot introduce new failures.

`download` (receive) is used rather than `upload` because participants frequently join muted, so upload bitrate can legitimately be 0 — but receiving from the bridge proves the ICE pair is alive.