### PR TITLE
feat(whiteboard): enable image sharing on the inline web whiteboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@giphy/js-fetch-api": "4.9.3",
         "@giphy/react-components": "6.9.4",
         "@giphy/react-native-sdk": "5.0.1",
-        "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.6/jitsi-excalidraw-0.18.6.tgz",
+        "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.7/jitsi-excalidraw-v0.18.7.tgz",
         "@jitsi/js-utils": "6.3.2",
         "@jitsi/logger": "2.1.1",
         "@jitsi/rnnoise-wasm": "0.2.1",
@@ -4202,9 +4202,9 @@
       }
     },
     "node_modules/@jitsi/excalidraw": {
-      "version": "0.18.6",
-      "resolved": "https://github.com/jitsi/excalidraw/releases/download/0.18.6/jitsi-excalidraw-0.18.6.tgz",
-      "integrity": "sha512-nM7N5iEsh+eu/LKccO8FKPo/TvWZuoSoXiD+rVgAoA3aPhYIIoDLgBC1fNzkdfEJs6oFjhIMe85H5PRffXUvSw==",
+      "version": "0.18.7",
+      "resolved": "https://github.com/jitsi/excalidraw/releases/download/0.18.7/jitsi-excalidraw-v0.18.7.tgz",
+      "integrity": "sha512-dUnLDroHWzzR0C5x49njgR6YRx+drTPzzzGutg9wqrKRnnmKX5BXO+vWhRgna8Jr/O/CgPItOVIpm5f9oDOj3w==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "6.0.2",
@@ -30062,8 +30062,8 @@
       }
     },
     "@jitsi/excalidraw": {
-      "version": "https://github.com/jitsi/excalidraw/releases/download/0.18.6/jitsi-excalidraw-0.18.6.tgz",
-      "integrity": "sha512-nM7N5iEsh+eu/LKccO8FKPo/TvWZuoSoXiD+rVgAoA3aPhYIIoDLgBC1fNzkdfEJs6oFjhIMe85H5PRffXUvSw==",
+      "version": "https://github.com/jitsi/excalidraw/releases/download/0.18.7/jitsi-excalidraw-v0.18.7.tgz",
+      "integrity": "sha512-dUnLDroHWzzR0C5x49njgR6YRx+drTPzzzGutg9wqrKRnnmKX5BXO+vWhRgna8Jr/O/CgPItOVIpm5f9oDOj3w==",
       "requires": {
         "@braintree/sanitize-url": "6.0.2",
         "@excalidraw/laser-pointer": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@giphy/js-fetch-api": "4.9.3",
     "@giphy/react-components": "6.9.4",
     "@giphy/react-native-sdk": "5.0.1",
-    "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.6/jitsi-excalidraw-0.18.6.tgz",
+    "@jitsi/excalidraw": "https://github.com/jitsi/excalidraw/releases/download/0.18.7/jitsi-excalidraw-v0.18.7.tgz",
     "@jitsi/js-utils": "6.3.2",
     "@jitsi/logger": "2.1.1",
     "@jitsi/rnnoise-wasm": "0.2.1",

--- a/react/features/whiteboard/components/web/Whiteboard.tsx
+++ b/react/features/whiteboard/components/web/Whiteboard.tsx
@@ -13,7 +13,7 @@ import { getLocalParticipant } from '../../../base/participants/functions';
 import { getVerticalViewMaxWidth } from '../../../filmstrip/functions.web';
 import { getToolboxHeight } from '../../../toolbox/functions.web';
 import { shouldDisplayTileView } from '../../../video-layout/functions.any';
-import { WHITEBOARD_UI_OPTIONS } from '../../constants';
+import { WHITEBOARD_UI_OPTIONS, WHITEBOARD_UI_OPTIONS_WITH_IMAGES } from '../../constants';
 import {
     getCollabDetails,
     getCollabServerUrl,
@@ -46,6 +46,7 @@ interface IDimensions {
 }
 
 interface IMeetingDetails {
+    getStorageToken: () => Promise<string | undefined>;
     jwt: string;
     roomJid: string;
     sessionId: string;
@@ -82,10 +83,24 @@ const Whiteboard = (props: WithTranslation): JSX.Element => {
     const sessionId = conference?.getMeetingUniqueId();
     const roomJid = conference?.room?.roomjid;
 
+    // Provides a fresh short-term credential for each whiteboard storage
+    // request, so that image binaries are uploaded/fetched with a token that is
+    // refreshed transparently as the previous one expires.
+    const getStorageToken = useCallback(async () => {
+        const conf = getCurrentConference(store.getState());
+
+        if (!conf) {
+            return undefined;
+        }
+
+        return conf.getShortTermCredentials(conf.getFileSharing()?.getIdentityType());
+    }, [ store ]);
+
     const meetingDetails: IMeetingDetails = {
         sessionId: sessionId ?? '',
         roomJid: roomJid ?? '',
-        jwt: jwt
+        jwt: jwt,
+        getStorageToken
     };
 
     useEffect(() => {
@@ -178,7 +193,7 @@ const Whiteboard = (props: WithTranslation): JSX.Element => {
                                     isCollaborating: true,
                                     langCode: i18next.language,
                                     theme: 'light',
-                                    UIOptions: WHITEBOARD_UI_OPTIONS
+                                    UIOptions: storageBackendUrl ? WHITEBOARD_UI_OPTIONS_WITH_IMAGES : WHITEBOARD_UI_OPTIONS
                                 }}
                                 getCollabAPI = { getCollabAPI }
                                 getExcalidrawAPI = { getExcalidrawAPI }

--- a/react/features/whiteboard/constants.ts
+++ b/react/features/whiteboard/constants.ts
@@ -57,6 +57,23 @@ export const WHITEBOARD_UI_OPTIONS = {
 };
 
 /**
+ * Whiteboard UI Options with image support enabled.
+ *
+ * Used only for the inline web whiteboard, where a storage backend and a token
+ * provider are available to persist and sync image binaries. The standalone
+ * whiteboard page (mobile/native) keeps {@link WHITEBOARD_UI_OPTIONS}, since it
+ * has no conference context to supply storage credentials.
+ */
+export const WHITEBOARD_UI_OPTIONS_WITH_IMAGES = {
+    ...WHITEBOARD_UI_OPTIONS,
+    canvasActions: {
+        ...WHITEBOARD_UI_OPTIONS.canvasActions,
+        allowedShapes: [ ...WHITEBOARD_UI_OPTIONS.canvasActions.allowedShapes, 'image' ],
+        disableFileDrop: false
+    }
+};
+
+/**
  * Whiteboard default lower limit.
  */
 export const MIN_USER_LIMIT = 10;


### PR DESCRIPTION
Turn on Excalidraw's image tool and file drop for the inline web whiteboard so participants can add images that everyone sees on the board. Image binaries are persisted to the configured `whiteboard.storageBackendUrl` and fetched by other participants through Excalidraw's collaboration layer.

Authentication uses a `getStorageToken` provider passed in `meetingDetails`, which returns a fresh short-term credential per storage request (refreshed transparently as the previous one expires). This relies on @jitsi/excalidraw 0.18.7, which adds the provider hook.

Images are enabled only when a storage backend is configured and only for the inline web board; the standalone/native whiteboard page keeps the existing options since it has no conference context to supply credentials.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
