### PR TITLE
fix(recording): update dialog primary button copy when services idle

### DIFF
--- a/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
@@ -79,10 +79,14 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
             _transcriptionRunning
         } = this.props;
 
+        const sessionRunning = Boolean(_recordingRunning || _transcriptionRunning);
+
         return (
             <Dialog
                 ok = {{
-                    translationKey: 'dialog.applyChanges',
+                    // On first open (nothing running) the primary action starts a service; once a
+                    // service is active the dialog manages it, so the button applies the changes.
+                    translationKey: sessionRunning ? 'dialog.applyChanges' : 'dialog.startRecording',
                     disabled: this.isStartRecordingDisabled()
                 }}
                 onSubmit = { this._onSubmit }

--- a/tests/specs/misc/recordingTranscriptionDialog.spec.ts
+++ b/tests/specs/misc/recordingTranscriptionDialog.spec.ts
@@ -5,8 +5,8 @@ import RecordingTranscriptionDialog from '../../pageobjects/RecordingTranscripti
 
 /**
  * Turns both toggles off so the selection matches the idle (nothing-running) state. This makes the
- * OK ("Apply changes") button assertions deterministic regardless of whether the deployment
- * pre-checks transcription via autoTranscribeOnRecord (which JaaS forces server-side).
+ * OK button assertions deterministic regardless of whether the deployment pre-checks transcription
+ * via autoTranscribeOnRecord (which JaaS forces server-side).
  */
 async function clearToggles(dialog: RecordingTranscriptionDialog): Promise<void> {
     if (await dialog.isRecordingToggleChecked()) {
@@ -53,14 +53,15 @@ describe('Recording & Transcription dialog', () => {
         await dialog.cancel();
     });
 
-    it('OK button reads "Apply changes"', async () => {
+    it('OK button reads "Start recording" when nothing is running', async () => {
         const p1 = ctx.p1;
         const dialog = p1.getRecordingTranscriptionDialog();
 
         await p1.getToolbar().clickRecordingButton();
         await dialog.waitForDisplay();
 
-        expect(await dialog.getOkButtonText()).toBe('Apply changes');
+        // Nothing is running yet, so the primary action starts a service rather than applying changes.
+        expect(await dialog.getOkButtonText()).toBe('Start recording');
 
         await dialog.cancel();
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
