### PR TITLE
fix(audio-translation): make original-audio ducking work on iOS

### DIFF
--- a/config.js
+++ b/config.js
@@ -235,6 +235,11 @@ var config = {
     // Audio translation feature (requires bridge backend support).
     // audioTranslation: {
     //     enabled: false,
+    //
+    //     // Volume (0..1) a speaker's original audio is ducked to while its translation plays.
+    //     // Defaults to 0.15. Ignored on iOS, where the original is muted instead because the
+    //     // element volume cannot be lowered there.
+    //     duckedVolume: 0.15,
     // },
 
     // Noise suppression configuration. By default rnnoise is used. Optionally Krisp

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -223,6 +223,7 @@ export interface IConfig {
      * bridge translation backend; the toolbar control is only shown when enabled.
      */
     audioTranslation?: {
+        duckedVolume?: number;
         enabled?: boolean;
     };
     /**

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -21,6 +21,7 @@ export default [
     'analytics.watchRTCEnabled',
     'audioLevelsInterval',
     'audioQuality',
+    'audioTranslation',
     'autoKnockLobby',
     'apiLogLevels',
     'avgRtpStatsN',

--- a/react/features/base/media/components/web/AudioTrack.tsx
+++ b/react/features/base/media/components/web/AudioTrack.tsx
@@ -362,8 +362,14 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { audioTranslation: audioTranslationConfig } = state['features/base/config'];
     const audioTranslationEnabled = audioTranslationConfig?.enabled;
 
-    // The volume a speaker's original is ducked to while its translation plays; overridable via config.
-    const duckedVolume = audioTranslationConfig?.duckedVolume ?? DUCKED_ORIGINAL_VOLUME;
+    // The volume a speaker's original is ducked to while its translation plays; overridable via config, so
+    // validate it — a value outside 0..1 (or a non-number from configOverwrite/URL) would throw a
+    // DOMException when assigned to HTMLMediaElement.volume. Fall back to the default when invalid.
+    const configuredDuckedVolume = audioTranslationConfig?.duckedVolume;
+    const duckedVolume = typeof configuredDuckedVolume === 'number'
+        && configuredDuckedVolume >= 0 && configuredDuckedVolume <= 1
+        ? configuredDuckedVolume
+        : DUCKED_ORIGINAL_VOLUME;
 
     let _volume: number | boolean | undefined = participantsVolume[ownProps.participantId];
 

--- a/react/features/base/media/components/web/AudioTrack.tsx
+++ b/react/features/base/media/components/web/AudioTrack.tsx
@@ -6,13 +6,25 @@ import { sendAnalytics } from '../../../../analytics/functions';
 import { IReduxState } from '../../../../app/types';
 import { DEFAULT_ORIGINAL_VOLUME, DUCKED_ORIGINAL_VOLUME } from '../../../../audio-translation/constants';
 import { getTranslatedSourceNames } from '../../../../audio-translation/functions';
+import { browser } from '../../../lib-jitsi-meet';
 import { ITrack } from '../../../tracks/types';
 import logger from '../../logger';
+
+// iOS (WebKit) ignores programmatic HTMLMediaElement.volume — it is under the user's hardware control, so
+// assigning it is a no-op. Ducking therefore can't lower the volume there; we fall back to muting the
+// original entirely while its translation plays. `element.muted` IS honoured on iOS.
+const IS_IOS_BROWSER = browser.isIosBrowser();
 
 /**
  * The type of the React {@code Component} props of {@link AudioTrack}.
  */
 interface IProps {
+
+    /**
+     * Whether this track's original audio is currently ducked because its translated counterpart is playing.
+     * On iOS, where element volume cannot be lowered, this causes the element to be muted instead.
+     */
+    _ducked?: boolean;
 
     /**
      * Represents muted property of the underlying audio element.
@@ -105,15 +117,13 @@ class AudioTrack extends Component<IProps> {
 
         if (this._ref?.current) {
             const audio = this._ref?.current;
-            const { _muted, _volume } = this.props;
+            const { _volume } = this.props;
 
             if (typeof _volume === 'number') {
                 audio.volume = _volume;
             }
 
-            if (typeof _muted === 'boolean') {
-                audio.muted = _muted;
-            }
+            audio.muted = this._isMuted(this.props);
 
             // @ts-ignore
             audio.addEventListener('error', this._errorHandler);
@@ -166,16 +176,28 @@ class AudioTrack extends Component<IProps> {
             }
 
             const currentMuted = audio.muted;
-            const nextMuted = nextProps._muted;
+            const nextMuted = this._isMuted(nextProps);
 
-            if (typeof nextMuted === 'boolean' && currentMuted !== nextMuted) {
-                logger.debug(`Setting audio element ${nextProps?.id} muted to true`);
+            if (currentMuted !== nextMuted) {
+                logger.debug(`Setting audio element ${nextProps?.id} muted to ${nextMuted}`);
 
                 audio.muted = nextMuted;
             }
         }
 
         return false;
+    }
+
+    /**
+     * Computes the effective muted state of the audio element: muted when the conference is joined silently
+     * ({@code _muted}), or — on iOS, where the volume cannot be lowered — while the track is ducked because
+     * its translation is playing.
+     *
+     * @param {IProps} props - The props to evaluate.
+     * @returns {boolean}
+     */
+    _isMuted(props: IProps) {
+        return Boolean(props._muted) || (IS_IOS_BROWSER && Boolean(props._ducked));
     }
 
     /**
@@ -337,7 +359,11 @@ class AudioTrack extends Component<IProps> {
 function _mapStateToProps(state: IReduxState, ownProps: any) {
     const { participantsVolume } = state['features/filmstrip'];
     const { language: defaultLanguage, participantLanguages } = state['features/audio-translation'];
-    const audioTranslationEnabled = state['features/base/config'].audioTranslation?.enabled;
+    const { audioTranslation: audioTranslationConfig } = state['features/base/config'];
+    const audioTranslationEnabled = audioTranslationConfig?.enabled;
+
+    // The volume a speaker's original is ducked to while its translation plays; overridable via config.
+    const duckedVolume = audioTranslationConfig?.duckedVolume ?? DUCKED_ORIGINAL_VOLUME;
 
     let _volume: number | boolean | undefined = participantsVolume[ownProps.participantId];
 
@@ -358,7 +384,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
         const translatedSourceName = `${sourceName}.${effectiveLanguage}`;
 
         if (getTranslatedSourceNames(state).has(translatedSourceName)) {
-            _volume = DUCKED_ORIGINAL_VOLUME;
+            _volume = duckedVolume;
             ducked = true;
         }
     }
@@ -371,6 +397,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
     }
 
     return {
+        _ducked: ducked,
         _muted: state['features/base/config'].startSilent,
         _volume
     };


### PR DESCRIPTION
## Summary

- On iOS/WebKit, programmatic `HTMLMediaElement.volume` is ignored (the audio level is under the user's hardware control), so ducking a speaker's original audio to a lower volume while its translation plays had **no effect** — the listener heard the original and the translation at full volume. On iOS we now **mute** the original instead (`element.muted` is honoured there); Android/desktop keep the fractional-volume duck.
- Make the ducked volume configurable via `config.audioTranslation.duckedVolume` (default `0.15`), and whitelist `audioTranslation` so it (and `audioTranslation.enabled`) can be set through `configOverwrite` / URL.

## Test plan

- [ ] iOS Safari / Chrome-iOS: enable translation for a speaker → the original is muted while its translation plays and restored when it stops.
- [ ] Android Chrome / desktop: original still ducks to `0.15` (behaviour unchanged).
- [ ] Set `config.audioTranslation.duckedVolume` (e.g. `0.05`) → ducked level changes on non-iOS.
