### PR TITLE
feat(audio-translation): log when subscriptions/requests are suppressed

### DIFF
--- a/resources/prosody-plugins/mod_audio_translation_component.lua
+++ b/resources/prosody-plugins/mod_audio_translation_component.lua
@@ -256,15 +256,27 @@ local function publish(room)
     -- any non-false return, means allowed. This keeps any gating/entitlement logic out
     -- of this module (open by default). Follows the same false=deny / nil=no-opinion
     -- convention as 'jitsi-metadata-allow-moderation'.
-    local allow_publish = main_muc_module:fire_event('jitsi-audio-translation-allow-publish', { room = room; });
+    local allow_publish = main_muc_module:fire_event('jitsi-audio-translation-allow-publish', { room = room; }) ~= false;
 
-    local aggregate = (allow_publish ~= false and is_enabled(room)) and compute_aggregate(room) or nil;
+    -- The request set the receivers have asked for, independent of gating. Computed
+    -- unconditionally so we can tell "nothing requested" apart from "requests suppressed".
+    local requested = compute_aggregate(room);
+    local aggregate = (allow_publish and is_enabled(room)) and requested or nil;
     local encoded = aggregate and json.encode(aggregate) or nil;
 
     if encoded == room._audio_translation.last_published then
         return;
     end
     room._audio_translation.last_published = encoded;
+
+    -- Log when we transition to suppressing a non-empty request set (feature disabled for
+    -- the room, or an external handler vetoed publishing). Deduped by last_published above,
+    -- so this fires on the transition, not on every update. Normally the client hides the
+    -- control, so a suppressed request set is worth being able to discover.
+    if aggregate == nil and requested ~= nil then
+        module:log('warn', 'Not publishing audio-translation requests in room %s: %s', room.jid,
+            allow_publish and 'disabled for the room' or 'publishing vetoed by a handler');
+    end
 
     room._data.audioTranslationRequests = aggregate;
 
@@ -333,8 +345,11 @@ function on_message(event)
         return true;
     end
 
-    -- Disabled for the room → silent no-op.
+    -- Disabled for the room → no-op. Log it: the client normally hides the control when
+    -- translation is disabled, so a subscription arriving here is unexpected and worth
+    -- being able to discover.
     if not is_enabled(room) then
+        module:log('warn', 'Ignoring audio-translation subscription from %s: disabled for room %s', from, room.jid);
         return true;
     end
 


### PR DESCRIPTION
## What

Adds a `warn` on the two "translation not active" paths in `mod_audio_translation_component`, which were previously silent no-ops:

- **`on_message`** — a subscription arriving while translation is **disabled for the room** (`is_enabled` false). Today this returns silently; now it logs. (Reachable e.g. for a moderator, whose control stays visible even when the room flag is off.)
- **`publish()`** — transitioning to **suppressing a non-empty request set**, either because it's disabled for the room or because an external handler **vetoed publishing** (`jitsi-audio-translation-allow-publish` returned false). Deduped via `last_published`, so it logs on the state transition, not on every debounced update.

## Why

These states shouldn't occur in normal operation (the client hides the translation control when it's unavailable/disabled), so when they do it's a discoverable anomaly worth a log line — matching the warn-on-reject convention already used in `mod_room_metadata_component`.

## Notes
- **No behavior change to what's published.** The request set is now computed unconditionally so we can distinguish "nothing requested" from "requests suppressed", but the published `audioTranslationRequests` value is identical to before.
- `luac -p` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
