### PR TITLE
feat(audio-translation): hide the feature when unavailable for the room

### DIFF
--- a/react/features/audio-translation/functions.ts
+++ b/react/features/audio-translation/functions.ts
@@ -38,6 +38,13 @@ export function isAudioTranslationAvailable(state: IReduxState): boolean {
         return false;
     }
 
+    // A deployment can hide the feature for a room via the audioTranslationAvailable RoomMetadata flag
+    // (e.g. when the translation backend is not provisioned for it). Absent, or any value other than an
+    // explicit false, means available. Applies even to those who could otherwise manage it.
+    if (state['features/base/conference'].metadata?.audioTranslationAvailable === false) {
+        return false;
+    }
+
     return canManageAudioTranslation(state) || isAudioTranslationRoomEnabled(state);
 }
 

--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -57,6 +57,13 @@ export interface IConferenceMetadata {
     audioTranslation?: {
         enabled?: boolean;
     };
+
+    /**
+     * Server-controlled flag letting a deployment hide the audio-translation feature for a room (e.g. when
+     * the translation backend is not provisioned for it). Absent, or any value other than an explicit false,
+     * means available.
+     */
+    audioTranslationAvailable?: boolean;
     dialinEnabled?: boolean;
     files: {
         [fileId: string]: {

--- a/resources/prosody-plugins/mod_room_metadata_component.lua
+++ b/resources/prosody-plugins/mod_room_metadata_component.lua
@@ -106,6 +106,7 @@ local extdisco_occpuant_check = module:get_option_boolean('extdisco_occpuant_che
 local blocked_metadata_keys = module:get_option_set('room_metadata_blocked_keys', {
     'allownersEnabled',
     'asyncTranscription',
+    'audioTranslationAvailable',
     'conferencePresetsServiceEnabled',
     'dialinEnabled',
     'moderators',


### PR DESCRIPTION
## What

Adds a server-controlled `audioTranslationAvailable` RoomMetadata flag so a deployment can hide the audio-translation feature for a room where it shouldn't be offered (e.g. the translation backend isn't provisioned for that room).

- `isAudioTranslationAvailable()` now treats `metadata.audioTranslationAvailable === false` as unavailable — absent, or any value other than an explicit `false`, means available (open by default). Applies even to users who could otherwise manage the feature, since the point is that translation won't work for this room at all.
- `IConferenceMetadata`: type the new optional flag.
- `mod_room_metadata_component`: add `audioTranslationAvailable` to the blocked keys so clients can't set it — it's server-controlled.

## Why

Today the audio-translation button is shown/subscribable whenever the feature is deployed and enabled for the room. If a deployment gates translation off for a particular room, the user could still open the control and pick a language, but no translated audio would ever arrive, with no explanation. This flag lets the server suppress the control cleanly. With no flag set, behavior is unchanged (open by default).

## Notes
- Generic mechanism: the client doesn't interpret *why* it's unavailable; a deployment sets the flag however it decides.
- `tsc` (web) + eslint clean on the changed files; `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
