### PR TITLE
feat(prosody): reject MUC nick changes in resource validate

### DIFF
--- a/resources/prosody-plugins/mod_muc_resource_validate.lua
+++ b/resources/prosody-plugins/mod_muc_resource_validate.lua
@@ -13,6 +13,11 @@
 -- The check is dynamic: the auth provider is read from prosody.hosts at
 -- join time, so no static domain list is needed.
 --
+-- The module also hooks muc-occupant-pre-change and rejects MUC nick (resource)
+-- changes: an occupant's resource is its stable identity for the session and
+-- must never change. Legitimate display-name changes travel in the presence
+-- <nick/> child, not the MUC resource, so they are unaffected.
+--
 -- Example configuration (place under the MUC component):
 --
 --   Component "conference.meet.jitsi" "muc"
@@ -86,8 +91,37 @@ local function check_resource(event)
     end
 end
 
+-- Returns true (halts event processing) when a MUC nick (resource) change should
+-- be rejected. In Jitsi the occupant resource is the stable per-session identity
+-- and must never change.
+local function reject_nick_change(event)
+    local room, origin, stanza = event.room, event.origin, event.stanza;
+
+    if is_healthcheck_room(room.jid) then
+        return;
+    end
+
+    local orig_occupant = event.orig_occupant;
+
+    -- No original occupant means there is no rename to police here.
+    if not orig_occupant then
+        return;
+    end
+
+    local _, _, current_resource = jid_split(orig_occupant.nick);
+    local _, _, new_resource = jid_split(stanza.attr.to);
+
+    if new_resource ~= current_resource then
+        module:log("warn", "Rejecting MUC nick change from %s (%s -> %s)",
+            stanza.attr.from, tostring(current_resource), tostring(new_resource));
+        origin.send(st.error_reply(stanza, "cancel", "not-allowed", "Nick changes are not allowed"));
+        return true;
+    end
+end
+
 module:log("info", "module loaded (anonymous_strict=%s)", tostring(anonymous_strict));
 
 module:hook("muc-occupant-pre-join", check_resource, 11);
+module:hook("muc-occupant-pre-change", reject_nick_change, 11);
 
 module:hook_global("config-reloaded", load_config);

--- a/tests/prosody/mod_muc_resource_validate_spec.js
+++ b/tests/prosody/mod_muc_resource_validate_spec.js
@@ -148,4 +148,52 @@ describe('mod_muc_resource_validate', () => {
         );
     });
 
+    // ── Nick (resource) changes ───────────────────────────────────────────────
+    //
+    // The MUC resource is the stable per-session identity and must not change
+    // after join. Display-name changes travel in the presence <nick/> child and
+    // keep the same resource, so they must still be allowed.
+
+    it('rejects a nick change to a different resource', async () => {
+        const r = room();
+
+        await ctx.connectFocus(r);
+        const c = await ctx.connect();
+
+        const joined = await c.joinRoom(r);
+
+        assert.ok(isAvailablePresence(joined), 'initial join must succeed');
+
+        // Send a presence to a different MUC resource, i.e. a nick change.
+        await c.sendPresence(`${r}/rotatednick`);
+
+        const presence = await c.waitForPresenceFrom(`${r}/rotatednick`, { type: 'error' });
+
+        assert.equal(presence.attrs.type, 'error', 'nick change must be rejected');
+        assert.ok(
+            presence.getChild('error')?.getChild('not-allowed'),
+            'error stanza must contain <not-allowed/>'
+        );
+    });
+
+    it('allows a presence update that keeps the same resource', async () => {
+        const r = room();
+
+        await ctx.connectFocus(r);
+        const c = await ctx.connect();
+
+        const joined = await c.joinRoom(r);
+
+        assert.ok(isAvailablePresence(joined), 'initial join must succeed');
+
+        // A presence update to the same MUC resource (e.g. a display-name change)
+        // is not a nick change and must be allowed through.
+        await c.sendPresence(`${r}/${c.nick}`);
+
+        const presence = await c.waitForPresenceFrom(`${r}/${c.nick}`);
+
+        assert.notEqual(presence.attrs.type, 'error',
+            'presence update keeping the same resource must be allowed');
+    });
+
 });


### PR DESCRIPTION
## Description

An occupant's MUC resource is its stable per-session identity and should not change after join. This adds a `muc-occupant-pre-change` hook to `mod_muc_resource_validate` that rejects any presence targeting a different resource than the occupant's current one.

Legitimate display-name changes travel in the presence `<nick/>` child and keep the same MUC resource, so they are unaffected.

## Testing

Extends `mod_muc_resource_validate_spec.js`:
- rejects a nick change to a different resource
- allows a presence update that keeps the same resource

Full spec passes against Prosody 13:

```
mod_muc_resource_validate
  ✔ allows a valid alphanumeric resource
  ✔ allows a resource with underscore after the first character
  ✔ rejects a resource starting with an underscore
  ✔ rejects a resource containing a hyphen
  ✔ allows resource matching UUID prefix
  ✔ rejects resource not matching UUID prefix
  ✔ rejects a nick change to a different resource
  ✔ allows a presence update that keeps the same resource

  8 passing
```