### PR TITLE
feat(wake-lock): keep the screen awake while waiting in the lobby

### DIFF
--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -1,5 +1,6 @@
 import i18next from 'i18next';
 
+import { SET_KNOCKING_STATE } from '../../lobby/actionTypes';
 import {
     setPrejoinPageVisibility,
     setSkipPrejoinOnReload
@@ -58,6 +59,11 @@ async function releaseScreenLock() {
  * @returns {void}
  */
 function requestWakeLock() {
+    // A wake lock is already held (e.g. requested while knocking in the lobby), no need to request another one.
+    if (screenLock && !screenLock.released) {
+        return;
+    }
+
     if (navigator.wakeLock?.request) {
         navigator.wakeLock.request('screen')
             .then(lock => {
@@ -111,6 +117,17 @@ MiddlewareRegistry.register(store => next => action => {
         }
 
         requestWakeLock();
+
+        break;
+    }
+    case SET_KNOCKING_STATE: {
+        // Keep the screen awake while waiting in the lobby. The lock is kept on join (see CONFERENCE_JOINED, which
+        // no-ops if it is already held) and released by the CONFERENCE_FAILED/CONFERENCE_LEFT/KICKED_OUT handlers if
+        // knocking is rejected or the user leaves. We intentionally do not release here on knocking === false to avoid
+        // dropping the lock mid-meeting once a participant has been admitted.
+        if (action.knocking) {
+            requestWakeLock();
+        }
 
         break;
     }


### PR DESCRIPTION
## Problem

The screen wake lock is only requested on `CONFERENCE_JOINED`. While the local participant is knocking and waiting on the lobby screen, no wake lock is held, so the device can dim/sleep before they are admitted.

## Change

- Request a screen wake lock on `SET_KNOCKING_STATE` when `knocking === true`, so the screen stays awake while waiting in the lobby.
- `requestWakeLock()` now no-ops when a non-released lock is already held. This means the lock acquired while knocking carries over into the meeting on `CONFERENCE_JOINED` without orphaning the existing `WakeLockSentinel` (and leaking its `release` listener).
- Release continues to be owned solely by the existing `CONFERENCE_FAILED` (rejection / `ACCESS_DENIED`), `CONFERENCE_LEFT`, and `KICKED_OUT` handlers. We intentionally do **not** release on `knocking === false`, to avoid any chance of dropping the lock mid-meeting once admitted.

Lifecycle: **knock → lock acquired → (admitted: lock kept through join) / (rejected or left: lock released)**.

## Notes

- Web-only change (`middleware.web.ts`); native wake lock is handled separately in `react/features/mobile/wake-lock`.
- The `visibilitychange` re-acquire handler is now also wired up during knocking, so a lock dropped by the OS while the tab is hidden is re-requested when the user returns to the lobby tab.