### PR TITLE
fix(participants-pane): close context menus on outside click

### DIFF
--- a/react/features/base/ui/components/web/ContextMenu.tsx
+++ b/react/features/base/ui/components/web/ContextMenu.tsx
@@ -98,6 +98,13 @@ interface IProps {
     onClick?: (e?: React.MouseEvent) => void;
 
     /**
+     * Callback invoked when a click occurs outside the menu (non-drawer path only).
+     * Prefer this over onDrawerClose for outside-click handling to avoid conflating
+     * the drawer-close and the click-outside concerns.
+     */
+    onClickOutside?: () => void;
+
+    /**
      * Callback for drawer close.
      */
     onDrawerClose?: (e?: React.MouseEvent) => void;
@@ -181,6 +188,7 @@ const ContextMenu = ({
     offsetTarget,
     onClick,
     onKeyDown,
+    onClickOutside,
     onDrawerClose,
     onMouseEnter,
     onMouseLeave,
@@ -358,8 +366,8 @@ const ContextMenu = ({
     }, [ containerRef ]);
 
     const removeFocus = useCallback(() => {
-        onDrawerClose?.();
-    }, [ onMouseLeave ]);
+        (onClickOutside ?? onDrawerClose)?.();
+    }, [ onClickOutside, onDrawerClose ]);
 
     if (_overflowDrawer && inDrawer) {
         return (<div
@@ -387,8 +395,10 @@ const ContextMenu = ({
             // to prevent UI stutter on dialog appearance. It seems the focus guards generated annoy
             // our DialogPortal positioning calculations.
             enabled = { activateFocusTrap && !isHidden }
+            noIsolation = { true }
             onClickOutside = { removeFocus }
-            onEscapeKey = { removeFocus }>
+            onEscapeKey = { removeFocus }
+            scrollLock = { false }>
             <div
                 { ...aria }
                 aria-label = { accessibilityLabel }

--- a/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
+++ b/react/features/participants-pane/components/breakout-rooms/components/web/RoomParticipantContextMenu.tsx
@@ -108,10 +108,12 @@ export const RoomParticipantContextMenu = ({
 
     return isLocalModerator ? (
         <ContextMenu
+            activateFocusTrap = { true }
             entity = { entity }
             isDrawerOpen = { Boolean(entity) }
             offsetTarget = { offsetTarget }
             onClick = { lowerMenu }
+            onClickOutside = { lowerMenu }
             onDrawerClose = { onSelect }
             onMouseEnter = { onEnter }
             onMouseLeave = { onLeave }>

--- a/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
@@ -140,6 +140,7 @@ const FakeParticipantContextMenu = ({
 
     return (
         <ContextMenu
+            activateFocusTrap = { !thumbnailMenu }
             className = { className }
             entity = { participant }
             hidden = { thumbnailMenu ? false : undefined }
@@ -147,6 +148,7 @@ const FakeParticipantContextMenu = ({
             isDrawerOpen = { Boolean(drawerParticipant) }
             offsetTarget = { offsetTarget }
             onClick = { onSelect }
+            onClickOutside = { thumbnailMenu ? undefined : clickHandler }
             onDrawerClose = { thumbnailMenu ? onSelect : closeDrawer }
             onMouseEnter = { onEnter }
             onMouseLeave = { onLeave }>

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -193,6 +193,10 @@ const ParticipantContextMenu = ({
         onSelect(true);
     }, [ onSelect ]);
 
+    const onClickOutside = useCallback(() => {
+        onSelect(true);
+    }, [ onSelect ]);
+
     const isClickedFromParticipantPane = useMemo(
         () => !_overflowDrawer && !thumbnailMenu,
     [ _overflowDrawer, thumbnailMenu ]);
@@ -354,7 +358,7 @@ const ParticipantContextMenu = ({
             isDrawerOpen = { Boolean(drawerParticipant) }
             offsetTarget = { offsetTarget }
             onClick = { onSelect }
-            onClickOutside = { thumbnailMenu ? undefined : () => onSelect(true) }
+            onClickOutside = { thumbnailMenu ? undefined : onClickOutside }
             onDrawerClose = { thumbnailMenu ? onSelect : closeDrawer }
             onMouseEnter = { onEnter }
             onMouseLeave = { onLeave }>

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -346,6 +346,7 @@ const ParticipantContextMenu = ({
 
     return (
         <ContextMenu
+            activateFocusTrap = { !thumbnailMenu }
             className = { className }
             entity = { participant }
             hidden = { thumbnailMenu ? false : undefined }
@@ -353,6 +354,7 @@ const ParticipantContextMenu = ({
             isDrawerOpen = { Boolean(drawerParticipant) }
             offsetTarget = { offsetTarget }
             onClick = { onSelect }
+            onClickOutside = { thumbnailMenu ? undefined : () => onSelect(true) }
             onDrawerClose = { thumbnailMenu ? onSelect : closeDrawer }
             onMouseEnter = { onEnter }
             onMouseLeave = { onLeave }>


### PR DESCRIPTION
## Summary

- Adds a dedicated `onClickOutside` prop to `ContextMenu` (separate from `onDrawerClose`) so the FocusOn outside-click path and the Drawer backdrop-close path use distinct callbacks and don't interfere with each other.
- Fixes the pre-existing stale closure in `removeFocus` (wrong dep `[onMouseLeave]` → `[onClickOutside, onDrawerClose]`).
- Passes `scrollLock={false}` and `noIsolation={true}` to `FocusOn` so enabling the trap does not lock pane scroll or `aria-hidden` the rest of the participants pane.
- Enables `activateFocusTrap` and `onClickOutside` in `ParticipantContextMenu`, `FakeParticipantContextMenu`, and `RoomParticipantContextMenu` for the non-thumbnail (participants pane) case.
- `onClickOutside` always uses `force=true` to bypass the `isMouseOverMenu` guard in `lowerMenu`, ensuring an outside click always dismisses the menu.

The overflow-drawer path (mobile/narrow viewports) is already handled by `Drawer`'s existing backdrop `onClose` and required no changes.

Fixes the issue originally reported in #17128.

## Test plan

- [ ] Open participants pane with 2+ participants — clicking outside an open context menu closes it (main room)
- [ ] Same for a breakout room participant menu
- [ ] Clicking a menu item still works (menu closes after action)
- [ ] On a narrow viewport (overflow drawer), tapping inside a drawer menu item still fires the action
- [ ] Keyboard: Tab stays inside the menu while open; Escape closes it
- [ ] Screen reader: the rest of the participants pane remains accessible while a context menu is open
- [ ] Participants pane can still be scrolled while a context menu is open