### PR TITLE
feat(audio-translation): neutral default-open hooks for external gating

### DIFF
--- a/resources/prosody-plugins/mod_audio_translation_component.lua
+++ b/resources/prosody-plugins/mod_audio_translation_component.lua
@@ -251,7 +251,14 @@ local function publish(room)
         return;
     end
 
-    local aggregate = is_enabled(room) and compute_aggregate(room) or nil;
+    -- Neutral, default-open extension point: an external module may veto publishing
+    -- the translation request map by returning false from this event. No handler, or
+    -- any non-false return, means allowed. This keeps any gating/entitlement logic out
+    -- of this module (open by default). Follows the same false=deny / nil=no-opinion
+    -- convention as 'jitsi-metadata-allow-moderation'.
+    local allow_publish = main_muc_module:fire_event('jitsi-audio-translation-allow-publish', { room = room; });
+
+    local aggregate = (allow_publish ~= false and is_enabled(room)) and compute_aggregate(room) or nil;
     local encoded = aggregate and json.encode(aggregate) or nil;
 
     if encoded == room._audio_translation.last_published then

--- a/resources/prosody-plugins/mod_room_metadata_component.lua
+++ b/resources/prosody-plugins/mod_room_metadata_component.lua
@@ -175,6 +175,20 @@ function send_metadata(occupant, room, json_msg, include_services)
             -- broadcast to regular clients.
             metadata_to_send.audioTranslationRequests = room._data.audioTranslationRequests;
 
+            -- Neutral, default-open extension point: an external module may contribute
+            -- additional jicofo-only metadata fields by returning a table from this
+            -- event -- for instance per-room translator connect headers. Fired inside
+            -- the admin branch, so injected fields reach only jicofo and are never
+            -- broadcast to client occupants. No handler means nothing is added; this
+            -- module holds no token/entitlement logic of its own.
+            local admin_extra = main_muc_module and main_muc_module:fire_event(
+                'jitsi-room-metadata-admin-extra', { room = room; });
+            if type(admin_extra) == 'table' then
+                for k, v in pairs(admin_extra) do
+                    metadata_to_send[k] = v;
+                end
+            end
+
             module:log('info', 'Sending metadata to jicofo room=%s,meeting_id=%s', room.jid, room._data.meetingId);
         elseif include_services then
             metadata_to_send.services = {};


### PR DESCRIPTION
## What

Adds two neutral, **default-open** prosody extension points so that an external module can gate live audio translation and attach extra jicofo-only connect metadata — without any gating, token, or entitlement logic living in these open-source modules.

### `mod_audio_translation_component`
`publish()` now fires `jitsi-audio-translation-allow-publish` before building the aggregated request map. A handler returning `false` suppresses publishing (so the focus starts no translators); no handler — or any non-`false` return — means allowed. This follows the existing `jitsi-metadata-allow-moderation` convention (`false`=deny, `nil`=no-opinion).

### `mod_room_metadata_component`
`send_metadata()` fires `jitsi-room-metadata-admin-extra` inside the **admin-only** branch. A handler may return a table of extra fields to merge into the metadata sent to the focus. Because it is inside the admin branch, injected fields reach only the focus and are never broadcast to client occupants (same guarantee `audioTranslationRequests` relies on).

## Why

These are generic seams for deployment-specific modules to (a) make an allow/deny decision about translation and (b) hand the focus additional per-room connect configuration (e.g. connect HTTP headers), without that policy leaking into the open-source component. With no handler registered, behavior is identical to today.

## Notes
- Stacked on the live-translation branch (`translation`).
- No default behavior change; both hooks are no-ops when unhandled.
- `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
