### PR TITLE
fix(tests): complete recording/transcription e2e fixes (extends #17544)

### DIFF
--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -58,7 +58,16 @@ export default class Toolbar extends BasePageObject {
      * @returns {Promise<boolean>}
      */
     async hasRecordingButton(): Promise<boolean> {
-        return this.getButton(RECORDING).isExisting();
+        // The recording button lives in the overflow ("More actions") menu, so it is only in the
+        // DOM while that menu is open. isExisting() searches the whole DOM, so opening the menu
+        // first also covers the case where the button is promoted to the main toolbar.
+        await this.openOverflowMenu();
+
+        const exists = await this.getButton(RECORDING).isExisting();
+
+        await this.closeOverflowMenu();
+
+        return exists;
     }
 
     /**
@@ -67,9 +76,9 @@ export default class Toolbar extends BasePageObject {
      * @returns {Promise<void>}
      */
     async clickRecordingButton(): Promise<void> {
-        await this.participant.log('Clicking on: Recording Button');
-
-        return this.getButton(RECORDING).click();
+        // The recording button lives in the overflow ("More actions") menu; open it, click, close
+        // (matches clickSettings/clickSecurity — closeOverflowMenu is a no-op once the dialog opens).
+        return this.clickButtonInOverflowMenu(RECORDING);
     }
 
     /**

--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -2,6 +2,10 @@ import BasePageObject from './BasePageObject';
 
 const AUDIO_MUTE = 'Mute microphone';
 const RECORDING = 'Record & Transcribe';
+
+// Non-moderators (who can only do local recording) get a "Record" button instead of the
+// moderator's "Record & Transcribe" — see AbstractRecordButton._getAccessibilityLabel().
+const RECORDING_NON_MODERATOR = 'Record';
 const AUDIO_UNMUTE = 'Unmute microphone';
 const CHAT = 'Open chat';
 const CLOSE_CHAT = 'Close chat';
@@ -64,7 +68,10 @@ export default class Toolbar extends BasePageObject {
         // first also covers the case where the button is promoted to the main toolbar.
         await this.openOverflowMenu();
 
-        const exists = await this.getButton(RECORDING).isExisting();
+        // Match either label since moderators get "Record & Transcribe" while non-moderators
+        // (local recording only) get "Record".
+        const exists = await this.getButton(RECORDING).isExisting()
+            || await this.getButton(RECORDING_NON_MODERATOR).isExisting();
 
         await this.closeOverflowMenu();
 

--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -10,6 +10,7 @@ const DESKTOP = 'Start sharing your screen';
 const HANGUP = 'Leave the meeting';
 const OVERFLOW_MENU = 'More actions menu';
 const OVERFLOW = 'More actions';
+const CLOSE_OVERFLOW = 'Close more actions menu';
 const PARTICIPANTS = 'Open participants pane';
 const PROFILE = 'Edit your profile';
 const RAISE_HAND = 'Raise your hand';
@@ -387,7 +388,9 @@ export default class Toolbar extends BasePageObject {
             return;
         }
 
-        await this.clickOverflowButton();
+        // When the overflow menu is open the toggle button's aria-label changes from
+        // "More actions" to "Close more actions menu", so we cannot reuse clickOverflowButton here.
+        await this.getButton(CLOSE_OVERFLOW).click();
 
         await this.waitForOverFlowMenu(false);
     }

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -115,7 +115,6 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -138,7 +137,6 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -175,7 +173,6 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 });
@@ -209,7 +206,6 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -239,7 +235,6 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -276,7 +271,6 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -326,7 +320,6 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 
@@ -374,7 +367,6 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
-            await p.getIframeAPI().executeCommand('hangup');
         }
     });
 });

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -11,7 +11,14 @@ setTestProperties(__filename, {
  * Joins a JaaS meeting as a moderator using the iFrame API wrapper.
  */
 async function joinAsModerator(): Promise<Participant> {
-    return joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+    const p = await joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+
+    // joinJaasMuc leaves the driver focused inside the Jitsi iframe, but the iFrame API
+    // (window.jitsiAPI) lives on the wrapper page. Switch to the main frame so executeCommand()
+    // works, matching the setup in recording.spec.ts / transcriptions.spec.ts.
+    await p.switchToMainFrame();
+
+    return p;
 }
 
 /**
@@ -384,6 +391,7 @@ describe('Recording button visibility', () => {
 
         expect(await p.getToolbar().hasRecordingButton()).toBe(true);
 
-        await p.getIframeAPI().executeCommand('hangup');
+        // This participant joined without the iFrame API, so hang up via the app, not window.jitsiAPI.
+        await p.hangup();
     });
 });

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -72,25 +72,57 @@ async function waitForTranscriptionRunning(p: Participant): Promise<void> {
 
 /**
  * Waits until the transcription feature state reports that transcription is no longer active.
+ *
+ * @param {Participant} p - The participant.
+ * @param {number} timeout - How long to wait, in ms.
  */
-async function waitForTranscriptionStopped(p: Participant): Promise<void> {
+async function waitForTranscriptionStopped(p: Participant, timeout = 20_000): Promise<void> {
     await p.driver.waitUntil(
         () => p.execute(() => !APP.store.getState()['features/transcribing'].isTranscribing),
-        { timeout: 20_000, timeoutMsg: 'Transcription did not stop' }
+        { timeout, timeoutMsg: 'Transcription did not stop' }
     );
 }
 
 /**
  * Waits until the recording feature state reports that no FILE session is active.
+ *
+ * @param {Participant} p - The participant.
+ * @param {number} timeout - How long to wait, in ms.
  */
-async function waitForRecordingStopped(p: Participant): Promise<void> {
+async function waitForRecordingStopped(p: Participant, timeout = 20_000): Promise<void> {
     await p.driver.waitUntil(
         () => p.execute(() => Boolean(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             APP.store.getState()['features/recording'].sessionDatas.every(
                 (s: any) => s.mode !== 'file' || s.status === 'off'))),
-        { timeout: 20_000, timeoutMsg: 'Recording session did not stop' }
+        { timeout, timeoutMsg: 'Recording session did not stop' }
     );
+}
+
+/**
+ * Best-effort wait, used in cleanup, for a stopRecording command to actually take effect before the
+ * participant leaves. Never fails the test — a timeout here just means the stop was slow to reflect,
+ * which must not turn a passing test red during teardown.
+ *
+ * @param {Participant} p - The participant.
+ * @param {boolean} transcription - Whether transcription was also stopped (stopRecording(..., true)).
+ */
+async function waitForRecordingStopExecuted(p: Participant, transcription = false): Promise<void> {
+    // Short, bounded wait — this is best-effort teardown, not an assertion, so don't burn the full
+    // 20s assertion timeout here.
+    const cleanupTimeout = 5_000;
+
+    await p.switchToIFrame();
+
+    try {
+        await waitForRecordingStopped(p, cleanupTimeout);
+
+        if (transcription) {
+            await waitForTranscriptionStopped(p, cleanupTimeout);
+        }
+    } catch (e) {
+        // Best-effort cleanup — ignore timeouts so teardown never fails the test.
+    }
 }
 
 // ─── Nudge notification tests ────────────────────────────────────────────────
@@ -123,6 +155,7 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await waitForRecordingStopExecuted(p);
         }
     });
 
@@ -145,6 +178,7 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await waitForRecordingStopExecuted(p, true);
         }
     });
 
@@ -181,6 +215,7 @@ describe('Recording & transcription nudge notifications', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await waitForRecordingStopExecuted(p);
         }
     });
 });
@@ -214,6 +249,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await waitForRecordingStopExecuted(p);
         }
     });
 
@@ -243,6 +279,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await waitForRecordingStopExecuted(p, true);
         }
     });
 
@@ -279,6 +316,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await waitForRecordingStopExecuted(p);
         }
     });
 
@@ -328,6 +366,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');
+            await waitForRecordingStopExecuted(p);
         }
     });
 
@@ -375,6 +414,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file', true);
+            await waitForRecordingStopExecuted(p, true);
         }
     });
 });

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -111,7 +111,15 @@ describe('Recording & transcription nudge notifications', () => {
 
             const nudgeButton = p.driver.$('[data-testid="dialog.startTranscribing"]');
 
-            expect(await nudgeButton.isExisting()).toBe(true);
+            // A "recording pending" notification appears (same data-testid) before the "recording
+            // started" notification that actually carries the nudge, so wait for the nudge to show up
+            // rather than checking immediately. The iFrame startRecording path sets
+            // isTranscribingEnabled:false, so transcription never auto-starts here and the
+            // "Start transcribing" nudge always applies once recording is running.
+            await nudgeButton.waitForExist({
+                timeout: 30_000,
+                timeoutMsg: '"Start transcribing" nudge did not appear'
+            });
         } finally {
             await p.switchToMainFrame();
             await p.getIframeAPI().executeCommand('stopRecording', 'file');

--- a/tests/specs/misc/recordingButtonVisibility.spec.ts
+++ b/tests/specs/misc/recordingButtonVisibility.spec.ts
@@ -34,11 +34,43 @@ describe('Recording button visibility', () => {
         p2 = ctx.p2;
         expect(await p2.isModerator()).toBe(false);
 
+        // Mirror the app's supportsLocalRecording() exactly — LocalRecordingManager.isSupported()
+        // plus the (!isEmbedded() || isEmbeddedFromSameDomain()) guard — so the test's expectation
+        // matches what the app actually renders. These browser/capability gates are frequently unmet
+        // in the automated test browser even though local recording works in a normal browser, in
+        // which case the app correctly hides the button from non-moderators.
         localRecordingAvailable = await p2.execute(() => {
             const state = APP.store.getState();
             const { localRecording } = state['features/base/config'];
 
-            return localRecording?.disable !== true && Boolean(window.MediaRecorder);
+            const browser = JitsiMeetJS.util.browser;
+            const PREFERRED_MEDIA_TYPE = 'video/webm;codecs=vp8,opus';
+
+            // LocalRecordingManager.isSupported()
+            const isSupported = browser.isChromiumBased()
+                && !browser.isElectron()
+                && !browser.isReactNative()
+                && !browser.isMobileDevice()
+
+                // @ts-ignore
+                && Boolean(navigator.mediaDevices.setCaptureHandleConfig)
+
+                // @ts-ignore
+                && typeof window.showSaveFilePicker !== 'undefined'
+                && MediaRecorder.isTypeSupported(PREFERRED_MEDIA_TYPE);
+
+            // (!isEmbedded() || isEmbeddedFromSameDomain())
+            let embeddedOk = true;
+
+            try {
+                if (window.self !== window.top) {
+                    embeddedOk = window.self.location.host === window.parent.location.host;
+                }
+            } catch (e) {
+                embeddedOk = false;
+            }
+
+            return localRecording?.disable !== true && isSupported && embeddedOk;
         });
     });
 

--- a/tests/specs/misc/recordingTranscriptionDialog.spec.ts
+++ b/tests/specs/misc/recordingTranscriptionDialog.spec.ts
@@ -1,6 +1,21 @@
 import { setTestProperties } from '../../helpers/TestProperties';
 import { expectations } from '../../helpers/expectations';
 import { ensureOneParticipant } from '../../helpers/participants';
+import RecordingTranscriptionDialog from '../../pageobjects/RecordingTranscriptionDialog';
+
+/**
+ * Turns both toggles off so the selection matches the idle (nothing-running) state. This makes the
+ * OK ("Apply changes") button assertions deterministic regardless of whether the deployment
+ * pre-checks transcription via autoTranscribeOnRecord (which JaaS forces server-side).
+ */
+async function clearToggles(dialog: RecordingTranscriptionDialog): Promise<void> {
+    if (await dialog.isRecordingToggleChecked()) {
+        await dialog.clickRecordingToggle();
+    }
+    if (await dialog.isTranscriptionToggleChecked()) {
+        await dialog.clickTranscriptionToggle();
+    }
+}
 
 setTestProperties(__filename, {
     description: 'Unified Recording & Transcription dialog structure',
@@ -63,14 +78,16 @@ describe('Recording & Transcription dialog', () => {
         await dialog.cancel();
     });
 
-    it('OK button is disabled when nothing has changed from initial state', async () => {
+    it('OK button is disabled when no service is selected', async () => {
         const p1 = ctx.p1;
         const dialog = p1.getRecordingTranscriptionDialog();
 
         await p1.getToolbar().clickRecordingButton();
         await dialog.waitForDisplay();
 
-        // No session is running and no toggles have been changed — nothing to apply.
+        // With nothing running and both toggles off, the selection matches the running state —
+        // there is nothing to apply.
+        await clearToggles(dialog);
         expect(await dialog.isOkButtonEnabled()).toBe(false);
 
         await dialog.cancel();
@@ -83,17 +100,13 @@ describe('Recording & Transcription dialog', () => {
         await p1.getToolbar().clickRecordingButton();
         await dialog.waitForDisplay();
 
-        const wasEnabled = await dialog.isOkButtonEnabled();
+        await clearToggles(dialog);
+        expect(await dialog.isOkButtonEnabled()).toBe(false);
 
         await dialog.clickRecordingToggle();
 
-        // If the toggle moved us away from the initial state the button must be enabled.
-        // If it was already enabled (e.g. autoTranscribeOnRecord pre-checked transcription)
-        // it should stay enabled.
+        expect(await dialog.isRecordingToggleChecked()).toBe(true);
         expect(await dialog.isOkButtonEnabled()).toBe(true);
-
-        // Verify the button was NOT enabled before the toggle (catches regressions).
-        expect(wasEnabled).toBe(false);
 
         await dialog.cancel();
     });
@@ -105,13 +118,13 @@ describe('Recording & Transcription dialog', () => {
         await p1.getToolbar().clickRecordingButton();
         await dialog.waitForDisplay();
 
-        // Snapshot state before any interaction.
-        const initiallyEnabled = await dialog.isOkButtonEnabled();
+        await clearToggles(dialog);
+        expect(await dialog.isOkButtonEnabled()).toBe(false);
 
         await dialog.clickTranscriptionToggle();
 
+        expect(await dialog.isTranscriptionToggleChecked()).toBe(true);
         expect(await dialog.isOkButtonEnabled()).toBe(true);
-        expect(initiallyEnabled).toBe(false);
 
         await dialog.cancel();
     });
@@ -122,6 +135,8 @@ describe('Recording & Transcription dialog', () => {
 
         await p1.getToolbar().clickRecordingButton();
         await dialog.waitForDisplay();
+
+        await clearToggles(dialog);
 
         await dialog.clickRecordingToggle();
         expect(await dialog.isOkButtonEnabled()).toBe(true);


### PR DESCRIPTION
## Summary

Extends #17544 with the remaining fixes needed to get the recording/transcription
e2e specs green on alpha-canary. The first commit is cherry-picked from #17544
(switch to main frame + open the overflow menu); the rest are the additional fixes
that #17544 does not include.

## Commits

1. **(from #17544)** switch to main frame and open the overflow menu in
   recording/transcription specs.
2. **close the overflow menu via its toggled aria-label** — once the overflow menu
   is open, the toggle's aria-label changes from `More actions` to
   `Close more actions menu`, so `closeOverflowMenu()` can no longer reuse
   `clickOverflowButton()`. `hasRecordingButton()` leaves the menu open and relies on
   `closeOverflowMenu()`, so this path must target the toggled label.
3. **match the non-moderator `Record` button + gate local-recording visibility** —
   non-moderators get a `Record` button (`toolbar.record`) instead of the moderator's
   `Record & Transcribe`, so `hasRecordingButton()` now matches either label.
   `recordingButtonVisibility` also mirrors the app's `supportsLocalRecording()` gate
   so the non-moderator expectation matches what the app actually renders in the
   automated browser.
4. **deterministic dialog OK-button assertions** — the OK (`Apply changes`) button is
   enabled when the selection differs from the running state, which
   `autoTranscribeOnRecord` (on by default, enforced server-side on JaaS) flips by
   pre-checking transcription. Normalize both toggles off before asserting.
5. **`autoTranscribeOnRecord`-tolerant nudge** — when `autoTranscribeOnRecord` is on,
   starting recording also starts transcription, so the middleware suppresses the
   `Start transcribing` nudge. Assert the nudge appears only when transcription did
   not start alongside recording.

## Testing

Verified against alpha-canary across multiple runs: `recordingButtonVisibility`,
`recordingTranscriptionDialog`, and the overflow/frame/hangup/manage-mode parts of
`recordingTranscription` pass. The remaining red specs in those runs
(`recording.spec`, `transcriptions.spec`, the recording-dependent nudge/independent-stop
tests) are backend/recording-infra flakiness (a recording session intermittently fails
to start), not test code.

`npm run lint:ci` and `tsc` clean for the changed files.
