### PR TITLE
feat(multi-screen): render a meeting surface on a second screen via the iframe API

### DIFF
--- a/config.js
+++ b/config.js
@@ -1578,6 +1578,15 @@ var config = {
     // If true, tile view will not be enabled automatically when the participants count threshold is reached.
     // disableTileView: true,
 
+    // Multi-screen support: lets an embedder (via the iframe External API `setSecondScreen` command)
+    // render a meeting surface (the active-speaker stage, the screenshare, or a pinned participant) on
+    // a second display, in its own fullscreen window. Disabled by default; it is Chromium-only and
+    // intended for managed/kiosk room appliances, which must also delegate `allow="window-management;
+    // fullscreen"` to the iframe and grant the window-management + automatic-fullscreen permissions.
+    // secondScreen: {
+    //     enabled: false
+    // },
+
     // If true, the tiles will be displayed contained within the available space rather than enlarged to cover it,
     // with a 16:9 aspect ratio (old behaviour).
     // disableTileEnlargement: true,

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -99,6 +99,7 @@ import {
     resizeLargeVideo
 } from '../../react/features/large-video/actions.web';
 import { answerKnockingParticipant, toggleLobbyMode } from '../../react/features/lobby/actions';
+import { setSecondScreen } from '../../react/features/multi-screen/actions.web';
 import { setNoiseSuppressionEnabled } from '../../react/features/noise-suppression/actions';
 import { hideNotification, showNotification } from '../../react/features/notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE } from '../../react/features/notifications/constants';
@@ -544,6 +545,9 @@ function initCommands() {
             sendAnalytics(createApiEvent('tile-view.toggled'));
 
             APP.store.dispatch(toggleTileView());
+        },
+        'set-second-screen': (options = {}) => {
+            APP.store.dispatch(setSecondScreen(options.id ?? 'default', options.source, options.screen));
         },
         'set-tile-view': enabled => {
             APP.store.dispatch(setTileView(enabled));
@@ -2416,6 +2420,47 @@ class API {
         logger.debug('Sending pip-left event to External API');
         this._sendEvent({
             name: 'pip-left'
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that a second-screen window now renders a
+     * given source/participant.
+     *
+     * @param {Object} data - The event payload ({ id, source, participantId }).
+     * @returns {void}
+     */
+    notifySecondScreenSourceChanged(data) {
+        this._sendEvent({
+            name: 'second-screen-source-changed',
+            ...data
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that a second-screen window was closed.
+     *
+     * @param {Object} data - The event payload ({ id }).
+     * @returns {void}
+     */
+    notifySecondScreenClosed(data) {
+        this._sendEvent({
+            name: 'second-screen-closed',
+            ...data
+        });
+    }
+
+    /**
+     * Notify external application (if API is enabled) that a second-screen window could not be
+     * opened/updated (e.g. popup blocked or the feature disabled).
+     *
+     * @param {Object} data - The event payload ({ id, error }).
+     * @returns {void}
+     */
+    notifySecondScreenError(data) {
+        this._sendEvent({
+            name: 'second-screen-error',
+            ...data
         });
     }
 

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -70,6 +70,7 @@ const commands = {
     setMeetingTimer: 'set-meeting-timer',
     setNoiseSuppressionEnabled: 'set-noise-suppression-enabled',
     setParticipantVolume: 'set-participant-volume',
+    setSecondScreen: 'set-second-screen',
     setSubtitles: 'set-subtitles',
     setTileView: 'set-tile-view',
     setVideoQuality: 'set-video-quality',
@@ -110,6 +111,9 @@ const events = {
     '_pip-requested': '_pipRequested',
     'pip-entered': 'pipEntered',
     'pip-left': 'pipLeft',
+    'second-screen-source-changed': 'secondScreenSourceChanged',
+    'second-screen-closed': 'secondScreenClosed',
+    'second-screen-error': 'secondScreenError',
     'avatar-changed': 'avatarChanged',
     'audio-availability-changed': 'audioAvailabilityChanged',
     'audio-mute-status-changed': 'audioMuteStatusChanged',
@@ -368,10 +372,16 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             'clipboard-write',
             'compute-pressure',
             'display-capture',
+            'fullscreen',
             'hid',
             'microphone',
             'screen-wake-lock',
-            'speaker-selection'
+            'speaker-selection',
+
+            // Needed by the multi-screen feature (`setSecondScreen`) to enumerate displays and place
+            // a window on a second screen. Only delegates the capability; the actual permission is
+            // still user/policy-gated (granted on managed/kiosk devices).
+            'window-management'
         ].join('; ');
         this._frame.name = frameName;
         this._frame.id = frameName;

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1,4 +1,3 @@
-import { BrowserDetection } from '@jitsi/js-utils/browser-detection';
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
 import EventEmitter from 'events';
 
@@ -383,10 +382,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
 
         // Needed by the multi-screen feature (`setSecondScreen`) to enumerate displays and place
         // a window on a second screen. Only delegates the capability; the actual permission is
-        // still user/policy-gated (granted on managed/kiosk devices). Gated to Chromium engines
-        // because `window-management` is Chromium-only and the directive logs a console warning on
-        // browsers that do not recognize it.
-        if (new BrowserDetection().isChromiumBased()) {
+        // still user/policy-gated (granted on managed/kiosk devices). Gated to engines that expose
+        // the Window Management API (Chromium): elsewhere the directive is unrecognized and logs a
+        // console warning. Checking for the API directly avoids pulling a browser-detection library
+        // into this (size-limited) embedder bundle.
+        if ('getScreenDetails' in window) {
             allow.push('window-management');
         }
 

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -1,3 +1,4 @@
+import { BrowserDetection } from '@jitsi/js-utils/browser-detection';
 import { jitsiLocalStorage } from '@jitsi/js-utils/jitsi-local-storage';
 import EventEmitter from 'events';
 
@@ -366,7 +367,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow = [
+
+        const allow = [
             'autoplay',
             'camera',
             'clipboard-write',
@@ -376,13 +378,19 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             'hid',
             'microphone',
             'screen-wake-lock',
-            'speaker-selection',
+            'speaker-selection'
+        ];
 
-            // Needed by the multi-screen feature (`setSecondScreen`) to enumerate displays and place
-            // a window on a second screen. Only delegates the capability; the actual permission is
-            // still user/policy-gated (granted on managed/kiosk devices).
-            'window-management'
-        ].join('; ');
+        // Needed by the multi-screen feature (`setSecondScreen`) to enumerate displays and place
+        // a window on a second screen. Only delegates the capability; the actual permission is
+        // still user/policy-gated (granted on managed/kiosk devices). Gated to Chromium engines
+        // because `window-management` is Chromium-only and the directive logs a console warning on
+        // browsers that do not recognize it.
+        if (new BrowserDetection().isChromiumBased()) {
+            allow.push('window-management');
+        }
+
+        this._frame.allow = allow.join('; ');
         this._frame.name = frameName;
         this._frame.id = frameName;
         this._setSize(height, width);

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
         "@types/uuid": "8.3.4",
         "@types/w3c-image-capture": "1.0.6",
         "@types/w3c-web-hid": "1.0.3",
+        "@types/webscreens-window-placement": "0.1.3",
         "@types/zxcvbn": "4.4.1",
         "@wdio/allure-reporter": "9.27.0",
         "@wdio/cli": "9.27.0",
@@ -8059,6 +8060,13 @@
       "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.32.tgz",
       "integrity": "sha512-+F0Ozq+ksnKtjcMHujSgb4A1Vjt0b4wvvxP3/pTnXKsIrLo34EgHh2z3qJq3ntX4dbK6ytxpY1rzO/4Z8rVrHg==",
       "dev": true
+    },
+    "node_modules/@types/webscreens-window-placement": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/webscreens-window-placement/-/webscreens-window-placement-0.1.3.tgz",
+      "integrity": "sha512-OunHLGJkmAuNlvd7PrRbQy/VleLyxxP3NKwuUo9OS412vO/tzKGwW2K3FqvnM1yebTkCM0W+gszr08m9oDz0lg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/which": {
       "version": "2.0.2",
@@ -32731,6 +32739,12 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/webrtc/-/webrtc-0.0.32.tgz",
       "integrity": "sha512-+F0Ozq+ksnKtjcMHujSgb4A1Vjt0b4wvvxP3/pTnXKsIrLo34EgHh2z3qJq3ntX4dbK6ytxpY1rzO/4Z8rVrHg==",
+      "dev": true
+    },
+    "@types/webscreens-window-placement": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/webscreens-window-placement/-/webscreens-window-placement-0.1.3.tgz",
+      "integrity": "sha512-OunHLGJkmAuNlvd7PrRbQy/VleLyxxP3NKwuUo9OS412vO/tzKGwW2K3FqvnM1yebTkCM0W+gszr08m9oDz0lg==",
       "dev": true
     },
     "@types/which": {

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@types/uuid": "8.3.4",
     "@types/w3c-image-capture": "1.0.6",
     "@types/w3c-web-hid": "1.0.3",
+    "@types/webscreens-window-placement": "0.1.3",
     "@types/zxcvbn": "4.4.1",
     "@wdio/allure-reporter": "9.27.0",
     "@wdio/cli": "9.27.0",

--- a/react/features/app/middlewares.web.ts
+++ b/react/features/app/middlewares.web.ts
@@ -9,6 +9,7 @@ import '../dynamic-branding/middleware';
 import '../e2ee/middleware';
 import '../external-api/middleware';
 import '../keyboard-shortcuts/middleware';
+import '../multi-screen/middleware.web';
 import '../no-audio-signal/middleware';
 import '../notifications/middleware';
 import '../noise-detection/middleware';

--- a/react/features/app/reducers.web.ts
+++ b/react/features/app/reducers.web.ts
@@ -6,6 +6,7 @@ import '../e2ee/reducer';
 import '../face-landmarks/reducer';
 import '../feedback/reducer';
 import '../keyboard-shortcuts/reducer';
+import '../multi-screen/reducer';
 import '../no-audio-signal/reducer';
 import '../noise-detection/reducer';
 import '../participants-pane/reducer';

--- a/react/features/app/types.ts
+++ b/react/features/app/types.ts
@@ -53,6 +53,7 @@ import { IMobileAudioModeState } from '../mobile/audio-mode/reducer';
 import { IMobileBackgroundState } from '../mobile/background/reducer';
 import { ICallIntegrationState } from '../mobile/call-integration/reducer';
 import { IMobileExternalApiState } from '../mobile/external-api/reducer';
+import { IMultiScreenState } from '../multi-screen/reducer';
 import { INoAudioSignalState } from '../no-audio-signal/reducer';
 import { INoiseDetectionState } from '../noise-detection/reducer';
 import { INoiseSuppressionState } from '../noise-suppression/reducer';
@@ -144,6 +145,7 @@ export interface IReduxState {
     'features/mobile/audio-mode': IMobileAudioModeState;
     'features/mobile/background': IMobileBackgroundState;
     'features/mobile/external-api': IMobileExternalApiState;
+    'features/multi-screen': IMultiScreenState;
     'features/no-audio-signal': INoAudioSignalState;
     'features/noise-detection': INoiseDetectionState;
     'features/noise-suppression': INoiseSuppressionState;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -653,6 +653,17 @@ export interface IConfig {
         enabled?: boolean;
         mode?: 'always' | 'recording';
     };
+
+    /**
+     * Multi-screen support. When enabled, an embedder can use the iframe External
+     * API `setSecondScreen` command to render a meeting surface (the stage, the
+     * screenshare, or a pinned participant) on a second display in its own
+     * fullscreen window. Chromium-only; intended for managed/kiosk room
+     * appliances. Disabled by default.
+     */
+    secondScreen?: {
+        enabled?: boolean;
+    };
     securityUi?: {
         disableLobbyPassword?: boolean;
         hideLobbyButton?: boolean;

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -219,6 +219,7 @@ export default [
     'replaceParticipant',
     'resolution',
     'screenshotCapture',
+    'secondScreen',
     'securityUi',
     'showChatPermissionsModeratorSetting',
     'speakerStats',

--- a/react/features/multi-screen/actionTypes.ts
+++ b/react/features/multi-screen/actionTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * The type of (redux) action which opens or updates a second-screen window with
+ * a given source descriptor.
+ *
+ * {
+ *     type: SET_SECOND_SCREEN,
+ *     id: string,
+ *     source: ISecondScreenSource,
+ *     screenId?: number
+ * }
+ */
+export const SET_SECOND_SCREEN = 'SET_SECOND_SCREEN';
+
+/**
+ * The type of (redux) action which closes a single second-screen window.
+ *
+ * {
+ *     type: REMOVE_SECOND_SCREEN,
+ *     id: string
+ * }
+ */
+export const REMOVE_SECOND_SCREEN = 'REMOVE_SECOND_SCREEN';
+
+/**
+ * The type of (redux) action which closes all second-screen windows (e.g. when
+ * the conference ends).
+ *
+ * {
+ *     type: RESET_SECOND_SCREENS
+ * }
+ */
+export const RESET_SECOND_SCREENS = 'RESET_SECOND_SCREENS';

--- a/react/features/multi-screen/actionTypes.ts
+++ b/react/features/multi-screen/actionTypes.ts
@@ -12,6 +12,19 @@
 export const SET_SECOND_SCREEN = 'SET_SECOND_SCREEN';
 
 /**
+ * The type of (redux) action which attaches the live window handle (the
+ * {@code Window}, its {@code <video>} and tracks) to a second-screen entry,
+ * once the middleware has opened the window.
+ *
+ * {
+ *     type: SET_SECOND_SCREEN_WINDOW,
+ *     id: string,
+ *     handle: unknown
+ * }
+ */
+export const SET_SECOND_SCREEN_WINDOW = 'SET_SECOND_SCREEN_WINDOW';
+
+/**
  * The type of (redux) action which closes a single second-screen window.
  *
  * {

--- a/react/features/multi-screen/actions.web.ts
+++ b/react/features/multi-screen/actions.web.ts
@@ -1,0 +1,48 @@
+import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
+import { ISecondScreenSource } from './types';
+
+/**
+ * Opens or updates the second-screen window identified by {@code id} to render
+ * the given source. Passing an empty/invalid source closes that window instead.
+ *
+ * @param {string} id - The window identifier (allows more than one second screen).
+ * @param {ISecondScreenSource} source - What to render.
+ * @param {number} screenId - Optional physical screen index to place the window on.
+ * @returns {Object}
+ */
+export function setSecondScreen(id: string, source?: ISecondScreenSource, screenId?: number) {
+    if (!source || (!source.role && !source.participant)) {
+        return { type: REMOVE_SECOND_SCREEN, id };
+    }
+
+    return {
+        type: SET_SECOND_SCREEN,
+        id,
+        source,
+        screenId
+    };
+}
+
+/**
+ * Closes a single second-screen window.
+ *
+ * @param {string} id - The window identifier.
+ * @returns {{ type: REMOVE_SECOND_SCREEN, id: string }}
+ */
+export function removeSecondScreen(id: string) {
+    return {
+        type: REMOVE_SECOND_SCREEN,
+        id
+    };
+}
+
+/**
+ * Closes all second-screen windows.
+ *
+ * @returns {{ type: RESET_SECOND_SCREENS }}
+ */
+export function resetSecondScreens() {
+    return {
+        type: RESET_SECOND_SCREENS
+    };
+}

--- a/react/features/multi-screen/actions.web.ts
+++ b/react/features/multi-screen/actions.web.ts
@@ -1,4 +1,9 @@
-import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
+import {
+    REMOVE_SECOND_SCREEN,
+    RESET_SECOND_SCREENS,
+    SET_SECOND_SCREEN,
+    SET_SECOND_SCREEN_WINDOW
+} from './actionTypes';
 import { ISecondScreenSource } from './types';
 
 /**
@@ -20,6 +25,24 @@ export function setSecondScreen(id: string, source?: ISecondScreenSource, screen
         id,
         source,
         screenId
+    };
+}
+
+/**
+ * Attaches the live window handle to a second-screen entry once the middleware
+ * has opened the window. The handle is typed opaquely ({@code unknown}) because
+ * it holds DOM/media objects the shared/native build cannot type; see
+ * {@code functions.web.ts}.
+ *
+ * @param {string} id - The window identifier.
+ * @param {unknown} handle - The live window handle.
+ * @returns {{ type: SET_SECOND_SCREEN_WINDOW, id: string, handle: unknown }}
+ */
+export function setSecondScreenWindow(id: string, handle: unknown) {
+    return {
+        type: SET_SECOND_SCREEN_WINDOW,
+        id,
+        handle
     };
 }
 

--- a/react/features/multi-screen/constants.ts
+++ b/react/features/multi-screen/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * The default window id used when the embedder does not specify one.
+ */
+export const DEFAULT_SECOND_SCREEN_ID = 'default';
+
+/**
+ * Default size of a second-screen window when physical-screen placement is not
+ * available. On a managed/kiosk device the Window Management API sizes it to the
+ * target display instead.
+ */
+export const DEFAULT_WINDOW_WIDTH = 1280;
+export const DEFAULT_WINDOW_HEIGHT = 720;

--- a/react/features/multi-screen/constants.ts
+++ b/react/features/multi-screen/constants.ts
@@ -2,11 +2,3 @@
  * The default window id used when the embedder does not specify one.
  */
 export const DEFAULT_SECOND_SCREEN_ID = 'default';
-
-/**
- * Default size of a second-screen window when physical-screen placement is not
- * available. On a managed/kiosk device the Window Management API sizes it to the
- * target display instead.
- */
-export const DEFAULT_WINDOW_WIDTH = 1280;
-export const DEFAULT_WINDOW_HEIGHT = 720;

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -1,0 +1,383 @@
+import { IReduxState, IStore } from '../app/types';
+import { MEDIA_TYPE, VIDEO_TYPE } from '../base/media/constants';
+import { getTrackByMediaTypeAndParticipant, getVideoTrackByParticipant } from '../base/tracks/functions.any';
+import { getLargeVideoParticipant } from '../large-video/functions';
+
+import { removeSecondScreen } from './actions.web';
+import { DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH } from './constants';
+import logger from './logger';
+import { ISecondScreenSource } from './types';
+
+/**
+ * Minimal typings for the Window Management API, not yet in the TS DOM lib.
+ * Declared in this web-only module so the native build never sees it.
+ */
+interface IScreenDetailed {
+    availHeight: number;
+    availLeft: number;
+    availTop: number;
+    availWidth: number;
+    left: number;
+    top: number;
+}
+interface IScreenDetails {
+    currentScreen: IScreenDetailed;
+    screens: IScreenDetailed[];
+}
+declare global {
+
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface Window {
+        getScreenDetails?: () => Promise<IScreenDetails>;
+    }
+}
+
+/**
+ * A second-screen window, constructed via {@code window.open} in the same
+ * origin/process as the meeting so its {@code <video>} can render the meeting's
+ * tracks by reference.
+ */
+type ISecondScreenWindow = Window & { MediaStream: typeof MediaStream; };
+
+interface IWindowEntry {
+    clone?: MediaStreamTrack;
+    screenId?: number;
+    source: ISecondScreenSource;
+    video: HTMLVideoElement;
+    win: Window;
+}
+
+/**
+ * The live second-screen windows, keyed by id. Module scope because the windows
+ * outlive any single React render and the middleware reconciles them.
+ */
+const windows = new Map<string, IWindowEntry>();
+
+/**
+ * Whether second-screen windows can be opened in this environment.
+ *
+ * @returns {boolean}
+ */
+export function isSecondScreenSupported(): boolean {
+    return typeof window !== 'undefined' && typeof window.open === 'function';
+}
+
+/**
+ * Whether the multi-screen feature is enabled (config flag + support). The
+ * Window Management API and AutomaticFullscreen permission (Chromium, managed
+ * kiosk) are used opportunistically and degrade gracefully when absent.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {boolean}
+ */
+export function isSecondScreenEnabled(state: IReduxState): boolean {
+    return Boolean(state['features/base/config'].secondScreen?.enabled) && isSecondScreenSupported();
+}
+
+/**
+ * Resolves a source descriptor to a native {@code MediaStreamTrack} and the
+ * participant currently backing it.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {ISecondScreenSource} source - The source descriptor.
+ * @returns {Object} The resolved native track and backing participant id.
+ */
+function resolveSource(state: IReduxState, source: ISecondScreenSource) {
+    const tracks = state['features/base/tracks'];
+    let iTrack;
+    let participantId: string | undefined;
+
+    if (source.role === 'stage') {
+        const participant = getLargeVideoParticipant(state);
+
+        participantId = participant?.id;
+        iTrack = getVideoTrackByParticipant(state, participant);
+    } else if (source.role === 'screenshare') {
+        iTrack = tracks.find(t => t.videoType === VIDEO_TYPE.DESKTOP && !t.muted && Boolean(t.jitsiTrack));
+        participantId = iTrack?.participantId;
+    } else if (source.participant) {
+        participantId = source.participant;
+        const mediaType = source.media === 'desktop' ? MEDIA_TYPE.SCREENSHARE : MEDIA_TYPE.VIDEO;
+
+        iTrack = getTrackByMediaTypeAndParticipant(tracks, mediaType, source.participant);
+    }
+
+    return {
+        track: (iTrack?.jitsiTrack?.getTrack?.() as MediaStreamTrack) ?? null,
+        participantId: participantId ?? null
+    };
+}
+
+/**
+ * A stable signature of what every second-screen window should currently render
+ * (its resolved track id). When it changes — e.g. the active speaker switches —
+ * the subscriber re-applies the sources, swapping {@code srcObject} in place.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {string}
+ */
+export function getSecondScreenSignature(state: IReduxState): string {
+    const { screens } = state['features/multi-screen'];
+
+    return Object.keys(screens).sort()
+        .map(id => {
+            const { track } = resolveSource(state, screens[id].source);
+
+            return `${id}:${track ? track.id : 'none'}`;
+        })
+        .join('|');
+}
+
+/**
+ * Computes the {@code window.open} features string, placing the window on a
+ * physical screen via the Window Management API when available.
+ *
+ * @param {number} screenId - Optional target screen index.
+ * @returns {Promise<string>}
+ */
+async function computeFeatures(screenId?: number): Promise<string> {
+    const fallback = `popup,width=${DEFAULT_WINDOW_WIDTH},height=${DEFAULT_WINDOW_HEIGHT}`;
+
+    if (typeof window.getScreenDetails !== 'function') {
+        return fallback;
+    }
+
+    try {
+        const details = await window.getScreenDetails();
+        const screen = typeof screenId === 'number' && details.screens[screenId]
+            ? details.screens[screenId]
+            : details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top);
+
+        if (screen) {
+            return `popup,left=${screen.availLeft},top=${screen.availTop},width=${screen.availWidth},height=${screen.availHeight}`;
+        }
+    } catch (e) {
+        logger.warn('getScreenDetails failed; opening an unplaced window', e);
+    }
+
+    return fallback;
+}
+
+/**
+ * Builds the (empty) second-screen document: a full-bleed video on black. Uses
+ * element styles (not a stylesheet/inline script) to stay CSP-safe.
+ *
+ * @param {Window} win - The opened window.
+ * @returns {HTMLVideoElement}
+ */
+function buildWindow(win: Window): HTMLVideoElement {
+    const doc = win.document;
+
+    doc.title = 'Jitsi Meet';
+    Object.assign(doc.documentElement.style, { height: '100%' });
+    Object.assign(doc.body.style, { margin: '0', height: '100%', background: '#000', overflow: 'hidden' });
+
+    const video = doc.createElement('video');
+
+    video.autoplay = true;
+    video.muted = true;
+    video.setAttribute('playsinline', '');
+    Object.assign(video.style, {
+        position: 'fixed', inset: '0', width: '100%', height: '100%', objectFit: 'contain', background: '#000'
+    });
+    doc.body.appendChild(video);
+
+    return video;
+}
+
+/**
+ * Renders a track into a window's video by reference (cloning so the meeting
+ * keeps its own copy), stopping any previously rendered clone.
+ *
+ * @param {IWindowEntry} entry - The window entry.
+ * @param {MediaStreamTrack | null} track - The track to render.
+ * @returns {void}
+ */
+function renderTrack(entry: IWindowEntry, track: MediaStreamTrack | null) {
+    if (entry.clone) {
+        try {
+            entry.clone.stop();
+        } catch (e) { /* ignore */ }
+        entry.clone = undefined;
+    }
+    if (!track) {
+        entry.video.srcObject = null;
+
+        return;
+    }
+    const clone = track.clone();
+
+    entry.clone = clone;
+    entry.video.srcObject = new (entry.win as ISecondScreenWindow).MediaStream([ clone ]);
+}
+
+/**
+ * Notifies the iframe embedder that a window's resolved source changed.
+ *
+ * @param {string} id - The window id.
+ * @param {ISecondScreenSource} source - The window's source descriptor.
+ * @param {string | null} participantId - The participant currently backing it.
+ * @returns {void}
+ */
+function notifySourceChanged(id: string, source: ISecondScreenSource, participantId: string | null) {
+    APP.API?.notifySecondScreenSourceChanged?.({ id, source, participantId });
+}
+
+/**
+ * Resolves and renders the current track for a window, and notifies the embedder.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @returns {void}
+ */
+function applySource(store: IStore, id: string) {
+    const entry = windows.get(id);
+
+    if (!entry || entry.win.closed) {
+        return;
+    }
+    const { track, participantId } = resolveSource(store.getState(), entry.source);
+
+    renderTrack(entry, track);
+    notifySourceChanged(id, entry.source, participantId);
+}
+
+/**
+ * Cleans up an entry's resources without dispatching (used by both explicit
+ * close and the window being closed externally).
+ *
+ * @param {string} id - The window id.
+ * @param {boolean} closeWindow - Whether to also close the OS window.
+ * @returns {void}
+ */
+function teardown(id: string, closeWindow: boolean) {
+    const entry = windows.get(id);
+
+    if (!entry) {
+        return;
+    }
+    if (entry.clone) {
+        try {
+            entry.clone.stop();
+        } catch (e) { /* ignore */ }
+    }
+    windows.delete(id);
+    if (closeWindow) {
+        try {
+            !entry.win.closed && entry.win.close();
+        } catch (e) { /* ignore */ }
+    }
+}
+
+/**
+ * Handles the user closing a second-screen window directly: clean up and reflect
+ * it in state.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @returns {void}
+ */
+function handleWindowClosed(store: IStore, id: string) {
+    if (!windows.has(id)) {
+        return;
+    }
+    teardown(id, false);
+    APP.API?.notifySecondScreenClosed?.({ id });
+    store.dispatch(removeSecondScreen(id));
+}
+
+/**
+ * Opens a new second-screen window (or updates an existing one) and renders the
+ * given source. Best-effort placement + fullscreen; both require the Window
+ * Management / AutomaticFullscreen permissions on a managed/kiosk device.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {ISecondScreenSource} source - What to render.
+ * @param {number} screenId - Optional target screen index.
+ * @returns {Promise<void>}
+ */
+export async function openOrUpdateSecondScreen(
+        store: IStore, id: string, source: ISecondScreenSource, screenId?: number): Promise<void> {
+    if (!isSecondScreenEnabled(store.getState())) {
+        APP.API?.notifySecondScreenError?.({ id, error: 'second-screen-disabled' });
+
+        return;
+    }
+
+    const existing = windows.get(id);
+
+    if (existing && !existing.win.closed) {
+        existing.source = source;
+        existing.screenId = screenId;
+        applySource(store, id);
+
+        return;
+    }
+
+    const features = await computeFeatures(screenId);
+    const win = window.open('', `jitsiSecondScreen_${id}`, features);
+
+    if (!win) {
+        logger.warn(`Failed to open second-screen window "${id}" (popup blocked?)`);
+        APP.API?.notifySecondScreenError?.({ id, error: 'popup-blocked' });
+        store.dispatch(removeSecondScreen(id));
+
+        return;
+    }
+
+    const entry: IWindowEntry = { win, source, screenId, video: buildWindow(win) };
+
+    windows.set(id, entry);
+    win.addEventListener('pagehide', () => handleWindowClosed(store, id), { once: true });
+
+    try {
+        await win.document.documentElement.requestFullscreen();
+    } catch (e) {
+        logger.debug(`Auto-fullscreen not granted for second screen "${id}"`, e);
+    }
+
+    applySource(store, id);
+}
+
+/**
+ * Closes a single second-screen window.
+ *
+ * @param {string} id - The window id.
+ * @returns {void}
+ */
+export function closeSecondScreen(id: string) {
+    if (!windows.has(id)) {
+        return;
+    }
+    teardown(id, true);
+    APP.API?.notifySecondScreenClosed?.({ id });
+}
+
+/**
+ * Closes every second-screen window.
+ *
+ * @returns {void}
+ */
+export function closeAllSecondScreens() {
+    Array.from(windows.keys()).forEach(closeSecondScreen);
+}
+
+/**
+ * Re-resolves and re-renders every open second-screen window. Called by the
+ * subscriber when the active speaker / tracks change.
+ *
+ * @param {IStore} store - The redux store.
+ * @returns {void}
+ */
+export function refreshSecondScreens(store: IStore) {
+    Array.from(windows.keys()).forEach(id => {
+        const entry = windows.get(id);
+
+        if (entry?.win.closed) {
+            handleWindowClosed(store, id);
+        } else {
+            applySource(store, id);
+        }
+    });
+}

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -6,7 +6,7 @@ import { getTrackByMediaTypeAndParticipant, getVideoTrackByParticipant } from '.
 import { getLargeVideoParticipant } from '../large-video/functions';
 import { renderAvatarOnCanvas } from '../pip/functions';
 
-import { removeSecondScreen } from './actions.web';
+import { removeSecondScreen, setSecondScreenWindow } from './actions.web';
 import logger from './logger';
 import { ISecondScreenSource } from './types';
 
@@ -27,12 +27,13 @@ type ISecondScreenWindow = Window & { MediaStream: typeof MediaStream; };
 type IFrameRequestingTrack = MediaStreamTrack & { requestFrame?: () => void; };
 
 /**
- * The live handles backing a single second-screen window. Only the
- * non-serializable DOM/media objects live here; the window's source/screen
- * configuration is held in redux ({@code features/multi-screen}), which is the
- * single source of truth.
+ * The live, non-serializable handles backing a single second-screen window. This
+ * object is stored on the redux entry (typed opaquely there as {@code unknown}
+ * because the shared/native build has no DOM lib) and mutated in place as the
+ * rendered source changes — the same way the rest of the app keeps mutable
+ * lib-jitsi-meet objects in redux.
  */
-interface IWindowEntry {
+interface ISecondScreenHandle {
 
     /**
      * The off-screen canvas used to render a participant's avatar when their
@@ -70,14 +71,6 @@ interface IWindowEntry {
 }
 
 /**
- * The live second-screen windows, keyed by id. Module scope because the windows
- * (and their {@code Window}/{@code <video>}/cloned-track objects) are not
- * serializable and outlive any single React render; redux holds the serializable
- * configuration and the middleware reconciles the two.
- */
-const windows = new Map<string, IWindowEntry>();
-
-/**
  * The avatar canvas is rendered at a modest 4:3 size and scaled up by the
  * full-bleed {@code <video>} (object-fit: contain) on the second screen.
  */
@@ -90,6 +83,18 @@ const AVATAR_CANVAS_HEIGHT = 480;
 const AVATAR_BACKGROUND = '#000';
 const AVATAR_TEXT_COLOR = '#fff';
 const AVATAR_FONT_FAMILY = 'Inter, sans-serif';
+
+/**
+ * Returns the live window handle for a second screen, or {@code undefined} if
+ * its window has not been opened yet.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {string} id - The window id.
+ * @returns {ISecondScreenHandle | undefined}
+ */
+function getHandle(state: IReduxState, id: string): ISecondScreenHandle | undefined {
+    return state['features/multi-screen'].screens[id]?.handle as ISecondScreenHandle | undefined;
+}
 
 /**
  * Whether second-screen windows can be opened in this environment. The feature
@@ -225,19 +230,19 @@ function buildWindow(win: Window): HTMLVideoElement {
  * Renders a meeting track into a window's video by reference (cloning so the
  * meeting keeps its own copy), stopping any previously rendered clone.
  *
- * @param {IWindowEntry} entry - The window entry.
+ * @param {ISecondScreenHandle} handle - The window handle.
  * @param {MediaStreamTrack} track - The track to render.
  * @returns {void}
  */
-function renderTrack(entry: IWindowEntry, track: MediaStreamTrack) {
-    if (entry.clone) {
-        entry.clone.stop();
-        entry.clone = undefined;
+function renderTrack(handle: ISecondScreenHandle, track: MediaStreamTrack) {
+    if (handle.clone) {
+        handle.clone.stop();
+        handle.clone = undefined;
     }
     const clone = track.clone();
 
-    entry.clone = clone;
-    entry.video.srcObject = new (entry.win as ISecondScreenWindow).MediaStream([ clone ]);
+    handle.clone = clone;
+    handle.video.srcObject = new (handle.win as ISecondScreenWindow).MediaStream([ clone ]);
 }
 
 /**
@@ -247,17 +252,17 @@ function renderTrack(entry: IWindowEntry, track: MediaStreamTrack) {
  * the window by reference, mirroring {@link renderTrack}.
  *
  * @param {IReduxState} state - The redux state.
- * @param {IWindowEntry} entry - The window entry.
+ * @param {ISecondScreenHandle} handle - The window handle.
  * @param {IParticipant | undefined} participant - The participant whose avatar to render.
  * @returns {void}
  */
-function renderAvatar(state: IReduxState, entry: IWindowEntry, participant: IParticipant | undefined) {
-    if (entry.clone) {
-        entry.clone.stop();
-        entry.clone = undefined;
+function renderAvatar(state: IReduxState, handle: ISecondScreenHandle, participant: IParticipant | undefined) {
+    if (handle.clone) {
+        handle.clone.stop();
+        handle.clone = undefined;
     }
 
-    let canvas = entry.avatarCanvas;
+    let canvas = handle.avatarCanvas;
 
     if (!canvas) {
         canvas = document.createElement('canvas');
@@ -267,16 +272,16 @@ function renderAvatar(state: IReduxState, entry: IWindowEntry, participant: IPar
         // captureStream(0): on-demand; we push a frame via requestFrame() after each draw.
         const track = canvas.captureStream(0).getVideoTracks()[0] as IFrameRequestingTrack;
 
-        entry.avatarCanvas = canvas;
-        entry.avatarTrack = track;
+        handle.avatarCanvas = canvas;
+        handle.avatarTrack = track;
 
         // The track is created in this (meeting) document; wrap it in the second window's
         // MediaStream so its <video> renders it by reference (same trick as renderTrack()).
-        entry.avatarSrc = new (entry.win as ISecondScreenWindow).MediaStream([ track ]);
+        handle.avatarSrc = new (handle.win as ISecondScreenWindow).MediaStream([ track ]);
     }
 
-    if (entry.video.srcObject !== entry.avatarSrc) {
-        entry.video.srcObject = entry.avatarSrc ?? null;
+    if (handle.video.srcObject !== handle.avatarSrc) {
+        handle.video.srcObject = handle.avatarSrc ?? null;
     }
 
     const ctx = canvas.getContext('2d');
@@ -292,7 +297,7 @@ function renderAvatar(state: IReduxState, entry: IWindowEntry, participant: IPar
     renderAvatarOnCanvas(
         canvas, ctx, participant, displayName, customAvatarBackgrounds,
         null, AVATAR_BACKGROUND, AVATAR_FONT_FAMILY, AVATAR_TEXT_COLOR, AVATAR_TEXT_COLOR)
-        .then(() => entry.avatarTrack?.requestFrame?.())
+        .then(() => handle.avatarTrack?.requestFrame?.())
         .catch(e => logger.warn('Failed to render second-screen avatar', e));
 }
 
@@ -310,75 +315,62 @@ function notifySourceChanged(id: string, source: ISecondScreenSource, participan
 
 /**
  * Resolves and renders the current source for a window, and notifies the
- * embedder. Reads the window's configured source from redux (the single source
- * of truth). Falls back to the participant's avatar when there is no live video.
+ * embedder. Reads the window's configuration and live handle from redux (the
+ * single source of truth). Falls back to the participant's avatar when there is
+ * no live video.
  *
  * @param {IStore} store - The redux store.
  * @param {string} id - The window id.
  * @returns {void}
  */
 function applySource(store: IStore, id: string) {
-    const entry = windows.get(id);
-
-    if (!entry || entry.win.closed) {
-        return;
-    }
     const state = store.getState();
-    const config = state['features/multi-screen'].screens[id];
+    const entry = state['features/multi-screen'].screens[id];
+    const handle = getHandle(state, id);
 
-    if (!config) {
+    if (!entry || !handle || handle.win.closed) {
         return;
     }
-    const { track, participant } = resolveSource(state, config.source);
+    const { track, participant } = resolveSource(state, entry.source);
 
     if (track) {
-        renderTrack(entry, track);
+        renderTrack(handle, track);
     } else {
-        renderAvatar(state, entry, participant);
+        renderAvatar(state, handle, participant);
     }
-    notifySourceChanged(id, config.source, participant?.id ?? null);
+    notifySourceChanged(id, entry.source, participant?.id ?? null);
 }
 
 /**
- * Cleans up an entry's resources without dispatching (used by both explicit
- * close and the window being closed externally). The map entry is dropped before
- * the window is closed, so no reference to a closed window is retained.
+ * Stops a handle's tracks and (optionally) closes its window. Pure cleanup of
+ * the live objects; the redux entry is removed by the caller's action.
  *
- * @param {string} id - The window id.
+ * @param {ISecondScreenHandle} handle - The window handle.
  * @param {boolean} closeWindow - Whether to also close the OS window.
  * @returns {void}
  */
-function teardown(id: string, closeWindow: boolean) {
-    const entry = windows.get(id);
-
-    if (!entry) {
-        return;
-    }
-
+function teardownHandle(handle: ISecondScreenHandle, closeWindow: boolean) {
     // MediaStreamTrack.stop() is infallible per spec, so no try/catch.
-    entry.clone?.stop();
-    entry.avatarTrack?.stop();
-    windows.delete(id);
+    handle.clone?.stop();
+    handle.avatarTrack?.stop();
 
-    if (closeWindow && !entry.win.closed) {
-        entry.win.close();
+    if (closeWindow && !handle.win.closed) {
+        handle.win.close();
     }
 }
 
 /**
- * Handles the user closing a second-screen window directly: clean up and reflect
- * it in state.
+ * Handles the user closing a second-screen window directly: remove it from
+ * state, which tears it down and notifies the embedder via the REMOVE handler.
  *
  * @param {IStore} store - The redux store.
  * @param {string} id - The window id.
  * @returns {void}
  */
 function handleWindowClosed(store: IStore, id: string) {
-    if (!windows.has(id)) {
+    if (!getHandle(store.getState(), id)) {
         return;
     }
-    teardown(id, false);
-    APP.API?.notifySecondScreenClosed?.({ id });
     store.dispatch(removeSecondScreen(id));
 }
 
@@ -400,7 +392,7 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
         return;
     }
 
-    const existing = windows.get(id);
+    const existing = getHandle(store.getState(), id);
 
     if (existing) {
         if (!existing.win.closed) {
@@ -409,9 +401,9 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
             return;
         }
 
-        // The window was closed without us being notified; purge the stale entry (stopping its
-        // tracks) before reopening, so no handle to a closed window is retained.
-        teardown(id, false);
+        // The window was closed without us being notified; stop its tracks before reopening
+        // (its handle is overwritten by the dispatch below), so nothing leaks.
+        teardownHandle(existing, false);
     }
 
     let features;
@@ -436,9 +428,9 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
         return;
     }
 
-    const entry: IWindowEntry = { win, video: buildWindow(win) };
+    const handle: ISecondScreenHandle = { win, video: buildWindow(win) };
 
-    windows.set(id, entry);
+    store.dispatch(setSecondScreenWindow(id, handle));
     win.addEventListener('pagehide', () => handleWindowClosed(store, id), { once: true });
 
     try {
@@ -451,26 +443,32 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
 }
 
 /**
- * Closes a single second-screen window.
+ * Closes a single second-screen window: tears down its live handle and notifies
+ * the embedder. Called by the middleware as the window's entry is removed from
+ * state, so it does not dispatch itself.
  *
+ * @param {IStore} store - The redux store.
  * @param {string} id - The window id.
  * @returns {void}
  */
-export function closeSecondScreen(id: string) {
-    if (!windows.has(id)) {
+export function closeSecondScreen(store: IStore, id: string) {
+    const handle = getHandle(store.getState(), id);
+
+    if (!handle) {
         return;
     }
-    teardown(id, true);
+    teardownHandle(handle, true);
     APP.API?.notifySecondScreenClosed?.({ id });
 }
 
 /**
  * Closes every second-screen window.
  *
+ * @param {IStore} store - The redux store.
  * @returns {void}
  */
-export function closeAllSecondScreens() {
-    Array.from(windows.keys()).forEach(closeSecondScreen);
+export function closeAllSecondScreens(store: IStore) {
+    Object.keys(store.getState()['features/multi-screen'].screens).forEach(id => closeSecondScreen(store, id));
 }
 
 /**
@@ -481,12 +479,12 @@ export function closeAllSecondScreens() {
  * @returns {void}
  */
 export function refreshSecondScreens(store: IStore) {
-    Array.from(windows.keys()).forEach(id => {
-        const entry = windows.get(id);
+    Object.keys(store.getState()['features/multi-screen'].screens).forEach(id => {
+        const handle = getHandle(store.getState(), id);
 
-        if (entry?.win.closed) {
+        if (handle?.win.closed) {
             handleWindowClosed(store, id);
-        } else {
+        } else if (handle) {
             applySource(store, id);
         }
     });

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -1,36 +1,17 @@
 import { IReduxState, IStore } from '../app/types';
 import { MEDIA_TYPE, VIDEO_TYPE } from '../base/media/constants';
+import { getParticipantById, getParticipantDisplayName } from '../base/participants/functions';
+import { IParticipant } from '../base/participants/types';
 import { getTrackByMediaTypeAndParticipant, getVideoTrackByParticipant } from '../base/tracks/functions.any';
 import { getLargeVideoParticipant } from '../large-video/functions';
+import { renderAvatarOnCanvas } from '../pip/functions';
 
 import { removeSecondScreen } from './actions.web';
-import { DEFAULT_WINDOW_HEIGHT, DEFAULT_WINDOW_WIDTH } from './constants';
 import logger from './logger';
 import { ISecondScreenSource } from './types';
 
-/**
- * Minimal typings for the Window Management API, not yet in the TS DOM lib.
- * Declared in this web-only module so the native build never sees it.
- */
-interface IScreenDetailed {
-    availHeight: number;
-    availLeft: number;
-    availTop: number;
-    availWidth: number;
-    left: number;
-    top: number;
-}
-interface IScreenDetails {
-    currentScreen: IScreenDetailed;
-    screens: IScreenDetailed[];
-}
-declare global {
-
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    interface Window {
-        getScreenDetails?: () => Promise<IScreenDetails>;
-    }
-}
+// The Window Management API typings (Window.getScreenDetails, ScreenDetails, ScreenDetailed) come
+// from the `@types/webscreens-window-placement` devDependency.
 
 /**
  * A second-screen window, constructed via {@code window.open} in the same
@@ -39,33 +20,91 @@ declare global {
  */
 type ISecondScreenWindow = Window & { MediaStream: typeof MediaStream; };
 
+/**
+ * A canvas {@code captureStream} track exposes a non-standard {@code requestFrame}
+ * used to push a single frame on demand.
+ */
+type IFrameRequestingTrack = MediaStreamTrack & { requestFrame?: () => void; };
+
+/**
+ * The live handles backing a single second-screen window. Only the
+ * non-serializable DOM/media objects live here; the window's source/screen
+ * configuration is held in redux ({@code features/multi-screen}), which is the
+ * single source of truth.
+ */
 interface IWindowEntry {
+
+    /**
+     * The off-screen canvas used to render a participant's avatar when their
+     * video is unavailable (created lazily, reused across redraws).
+     */
+    avatarCanvas?: HTMLCanvasElement;
+
+    /**
+     * The second window's {@code MediaStream} wrapping the avatar canvas track
+     * (what {@code video.srcObject} points at while the avatar is shown).
+     */
+    avatarSrc?: MediaStream;
+
+    /**
+     * The avatar canvas {@code captureStream} track (kept to push frames and to
+     * stop it on teardown).
+     */
+    avatarTrack?: IFrameRequestingTrack;
+
+    /**
+     * The clone of the currently rendered meeting track (the meeting keeps its
+     * own copy; the clone is stopped when swapped out or on teardown).
+     */
     clone?: MediaStreamTrack;
-    screenId?: number;
-    source: ISecondScreenSource;
+
+    /**
+     * The {@code <video>} in the second window.
+     */
     video: HTMLVideoElement;
+
+    /**
+     * The second-screen window itself.
+     */
     win: Window;
 }
 
 /**
  * The live second-screen windows, keyed by id. Module scope because the windows
- * outlive any single React render and the middleware reconciles them.
+ * (and their {@code Window}/{@code <video>}/cloned-track objects) are not
+ * serializable and outlive any single React render; redux holds the serializable
+ * configuration and the middleware reconciles the two.
  */
 const windows = new Map<string, IWindowEntry>();
 
 /**
- * Whether second-screen windows can be opened in this environment.
+ * The avatar canvas is rendered at a modest 4:3 size and scaled up by the
+ * full-bleed {@code <video>} (object-fit: contain) on the second screen.
+ */
+const AVATAR_CANVAS_WIDTH = 640;
+const AVATAR_CANVAS_HEIGHT = 480;
+
+/**
+ * Avatar colours, matched to the black second-screen window background.
+ */
+const AVATAR_BACKGROUND = '#000';
+const AVATAR_TEXT_COLOR = '#fff';
+const AVATAR_FONT_FAMILY = 'Inter, sans-serif';
+
+/**
+ * Whether second-screen windows can be opened in this environment. The feature
+ * requires the Window Management API (Chromium) so it can enumerate displays and
+ * place the window on a second screen; without it we have no control over the
+ * second screen, so we do not support the feature.
  *
  * @returns {boolean}
  */
 export function isSecondScreenSupported(): boolean {
-    return typeof window !== 'undefined' && typeof window.open === 'function';
+    return typeof window !== 'undefined' && 'getScreenDetails' in window;
 }
 
 /**
- * Whether the multi-screen feature is enabled (config flag + support). The
- * Window Management API and AutomaticFullscreen permission (Chromium, managed
- * kiosk) are used opportunistically and degrade gracefully when absent.
+ * Whether the multi-screen feature is enabled (config flag + support).
  *
  * @param {IReduxState} state - The redux state.
  * @returns {boolean}
@@ -75,43 +114,49 @@ export function isSecondScreenEnabled(state: IReduxState): boolean {
 }
 
 /**
- * Resolves a source descriptor to a native {@code MediaStreamTrack} and the
- * participant currently backing it.
+ * Resolves a source descriptor to a native {@code MediaStreamTrack} (when the
+ * backing participant has live, unmuted video) and the participant backing it.
+ * When there is no usable video track, {@code track} is {@code null} and the
+ * caller falls back to rendering the participant's avatar.
  *
  * @param {IReduxState} state - The redux state.
  * @param {ISecondScreenSource} source - The source descriptor.
- * @returns {Object} The resolved native track and backing participant id.
+ * @returns {Object} The resolved native track (or {@code null}) and backing participant.
  */
 function resolveSource(state: IReduxState, source: ISecondScreenSource) {
     const tracks = state['features/base/tracks'];
     let iTrack;
-    let participantId: string | undefined;
+    let participant: IParticipant | undefined;
 
     if (source.role === 'stage') {
-        const participant = getLargeVideoParticipant(state);
-
-        participantId = participant?.id;
+        participant = getLargeVideoParticipant(state);
         iTrack = getVideoTrackByParticipant(state, participant);
     } else if (source.role === 'screenshare') {
         iTrack = tracks.find(t => t.videoType === VIDEO_TYPE.DESKTOP && !t.muted && Boolean(t.jitsiTrack));
-        participantId = iTrack?.participantId;
+        participant = iTrack ? getParticipantById(state, iTrack.participantId) : undefined;
     } else if (source.participant) {
-        participantId = source.participant;
+        participant = getParticipantById(state, source.participant);
         const mediaType = source.media === 'desktop' ? MEDIA_TYPE.SCREENSHARE : MEDIA_TYPE.VIDEO;
 
         iTrack = getTrackByMediaTypeAndParticipant(tracks, mediaType, source.participant);
     }
 
+    const track = iTrack && !iTrack.muted
+        ? (iTrack.jitsiTrack?.getTrack?.() as MediaStreamTrack) ?? null
+        : null;
+
     return {
-        track: (iTrack?.jitsiTrack?.getTrack?.() as MediaStreamTrack) ?? null,
-        participantId: participantId ?? null
+        participant,
+        track
     };
 }
 
 /**
- * A stable signature of what every second-screen window should currently render
- * (its resolved track id). When it changes — e.g. the active speaker switches —
- * the subscriber re-applies the sources, swapping {@code srcObject} in place.
+ * A stable signature of what every second-screen window should currently render.
+ * When it changes — the active speaker switches, a source mutes/unmutes, or an
+ * avatar finishes loading — the subscriber re-applies the sources, swapping the
+ * window content in place. Includes the avatar identity (id/url/name) so the
+ * fallback avatar redraws even while no track is present.
  *
  * @param {IReduxState} state - The redux state.
  * @returns {string}
@@ -121,41 +166,32 @@ export function getSecondScreenSignature(state: IReduxState): string {
 
     return Object.keys(screens).sort()
         .map(id => {
-            const { track } = resolveSource(state, screens[id].source);
+            const { track, participant } = resolveSource(state, screens[id].source);
+            const key = track
+                ? track.id
+                : `avatar:${participant?.id ?? ''}:${participant?.loadableAvatarUrl ?? ''}:${participant?.name ?? ''}`;
 
-            return `${id}:${track ? track.id : 'none'}`;
+            return `${id}:${key}`;
         })
         .join('|');
 }
 
 /**
  * Computes the {@code window.open} features string, placing the window on a
- * physical screen via the Window Management API when available.
+ * physical screen via the Window Management API. Rejects if the API is
+ * unavailable/denied (the feature requires it).
  *
  * @param {number} screenId - Optional target screen index.
  * @returns {Promise<string>}
  */
 async function computeFeatures(screenId?: number): Promise<string> {
-    const fallback = `popup,width=${DEFAULT_WINDOW_WIDTH},height=${DEFAULT_WINDOW_HEIGHT}`;
+    const details = await window.getScreenDetails();
+    const target = (typeof screenId === 'number' && details.screens[screenId])
+        || details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top)
+        || details.currentScreen;
 
-    if (typeof window.getScreenDetails !== 'function') {
-        return fallback;
-    }
-
-    try {
-        const details = await window.getScreenDetails();
-        const screen = typeof screenId === 'number' && details.screens[screenId]
-            ? details.screens[screenId]
-            : details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top);
-
-        if (screen) {
-            return `popup,left=${screen.availLeft},top=${screen.availTop},width=${screen.availWidth},height=${screen.availHeight}`;
-        }
-    } catch (e) {
-        logger.warn('getScreenDetails failed; opening an unplaced window', e);
-    }
-
-    return fallback;
+    // No avail* offsets: the window is auto-fullscreened, so the full screen bounds are what matter.
+    return `popup,left=${target.left},top=${target.top},width=${target.width},height=${target.height}`;
 }
 
 /**
@@ -186,29 +222,78 @@ function buildWindow(win: Window): HTMLVideoElement {
 }
 
 /**
- * Renders a track into a window's video by reference (cloning so the meeting
- * keeps its own copy), stopping any previously rendered clone.
+ * Renders a meeting track into a window's video by reference (cloning so the
+ * meeting keeps its own copy), stopping any previously rendered clone.
  *
  * @param {IWindowEntry} entry - The window entry.
- * @param {MediaStreamTrack | null} track - The track to render.
+ * @param {MediaStreamTrack} track - The track to render.
  * @returns {void}
  */
-function renderTrack(entry: IWindowEntry, track: MediaStreamTrack | null) {
+function renderTrack(entry: IWindowEntry, track: MediaStreamTrack) {
     if (entry.clone) {
-        try {
-            entry.clone.stop();
-        } catch (e) { /* ignore */ }
+        entry.clone.stop();
         entry.clone = undefined;
-    }
-    if (!track) {
-        entry.video.srcObject = null;
-
-        return;
     }
     const clone = track.clone();
 
     entry.clone = clone;
     entry.video.srcObject = new (entry.win as ISecondScreenWindow).MediaStream([ clone ]);
+}
+
+/**
+ * Renders a participant's avatar (image, initials, or default) into a window's
+ * video as a fallback when there is no usable video track (e.g. the source muted
+ * their camera). Reuses the PiP feature's canvas-avatar rendering and feeds it to
+ * the window by reference, mirroring {@link renderTrack}.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {IWindowEntry} entry - The window entry.
+ * @param {IParticipant | undefined} participant - The participant whose avatar to render.
+ * @returns {void}
+ */
+function renderAvatar(state: IReduxState, entry: IWindowEntry, participant: IParticipant | undefined) {
+    if (entry.clone) {
+        entry.clone.stop();
+        entry.clone = undefined;
+    }
+
+    let canvas = entry.avatarCanvas;
+
+    if (!canvas) {
+        canvas = document.createElement('canvas');
+        canvas.width = AVATAR_CANVAS_WIDTH;
+        canvas.height = AVATAR_CANVAS_HEIGHT;
+
+        // captureStream(0): on-demand; we push a frame via requestFrame() after each draw.
+        const track = canvas.captureStream(0).getVideoTracks()[0] as IFrameRequestingTrack;
+
+        entry.avatarCanvas = canvas;
+        entry.avatarTrack = track;
+
+        // The track is created in this (meeting) document; wrap it in the second window's
+        // MediaStream so its <video> renders it by reference (same trick as renderTrack()).
+        entry.avatarSrc = new (entry.win as ISecondScreenWindow).MediaStream([ track ]);
+    }
+
+    if (entry.video.srcObject !== entry.avatarSrc) {
+        entry.video.srcObject = entry.avatarSrc ?? null;
+    }
+
+    const ctx = canvas.getContext('2d');
+
+    if (!ctx) {
+        return;
+    }
+
+    const displayName = participant?.id ? getParticipantDisplayName(state, participant.id) : '';
+    const customAvatarBackgrounds = state['features/dynamic-branding']?.avatarBackgrounds ?? [];
+
+    // Reuses the PiP feature's canvas-avatar rendering (image → initials → default icon).
+    renderAvatarOnCanvas(
+        canvas, ctx, participant, displayName, customAvatarBackgrounds,
+        null, AVATAR_BACKGROUND, AVATAR_FONT_FAMILY, AVATAR_TEXT_COLOR, AVATAR_TEXT_COLOR)
+        .then(() => entry.avatarTrack?.requestFrame?.())
+        .catch(e => logger.warn('Failed to render second-screen avatar', e));
 }
 
 /**
@@ -224,7 +309,9 @@ function notifySourceChanged(id: string, source: ISecondScreenSource, participan
 }
 
 /**
- * Resolves and renders the current track for a window, and notifies the embedder.
+ * Resolves and renders the current source for a window, and notifies the
+ * embedder. Reads the window's configured source from redux (the single source
+ * of truth). Falls back to the participant's avatar when there is no live video.
  *
  * @param {IStore} store - The redux store.
  * @param {string} id - The window id.
@@ -236,15 +323,26 @@ function applySource(store: IStore, id: string) {
     if (!entry || entry.win.closed) {
         return;
     }
-    const { track, participantId } = resolveSource(store.getState(), entry.source);
+    const state = store.getState();
+    const config = state['features/multi-screen'].screens[id];
 
-    renderTrack(entry, track);
-    notifySourceChanged(id, entry.source, participantId);
+    if (!config) {
+        return;
+    }
+    const { track, participant } = resolveSource(state, config.source);
+
+    if (track) {
+        renderTrack(entry, track);
+    } else {
+        renderAvatar(state, entry, participant);
+    }
+    notifySourceChanged(id, config.source, participant?.id ?? null);
 }
 
 /**
  * Cleans up an entry's resources without dispatching (used by both explicit
- * close and the window being closed externally).
+ * close and the window being closed externally). The map entry is dropped before
+ * the window is closed, so no reference to a closed window is retained.
  *
  * @param {string} id - The window id.
  * @param {boolean} closeWindow - Whether to also close the OS window.
@@ -256,16 +354,14 @@ function teardown(id: string, closeWindow: boolean) {
     if (!entry) {
         return;
     }
-    if (entry.clone) {
-        try {
-            entry.clone.stop();
-        } catch (e) { /* ignore */ }
-    }
+
+    // MediaStreamTrack.stop() is infallible per spec, so no try/catch.
+    entry.clone?.stop();
+    entry.avatarTrack?.stop();
     windows.delete(id);
-    if (closeWindow) {
-        try {
-            !entry.win.closed && entry.win.close();
-        } catch (e) { /* ignore */ }
+
+    if (closeWindow && !entry.win.closed) {
+        entry.win.close();
     }
 }
 
@@ -287,18 +383,17 @@ function handleWindowClosed(store: IStore, id: string) {
 }
 
 /**
- * Opens a new second-screen window (or updates an existing one) and renders the
- * given source. Best-effort placement + fullscreen; both require the Window
- * Management / AutomaticFullscreen permissions on a managed/kiosk device.
+ * Opens a new second-screen window (or updates an existing one) to render its
+ * configured source. The window is placed on a physical screen via the Window
+ * Management API and auto-fullscreened; both require the window-management and
+ * AutomaticFullscreen permissions on a managed/kiosk device.
  *
  * @param {IStore} store - The redux store.
  * @param {string} id - The window id.
- * @param {ISecondScreenSource} source - What to render.
  * @param {number} screenId - Optional target screen index.
  * @returns {Promise<void>}
  */
-export async function openOrUpdateSecondScreen(
-        store: IStore, id: string, source: ISecondScreenSource, screenId?: number): Promise<void> {
+export async function openOrUpdateSecondScreen(store: IStore, id: string, screenId?: number): Promise<void> {
     if (!isSecondScreenEnabled(store.getState())) {
         APP.API?.notifySecondScreenError?.({ id, error: 'second-screen-disabled' });
 
@@ -307,15 +402,30 @@ export async function openOrUpdateSecondScreen(
 
     const existing = windows.get(id);
 
-    if (existing && !existing.win.closed) {
-        existing.source = source;
-        existing.screenId = screenId;
-        applySource(store, id);
+    if (existing) {
+        if (!existing.win.closed) {
+            applySource(store, id);
+
+            return;
+        }
+
+        // The window was closed without us being notified; purge the stale entry (stopping its
+        // tracks) before reopening, so no handle to a closed window is retained.
+        teardown(id, false);
+    }
+
+    let features;
+
+    try {
+        features = await computeFeatures(screenId);
+    } catch (e) {
+        logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
+        APP.API?.notifySecondScreenError?.({ id, error: 'window-management-unavailable' });
+        store.dispatch(removeSecondScreen(id));
 
         return;
     }
 
-    const features = await computeFeatures(screenId);
     const win = window.open('', `jitsiSecondScreen_${id}`, features);
 
     if (!win) {
@@ -326,7 +436,7 @@ export async function openOrUpdateSecondScreen(
         return;
     }
 
-    const entry: IWindowEntry = { win, source, screenId, video: buildWindow(win) };
+    const entry: IWindowEntry = { win, video: buildWindow(win) };
 
     windows.set(id, entry);
     win.addEventListener('pagehide', () => handleWindowClosed(store, id), { once: true });

--- a/react/features/multi-screen/logger.ts
+++ b/react/features/multi-screen/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('app:multi-screen');

--- a/react/features/multi-screen/middleware.web.ts
+++ b/react/features/multi-screen/middleware.web.ts
@@ -26,20 +26,18 @@ MiddlewareRegistry.register((store: IStore) => next => action => {
 
         return result;
     }
-    case REMOVE_SECOND_SCREEN: {
-        const result = next(action);
+    case REMOVE_SECOND_SCREEN:
 
-        closeSecondScreen(action.id);
+        // Tear down before next(action) removes the entry, since the live handle is read from state.
+        closeSecondScreen(store, action.id);
 
-        return result;
-    }
-    case RESET_SECOND_SCREENS: {
-        const result = next(action);
+        return next(action);
+    case RESET_SECOND_SCREENS:
 
-        closeAllSecondScreens();
+        // Same ordering: close the windows while their entries are still in state.
+        closeAllSecondScreens(store);
 
-        return result;
-    }
+        return next(action);
     case CONFERENCE_FAILED:
     case CONFERENCE_LEFT:
 

--- a/react/features/multi-screen/middleware.web.ts
+++ b/react/features/multi-screen/middleware.web.ts
@@ -21,7 +21,7 @@ MiddlewareRegistry.register((store: IStore) => next => action => {
     case SET_SECOND_SCREEN: {
         const result = next(action);
 
-        openOrUpdateSecondScreen(store, action.id, action.source, action.screenId)
+        openOrUpdateSecondScreen(store, action.id, action.screenId)
             .catch(e => logger.error('Failed to open second screen', e));
 
         return result;
@@ -42,7 +42,9 @@ MiddlewareRegistry.register((store: IStore) => next => action => {
     }
     case CONFERENCE_FAILED:
     case CONFERENCE_LEFT:
-        closeAllSecondScreens();
+
+        // Resetting closes every second-screen window (via the RESET_SECOND_SCREENS
+        // case above), so there is no need to close them explicitly here.
         store.dispatch(resetSecondScreens());
         break;
     }

--- a/react/features/multi-screen/middleware.web.ts
+++ b/react/features/multi-screen/middleware.web.ts
@@ -1,0 +1,51 @@
+import { IStore } from '../app/types';
+import { CONFERENCE_FAILED, CONFERENCE_LEFT } from '../base/conference/actionTypes';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+
+import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
+import { resetSecondScreens } from './actions.web';
+import { closeAllSecondScreens, closeSecondScreen, openOrUpdateSecondScreen } from './functions.web';
+import logger from './logger';
+
+import './subscriber.web';
+
+/**
+ * Middleware that reconciles the live second-screen windows with the requested
+ * state, and tears them all down when the conference ends.
+ *
+ * @param {IStore} store - The redux store.
+ * @returns {Function}
+ */
+MiddlewareRegistry.register((store: IStore) => next => action => {
+    switch (action.type) {
+    case SET_SECOND_SCREEN: {
+        const result = next(action);
+
+        openOrUpdateSecondScreen(store, action.id, action.source, action.screenId)
+            .catch(e => logger.error('Failed to open second screen', e));
+
+        return result;
+    }
+    case REMOVE_SECOND_SCREEN: {
+        const result = next(action);
+
+        closeSecondScreen(action.id);
+
+        return result;
+    }
+    case RESET_SECOND_SCREENS: {
+        const result = next(action);
+
+        closeAllSecondScreens();
+
+        return result;
+    }
+    case CONFERENCE_FAILED:
+    case CONFERENCE_LEFT:
+        closeAllSecondScreens();
+        store.dispatch(resetSecondScreens());
+        break;
+    }
+
+    return next(action);
+});

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -1,20 +1,25 @@
 import ReducerRegistry from '../base/redux/ReducerRegistry';
 
-import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
-import { ISecondScreenConfig } from './types';
+import {
+    REMOVE_SECOND_SCREEN,
+    RESET_SECOND_SCREENS,
+    SET_SECOND_SCREEN,
+    SET_SECOND_SCREEN_WINDOW
+} from './actionTypes';
+import { ISecondScreenEntry } from './types';
 
 export interface IMultiScreenState {
 
     /**
-     * The configured second-screen windows, keyed by window id. This is the
-     * single source of truth for which windows exist and what each renders
-     * (source + target screen); the middleware reconciles the live windows to
-     * it. The non-serializable live handles (the {@code Window}, its
-     * {@code <video>} and cloned tracks) are held in a module-scoped map in
-     * {@code functions.web.ts}, keyed by the same id — it duplicates none of the
-     * configuration kept here.
+     * The second-screen windows, keyed by window id. This is the single source
+     * of truth for the feature: each entry holds both the configuration (source
+     * + target screen) and the live window handle. Redux state is never
+     * serialized for storage here, so the non-serializable handle (the
+     * {@code Window}, its {@code <video>} and tracks) lives on the entry too,
+     * rather than in a separate module-scoped map; the middleware reconciles the
+     * live windows to this state.
      */
-    screens: { [id: string]: ISecondScreenConfig; };
+    screens: { [id: string]: ISecondScreenEntry; };
 }
 
 const DEFAULT_STATE: IMultiScreenState = {
@@ -25,13 +30,34 @@ ReducerRegistry.register<IMultiScreenState>('features/multi-screen',
 (state = DEFAULT_STATE, action): IMultiScreenState => {
     switch (action.type) {
     case SET_SECOND_SCREEN:
+
+        // Merge so a re-configuration of an existing window keeps its live handle.
         return {
             ...state,
             screens: {
                 ...state.screens,
-                [action.id]: { source: action.source, screenId: action.screenId }
+                [action.id]: {
+                    ...state.screens[action.id],
+                    source: action.source,
+                    screenId: action.screenId
+                }
             }
         };
+    case SET_SECOND_SCREEN_WINDOW: {
+        const entry = state.screens[action.id];
+
+        if (!entry) {
+            return state;
+        }
+
+        return {
+            ...state,
+            screens: {
+                ...state.screens,
+                [action.id]: { ...entry, handle: action.handle }
+            }
+        };
+    }
     case REMOVE_SECOND_SCREEN: {
         const screens = { ...state.screens };
 

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -1,0 +1,42 @@
+import ReducerRegistry from '../base/redux/ReducerRegistry';
+
+import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
+import { ISecondScreenConfig } from './types';
+
+export interface IMultiScreenState {
+
+    /**
+     * The configured second-screen windows, keyed by window id. Reflects what
+     * the embedder requested; the middleware reconciles the real windows to it.
+     */
+    screens: { [id: string]: ISecondScreenConfig; };
+}
+
+const DEFAULT_STATE: IMultiScreenState = {
+    screens: {}
+};
+
+ReducerRegistry.register<IMultiScreenState>('features/multi-screen',
+(state = DEFAULT_STATE, action): IMultiScreenState => {
+    switch (action.type) {
+    case SET_SECOND_SCREEN:
+        return {
+            ...state,
+            screens: {
+                ...state.screens,
+                [action.id]: { source: action.source, screenId: action.screenId }
+            }
+        };
+    case REMOVE_SECOND_SCREEN: {
+        const screens = { ...state.screens };
+
+        delete screens[action.id];
+
+        return { ...state, screens };
+    }
+    case RESET_SECOND_SCREENS:
+        return { ...state, screens: {} };
+    }
+
+    return state;
+});

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -6,8 +6,13 @@ import { ISecondScreenConfig } from './types';
 export interface IMultiScreenState {
 
     /**
-     * The configured second-screen windows, keyed by window id. Reflects what
-     * the embedder requested; the middleware reconciles the real windows to it.
+     * The configured second-screen windows, keyed by window id. This is the
+     * single source of truth for which windows exist and what each renders
+     * (source + target screen); the middleware reconciles the live windows to
+     * it. The non-serializable live handles (the {@code Window}, its
+     * {@code <video>} and cloned tracks) are held in a module-scoped map in
+     * {@code functions.web.ts}, keyed by the same id — it duplicates none of the
+     * configuration kept here.
      */
     screens: { [id: string]: ISecondScreenConfig; };
 }

--- a/react/features/multi-screen/subscriber.web.ts
+++ b/react/features/multi-screen/subscriber.web.ts
@@ -1,0 +1,18 @@
+import StateListenerRegistry from '../base/redux/StateListenerRegistry';
+
+import { getSecondScreenSignature, refreshSecondScreens } from './functions.web';
+
+/**
+ * Re-applies the second-screen sources whenever what they should render changes
+ * — most importantly when the active speaker switches (the {@code role: 'stage'}
+ * source resolves to a different track), so the window's {@code srcObject} is
+ * swapped in place without ever re-opening it.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => getSecondScreenSignature(state),
+    /* listener */ (signature, store) => {
+        if (signature) {
+            refreshSecondScreens(store);
+        }
+    }
+);

--- a/react/features/multi-screen/types.ts
+++ b/react/features/multi-screen/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Describes what a second-screen window should render. Resolved to an actual
+ * media track by the feature and kept live (e.g. {@code role: 'stage'} follows
+ * the active speaker). Because an iframe embedder has no access to the media
+ * tracks (they live in the meeting document), an explicit selection can only
+ * name a participant — never a stream — which the feature resolves internally.
+ */
+export interface ISecondScreenSource {
+
+    /**
+     * The media type of an explicitly pinned participant. Defaults to camera.
+     */
+    media?: 'camera' | 'desktop';
+
+    /**
+     * The id of an explicitly pinned participant to render.
+     */
+    participant?: string;
+
+    /**
+     * A role to follow: the active-speaker stage, or the current screenshare.
+     */
+    role?: 'stage' | 'screenshare';
+}
+
+/**
+ * The configuration of a single second-screen window.
+ */
+export interface ISecondScreenConfig {
+
+    /**
+     * The (optional) index of the physical screen to place the window on, as
+     * reported by the Window Management API.
+     */
+    screenId?: number;
+
+    /**
+     * What the window renders.
+     */
+    source: ISecondScreenSource;
+}

--- a/react/features/multi-screen/types.ts
+++ b/react/features/multi-screen/types.ts
@@ -24,9 +24,20 @@ export interface ISecondScreenSource {
 }
 
 /**
- * The configuration of a single second-screen window.
+ * A single second-screen entry: its configuration plus its live window handle.
+ * This is the single source of truth for the feature; the middleware reconciles
+ * the real windows to it.
  */
-export interface ISecondScreenConfig {
+export interface ISecondScreenEntry {
+
+    /**
+     * The live, non-serializable window handle (the {@code Window}, its
+     * {@code <video>} and the cloned/avatar tracks), populated by the middleware
+     * once the window is open. Typed opaquely here because the shared (and
+     * React Native) build has no DOM lib; its real shape is {@code ISecondScreenHandle}
+     * in {@code functions.web.ts}, where it is read back with a cast.
+     */
+    handle?: unknown;
 
     /**
      * The (optional) index of the physical screen to place the window on, as


### PR DESCRIPTION
## What

Adds an **opt-in** capability for iframe embedders (e.g. room appliances such as Jitsi Spot / 8x8 Spaces) to render a meeting surface — the active-speaker **stage**, the **screenshare**, or a **pinned participant** — on a **second display**, in its own fullscreen window, driven by the **single existing conference connection**. No extra peer connection, no additional participant in the roster.

## How it works

The meeting client opens a same-origin `window.open` window, places it on a chosen physical display via the **Window Management API**, fullscreens it via the **AutomaticFullscreen** permission, and renders the resolved track **by reference** (one decode, two sinks). When the active speaker changes, it swaps the window's `srcObject` in place — the window is **never re-opened**. Windows are torn down on conference end.

## iframe / External API

```js
api.executeCommand('setSecondScreen', {
  screen: 1,                       // optional physical screen index
  source: { role: 'stage' }        // or { role: 'screenshare' } | { participant: '<id>', media: 'camera' | 'desktop' }
});

api.addListener('secondScreenSourceChanged', e => { /* { id, source, participantId } */ });
// also emitted: secondScreenClosed, secondScreenError
```

Passing an empty/invalid `source` closes that window. Multiple second-screen windows are supported via an optional `id` (defaults to `'default'`).

Because an embedder has no access to the media tracks (they live in the meeting document), an explicit selection can only name a **participant** — never a stream — which the feature resolves internally.

## Enabling / requirements

- Opt-in via `config.secondScreen.enabled` (default **off**).
- Chromium-only; intended for **managed / kiosk** room devices. The embedder must delegate `allow="window-management; fullscreen"` (now included in the External API iframe `allow` list), and the device must grant the **window-management**, **automatic-fullscreen** and **popups** permissions to the meeting origin (e.g. via the `AutomaticFullscreenAllowedForUrls` enterprise policy). Degrades to a no-op where unsupported.

## Scope

- No `lib-jitsi-meet` or bridge changes.
- Receiver constraints already keep the stage participant at high quality (`maxReceiverVideoQualityForLargeVideo`).
- **v2 (follow-up):** composed layouts — a tile grid, or stage + filmstrip in one window. The source descriptor will grow a `layout` variant without an API break.

## Testing

Verified end-to-end in a kiosk-configured Chromium against a real meeting: `setSecondScreen({ role: 'stage' })` opens a placed, **auto-fullscreened** second window rendering the stage at **1280×720** by reference; an active-speaker change reuses the same window (swaps `srcObject`). `npm run lint:ci` and `tsc:web` pass.

> Draft: opening for early CI/visibility. A matching jitsi-meet-handbook docs PR for the new command/events will follow.
