### PR TITLE
fix(recording): local recording fixes for participants without the recording JWT feature

### DIFF
--- a/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialog.ts
@@ -14,7 +14,7 @@ import { getNewAccessToken, isEnabled as isDropboxEnabled } from '../../../dropb
 import { getDropboxData } from '../../../dropbox/functions.any';
 import { showErrorNotification } from '../../../notifications/actions';
 import { setRequestingSubtitles } from '../../../subtitles/actions.any';
-import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
+import { canAddTranscriber, isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import {
     setSelectedRecordingService,
     setStartRecordingIntent,
@@ -45,6 +45,11 @@ export interface IProps extends WithTranslation {
      * Requests transcribing when recording is turned on.
      */
     _autoTranscribeOnRecord: boolean;
+
+    /**
+     * Whether the local participant can start/stop transcription.
+     */
+    _canTranscribe: boolean;
 
     /**
      * The {@code JitsiConference} for the current conference.
@@ -650,6 +655,7 @@ export function mapStateToProps(state: IReduxState, _ownProps: any) {
     return {
         _appKey: dropbox.appKey ?? '',
         _autoTranscribeOnRecord: shouldAutoTranscribeOnRecord(state),
+        _canTranscribe: canAddTranscriber(state),
         _conference: state['features/base/conference'].conference,
         _displaySubtitles,
         _fileRecordingSession: getActiveSession(state, JitsiRecordingConstants.mode.FILE),

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -57,6 +57,11 @@ export interface IProps extends WithTranslation {
     _localRecordingNoNotification: boolean;
 
     /**
+     * Whether a local recording is currently in progress.
+     */
+    _localRecordingRunning: boolean;
+
+    /**
      * Whether self local recording is enabled or not.
      */
     _localRecordingSelfEnabled: boolean;
@@ -477,6 +482,7 @@ export function mapStateToProps(state: IReduxState) {
         _transcriptionRunning: canControlCloud ? isRecorderTranscriptionsRunning(state) : false,
         _localRecordingAvailable,
         _localRecordingEnabled: !localRecording?.disable,
+        _localRecordingRunning: Boolean(state['features/recording'].localRecordingRunning),
         _localRecordingSelfEnabled: !localRecording?.disableSelfRecording,
         _localRecordingNoNotification: !localRecording?.notifyAllParticipants,
         _styles: ColorSchemeRegistry.get(state, 'StartRecordingDialogContent')

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -418,18 +418,21 @@ class AbstractStartRecordingDialogContent extends Component<IProps, IState> {
             return;
         }
 
+        // Selecting local recording implies audio+video — ensure the flag is on
+        // so _isChanged() reflects the selection and the Start button enables.
+        // This must happen before the early return below: when LOCAL is
+        // pre-selected by the dialog (no other service available) the flag
+        // would otherwise never be set and the button would stay disabled.
+        if (!shouldRecordAudioAndVideo) {
+            onRecordAudioAndVideoChange(true);
+        }
+
         // act like group, cannot toggle off
         if (selectedRecordingService === RECORDING_TYPES.LOCAL) {
             return;
         }
 
         onChange(RECORDING_TYPES.LOCAL);
-
-        // Selecting local recording implies audio+video — ensure the flag is on
-        // so _isChanged() reflects the selection and the Apply button enables.
-        if (!shouldRecordAudioAndVideo) {
-            onRecordAudioAndVideoChange(true);
-        }
     }
 
     /**

--- a/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
+++ b/react/features/recording/components/Recording/web/RecordingTranscriptionDialog.tsx
@@ -72,9 +72,9 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
             userName
         } = this.state;
         const {
+            _canTranscribe,
             _fileRecordingsServiceEnabled,
             _fileRecordingsServiceSharingEnabled,
-            _isModerator,
             _recordingRunning,
             _transcriptionRunning
         } = this.props;
@@ -90,7 +90,7 @@ class RecordingTranscriptionDialog extends AbstractStartRecordingDialog {
                     disabled: this.isStartRecordingDisabled()
                 }}
                 onSubmit = { this._onSubmit }
-                titleKey = { _isModerator ? 'dialog.recordAndTranscribe' : 'toolbar.record' }>
+                titleKey = { _canTranscribe ? 'dialog.recordAndTranscribe' : 'toolbar.record' }>
                 <StartRecordingDialogContent
                     fileRecordingsServiceEnabled = { _fileRecordingsServiceEnabled }
                     fileRecordingsServiceSharingEnabled = { _fileRecordingsServiceSharingEnabled }

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -38,11 +38,21 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      * @returns {React$Component}
      */
     _renderSessionToggles() {
-        const { _renderRecording, shouldRecordAudioAndVideo, shouldRecordTranscription, t } = this.props;
+        const {
+            _localRecordingRunning,
+            _renderRecording,
+            shouldRecordAudioAndVideo,
+            shouldRecordTranscription,
+            t
+        } = this.props;
+
+        // A participant who started a local recording must always be able to stop it,
+        // even without the JWT recording feature that _renderRecording reflects.
+        const renderRecordingToggle = _renderRecording || _localRecordingRunning;
 
         return (
             <>
-                { _renderRecording && (
+                { renderRecordingToggle && (
                     <div className = 'recording-header space-top'>
                         <label
                             className = 'recording-title'

--- a/react/features/recording/middleware.ts
+++ b/react/features/recording/middleware.ts
@@ -473,10 +473,13 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         const { localRecording } = getState()['features/base/config'];
 
         if (LocalRecordingManager.isRecordingLocally()) {
+            // Capture before stopping — the recorder's stop handler resets the flag.
+            const wasSelfRecording = LocalRecordingManager.selfRecording.on;
+
             LocalRecordingManager.stopLocalRecording();
             dispatch(setLocalRecordingRunning(false));
             dispatch(updateLocalRecordingStatus(false));
-            if (localRecording?.notifyAllParticipants && !LocalRecordingManager.selfRecording) {
+            if (localRecording?.notifyAllParticipants && !wasSelfRecording) {
                 dispatch(playSound(RECORDING_OFF_SOUND_ID));
             }
             if (typeof APP !== 'undefined') {

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -62,14 +62,16 @@ async function dismissRecordingNotification(p: Participant): Promise<void> {
 }
 
 /**
- * Waits until the recording feature state reports that a FILE-mode session is active.
+ * Waits until the recording feature state reports that a FILE-mode session is fully ON.
+ * A PENDING session is not enough: jicofo rejects a stop request for a session whose jibri
+ * is still starting (policy-violation/wait), so acting on a PENDING session races the backend.
  */
 async function waitForRecordingRunning(p: Participant): Promise<void> {
     await p.driver.waitUntil(
         () => p.execute(() => Boolean(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             APP.store.getState()['features/recording'].sessionDatas.some(
-                (s: any) => s.mode === 'file' && s.status !== 'off'))),
+                (s: any) => s.mode === 'file' && s.status === 'on'))),
         { timeout: 30_000, timeoutMsg: 'Recording session did not become active' }
     );
 }

--- a/tests/specs/jaas/recordingTranscription.spec.ts
+++ b/tests/specs/jaas/recordingTranscription.spec.ts
@@ -36,6 +36,41 @@ async function joinAsModerator(): Promise<Participant> {
 }
 
 /**
+ * Sends the startRecording command and waits until jicofo actually accepts it (a live FILE
+ * session shows up in the recording state), retrying on silent rejection.
+ *
+ * A start IQ that reaches jicofo right after joining can be rejected with policy-violation
+ * (type=wait) while the conference is still being set up, and the client surfaces nothing —
+ * the recording just never starts. The error type says "retry later", so do that. Waiting for
+ * the JVB session before starting instead is NOT an option: jicofo does not allocate a session
+ * for a lone participant at all, it does so only when a second endpoint (e.g. jibri) joins.
+ *
+ * Expects the driver on the main frame; leaves it there.
+ */
+async function startFileRecording(p: Participant, options: { mode: string; transcription?: boolean; }) {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        await p.getIframeAPI().executeCommand('startRecording', options);
+        await p.switchToIFrame();
+
+        const accepted = await p.driver.waitUntil(
+            () => p.execute(() => Boolean(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                APP.store.getState()['features/recording'].sessionDatas.some(
+                    (s: any) => s.mode === 'file' && (s.status === 'pending' || s.status === 'on')))),
+            { timeout: 5_000, timeoutMsg: '' }
+        ).catch(() => false);
+
+        await p.switchToMainFrame();
+
+        if (accepted) {
+            return;
+        }
+    }
+
+    throw new Error('startRecording was not accepted by jicofo after 3 attempts');
+}
+
+/**
  * Waits for the "dialog.recording" notification to appear inside the current iframe context.
  * The notification fires whenever recording or transcription starts (or both).
  */
@@ -152,7 +187,7 @@ describe('Recording & transcription nudge notifications', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', { mode: 'file' });
+            await startFileRecording(p, { mode: 'file' });
             await p.switchToIFrame();
 
             await waitForRecordingNotification(p, 'Recording-started notification did not appear');
@@ -206,7 +241,7 @@ describe('Recording & transcription nudge notifications', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', {
+            await startFileRecording(p, {
                 mode: 'file',
                 transcription: true
             });
@@ -247,7 +282,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', { mode: 'file' });
+            await startFileRecording(p, { mode: 'file' });
             await p.switchToIFrame();
 
             await waitForRecordingRunning(p);
@@ -307,7 +342,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', {
+            await startFileRecording(p, {
                 mode: 'file',
                 transcription: true
             });
@@ -344,7 +379,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', {
+            await startFileRecording(p, {
                 mode: 'file',
                 transcription: true
             });
@@ -394,7 +429,7 @@ describe('Recording & transcription dialog — manage mode', () => {
         const p = await joinAsModerator();
 
         try {
-            await p.getIframeAPI().executeCommand('startRecording', {
+            await startFileRecording(p, {
                 mode: 'file',
                 transcription: true
             });


### PR DESCRIPTION
## Summary

Four fixes around the recording dialog and local recording, found while testing as a non-moderator participant without a JWT:

- **Enable the Start Recording button when local recording is preselected.** When no other recording service is available the dialog preselects the local service, and `_onLocalRecordingSwitchChange` bailed out early (group semantics) before ever setting `shouldRecordAudioAndVideo`. For a participant without the JWT recording feature that flag initializes to `false` and the record toggle is not rendered, so `_isChanged()` could never become true and the button stayed permanently disabled.

- **Allow stopping a local recording without the JWT recording feature.** In manage mode the record audio+video toggle is the only control that can enable the Apply button again, but it was gated on `_renderRecording` (the JWT recording feature). Whoever started a local recording must always be able to stop it, so the toggle now renders whenever a local recording is running.

- **Base the dialog title on the transcription capability.** The title showed "Record & Transcribe" for any moderator, even with `config.transcription.enabled: false`. It now uses `canAddTranscriber()`, matching what the toolbar button label already does.

- **Play the off sound when a local recording stops.** The `STOP_LOCAL_RECORDING` handler gated the sound on `!LocalRecordingManager.selfRecording`, which is an object and always truthy, so the recording-off sound never played (the start path uses the boolean `onlySelf` flag, which is why the on sound worked). Now checks `selfRecording.on`, captured before `stopLocalRecording()` resets it.

## Testing

- Manually tested on web as a non-moderator without JWT on a deployment with `recordingService.enabled: false`: starting a local recording now works, stopping it works, and both the on and off sounds play (with `localRecording.notifyAllParticipants`).
- Verified the dialog title shows "Record" for a moderator when `config.transcription.enabled` is false, and "Record & Transcribe" when the transcription capability is granted (JWT features or default permissions from mod_jitsi_permissions).
- `npm run lint:ci` and `npm run tsc:ci` pass.