### PR TITLE
test(helpers): gate prejoin button click on APP.store for all participants

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -275,20 +275,18 @@ export class Participant {
         if (!options.skipPrejoinButtonClick
             // @ts-ignore
             && !Boolean(await this.execute(() => config.prejoinConfig?.enabled === false))) {
-            // For iFrame API tests, the wrapper page's iframeAPI.onload fires before the embedded Jitsi
-            // app inside the iframe has finished its own init, so the prejoin Join button can be in the
-            // DOM with no React click handler attached yet. APP.store is created during conference.init,
-            // which is also when prejoin's handlers mount; gating the click on it avoids the race.
-            if (this._iFrameApi) {
-                await this.driver.waitUntil(
-                    // @ts-ignore
-                    () => this.execute(() => typeof APP !== 'undefined' && Boolean(APP.store)),
-                    {
-                        timeout: 30_000,
-                        timeoutMsg: `Timeout waiting for embedded Jitsi app to initialize for ${this._name}.`
-                    }
-                );
-            }
+            // The prejoin Join button can be in the DOM before conference.init has run and React click
+            // handlers are mounted (e.g. when driver.url() returns before the page fully loads on a slow
+            // remote grid, or when the iFrame API wrapper fires onload before the embedded app inits).
+            // APP.store is created during conference.init, so gate the click on it to avoid the race.
+            await this.driver.waitUntil(
+                // @ts-ignore
+                () => this.execute(() => typeof APP !== 'undefined' && Boolean(APP.store)),
+                {
+                    timeout: 30_000,
+                    timeoutMsg: `Timeout waiting for Jitsi app to initialize for ${this._name}.`
+                }
+            );
 
             // if prejoin is enabled we want to click the join button
             const p1PreJoinScreen = this.getPreJoinScreen();


### PR DESCRIPTION
## Summary

- The `APP.store` guard that prevents clicking the prejoin Join button before `conference.init` has mounted its React handlers was only applied for iFrame API participants.
- On slow remote grids, `driver.url()` can return before the page fully loads. The prejoin screen DOM element exists (React renders it early) but the click handler is not yet attached, so the click is silently lost and `waitForMucJoinedOrError` times out 30s later.
- Apply the `APP.store` waitUntil unconditionally for all participants.

## Root cause (from log analysis)

P2's conference page took ~16s to fully load. `driver.url()` returned in ~336ms (the remote grid does not honour the `pageLoad` timeout). `waitForPageToLoad()` evaluated `document.readyState` against the already-loaded `base.html` and returned immediately. The prejoin screen rendered (React mounts it before `conference.init` runs), `waitForLoading()` succeeded, and `joinButton.click()` was sent 16s before `conference.init` — before the React click handler was mounted. `waitForMucJoinedOrError()` then ran its 30s window starting at click time, expiring exactly when the test failed.

The comment in the original code (lines 278–281) already described this race for iFrame API tests. This fix extends the guard to cover the identical race for regular participants on slow environments.

## Test plan

- [ ] Existing tests: the guard was already applied for iFrame API participants; this just applies it to all, so no regression expected for normal fast environments (the `APP.store` condition is met within milliseconds of page load in typical runs).
- [ ] The lobby `enable with more than two participants` failure on should be resolved.