### PR TITLE
fix(tests): wait for iframe to exist before switching in iFrame API tests

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -742,6 +742,10 @@ export class Participant {
 
         const iframe = this.driver.$('iframe');
 
+        // The External API inserts the iframe asynchronously after the wrapper page loads, so wait for it to exist
+        // before switching rather than failing immediately with "iframe doesn't exist" on slower backends.
+        await iframe.waitForExist({ timeout: 10_000 });
+
         await this.driver.switchFrame(iframe);
         this._inMainFrame = false;
     }


### PR DESCRIPTION
## Problem

Every iFrame API spec (`tests/specs/iframe/*` — chat, kick, participantsPresence, setMeetingTimer) intermittently failed at join/setup with:

```
Can't switch to frame with selector iframe because it doesn't exist
  at Participant.switchToIFrame (tests/helpers/Participant.ts:745)
  at Participant.joinConference (Participant.ts:272)
  at joinMuc (joinMuc.ts:36)
```

Observed across a full shard on a slower backend (beta-us-ashburn): all four iframe specs went down at the same step in one run.

## Root cause

`switchToIFrame()` resolved the `iframe` element and called `driver.switchFrame()` immediately. But the wrapper page (`iframeAPITest.html`) creates the `<iframe>` **asynchronously** via the External API (`JitsiMeetExternalAPI`) after the page loads. When the backend was slightly slow, the element was not yet in the DOM, so `switchFrame` failed right away instead of waiting.

## Fix

Wait for the iframe element to exist before switching:

```js
const iframe = this.driver.$('iframe');

await iframe.waitForExist({ timeout: 10_000 });
await this.driver.switchFrame(iframe);
```

Harmless on the fast path (resolves immediately when the iframe is already present) and eliminates the race on slower backends.