### PR TITLE
fix(tests): switch to main frame and open overflow menu in recording/transcription specs

### DIFF
--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -58,7 +58,16 @@ export default class Toolbar extends BasePageObject {
      * @returns {Promise<boolean>}
      */
     async hasRecordingButton(): Promise<boolean> {
-        return this.getButton(RECORDING).isExisting();
+        // The recording button lives in the overflow ("More actions") menu, so it is only in the
+        // DOM while that menu is open. isExisting() searches the whole DOM, so opening the menu
+        // first also covers the case where the button is promoted to the main toolbar.
+        await this.openOverflowMenu();
+
+        const exists = await this.getButton(RECORDING).isExisting();
+
+        await this.closeOverflowMenu();
+
+        return exists;
     }
 
     /**
@@ -67,9 +76,9 @@ export default class Toolbar extends BasePageObject {
      * @returns {Promise<void>}
      */
     async clickRecordingButton(): Promise<void> {
-        await this.participant.log('Clicking on: Recording Button');
-
-        return this.getButton(RECORDING).click();
+        // The recording button lives in the overflow ("More actions") menu; open it, click, close
+        // (matches clickSettings/clickSecurity — closeOverflowMenu is a no-op once the dialog opens).
+        return this.clickButtonInOverflowMenu(RECORDING);
     }
 
     /**

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -11,7 +11,14 @@ setTestProperties(__filename, {
  * Joins a JaaS meeting as a moderator using the iFrame API wrapper.
  */
 async function joinAsModerator(): Promise<Participant> {
-    return joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+    const p = await joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+
+    // joinJaasMuc leaves the driver focused inside the Jitsi iframe, but the iFrame API
+    // (window.jitsiAPI) lives on the wrapper page. Switch to the main frame so executeCommand()
+    // works, matching the setup in recording.spec.ts / transcriptions.spec.ts.
+    await p.switchToMainFrame();
+
+    return p;
 }
 
 /**
@@ -384,6 +391,7 @@ describe('Recording button visibility', () => {
 
         expect(await p.getToolbar().hasRecordingButton()).toBe(true);
 
-        await p.getIframeAPI().executeCommand('hangup');
+        // This participant joined without the iFrame API, so hang up via the app, not window.jitsiAPI.
+        await p.hangup();
     });
 });


### PR DESCRIPTION
The recording/transcription JaaS specs added in #17469 failed at startup:

- joinAsModerator() returned with the WebDriver focused inside the Jitsi iframe, but the iFrame API (window.jitsiAPI) lives on the wrapper frame, so the first executeCommand() threw "Cannot read properties of undefined (reading 'executeCommand')". Switch to the main frame after join, matching the setup in recording.spec.ts / transcriptions.spec.ts.

- hasRecordingButton()/clickRecordingButton() queried the "Record & Transcribe" button directly, but it renders in the overflow ("More actions") menu (toolbar priority rank #17; the main bar holds 8 buttons), so it is only in the DOM while that menu is open. Open the overflow menu first, mirroring clickButtonInOverflowMenu() / getProfileImage().

Also hang up the non-iFrame button-visibility participant via p.hangup() instead of window.jitsiAPI, which does not exist outside the iFrame API wrapper.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
