### PR TITLE
fix: Make sure we deliver videoConferenceLeft.

### DIFF
--- a/react/features/app/actions.web.ts
+++ b/react/features/app/actions.web.ts
@@ -189,6 +189,15 @@ export function reloadNow() {
         const reloadAction = () => {
             logger.info(`Reloading the conference using URL: ${locationURL}`);
 
+            // Fire videoConferenceLeft before navigation so it is delivered
+            // while the postis channel is still active. postMessage sent from
+            // beforeunload is unreliable in Chrome when the iframe navigates.
+            // @ts-ignore
+            APP.API.notifyConferenceLeft(APP.conference.roomName);
+
+            // @ts-ignore
+            APP.API.dispose(); // prevent double-fire from the beforeunload handler
+
             dispatch(reloadWithStoredParams());
         };
 


### PR DESCRIPTION
Browsers (especially Chrome) don't reliably deliver postMessage sent from beforeunload because the page is already unloading. The videoConferenceLeft event races against the browser tearing down the iframe. Fire notifyConferenceLeft inside reloadNow() — before navigation starts — while the postis channel is fully alive, then call APP.API.dispose() so the beforeunload handler doesn't double-fire it.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
