### PR TITLE
fix(tests): use a unique room per recording test to avoid jibri rate-limit

### DIFF
--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -7,11 +7,25 @@ setTestProperties(__filename, {
     useJaas: true
 });
 
+// Counter used to give each test its own room — see joinAsModerator().
+let roomCounter = 0;
+
 /**
  * Joins a JaaS meeting as a moderator using the iFrame API wrapper.
+ *
+ * Each call joins a unique room. All tests in this spec otherwise share ctx.roomName, and joinMuc
+ * rejoins it each test, so prosody's per-room jibri start/stop throttle (mod_filter_iq_jibri,
+ * max_number_room_attempts_per_minute, default 3 — both start and stop count) accumulates across
+ * the suite and trips the "started a recording too quickly" policy error. A fresh room per test
+ * resets that throttle, keeping each test's ≤2 start/stop attempts well under the limit. The
+ * moderator token is room-agnostic (room defaults to '*'), so it is valid for any room.
  */
 async function joinAsModerator(): Promise<Participant> {
-    const p = await joinJaasMuc({ iFrameApi: true, token: t({ moderator: true }) });
+    roomCounter += 1;
+
+    const p = await joinJaasMuc(
+        { iFrameApi: true, token: t({ moderator: true }) },
+        { roomName: `${ctx.roomName}-${roomCounter}` });
 
     // joinJaasMuc leaves the driver focused inside the Jitsi iframe, but the iFrame API
     // (window.jitsiAPI) lives on the wrapper page. Switch to the main frame so executeCommand()


### PR DESCRIPTION
## Summary

Follow-up to #17545. The `recordingTranscription` tests share one room
(`ctx.roomName`) across the whole spec, and `joinMuc` rejoins it each test. Prosody's
per-room jibri start/stop throttle (`mod_filter_iq_jibri`,
`max_number_room_attempts_per_minute`, default **3/min**, where **both start and stop
count**) therefore accumulates across the ~12 recording start/stops in the suite and
trips the `recording.policyError` rejection ("You tried to start a recording too
quickly"). That surfaced as the intermittent **"Recording session did not become
active"** failures on the later tests.

## Fix

`joinAsModerator()` now joins a **unique room per test** (`${ctx.roomName}-${n}`), so the
per-room throttle resets each test and each test's ≤2 start/stop attempts stay well under
the limit. The moderator token is room-agnostic (`room` defaults to `'*'`), so it is valid
for any room. This spec checks redux state (not the webhook proxy, which is keyed to
`ctx.roomName`), so per-test rooms are safe here.

## Notes

- Diagnosed from a failing run: the (now non-white, thanks to #17545's `finally`-hangup
  removal) screenshot showed "Recording failed to start — You tried to start a recording
  too quickly. Please try again later!" — `recording.policyError`, emitted by
  `mod_filter_iq_jibri` as `wait/policy-violation`.
- Single-file change; `lint:ci` and `tsc` clean.
