### PR TITLE
fix(reactions,polls,subtitles): handle unexpected field types in endpoint messages

### DIFF
--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -151,7 +151,7 @@ MiddlewareRegistry.register(store => next => action => {
 
         if (data?.name === ENDPOINT_REACTION_NAME) {
             // Only accept known reaction keys, skip duplicates and keep just 3.
-            const reactions = Array.from(new Set(data.reactions))
+            const reactions = Array.from(new Set(Array.isArray(data.reactions) ? data.reactions : []))
                 .filter((reaction): reaction is string => typeof reaction === 'string' && reaction in REACTIONS)
                 .slice(0, 3);
 

--- a/react/features/polls/middleware.ts
+++ b/react/features/polls/middleware.ts
@@ -143,7 +143,7 @@ function _handleReceivedPollsAnswer(data: any, dispatch: IStore['dispatch'], get
     const { pollId, answers, senderId, senderName } = data;
 
     const receivedAnswer: IIncomingAnswerData = {
-        answers: answers.slice(0, MAX_ANSWERS).map(Boolean),
+        answers: Array.isArray(answers) ? answers.slice(0, MAX_ANSWERS).map(Boolean) : [],
         pollId,
         senderId,
         voterName: getParticipantById(getState(), senderId)

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -148,7 +148,7 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
     const state = getState();
     const _areClosedCaptionsEnabled = areClosedCaptionsEnabled(store.getState());
     const transcriptMessageID = json.message_id;
-    const { name, id, avatar_url: avatarUrl } = json.participant;
+    const { name, id, avatar_url: avatarUrl } = json.participant ?? {};
     const participant = {
         avatarUrl,
         id,
@@ -219,6 +219,9 @@ function _endpointMessageReceived(store: IStore, next: Function, action: AnyActi
         // Displays interim and final results without any translation if
         // translations are disabled.
 
+        if (!Array.isArray(json.transcript) || !json.transcript[0]) {
+            return next(action);
+        }
         const { text } = json.transcript[0];
         const displayText = `${detailsPrefix}${text}`;
 


### PR DESCRIPTION
## Summary

Receiving participants crash with a `TypeError` when a sender passes unexpected types in endpoint message fields. Three handlers assumed specific types without validating first:

- **reactions** (`chat/middleware.ts`): `new Set(data.reactions)` throws when `reactions` is a number or any non-iterable. Now guarded with `Array.isArray`.
- **polls** (`polls/middleware.ts`): `answers.slice(...)` throws when `answers` is not an array. Now guarded with `Array.isArray`, falls back to `[]`.
- **subtitles** (`subtitles/middleware.ts`): destructuring `json.participant` crashes when it is `null`; accessing `json.transcript[0]` crashes when `transcript` is null or empty. Both are now guarded.

All fixes are defensive no-ops: malformed messages are silently dropped rather than crashing the receiver.

## Reproducer (reactions)
```js
APP.conference._room.sendMessage({ name: 'endpoint-reaction', reactions: 5, timestamp: Date.now() }, '', false);
```
Other participants received: `TypeError: number 5 is not iterable (cannot read property Symbol(Symbol.iterator))`

## Test plan
- [ ] Send a normal reaction — still works
- [ ] Send `reactions: 5` from console — no crash on receiving end
- [ ] Send a poll answer with `answers: null` — no crash
- [ ] Verify subtitles/transcription still render correctly