### PR TITLE
fix(reactions): ignore unknown reaction keys in endpoint messages

### DIFF
--- a/react/features/base/app/components/BaseApp.tsx
+++ b/react/features/base/app/components/BaseApp.tsx
@@ -22,6 +22,12 @@ import logger from '../logger';
 interface IState {
 
     /**
+     * Whether an error was caught while rendering the tree below this
+     * {@code BaseApp}.
+     */
+    hasError?: boolean;
+
+    /**
      * The {@code Route} rendered by the {@code BaseApp}.
      */
     route: {
@@ -57,8 +63,19 @@ export default class BaseApp<P> extends Component<P, IState> {
 
         this.state = {
             route: {},
-            store: undefined
+            store: undefined,
+            hasError: false
         };
+    }
+
+    /**
+     * Updates the state so the next render shows the fallback instead of
+     * unmounting the whole tree when a descendant throws while rendering.
+     *
+     * @returns {Object}
+     */
+    static getDerivedStateFromError() {
+        return { hasError: true };
     }
 
     /**
@@ -164,7 +181,11 @@ export default class BaseApp<P> extends Component<P, IState> {
      * @returns {ReactElement}
      */
     override render() {
-        const { route: { component, props }, store } = this.state;
+        const { hasError, route: { component, props }, store } = this.state;
+
+        if (hasError) {
+            return null;
+        }
 
         if (store) {
             return (

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -34,7 +34,7 @@ import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 import { resetUnreadPollsCount } from '../polls/actions';
 import { ADD_REACTION_MESSAGE } from '../reactions/actionTypes';
 import { pushReactions } from '../reactions/actions.any';
-import { ENDPOINT_REACTION_NAME } from '../reactions/constants';
+import { ENDPOINT_REACTION_NAME, REACTIONS } from '../reactions/constants';
 import { getReactionMessageFromBuffer, isReactionsEnabled } from '../reactions/functions.any';
 import { isCCTabEnabled } from '../subtitles/functions.any';
 import { showToolbox } from '../toolbox/actions';
@@ -150,8 +150,14 @@ MiddlewareRegistry.register(store => next => action => {
         const { participant, data } = action;
 
         if (data?.name === ENDPOINT_REACTION_NAME) {
-            // Skip duplicates, keep just 3.
-            const reactions = Array.from(new Set(data.reactions)).slice(0, 3) as string[];
+            // Only accept known reaction keys, skip duplicates and keep just 3.
+            const reactions = Array.from(new Set(data.reactions))
+                .filter((reaction): reaction is string => typeof reaction === 'string' && reaction in REACTIONS)
+                .slice(0, 3);
+
+            if (!reactions.length) {
+                break;
+            }
 
             store.dispatch(pushReactions(reactions));
 

--- a/react/features/reactions/components/native/ReactionEmoji.tsx
+++ b/react/features/reactions/components/native/ReactionEmoji.tsx
@@ -59,6 +59,10 @@ function ReactionEmoji({ reaction, uid, index }: IProps) {
     }, [ animationVal ]);
 
 
+    if (!(reaction in REACTIONS)) {
+        return null;
+    }
+
     return (
         <Animated.Text
             style = {{

--- a/react/features/reactions/components/web/ReactionEmoji.tsx
+++ b/react/features/reactions/components/web/ReactionEmoji.tsx
@@ -75,6 +75,10 @@ class ReactionEmoji extends Component<IProps, IState> {
         const { reaction, uid } = this.props;
         const { index } = this.state;
 
+        if (!(reaction in REACTIONS)) {
+            return null;
+        }
+
         return (
             <div
                 className = { `reaction-emoji reaction-${index}` }

--- a/react/features/reactions/functions.any.ts
+++ b/react/features/reactions/functions.any.ts
@@ -27,7 +27,10 @@ export function getReactionsQueue(state: IReduxState): Array<IReactionEmojiProps
  * @returns {string}
  */
 export function getReactionMessageFromBuffer(buffer: Array<string>): string {
-    return buffer.map<string>(reaction => REACTIONS[reaction].message).reduce((acc, val) => `${acc}${val}`);
+    return buffer
+        .filter(reaction => reaction in REACTIONS)
+        .map<string>(reaction => REACTIONS[reaction].message)
+        .reduce((acc, val) => `${acc}${val}`, '');
 }
 
 /**
@@ -37,12 +40,14 @@ export function getReactionMessageFromBuffer(buffer: Array<string>): string {
  * @returns {Array}
  */
 export function getReactionsWithId(buffer: Array<string>): Array<IReactionEmojiProps> {
-    return buffer.map<IReactionEmojiProps>(reaction => {
-        return {
-            reaction,
-            uid: uuidv4()
-        };
-    });
+    return buffer
+        .filter(reaction => reaction in REACTIONS)
+        .map<IReactionEmojiProps>(reaction => {
+            return {
+                reaction,
+                uid: uuidv4()
+            };
+        });
 }
 
 /**


### PR DESCRIPTION
Filter incoming endpoint-reaction payloads to known REACTIONS keys and guard the REACTIONS lookups in the reaction message/emoji rendering so an unrecognized key no longer throws. Also add an error boundary fallback to BaseApp so a single render error can't unmount the whole app.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
