### PR TITLE
fix(android): ignore benign missing-viewState mount race (RN #57181)

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
@@ -25,6 +25,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.RetryableMountingLayerException;
 import com.facebook.react.defaults.DefaultReactHost;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.uimanager.ViewManager;
@@ -230,12 +231,31 @@ class ReactHostHolder {
             BuildConfig.DEBUG, /* useDevSupport */
             Collections.emptyList(), /* cxxReactPackageProviders */
             e -> {
-                JitsiMeetLogger.e(e, "ReactHost internal exception");
-                throw new RuntimeException(e);
+                // Backport of react-native #57181: ignore the benign missing-viewState
+                // mount race. Remove once RN ships the fix.
+                if (isMissingViewStateException(e)) {
+                    JitsiMeetLogger.w("ReactHost ignoring missing-viewState mount race: " + e.getMessage());
+                } else {
+                    JitsiMeetLogger.e(e, "ReactHost internal exception");
+                    throw new RuntimeException(e);
+                }
+                return kotlin.Unit.INSTANCE;
             }, /* exceptionHandler */
             null                    /* bindingsInstaller */
         );
 
         reactHost.start();
+    }
+
+    // Matches the missing-viewState mount race fixed upstream in react-native #57181.
+    private static boolean isMissingViewStateException(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof RetryableMountingLayerException
+                    && t.getMessage() != null
+                    && t.getMessage().contains("Unable to find viewState")) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Problem

On the New Architecture (Fabric), `SurfaceMountingManager.updateState` / `updatePadding` throw a
`RetryableMountingLayerException: Unable to find viewState for tag N` on a benign mount race — a view
torn down mid-batch (e.g. during navigation / animated state updates). This is a regular (non-command)
mount item, so RN rethrows it, and it propagates to the `ReactHostHolder` exception handler, which
escalates it to a fatal `RuntimeException`. It shows up in Crashlytics as a top crash, blamed on
`ReactHostHolder.initReactHost$0`, with unrelated underlying exceptions grouped together.

### Upstream fix

react-native [#57181](https://github.com/facebook/react-native/pull/57181) makes `updateState` /
`updatePadding` soft-log and return instead of throwing. It merged after the 0.86.0 cut, so it is not
in any release yet. Because the Android RN layer is consumed as a **prebuilt AAR**
(`com.facebook.react:react-android`), patching the `.kt` source in `node_modules` has no effect on the
built app.

### This change

An interim guard in `ReactHostHolder` (which *is* compiled from source): the host exception handler
swallows only a `RetryableMountingLayerException` whose message contains `"Unable to find viewState"`,
matching exactly what #57181 does upstream. Every other exception still crashes as before. To be
removed once we adopt an RN release that includes #57181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
