### PR TITLE
test(prosody): cover restrict_room_creation on the main MUC

### DIFF
--- a/tests/prosody/docker/prosody.cfg.lua
+++ b/tests/prosody/docker/prosody.cfg.lua
@@ -213,6 +213,11 @@ Component "conference.localhost" "muc"
 
     anonymous_strict = true
 
+    -- Same as prod: only Prosody admins (jicofo, i.e. focus@auth.localhost) may
+    -- create a room. Regular clients (anonymous or JWT) can only join a room
+    -- that focus has already created.
+    restrict_room_creation = true
+
     -- Used by mod_muc_max_occupants tests (2 occupants max).
     muc_max_occupants = 2
 

--- a/tests/prosody/mod_muc_meeting_id_spec.js
+++ b/tests/prosody/mod_muc_meeting_id_spec.js
@@ -57,17 +57,35 @@ describe('mod_muc_meeting_id', () => {
                 'regular user should be allowed in after focus unlocks');
         });
 
-        // NOTE: the queue-drain scenario (regular joins before jicofo, gets
-        // queued, then jicofo joins and the queue is flushed) is not tested
-        // here. When a non-focus user is the first to send a presence to a
-        // room, Prosody creates the room in "locked" state (XEP-0045 §10.1.3)
-        // and expects the creator to submit a config form. Because our hook
-        // stops the join (returning true), the creator never receives the
-        // status-201 self-presence and never submits the form, so the room
-        // stays locked. Subsequent joins by focus are then rejected by the MUC
-        // layer itself. In production this edge case does not arise: jicofo
-        // always joins first, creates and configures the room, then regular
-        // users arrive after the room is unlocked.
+        it('a regular user cannot create a room by joining first', async () => {
+            const r = room();
+
+            // restrict_room_creation = true (core Prosody mod_muc) limits
+            // :create-room to admins. A non-focus client's presence to a
+            // nonexistent room is rejected at muc-room-pre-create, before the
+            // room object exists and before mod_muc_meeting_id's jicofo lock
+            // ever comes into play.
+            const c = await ctx.connect();
+            const presence = await c.joinRoom(r);
+
+            assert.strictEqual(presence.attrs.type, 'error', 'join must be rejected');
+            const error = presence.getChild('error');
+
+            assert.ok(error, 'response must carry an <error>');
+            assert.strictEqual(error.attrs.type, 'cancel');
+            assert.ok(error.getChild('not-allowed'), 'error condition must be not-allowed');
+        });
+
+        it('focus can still create the room after a rejected creation attempt', async () => {
+            const r = room();
+
+            const c = await ctx.connect();
+
+            await c.joinRoom(r);
+
+            // connectFocus throws (timeout) if the join is blocked.
+            await ctx.connectFocus(r);
+        });
     });
 
     // -------------------------------------------------------------------------

--- a/tests/prosody/mod_muc_wait_for_host_spec.js
+++ b/tests/prosody/mod_muc_wait_for_host_spec.js
@@ -113,6 +113,30 @@ describe('mod_muc_wait_for_host', () => {
     });
 
     // -------------------------------------------------------------------------
+    // Room does not exist yet — creator bypass
+    // -------------------------------------------------------------------------
+    describe('room does not exist yet', () => {
+
+        it('anonymous guest creates the room and is admitted despite no host present', async () => {
+            const r = room();
+
+            // No focus, no prior occupant: the guest's join is the stanza that
+            // creates the MUC room. Prosody grants room creators a free pass
+            // (XEP-0045 §10.1.3 locked-room bypass) before muc_wait_for_host's
+            // muc-occupant-pre-join check can block it, and joinRoom() submits
+            // the empty config form to unlock the room on status code 201.
+            // This is why production locks room creation to jicofo alone
+            // (restrict_room_creation + the mod_muc_meeting_id jicofo lock) —
+            // this isolated test component has neither.
+            const guest = await connect();
+            const presence = await guest.joinRoom(r);
+
+            assert.ok(isAvailablePresence(presence),
+                'guest should be admitted: it created the room, so the host check never blocked it');
+        });
+    });
+
+    // -------------------------------------------------------------------------
     // Host present — guests admitted
     // -------------------------------------------------------------------------
     describe('host present', () => {


### PR DESCRIPTION
## Summary
- Enable `restrict_room_creation = true` on `conference.localhost` in the test Prosody config, matching prod (lobby already had it; breakout has no test component yet)
- Add a test asserting a non-focus client cannot create a room by joining first, and that focus can still create it afterwards
- Add a `mod_muc_wait_for_host` test documenting the XEP-0045 creator-bypass on its isolated test component, which intentionally has no room-creation restriction

Full `tests/prosody` suite passes (430 tests).