### PR TITLE
fix(chat): render native GIFs via GiphyMediaView

### DIFF
--- a/react/features/chat/components/native/GifMessage.tsx
+++ b/react/features/chat/components/native/GifMessage.tsx
@@ -1,7 +1,8 @@
+import { GiphyMediaView } from '@giphy/react-native-sdk';
 import React from 'react';
 import { Image, ImageStyle, View } from 'react-native';
 
-import { extractGifURL } from '../../../gifs/function.any';
+import { extractGifMediaId, extractGifURL } from '../../../gifs/function.any';
 
 import styles from './styles';
 
@@ -15,13 +16,19 @@ interface IProps {
 
 const GifMessage = ({ message }: IProps) => {
     const url = extractGifURL(message);
+    const mediaId = extractGifMediaId(url);
 
     return (<View
         id = 'gif-message'
         style = { styles.gifContainer }>
-        <Image
-            source = {{ uri: url }}
-            style = { styles.gifImage as ImageStyle } />
+        {mediaId
+            ? <GiphyMediaView
+                media = {{ id: mediaId }}
+                resizeMode = 'contain'
+                style = { styles.gifMedia } />
+            : <Image
+                source = {{ uri: url }}
+                style = { styles.gifImage as ImageStyle } />}
     </View>);
 };
 

--- a/react/features/chat/components/native/styles.ts
+++ b/react/features/chat/components/native/styles.ts
@@ -233,10 +233,16 @@ export default {
     },
 
     gifImage: {
+        flexGrow: 1,
+        height: undefined,
+        resizeMode: 'contain',
+        width: 250
+    },
+
+    gifMedia: {
+        height: 150,
         resizeMode: 'contain',
         width: 250,
-        height: undefined,
-        flexGrow: 1
     },
 
     senderDisplayName: {

--- a/react/features/gifs/function.any.ts
+++ b/react/features/gifs/function.any.ts
@@ -97,6 +97,30 @@ export function extractGifURL(message = '') {
 }
 
 /**
+ * Extracts the Giphy media id from a gif URL.
+ *
+ * Giphy media URLs have the shape `https://i.giphy.com/media/<id>/giphy.gif`
+ * (optionally with a rating segment before the id), so the id is the path
+ * segment immediately before the filename.
+ *
+ * @param {string} url - The gif URL.
+ * @returns {string} - The Giphy media id, or an empty string if it can't be parsed.
+ */
+export function extractGifMediaId(url = '') {
+    try {
+        const segments = new URL(url).pathname.split('/').filter(Boolean);
+
+        if (segments.length >= 2) {
+            return segments[segments.length - 2];
+        }
+    } catch (_error) {
+        // Not a parseable URL - fall through to the empty string.
+    }
+
+    return '';
+}
+
+/**
  * Returns the url of the gif selected in the gifs menu.
  *
  * @param {Object} gif - The gif data.


### PR DESCRIPTION
Fixes iOS animated-GIF decode crashes in chat (Crashlytics) by rendering through the Giphy native SDK instead of RN <Image>, bypassing RCTAnimatedImage/ImageIO
