### PR TITLE
docs(config): document the audioTranslation option

### DIFF
--- a/config.js
+++ b/config.js
@@ -232,6 +232,11 @@ var config = {
     //     enableOpusDtx: false,
     // },
 
+    // Audio translation feature (requires bridge backend support).
+    // audioTranslation: {
+    //     enabled: false,
+    // },
+
     // Noise suppression configuration. By default rnnoise is used. Optionally Krisp
     // can be used by enabling it below, but the Krisp JS SDK files must be supplied in your
     // installation. Specifically, these files are needed:


### PR DESCRIPTION
## Summary

Adds a commented `audioTranslation` sample block to `config.js`. The option already exists in `configType.ts` and is consumed by the audio-translation feature (`react/features/audio-translation/`), but was missing from the sample config. The feature remains disabled unless a deployment sets `audioTranslation.enabled: true`.

## Test plan

- `config.js` parses (comment-only change).
- Uncommenting the block and setting `enabled: true` shows the audio translation controls on a deployment with the bridge translation backend.