### PR TITLE
fix(authentication): close inline token auth popup when admitted to conference

### DIFF
--- a/react/features/authentication/actions.native.ts
+++ b/react/features/authentication/actions.native.ts
@@ -98,3 +98,12 @@ export function openTokenAuthUrl(tokenAuthServiceUrl: string) {
 export function loginWithPopup(tokenAuthServiceUrl: string): Promise<any> {
     return Promise.resolve(tokenAuthServiceUrl);
 }
+
+/**
+ * Not used. There is no inline login popup on native.
+ *
+ * @returns {void}
+ */
+export function closeLoginPopup() {
+    // No-op on native.
+}

--- a/react/features/authentication/actions.web.ts
+++ b/react/features/authentication/actions.web.ts
@@ -31,6 +31,27 @@ class PopupBlockedError extends Error {
 }
 
 /**
+ * Custom error thrown when a pending inline login popup is closed
+ * programmatically (e.g. the participant is admitted to the conference while
+ * the popup is still open), as opposed to failing to authenticate.
+ */
+class LoginCancelledError extends Error {
+    constructor(message: string = 'Login cancelled') {
+        super(message);
+        this.name = 'LoginCancelledError';
+        Error.captureStackTrace(this, LoginCancelledError);
+    }
+}
+
+/**
+ * Holds a function that closes the currently open inline login popup (if any)
+ * and settles its pending promise. It is set while a popup is open and cleared
+ * once the popup is closed, so it can be used to dismiss the popup when it is no
+ * longer needed (e.g. when the participant is admitted to the conference).
+ */
+let closeActiveLoginPopup: (() => void) | undefined;
+
+/**
  * Cancels {@ink LoginDialog}.
  *
  * @returns {{
@@ -142,6 +163,7 @@ export function loginWithPopup(tokenAuthServiceUrl: string, popup?: Window | nul
             window.removeEventListener('message', handler);
             clearInterval(closedPollInterval);
             popup?.close();
+            closeActiveLoginPopup = undefined;
 
             try {
                 sessionStorage.removeItem('oauth_nonce');
@@ -178,6 +200,14 @@ export function loginWithPopup(tokenAuthServiceUrl: string, popup?: Window | nul
 
         // Listen for messages from the popup
         window.addEventListener('message', handler);
+
+        // Expose a way to close this popup externally, so it can be dismissed
+        // when it is no longer needed (e.g. the participant was admitted to the
+        // conference while the popup was still open).
+        closeActiveLoginPopup = () => {
+            cleanup(handler);
+            reject(new LoginCancelledError());
+        };
 
         // Detect manual popup close before authentication completes
         closedPollInterval = setInterval(() => {
@@ -218,6 +248,17 @@ export function silentLogout(tokenAuthLogoutServiceUrl: string): any {
 
         window.addEventListener('message', handler);
     });
+}
+
+/**
+ * Closes the currently open inline login popup (if any) and settles its pending
+ * promise. Used to dismiss the popup when it is no longer needed, e.g. when the
+ * participant is admitted to the conference while the popup is still open.
+ *
+ * @returns {void}
+ */
+export function closeLoginPopup() {
+    closeActiveLoginPopup?.();
 }
 
 /**
@@ -285,14 +326,19 @@ export function openTokenAuthUrl(tokenAuthServiceUrl: string): any {
                         } ],
                         appearance: NOTIFICATION_TYPE.ERROR
                     }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
-
+                    logger.error(err);
+                } else if (err instanceof LoginCancelledError) {
+                    // The popup was closed programmatically (e.g. we were
+                    // admitted to the conference while it was still open); this
+                    // is not an authentication failure, so nothing to report.
+                    logger.info('Inline login popup closed:', err.message);
                 } else {
                     // let's add expand that will show the error message in the notification
                     dispatch(showErrorNotification({
                         titleKey: 'dialog.loginFailed'
                     }));
+                    logger.error(err);
                 }
-                logger.error(err);
             });
 
             return;

--- a/react/features/authentication/middleware.ts
+++ b/react/features/authentication/middleware.ts
@@ -26,6 +26,7 @@ import {
     WAIT_FOR_OWNER
 } from './actionTypes';
 import {
+    closeLoginPopup,
     disableModeratorLogin,
     enableModeratorLogin,
     hideLoginDialog,
@@ -132,6 +133,12 @@ MiddlewareRegistry.register(store => next => action => {
             dispatch(stopWaitForOwner());
         }
         dispatch(hideLoginDialog());
+
+        // We may have been admitted to the conference while an inline token
+        // auth popup was still open (e.g. an authenticated participant joined
+        // and the backend let us in automatically). Dismiss the popup so it
+        // doesn't linger on top of the conference.
+        closeLoginPopup();
         break;
     }
 


### PR DESCRIPTION
## Problem

With `tokenAuthInline` enabled, clicking **"I am host"** on the `WaitForOwnerDialog` opens an OAuth popup via `loginWithPopup`, while the `waitForOwner` cycle keeps retrying to join (`checkIfCanJoin` every 5s).

If an authenticated participant joins in the meantime, the backend admits the waiting user automatically, firing `CONFERENCE_JOINED`. That handler hid the `WaitForOwnerDialog` and `LoginDialog`, but **nothing closed the inline auth popup** — its cleanup handle lived entirely inside `loginWithPopup` with no external cancel path. Result: the popup lingers on top of the joined conference and its promise stays pending.

## Fix

- **`actions.web.ts`**: track the active popup via a module-level `closeActiveLoginPopup` handle (set while open, cleared by `cleanup` on every settle path). Add `LoginCancelledError` to distinguish a programmatic close from an auth failure — the `openTokenAuthUrl` catch now logs it quietly instead of showing a "login failed" notification. Export `closeLoginPopup()`, which runs the popup cleanup and rejects its pending promise.
- **`middleware.ts`**: `CONFERENCE_JOINED` now calls `closeLoginPopup()` alongside the existing dialog cleanup. Safe no-op when no popup is open (e.g. the normal success flow, where cleanup already ran).
- **`actions.native.ts`**: no-op `closeLoginPopup()` so the shared middleware resolves on native (no inline popup there, mirroring the existing `loginWithPopup` stub).

The **manual** popup-close path (user closing the SSO window themselves) is intentionally left unchanged.

## Testing

`npm run tsc:web`, `npm run tsc:native` and ESLint pass on the changed files.

Manual verification: guest opens the inline auth popup, a moderator joins to auto-admit them, and confirm the popup closes with no error toast.