### PR TITLE
fix(polls): validate answer structure from participants

### DIFF
--- a/react/features/polls/components/AbstractPollResults.tsx
+++ b/react/features/polls/components/AbstractPollResults.tsx
@@ -68,14 +68,17 @@ const AbstractPollResults = (Component: ComponentType<AbstractProps>) => (props:
 
         // Getting every voters ID that participates to the poll
         for (const answer of poll.answers) {
-            answer.voters?.forEach(k => allVoters.add(k.id));
+            const answerVoters = Array.isArray(answer.voters) ? answer.voters : undefined;
+
+            answerVoters?.forEach(k => allVoters.add(k.id));
         }
 
         return poll.answers.map(answer => {
-            const nrOfVotersPerAnswer = answer.voters?.length || 0;
+            const answerVoters = Array.isArray(answer.voters) ? answer.voters : undefined;
+            const nrOfVotersPerAnswer = answerVoters?.length || 0;
             const percentage = allVoters.size > 0 ? Math.round(nrOfVotersPerAnswer / allVoters.size * 100) : 0;
 
-            const voters = answer.voters?.reduce((acc, v) => {
+            const voters = answerVoters?.reduce((acc, v) => {
                 acc.push({
                     id: v.id,
                     name: getParticipantById(reduxState, v.id)

--- a/react/features/polls/middleware.ts
+++ b/react/features/polls/middleware.ts
@@ -12,12 +12,32 @@ import { NOTIFICATION_TIMEOUT_TYPE, NOTIFICATION_TYPE } from '../notifications/c
 
 import { RECEIVE_POLL } from './actionTypes';
 import { clearPolls, receiveAnswer, receivePoll } from './actions';
-import { IIncomingAnswerData } from './types';
+import { IAnswerData, IIncomingAnswerData } from './types';
 
 /**
  * The maximum number of answers a poll can have.
  */
 const MAX_ANSWERS = 32;
+
+/**
+ * Normalizes the answers received for a poll, keeping only the expected fields
+ * and shapes. Answers arrive from remote participants and cannot be trusted to
+ * match the expected structure, so we coerce the name to a string and only keep
+ * voters when it is an array.
+ *
+ * @param {any} answers - The raw answers array carried by the polls message.
+ * @returns {Array<IAnswerData>}
+ */
+function _sanitizeAnswers(answers: any): Array<IAnswerData> {
+    if (!Array.isArray(answers)) {
+        return [];
+    }
+
+    return answers.slice(0, MAX_ANSWERS).map((answer: any) => ({
+        name: String(answer?.name ?? ''),
+        voters: Array.isArray(answer?.voters) ? answer.voters : undefined
+    }));
+}
 
 /**
  * Set up state change listener to perform maintenance tasks when the conference
@@ -89,7 +109,7 @@ function _handleReceivedPollsData(data: any, dispatch: IStore['dispatch'], getSt
         showResults: false,
         lastVote: null,
         question,
-        answers: answers.slice(0, MAX_ANSWERS),
+        answers: _sanitizeAnswers(answers),
         saved: false,
         editing: false,
         pollId

--- a/react/features/polls/reducer.ts
+++ b/react/features/polls/reducer.ts
@@ -12,7 +12,7 @@ import {
     SAVE_POLL
 } from './actionTypes';
 import logger from './logger';
-import { IIncomingAnswerData, IPollData } from './types';
+import { IIncomingAnswerData, IPollData, IVoterData } from './types';
 
 const INITIAL_STATE = {
     polls: {},
@@ -96,7 +96,7 @@ ReducerRegistry.register<IPollsState>(STORE_NAME, (state = INITIAL_STATE, action
         // if the poll exists, we update it with the incoming answer
         for (let i = 0; i < poll.answers.length; i++) {
             // if the answer was chosen, we add the senderId to the array of voters of this answer
-            let voters = poll.answers[i].voters || [];
+            let voters = Array.isArray(poll.answers[i].voters) ? poll.answers[i].voters as IVoterData[] : [];
 
             if (voters.find(user => user.id === answer.senderId)) {
                 if (!answer.answers[i]) {

--- a/resources/prosody-plugins/mod_polls_component.lua
+++ b/resources/prosody-plugins/mod_polls_component.lua
@@ -255,6 +255,9 @@ end
             }
 
             -- now send message to all participants
+            -- Only relay the sanitized answers (name only) so no unexpected
+            -- fields from the sender's payload are forwarded to participants.
+            data.answers = answers;
             data.senderId = poll_creator.occupant_id;
             data.type = 'polls';
             local json_msg_str, error = json.encode(data);

--- a/tests/prosody/docker/prosody.cfg.lua
+++ b/tests/prosody/docker/prosody.cfg.lua
@@ -290,6 +290,15 @@ Component "filesharing.localhost" "filesharing_component"
     muc_mapper_domain_base = "localhost"
     muc_mapper_domain_prefix = "conference"
 
+-- Component for mod_polls_component tests. The module hooks message/host for
+-- new-poll / answer-poll json-messages, keeps per-room poll state (installed on
+-- conference.localhost via process_host_module) and re-broadcasts poll updates
+-- to all occupants. The sender must be an occupant of the room, located from
+-- jitsi_web_query_room (set by mod_jitsi_session from the ?room= param).
+Component "polls.localhost" "polls_component"
+    muc_mapper_domain_base = "localhost"
+    muc_mapper_domain_prefix = "conference"
+
 -- Plain MUC for mod_presence_identity tests. No token verification and no
 -- muc_meeting_id lock so any client can join freely without focus.
 Component "conference-identity.localhost" "muc"

--- a/tests/prosody/helpers/xmpp_client.js
+++ b/tests/prosody/helpers/xmpp_client.js
@@ -763,6 +763,65 @@ export async function createXmppClient({ host = 'localhost', domain, params, use
         },
 
         /**
+         * Sends a raw polls json-message to a polls component. The body is sent
+         * verbatim, so use this to exercise malformed payloads (invalid JSON,
+         * unexpected answer shapes, oversized bodies). Prefer createPoll /
+         * answerPoll for well-formed messages.
+         *
+         * The session must have jitsi_web_query_room set (connect with
+         * params: { room: '<roomname>' }) and the sender must be an occupant of
+         * the room for the component to process the message.
+         *
+         * @param {string} componentJid  e.g. 'polls.localhost'
+         * @param {string} rawPayload    raw text for the <json-message> body
+         */
+        sendPollsMessage(componentJid, rawPayload) {
+            return xmpp.send(
+                xml('message', { to: componentJid,
+                    id: `poll-${++_counter}` },
+                    xml('json-message', { xmlns: 'http://jitsi.org/jitmeet' }, rawPayload)
+                )
+            );
+        },
+
+        /**
+         * Creates a poll by sending a well-formed new-poll json-message to the
+         * polls component. Fire-and-forget — assert via the broadcast the
+         * component sends back to occupants (waitForMessage on a poll broadcast).
+         *
+         * @param {string} componentJid  e.g. 'polls.localhost'
+         * @param {string} pollId         unique poll id
+         * @param {string} question       poll question
+         * @param {Array}  answers        answer objects, e.g. [ { name: 'A' } ]
+         */
+        createPoll(componentJid, pollId, question, answers) {
+            return this.sendPollsMessage(componentJid, JSON.stringify({
+                answers,
+                command: 'new-poll',
+                pollId,
+                question,
+                type: 'polls'
+            }));
+        },
+
+        /**
+         * Answers a poll by sending a well-formed answer-poll json-message to the
+         * polls component. Fire-and-forget.
+         *
+         * @param {string} componentJid  e.g. 'polls.localhost'
+         * @param {string} pollId         id of the poll being answered
+         * @param {Array<boolean>} answers  one boolean per poll option
+         */
+        answerPoll(componentJid, pollId, answers) {
+            return this.sendPollsMessage(componentJid, JSON.stringify({
+                answers,
+                command: 'answer-poll',
+                pollId,
+                type: 'polls'
+            }));
+        },
+
+        /**
          * Sends a raw file-sharing message. Use this to test malformed payloads
          * or non-standard message types (e.g. type='error').
          *

--- a/tests/prosody/mod_polls_component_spec.js
+++ b/tests/prosody/mod_polls_component_spec.js
@@ -1,0 +1,425 @@
+import assert from 'assert';
+
+import { createXmppClient, joinWithFocus } from './helpers/xmpp_client.js';
+
+// mod_polls_component is loaded as the "polls.localhost" component (see
+// docker/prosody.cfg.lua). It hooks message/host for new-poll / answer-poll
+// json-messages, keeps per-room poll state (installed on conference.localhost
+// through process_host_module) and re-broadcasts poll updates to every
+// occupant. The sender must be an occupant of the room, located from
+// jitsi_web_query_room (set by mod_jitsi_session from the ?room= param).
+const CONFERENCE = 'conference.localhost';
+const POLLS_COMPONENT = 'polls.localhost';
+const JITMEET_NS = 'http://jitsi.org/jitmeet';
+
+let _roomCounter = 0;
+const nextRoom = () => `polls-${++_roomCounter}@${CONFERENCE}`;
+
+let _pollCounter = 0;
+const nextPollId = () => `poll-${++_pollCounter}`;
+
+/**
+ * True when msg is a polls broadcast from the polls component.
+ *
+ * @param {object} msg  Message stanza.
+ * @returns {boolean}
+ */
+function isPollsBroadcast(msg) {
+    return msg.name === 'message'
+        && msg.attrs.from === POLLS_COMPONENT
+        && msg.getChild('json-message', JITMEET_NS) !== undefined;
+}
+
+/**
+ * Parses the JSON payload carried by a polls broadcast stanza, or null.
+ *
+ * @param {object} msg  Message stanza.
+ * @returns {object|null}
+ */
+function parsePoll(msg) {
+    const text = msg.getChild('json-message', JITMEET_NS)?.getText();
+
+    try {
+        return text ? JSON.parse(text) : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Waits for a polls broadcast carrying the given command.
+ *
+ * @param {object} client   Connected client.
+ * @param {string} command  'new-poll' | 'answer-poll' | 'old-polls'
+ * @param {number} [timeout=3000]
+ * @returns {Promise<object>} The parsed poll payload.
+ */
+async function waitForPollCommand(client, command, timeout = 3000) {
+    const msg = await client.waitForMessage(
+        s => isPollsBroadcast(s) && parsePoll(s)?.command === command, timeout);
+
+    return parsePoll(msg);
+}
+
+/**
+ * Asserts that NO polls broadcast arrives within the given window.
+ *
+ * @param {object} client
+ * @param {number} [timeout=1000]
+ */
+async function assertNoPollBroadcast(client, timeout = 1000) {
+    try {
+        await client.waitForMessage(isPollsBroadcast, timeout);
+        throw new Error('received unexpected polls broadcast');
+    } catch (err) {
+        if (err.message.includes('Timeout')) {
+            return; // expected — no broadcast arrived
+        }
+        throw err;
+    }
+}
+
+describe('mod_polls_component', () => {
+
+    let clients;
+
+    beforeEach(() => {
+        clients = [];
+    });
+
+    afterEach(async () => {
+        await Promise.all(clients.map(c => c.disconnect()));
+    });
+
+    /**
+     * Focus-joins the room (creating and unlocking it) and registers the client
+     * for cleanup. conference.localhost has mod_muc_meeting_id, so a room must be
+     * created by focus before regular clients can join.
+     *
+     * @param {string} roomJid  Full room JID.
+     * @returns {Promise<object>}
+     */
+    async function focusJoin(roomJid) {
+        const c = await joinWithFocus(roomJid);
+
+        clients.push(c);
+
+        return c;
+    }
+
+    /**
+     * Connects a client with ?room=<roomName> (so mod_jitsi_session sets
+     * jitsi_web_query_room), joins the room, and registers it for cleanup.
+     *
+     * @param {string} roomJid  Full room JID.
+     * @returns {Promise<object>}
+     */
+    async function joinParticipant(roomJid) {
+        const roomName = roomJid.split('@')[0];
+        const c = await createXmppClient({ params: { room: roomName } });
+
+        clients.push(c);
+        await c.joinRoom(roomJid);
+
+        return c;
+    }
+
+    // ── Poll creation ───────────────────────────────────────────────────────
+
+    describe('poll creation', () => {
+
+        it('broadcasts a new poll to all occupants', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+            const other = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'Pick one', [
+                { name: 'Option A' },
+                { name: 'Option B' }
+            ]);
+
+            const [ atCreator, atOther ] = await Promise.all([
+                waitForPollCommand(creator, 'new-poll'),
+                waitForPollCommand(other, 'new-poll')
+            ]);
+
+            for (const poll of [ atCreator, atOther ]) {
+                assert.equal(poll.pollId, pollId);
+                assert.equal(poll.question, 'Pick one');
+                assert.deepEqual(poll.answers.map(a => a.name), [ 'Option A', 'Option B' ]);
+                assert.ok(poll.senderId, 'broadcast must carry the server-stamped senderId');
+            }
+        });
+
+        it('relayed answers contain only names — extra fields are stripped', async () => {
+            // Regression test: the component must re-broadcast only the sanitized
+            // answers ({ name }). A type-confused voters field (or any other extra
+            // field) on an answer must not survive to participants, otherwise it
+            // reaches the client reducer / results render which assume voters is
+            // an array.
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'Pick one', [
+                { name: 'Option A',
+                    voters: 1,
+                    evil: 'payload' },
+                { name: 'Option B',
+                    voters: [ { id: 'spoofed',
+                        name: 'spoofed' } ] }
+            ]);
+
+            const poll = await waitForPollCommand(creator, 'new-poll');
+
+            assert.equal(poll.answers.length, 2);
+            assert.deepEqual(poll.answers.map(a => a.name), [ 'Option A', 'Option B' ]);
+
+            for (const answer of poll.answers) {
+                assert.strictEqual(answer.voters, undefined, 'voters must be stripped from the broadcast');
+                assert.strictEqual(answer.evil, undefined, 'extra fields must be stripped from the broadcast');
+                assert.deepEqual(Object.keys(answer), [ 'name' ], 'answers must expose only the name field');
+            }
+        });
+
+        it('a duplicate pollId is rejected with an error', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'First', [ { name: 'A' } ]);
+            await waitForPollCommand(creator, 'new-poll');
+
+            // Same pollId — the module replies with an error and does not
+            // broadcast a second new-poll.
+            creator.createPoll(POLLS_COMPONENT, pollId, 'Second', [ { name: 'A' } ]);
+
+            const errorReply = await creator.waitForMessage(s => s.attrs.type === 'error');
+
+            assert.ok(errorReply.getChild('error'), 'duplicate pollId must be rejected with an error stanza');
+        });
+    });
+
+    // ── Poll answering ──────────────────────────────────────────────────────
+
+    describe('poll answering', () => {
+
+        it('broadcasts an answer to all occupants', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+            const voter = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'Pick one', [
+                { name: 'Option A' },
+                { name: 'Option B' }
+            ]);
+            await Promise.all([
+                waitForPollCommand(creator, 'new-poll'),
+                waitForPollCommand(voter, 'new-poll')
+            ]);
+
+            voter.answerPoll(POLLS_COMPONENT, pollId, [ true, false ]);
+
+            const [ atCreator, atVoter ] = await Promise.all([
+                waitForPollCommand(creator, 'answer-poll'),
+                waitForPollCommand(voter, 'answer-poll')
+            ]);
+
+            for (const answer of [ atCreator, atVoter ]) {
+                assert.equal(answer.pollId, pollId);
+                assert.deepEqual(answer.answers, [ true, false ]);
+                assert.ok(answer.senderId, 'answer broadcast must carry the server-stamped senderId');
+            }
+        });
+
+        it('an answer for an unknown poll is ignored', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const voter = await joinParticipant(r);
+
+            voter.answerPoll(POLLS_COMPONENT, nextPollId(), [ true ]);
+
+            await assertNoPollBroadcast(voter);
+        });
+    });
+
+    // ── History delivery ──────────────────────────────────────────────────────
+
+    describe('history delivery', () => {
+
+        it('a client joining after a poll was created receives it via old-polls', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'History question', [
+                { name: 'A' },
+                { name: 'B' }
+            ]);
+            await waitForPollCommand(creator, 'new-poll');
+
+            // A late joiner receives the current poll state as an old-polls
+            // message right after joining.
+            const late = await joinParticipant(r);
+            const history = await waitForPollCommand(late, 'old-polls');
+
+            assert.ok(Array.isArray(history.polls), 'old-polls must carry a polls array');
+
+            const stored = history.polls.find(p => p.pollId === pollId);
+
+            assert.ok(stored, 'the previously created poll must be present in history');
+            assert.equal(stored.question, 'History question');
+            assert.deepEqual(stored.answers.map(a => a.name), [ 'A', 'B' ]);
+        });
+    });
+
+    // ── Validation ──────────────────────────────────────────────────────────
+
+    describe('validation', () => {
+
+        /**
+         * Sends a raw new-poll-shaped payload, then asserts no broadcast arrives
+         * and the module is still functional afterwards.
+         *
+         * @param {object} rawPayload  The payload object to serialize and send.
+         */
+        async function assertRejected(rawPayload) {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            creator.sendPollsMessage(POLLS_COMPONENT, JSON.stringify(rawPayload));
+            await assertNoPollBroadcast(creator);
+
+            // The module must still process a well-formed poll afterwards.
+            const goodId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, goodId, 'Still working', [ { name: 'A' } ]);
+            const poll = await waitForPollCommand(creator, 'new-poll');
+
+            assert.equal(poll.pollId, goodId);
+        }
+
+        it('new-poll with a non-string answer name is ignored', () => assertRejected({
+            answers: [ { name: 42 } ],
+            command: 'new-poll',
+            pollId: nextPollId(),
+            question: 'Q',
+            type: 'polls'
+        }));
+
+        it('new-poll with an empty answers array is ignored', () => assertRejected({
+            answers: [],
+            command: 'new-poll',
+            pollId: nextPollId(),
+            question: 'Q',
+            type: 'polls'
+        }));
+
+        it('new-poll with a missing question is ignored', () => assertRejected({
+            answers: [ { name: 'A' } ],
+            command: 'new-poll',
+            pollId: nextPollId(),
+            type: 'polls'
+        }));
+
+        it('answer-poll with non-boolean answers is ignored', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            const pollId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, pollId, 'Pick one', [ { name: 'A' }, { name: 'B' } ]);
+            await waitForPollCommand(creator, 'new-poll');
+
+            // answers must be booleans; a numeric answer must be rejected.
+            creator.sendPollsMessage(POLLS_COMPONENT, JSON.stringify({
+                answers: [ 1, 0 ],
+                command: 'answer-poll',
+                pollId,
+                type: 'polls'
+            }));
+
+            await assertNoPollBroadcast(creator);
+        });
+
+        it('invalid JSON is ignored cleanly', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            creator.sendPollsMessage(POLLS_COMPONENT, '{not valid json{{');
+            await assertNoPollBroadcast(creator);
+
+            // Module must still be functional after the bad message.
+            const goodId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, goodId, 'After bad JSON', [ { name: 'A' } ]);
+            const poll = await waitForPollCommand(creator, 'new-poll');
+
+            assert.equal(poll.pollId, goodId);
+        });
+
+        it('an oversized payload is rejected', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+            const creator = await joinParticipant(r);
+
+            // The payload size is checked (>= 1024 bytes) before decoding.
+            creator.createPoll(POLLS_COMPONENT, nextPollId(), 'x'.repeat(1100), [ { name: 'A' } ]);
+            await assertNoPollBroadcast(creator);
+
+            // A normal poll must still go through afterwards.
+            const goodId = nextPollId();
+
+            creator.createPoll(POLLS_COMPONENT, goodId, 'Normal size', [ { name: 'A' } ]);
+            const poll = await waitForPollCommand(creator, 'new-poll');
+
+            assert.equal(poll.pollId, goodId);
+        });
+    });
+
+    // ── Sender must be an occupant ────────────────────────────────────────────
+
+    describe('sender authorization', () => {
+
+        it('a connected non-occupant cannot create a poll', async () => {
+            const r = nextRoom();
+
+            await focusJoin(r);
+
+            const roomName = r.split('@')[0];
+            const nonOccupant = await createXmppClient({ params: { room: roomName } });
+
+            clients.push(nonOccupant);
+
+            // Deliberately do NOT join the room — the sender is not an occupant.
+            nonOccupant.createPoll(POLLS_COMPONENT, nextPollId(), 'Q', [ { name: 'A' } ]);
+
+            await assertNoPollBroadcast(nonOccupant);
+        });
+    });
+});


### PR DESCRIPTION
Poll answers arrive from remote participants and were stored and rendered without checking their shape. A non-array voters field on an answer led to a TypeError in the RECEIVE_ANSWER reducer and in the poll results render path.

- Relay only sanitized answers (name only) from the polls component.
- Normalize incoming answers on the client, keeping voters only when it is an array.
- Guard the array assumptions in the reducer and results rendering.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
