### PR TITLE
refactor(flip): simplify occupant lookup to live scan

### DIFF
--- a/resources/prosody-plugins/mod_muc_flip.lua
+++ b/resources/prosody-plugins/mod_muc_flip.lua
@@ -7,7 +7,6 @@ local oss_util = module:require "util";
 local is_admin = oss_util.is_admin;
 local is_healthcheck_room = oss_util.is_healthcheck_room;
 local process_host_module = oss_util.process_host_module;
-local inspect = require('inspect');
 local jid_bare = require "util.jid".bare;
 local jid = require "util.jid";
 local MUC_NS = "http://jabber.org/protocol/muc";
@@ -19,6 +18,18 @@ local lobby_muc_component_config = 'lobby.' .. module:get_option_string("muc_map
 if lobby_muc_component_config == nil then
     module:log('error', 'lobby not enabled missing lobby_muc config');
     return ;
+end
+
+local function find_occupant_nick_by_user_id(room, user_id)
+    for _, occ in room:each_occupant() do
+        for full_jid in pairs(occ.sessions) do
+            local session = prosody.full_sessions[full_jid];
+            if session and session.jitsi_meet_context_user
+                    and session.jitsi_meet_context_user.id == user_id then
+                return occ.nick;
+            end
+        end
+    end
 end
 
 local function remove_flip_tag(stanza)
@@ -45,9 +56,8 @@ module:hook("muc-occupant-pre-join", function(event)
     end
     local flip_device_tag = stanza:get_child("flip_device");
     if session.jitsi_meet_context_user and session.jitsi_meet_context_user.id then
-        local participants = room._data.participants_details or {};
         local id = session.jitsi_meet_context_user.id;
-        local first_device_occ_nick = participants[id];
+        local first_device_occ_nick = find_occupant_nick_by_user_id(room, id);
         if flip_device_tag then
             if first_device_occ_nick and session.jitsi_meet_context_features.flip and (session.jitsi_meet_context_features.flip == true or session.jitsi_meet_context_features.flip == "true") then
                 room._data.kicked_participant_nick = first_device_occ_nick;
@@ -92,10 +102,6 @@ module:hook("muc-occupant-pre-join", function(event)
                 remove_flip_tag(stanza)
             end
         end
-        -- update authenticated participant list
-        participants[id] = occupant.nick;
-        room._data.participants_details = participants
-        -- module:log("debug", "current details list %s", inspect(participants))
     else
         if flip_device_tag then
             module:log("warn", "Flip device tag present for a guest user")
@@ -153,24 +159,6 @@ module:hook("muc-occupant-joined", function(event)
         event.room._data.kicked_participant_nick = nil;
     end
 end,-2)
-
--- Update the local table after a participant leaves
-module:hook("muc-occupant-left", function(event)
-    local occupant = event.occupant;
-    local session = event.origin;
-    if is_healthcheck_room(event.room.jid) or is_admin(occupant.bare_jid) then
-        return ;
-    end
-    if session and session.jitsi_meet_context_user and session.jitsi_meet_context_user.id then
-        local id = session.jitsi_meet_context_user.id
-        local participants = event.room._data.participants_details or {};
-        local occupant_left_nick = participants[id]
-        if occupant_left_nick == occupant.nick then
-            participants[id] = nil
-            event.room._data.participants_details = participants
-        end
-    end
-end)
 
 -- Add a flip_device tag on the unavailable presence from the kicked participant in order to silent the notifications
 module:hook('muc-broadcast-presence', function(event)

--- a/tests/prosody/mod_muc_flip_spec.js
+++ b/tests/prosody/mod_muc_flip_spec.js
@@ -2,7 +2,9 @@ import { xml } from '@xmpp/client';
 import assert from 'assert';
 
 
-import { enableLobby, getRoomParticipants, setAffiliation, setRoomMaxOccupants, setSessionContext } from './helpers/test_observer.js';
+import {
+    enableLobby, getRoomParticipants, setAffiliation, setRoomMaxOccupants, setSessionContext
+} from './helpers/test_observer.js';
 import { createXmppClient, joinWithFocus } from './helpers/xmpp_client.js';
 
 const CONFERENCE = 'conference.localhost';
@@ -291,7 +293,10 @@ describe('mod_muc_flip', () => {
             const observerKickPromise = observer.waitForPresenceFrom(
                 `${r}/${observerNick}`, { type: 'unavailable' }
             );
-            const kickResponse = await device2.sendMucAdmin(r, { nick: observerNick, role: 'none' });
+            const kickResponse = await device2.sendMucAdmin(r, {
+                nick: observerNick,
+                role: 'none'
+            });
 
             assert.notEqual(kickResponse.attrs.type, 'error', 'device2 must have moderator role');
             await observerKickPromise;

--- a/tests/prosody/mod_muc_flip_spec.js
+++ b/tests/prosody/mod_muc_flip_spec.js
@@ -2,7 +2,7 @@ import { xml } from '@xmpp/client';
 import assert from 'assert';
 
 
-import { enableLobby, getRoomParticipants, setRoomMaxOccupants, setSessionContext } from './helpers/test_observer.js';
+import { enableLobby, getRoomParticipants, setAffiliation, setRoomMaxOccupants, setSessionContext } from './helpers/test_observer.js';
 import { createXmppClient, joinWithFocus } from './helpers/xmpp_client.js';
 
 const CONFERENCE = 'conference.localhost';
@@ -177,60 +177,6 @@ describe('mod_muc_flip', () => {
     }); // flip_device tag stripping
 
     // -------------------------------------------------------------------------
-    // participants_details tracking
-    // -------------------------------------------------------------------------
-    describe('participants_details', () => {
-
-        it('records the occupant nick for a JWT user on join', async () => {
-            const r = room();
-
-            await focusJoin(r);
-
-            const clientA = await connect();
-
-            await setSessionContext(clientA.jid, USER_A_ID, { flip: false });
-            const joinPresence = await clientA.joinRoom(r);
-            const nick = nickFrom(joinPresence);
-
-            const state = await getRoomParticipants(r);
-
-            assert.ok(
-                state.participants_details[USER_A_ID],
-                `participants_details must have an entry for user id ${USER_A_ID}`
-            );
-            assert.ok(
-                state.participants_details[USER_A_ID].endsWith(`/${nick}`),
-                'recorded value must reference the occupant nick'
-            );
-        });
-
-        it('removes the occupant entry when the JWT user leaves', async () => {
-            const r = room();
-
-            await focusJoin(r);
-
-            const clientA = await connect();
-
-            await setSessionContext(clientA.jid, USER_A_ID, { flip: false });
-            await clientA.joinRoom(r);
-
-            await clientA.disconnect();
-            clients.splice(clients.indexOf(clientA), 1);
-
-            // Give Prosody a moment to process the leave.
-            await new Promise(res => setTimeout(res, 300));
-
-            const state = await getRoomParticipants(r);
-
-            assert.ok(
-                !state.participants_details[USER_A_ID],
-                'participants_details entry must be cleared after the user leaves'
-            );
-        });
-
-    }); // participants_details
-
-    // -------------------------------------------------------------------------
     // Successful flip
     // -------------------------------------------------------------------------
     describe('flip', () => {
@@ -299,6 +245,58 @@ describe('mod_muc_flip', () => {
             );
         });
 
+        it('transfers moderator role to flip device and tags the kicked occupant presence', async () => {
+            const r = room();
+
+            await focusJoin(r);
+            await setRoomMaxOccupants(r, 10);
+
+            const device1 = await connect();
+
+            await setSessionContext(device1.jid, USER_A_ID, { flip: true });
+            const d1Presence = await device1.joinRoom(r);
+            const d1Nick = nickFrom(d1Presence);
+
+            // Promote device1 to owner so it holds moderator role.
+            await setAffiliation(r, device1.jid.split('/')[0], 'owner');
+
+            // Watch for device1's own kick before device2 joins to avoid missing it.
+            const d1KickPromise = device1.waitForPresenceFrom(
+                `${r}/${d1Nick}`, { type: 'unavailable' }
+            );
+
+            const observer = await connect();
+            const observerJoinPresence = await observer.joinRoom(r);
+            const observerNick = nickFrom(observerJoinPresence);
+
+            const d1FlipTagPromise = observer.waitForPresenceFrom(
+                `${r}/${d1Nick}`, { type: 'unavailable' }
+            );
+
+            const device2 = await connect();
+
+            await setSessionContext(device2.jid, USER_A_ID, { flip: true });
+            await device2.joinRoom(r, null, { extensions: [ xml('flip_device') ] });
+
+            await d1KickPromise;
+            const d1KickPresence = await d1FlipTagPromise;
+
+            assert.ok(
+                d1KickPresence.getChild('flip_device'),
+                'kicked device presence must contain flip_device tag'
+            );
+
+            // Verify device2 has moderator role by performing a moderator-only action:
+            // kicking the observer. Only a moderator can set role='none'.
+            const observerKickPromise = observer.waitForPresenceFrom(
+                `${r}/${observerNick}`, { type: 'unavailable' }
+            );
+            const kickResponse = await device2.sendMucAdmin(r, { nick: observerNick, role: 'none' });
+
+            assert.notEqual(kickResponse.attrs.type, 'error', 'device2 must have moderator role');
+            await observerKickPromise;
+        });
+
     }); // flip
 
     // -------------------------------------------------------------------------
@@ -342,6 +340,42 @@ describe('mod_muc_flip', () => {
 
             // The flip also kicks device1 from the main room.
             await d1KickedPromise;
+        });
+
+        it('requires first device to be in main room for flip to proceed', async () => {
+            const r = room();
+
+            await focusJoin(r);
+            await enableLobby(r);
+
+            // device1 joins but does not reach the main room.
+            const device1 = await connect();
+
+            await setSessionContext(device1.jid, USER_A_ID, { flip: true });
+
+            const d1JoinResult = await device1.joinRoom(r, null, { displayName: 'Device One' });
+
+            assert.equal(
+                d1JoinResult.attrs.type, 'error',
+                'device1 must not reach the main room (precondition)'
+            );
+
+            // device2 joins with flip_device and the same JWT user id.
+            // No occupant with that id is in the main room, so the flip tag
+            // is ignored and device2 is treated as a regular join.
+            const device2 = await connect();
+
+            await setSessionContext(device2.jid, USER_A_ID, { flip: true });
+
+            const d2JoinResult = await device2.joinRoom(r, null, {
+                displayName: 'Device Two',
+                extensions: [ xml('flip_device') ]
+            });
+
+            assert.equal(
+                d2JoinResult.attrs.type, 'error',
+                'flip must not proceed when no matching occupant is in the main room'
+            );
         });
 
     }); // lobby interactions


### PR DESCRIPTION
## Summary

- Replaced the `participants_details` table (written in `muc-occupant-pre-join`) with a live scan of `room:each_occupant()` via `prosody.full_sessions` to find the existing device by JWT user id
- Removed the `muc-occupant-left` hook that maintained the now-deleted table
- Added integration tests covering lobby interaction edge cases and the moderator role transfer happy path

## Test plan

- [ ] `npm run test:one -- mod_muc_flip_spec.js` — all 8 tests pass