### PR TITLE
fix: Limit memory usage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: compile deploy
 
 compile: clean
 	NODE_OPTIONS=--max-old-space-size=8192 \
-	$(WEBPACK)
+	$(WEBPACK) --parallelism 1
 
 clean:
 	rm -fr $(BUILD_DIR)


### PR DESCRIPTION
On 9 bundles with a limit of 8GB we can hit up to 9x8GB of memory. This option reduces each compiler's internal concurrency but doesn't guarantee the 9 configs build one-at-a-time.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
