### PR TITLE
fix(tests): give overflow menu a generous wait for slow renders

### DIFF
--- a/tests/pageobjects/Toolbar.ts
+++ b/tests/pageobjects/Toolbar.ts
@@ -410,7 +410,11 @@ export default class Toolbar extends BasePageObject {
     private waitForOverFlowMenu(visible: boolean) {
         return this.getButton(OVERFLOW_MENU).waitForDisplayed({
             reverse: !visible,
-            timeout: 3000,
+
+            // The menu opens with an enter animation and its render can be delayed by several
+            // seconds when the main thread is busy (e.g. right after a rejoin or while a virtual
+            // background effect is loading), so allow a generous timeout before giving up.
+            timeout: 10000,
             timeoutMsg: `Overflow menu is not ${visible ? 'visible' : 'hidden'}`
         });
     }


### PR DESCRIPTION
## Problem

`virtualBackgroundV2.spec.ts › blur works on low tier` flaked in `openVBDialog` with:

```
Error: Overflow menu is not visible
    at Toolbar.openOverflowMenu (tests/pageobjects/Toolbar.ts)
    at Toolbar.clickButtonInOverflowMenu
    at openVBDialog (tests/specs/misc/virtualBackgroundV2.spec.ts:34)
```

## Diagnosis

The overflow button click actually **worked** — the failure screenshot and the captured DOM both show the menu open, with `#overflow-context-menu` (`aria-label="More actions menu"`) present and visible. The menu's enter animation/render just completed **later than the 3 s** `waitForOverFlowMenu` timeout.

This test block hangs up and rejoins right before the failing step, and the V2 segmentation effect loads around the same time — both saturate the main thread, so the menu render (and WebDriver's visibility polls) slip past 3 s. The element is uniquely identified, so this is purely a timeout-too-short issue, not a selector/occlusion problem.

## Fix

Raise the `waitForOverFlowMenu` timeout from 3 s to 10 s so a slow-but-correct menu open isn't reported as a failure. Affects every test that opens the overflow menu.