### PR TITLE
fix(breakout-rooms): prevent double-track-add crash when switching rooms with tab audio

### DIFF
--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -770,7 +770,15 @@ async function _trackAddedOrRemoved(store: IStore, next: Function, action: AnyAc
                         const audioMixerEffect = new AudioMixerEffect(desktopAudioTrack);
 
                         await jitsiTrack.setEffect(audioMixerEffect);
-                        await conference.replaceTrack(null, jitsiTrack);
+
+                        // Only add the track to the conference if it isn't already there. During a breakout room
+                        // switch, replaceLocalTrack already called conference.replaceTrack which invoked
+                        // _setupNewTrack and pushed the track into rtc.localTracks. A second replaceTrack(null,
+                        // track) call would push it again, creating a duplicate that makes setOfferAnswerCycle
+                        // fail with "is already in TPC" when the JVB session offer arrives.
+                        if (!conference.getLocalTracks().includes(jitsiTrack)) {
+                            await conference.replaceTrack(null, jitsiTrack);
+                        }
                     } else {
                         await _addLocalTracksToConference(conference, [ jitsiTrack ]);
                     }


### PR DESCRIPTION
## Summary

Fixes #17599 — conference fails with `LocalTrack[audio] is already in TPC` when switching breakout rooms while screen sharing with Chrome tab audio enabled.

- During a room switch, `replaceLocalTrack` already calls `conference.replaceTrack(null, track)` which pushes the mic track into `rtc.localTracks` via `_setupNewTrack`. The `TRACK_ADDED` middleware then detects the stale `desktopAudioTrack` in `features/screen-share` state and calls `conference.replaceTrack(null, track)` a **second** time, creating a duplicate entry in `rtc.localTracks`.
- When the JVB session offer arrives and `setOfferAnswerCycle` calls `TPC.addTrack` for each local track, the duplicate `rtcId` causes it to throw `"is already in TPC"` → `OFFER_ANSWER_FAILED` → client disconnects.
- Fix mirrors the guard already in `_addLocalTracksToConference`: skip `replaceTrack(null, track)` when the track is already in the conference's local track list.

## Test plan

- [ ] Join a conference with 3+ participants (JVB mode)
- [ ] Start screen sharing with "Share tab audio" enabled (Chrome)
- [ ] Join a breakout room without stopping screen share — client should connect successfully
- [ ] Leave the breakout room back to main room — client should reconnect successfully
- [ ] Verify no `conference.offerAnswerFailed` error in console
- [ ] Verify normal mic+screen share still works in a single room (no regression in AudioMixer effect setup)