### PR TITLE
jitsi-meet no longer compatible with prosody-0.12

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Description: Configuration for web serving of Jitsi Meet
 
 Package: jitsi-meet-prosody
 Architecture: all
-Depends: openssl, prosody (>= 0.12.0) | prosody-trunk | prosody-0.12 | prosody-13.0, ca-certificates-java, lua-sec, lua-basexx, lua-luaossl, lua-cjson, lua-inspect
+Depends: openssl, prosody (>= 13.0.0) | prosody-trunk | prosody-13.0, ca-certificates-java, lua-sec, lua-basexx, lua-luaossl, lua-cjson, lua-inspect
 Replaces: jitsi-meet-tokens
 Description: Prosody configuration for Jitsi Meet
  Jitsi Meet is a WebRTC JavaScript application that uses Jitsi
@@ -48,7 +48,7 @@ Description: Prosody configuration for Jitsi Meet
 
 Package: jitsi-meet-tokens
 Architecture: all
-Depends: ${misc:Depends}, prosody-trunk | prosody-0.12 | prosody-13.0 | prosody (>= 0.12.0), jitsi-meet-prosody
+Depends: ${misc:Depends}, prosody-trunk | prosody-13.0 | prosody (>= 13.0.0), jitsi-meet-prosody
 Description: Prosody token authentication plugin for Jitsi Meet
 
 Package: jitsi-meet-turnserver


### PR DESCRIPTION
As seen at https://github.com/jitsi/jitsi-meet/issues/17303, jitsi-meet no longer works with prosody 0.12 (since https://github.com/jitsi/jitsi-meet/commit/15ebf0d078efb63e68e85f529b3e41ed8accddbe following non-backward compatible change in prosody in https://hg.prosody.im/trunk/rev/d10957394a3c where `util.*` modules have had a `prosody.` prefix added as part of https://issues.prosody.im/1223 for 0.13)

Updating Debian package dependencies to reflect that.