### PR TITLE
feat(conference): log page visibility, BFCache freeze/restore events

### DIFF
--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -101,6 +101,18 @@ function onWakeLockReleased() {
     logger.debug('Wake lock released');
 }
 
+function onVisibilityChange() {
+    logger.debug(`Page visibility changed to: ${document.visibilityState}`);
+}
+
+function onPageHide(e: PageTransitionEvent) {
+    logger.debug(`Page hidden, persisted (BFCache freeze): ${e.persisted}`);
+}
+
+function onPageShow(e: PageTransitionEvent) {
+    logger.debug(`Page shown, persisted (BFCache restore): ${e.persisted}`);
+}
+
 MiddlewareRegistry.register(store => next => action => {
     const { dispatch, getState } = store;
     const { enableForcedReload } = getState()['features/base/config'];
@@ -108,6 +120,9 @@ MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
     case CONFERENCE_JOIN_IN_PROGRESS: {
         dispatch(setPrejoinPageVisibility(false));
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        window.addEventListener('pagehide', onPageHide);
+        window.addEventListener('pageshow', onPageShow);
 
         break;
     }
@@ -157,12 +172,18 @@ MiddlewareRegistry.register(store => next => action => {
         }
 
         releaseScreenLock();
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        window.removeEventListener('pagehide', onPageHide);
+        window.removeEventListener('pageshow', onPageShow);
 
         break;
     }
     case CONFERENCE_LEFT:
     case KICKED_OUT:
         releaseScreenLock();
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        window.removeEventListener('pagehide', onPageHide);
+        window.removeEventListener('pageshow', onPageShow);
 
         break;
     case CONNECTION_DISCONNECTED: {


### PR DESCRIPTION
## Summary

- Adds `visibilitychange`, `pagehide`, and `pageshow` listeners in the conference middleware to log page focus/visibility changes at `debug` level.
- Listeners are registered on `CONFERENCE_JOIN_IN_PROGRESS` and cleaned up on `CONFERENCE_LEFT`, `KICKED_OUT`, and `CONFERENCE_FAILED`.
- Works for all browsers, not only those supporting the Wake Lock API (the existing `handleVisibilityChange` listener was already gated behind `navigator.wakeLock`).
- The `pagehide`/`pageshow` `persisted` flag distinguishes BFCache freeze/restore from normal navigation — useful since BFCache is typically suppressed by active WebRTC connections and confirming that via logs is valuable.
- Handles breakout room transitions correctly: leave removes the listener, `CONFERENCE_JOIN_IN_PROGRESS` of the new room re-adds it. `addEventListener` with the same function reference is a no-op, so double-registration is safe.

## Test plan

- [ ] Join a conference, switch browser tabs — confirm `Page visibility changed to: hidden` / `visible` in debug logs
- [ ] Join a conference, navigate away and back — check `pagehide`/`pageshow` logs and `persisted` value
- [ ] Move to a breakout room and back — confirm listener is re-registered and logs appear in both rooms
- [ ] Leave a conference — confirm no further visibility events are logged