### PR TITLE
feat(external-api): add includeHidden and isJibri/isJigasi to getRoomsInfo

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1164,7 +1164,9 @@ function initCommands() {
             break;
         }
         case 'rooms-info': {
-            callback(getRoomsInfo(APP.store.getState()));
+            const { includeHidden } = request;
+
+            callback(getRoomsInfo(APP.store.getState(), includeHidden));
             break;
         }
         case 'get-shared-document-url': {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -757,11 +757,14 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     /**
      * Returns the rooms info in the conference.
      *
+     * @param {boolean} includeHidden - Whether to include hidden participants
+     * (e.g. Jibri, transcriber) in the result. Defaults to false.
      * @returns {Promise<Object>} Rooms info.
      */
-    getRoomsInfo() {
+    getRoomsInfo(includeHidden = false) {
         return this._transport.sendRequest({
-            name: 'rooms-info'
+            name: 'rooms-info',
+            includeHidden
         });
     }
 

--- a/react/features/base/participants/types.ts
+++ b/react/features/base/participants/types.ts
@@ -92,9 +92,11 @@ export interface IJitsiParticipant {
     getDisplayName: () => string;
     getId: () => string;
     getJid: () => string;
+    getProperty: (name: string) => any;
     getRole: () => string;
     getSources: () => Map<string, Map<string, ISourceInfo>>;
     isHidden: () => boolean;
+    isHiddenFromRecorder: () => boolean;
 }
 
 export type ParticipantFeaturesKey = keyof IParticipantFeatures;

--- a/react/features/breakout-rooms/functions.ts
+++ b/react/features/breakout-rooms/functions.ts
@@ -40,10 +40,11 @@ export const getMainRoom = (stateful: IStateful) => {
  * Returns the rooms info.
  *
  * @param {IStateful} stateful - The redux store, the redux.
-
-* @returns {IRoomsInfo} The rooms info.
+ * @param {boolean} includeHidden - Whether to include hidden participants
+ * (e.g. Jibri, transcriber) in the result. Defaults to false.
+ * @returns {IRoomsInfo} The rooms info.
  */
-export const getRoomsInfo = (stateful: IStateful) => {
+export const getRoomsInfo = (stateful: IStateful, includeHidden = false) => {
     const state = toState(stateful);
     const localParticipant = getLocalParticipant(stateful);
     const jwtUser = state['features/base/jwt']?.user;
@@ -65,7 +66,7 @@ export const getRoomsInfo = (stateful: IStateful) => {
     if (!breakoutRooms || Object.keys(breakoutRooms).length === 0) {
         // filter out hidden participants
         const conferenceParticipants = conference?.getParticipants()
-            .filter((participant: IJitsiParticipant) => !participant.isHidden());
+            .filter((participant: IJitsiParticipant) => includeHidden || !participant.isHidden());
 
         let localParticipantInfo;
 
@@ -97,7 +98,9 @@ export const getRoomsInfo = (stateful: IStateful) => {
                                 displayName: participantItem.getDisplayName(),
                                 avatarUrl: storeParticipant?.loadableAvatarUrl,
                                 id: participantItem.getId(),
-                                userContext: storeParticipant?.userContext
+                                userContext: storeParticipant?.userContext,
+                                isJigasi: participantItem.getProperty('features_jigasi') === true,
+                                isJibri: participantItem.isHidden() || participantItem.isHiddenFromRecorder()
                             } as IRoomInfoParticipant;
                         }) ]
                     : [ localParticipantInfo ]

--- a/react/features/breakout-rooms/types.ts
+++ b/react/features/breakout-rooms/types.ts
@@ -36,6 +36,8 @@ export interface IRoomInfoParticipant {
     avatarUrl: string;
     displayName: string;
     id: string;
+    isJibri?: boolean;
+    isJigasi?: boolean;
     jid: string;
     role: string;
     userContext?: {


### PR DESCRIPTION
`getRoomsInfo` had no way to include hidden participants or identify Jibri/Jigasi. Adds an includeHidden parameter (default false) to opt in, and adds isJibri/isJigasi fields to participants.