### PR TITLE
feat(transcription): add diarize flag advertised as a participant property

### DIFF
--- a/config.js
+++ b/config.js
@@ -547,7 +547,16 @@ var config = {
     //
     //     // When the backend provides diarization by setting a "speaker" field, append [Speaker N] for transcription
     //     // events from non-0 speakers.
-    //     renderTranscriptDetails: false
+    //     renderTranscriptDetails: false,
+    //
+    //     // Requests that the transcriber diarize (split by speaker) this participant's own audio, i.e. label
+    //     // segments as coming from different speakers. Enable it only for endpoints that genuinely carry
+    //     // multiple speakers on a single audio stream (conference-room systems, dial-in/PSTN legs); on a
+    //     // normal single-person stream a diarizer can spuriously split one talker into several speakers.
+    //     // The flag is advertised to jicofo in MUC presence and takes effect only at join time (it must be
+    //     // set before joining, e.g. via this config or the #config.transcription.diarize=true URL override;
+    //     // toggling it mid-call has no effect). Defaults to false.
+    //     diarize: false
 
     // },
 

--- a/react/features/base/conference/functions.ts
+++ b/react/features/base/conference/functions.ts
@@ -573,6 +573,10 @@ export function sendLocalParticipant(
 
     // Advertise to jicofo that this participant's audio should be diarized by the transcriber.
     // Only published when explicitly enabled, to keep presence clean.
+    // NOTE: this must be published here, before conference.join(), so it is part of the initial
+    // presence. jicofo allocates the colibri2 endpoint from the join presence and reads this flag
+    // only at allocation time (the endpoint create path, in both jicofo and the bridge). A value
+    // set after join would be ignored, so do not move this to a lazy/runtime toggle.
     if (toState(stateful)['features/base/config'].transcription?.diarize === true) {
         conference?.setLocalParticipantProperty(P_NAME_DIARIZE, true);
     }

--- a/react/features/base/conference/functions.ts
+++ b/react/features/base/conference/functions.ts
@@ -35,6 +35,12 @@ import logger from './logger';
 import { IJitsiConference } from './reducer';
 
 /**
+ * The local participant property used to advertise to jicofo that this
+ * participant's audio should be diarized by the transcriber.
+ */
+const P_NAME_DIARIZE = 'diarize';
+
+/**
  * Returns root conference state.
  *
  * @param {IReduxState} state - Global state.
@@ -563,6 +569,12 @@ export function sendLocalParticipant(
 
     if (features && features['screen-sharing'] === 'true') {
         conference?.setLocalParticipantProperty('features_screen-sharing', true);
+    }
+
+    // Advertise to jicofo that this participant's audio should be diarized by the transcriber.
+    // Only published when explicitly enabled, to keep presence clean.
+    if (toState(stateful)['features/base/config'].transcription?.diarize === true) {
+        conference?.setLocalParticipantProperty(P_NAME_DIARIZE, true);
     }
 
     conference?.setDisplayName(name);

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -747,6 +747,13 @@ export interface IConfig {
         autoCaptionOnTranscribe?: boolean;
         autoTranscribeOnRecord?: boolean;
         customLanguages?: object;
+
+        /**
+         * When true, advertises (via a MUC presence participant property) that this participant's audio
+         * should be diarized by the transcriber. Intended for endpoints carrying multiple speakers, e.g.
+         * conference-room systems or dial-in.
+         */
+        diarize?: boolean;
         disableClosedCaptions?: boolean;
         enabled?: boolean;
         preferredLanguage?: string;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -752,6 +752,10 @@ export interface IConfig {
          * When true, advertises (via a MUC presence participant property) that this participant's audio
          * should be diarized by the transcriber. Intended for endpoints carrying multiple speakers, e.g.
          * conference-room systems or dial-in.
+         *
+         * Takes effect only at join time: the flag is included in the initial presence and read by jicofo
+         * when it allocates the colibri endpoint. It must be set before joining (e.g. via config or the
+         * `#config.transcription.diarize=true` URL override); toggling it during a call has no effect.
          */
         diarize?: boolean;
         disableClosedCaptions?: boolean;


### PR DESCRIPTION
Enables speaker diarization on a **per-endpoint** basis rather than only globally, for endpoints that carry multiple speakers (conference-room systems, dial-in) where a single global diarizer setting is wrong.

This is the client side of the flow: a new `config.transcription.diarize` flag (URL-overridable via `#config.transcription.diarize=true`, already covered by the `transcription` whitelist entry). When set, the local participant advertises a `diarize` participant property, which surfaces as a `<jitsi_participant_diarize>` element in MUC presence and is read by jicofo. Published once at conference join in `sendLocalParticipant()`, gated so presence stays clean when unset. No lib-jitsi-meet change required.

The flag then flows: presence → jicofo → COLIBRI v2 endpoint attribute → the videobridge → the transcriber's `start` event.

---

**Related PRs** (per-endpoint speaker diarization, multi-repo):
- jitsi-meet: jitsi/jitsi-meet#17614
- jitsi-xmpp-extensions: jitsi/jitsi-xmpp-extensions#145
- jicoco: jitsi/jicoco#238
- jicofo: jitsi/jicofo#1291
- jitsi-videobridge: jitsi/jitsi-videobridge#2431
- opus-transcriber-proxy: jitsi/opus-transcriber-proxy#106
