### PR TITLE
dep(react-native-video): bump to 6.19.1

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2259,7 +2259,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-video (6.18.0):
+  - react-native-video (6.19.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2277,7 +2277,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-video/Video (= 6.18.0)
+    - react-native-video/Video (= 6.19.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2288,7 +2288,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-video/Fabric (6.18.0):
+  - react-native-video/Fabric (6.19.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2316,7 +2316,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-video/Video (6.18.0):
+  - react-native-video/Video (6.19.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3651,7 +3651,7 @@ SPEC CHECKSUMS:
   react-native-performance: b48d1aba7501a54af5e1a7efb0dab1ab25dc734f
   react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
   react-native-slider: 34064ca1a6864d7b263e44dd76a2d794e8d26744
-  react-native-video: 7b821291837d8ba7b9d7574bfeb0cd651e910141
+  react-native-video: ce907959c67ad2abaa0411082db621036944737a
   react-native-webrtc: e8f0ce746353adc2744a2b933645e1aeb41eaa74
   react-native-webview: 654f794a7686b47491cf43aa67f7f428bea00eed
   react-native-worklets-core: 28a6e2121dcf62543b703e81bc4860e9a0150cee

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "react-native-svg-transformer": "1.2.0",
         "react-native-tab-view": "3.5.2",
         "react-native-url-polyfill": "2.0.0",
-        "react-native-video": "6.18.0",
+        "react-native-video": "6.19.1",
         "react-native-webrtc": "https://github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
         "react-native-webview": "13.16.0",
         "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
@@ -22809,9 +22809,9 @@
       }
     },
     "node_modules/react-native-video": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.18.0.tgz",
-      "integrity": "sha512-9BjAtAh1uGq6h/GNCCh5yzb/iI9qJHuflwNGExyhoUxbhPD1s+15h+CdpJ2MKKJTXw6J7w+nQOp1Ywa54R8w7Q==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.19.1.tgz",
+      "integrity": "sha512-Tbiyt0JMirVHc4XzGIANjs3SaNjFXQO2qe+buvY7xMJjlyCekkDjJqD9YtlaEloJD2PGWhoPytEXB6gVT7T6lw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -42809,9 +42809,9 @@
       }
     },
     "react-native-video": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.18.0.tgz",
-      "integrity": "sha512-9BjAtAh1uGq6h/GNCCh5yzb/iI9qJHuflwNGExyhoUxbhPD1s+15h+CdpJ2MKKJTXw6J7w+nQOp1Ywa54R8w7Q=="
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/react-native-video/-/react-native-video-6.19.1.tgz",
+      "integrity": "sha512-Tbiyt0JMirVHc4XzGIANjs3SaNjFXQO2qe+buvY7xMJjlyCekkDjJqD9YtlaEloJD2PGWhoPytEXB6gVT7T6lw=="
     },
     "react-native-webrtc": {
       "version": "git+ssh://git@github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-native-svg-transformer": "1.2.0",
     "react-native-tab-view": "3.5.2",
     "react-native-url-polyfill": "2.0.0",
-    "react-native-video": "6.18.0",
+    "react-native-video": "6.19.1",
     "react-native-webrtc": "https://github.com/react-native-webrtc/react-native-webrtc.git#e5d87818289d36411d82d250ab1aee25fcf6c9cd",
     "react-native-webview": "13.16.0",
     "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",


### PR DESCRIPTION
Fixes the Crashlytics EXC_BREAKPOINT crash in RCTVideoManager.view() on iOS 26 (bridgeless mode).

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
