### PR TITLE
feat: expose connection stats via external api

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1048,6 +1048,10 @@ function initCommands() {
                 titleText }));
             break;
         }
+        case 'connection-stats': {
+            callback(APP.conference.getStats());
+            break;
+        }
         case 'deployment-info':
             callback(APP.store.getState()['features/base/config'].deploymentInfo);
             break;

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -777,6 +777,17 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns the connection stats of the conference.
+     *
+     * @returns {Object} Connection stats (bitrate, packet loss, etc).
+     */
+    getConnectionStats() {
+        return this._transport.sendRequest({
+            name: 'connection-stats'
+        });
+    }
+
+    /**
      * Returns whether the conference is P2P.
      *
      * @returns {Promise}


### PR DESCRIPTION
Adds a `connection-stats` request handler to the External API, exposed as `getConnectionStats()`.