### PR TITLE
fix(tile-view): shift up bottom indicators when toolbox is visible

### DIFF
--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -182,6 +182,11 @@ export interface IProps extends WithTranslation {
     _raisedHand: boolean;
 
     /**
+     * Whether or not the toolbox is shifted up.
+     */
+    _shiftUp?: boolean;
+
+    /**
      * Whether or not to display a tint background over tile.
      */
     _shouldDisplayTintBackground: boolean;
@@ -202,6 +207,11 @@ export interface IProps extends WithTranslation {
      * The type of thumbnail to display.
      */
     _thumbnailType: string;
+
+    /**
+     * Whether or not the toolbox is visible.
+     */
+    _toolboxVisible?: boolean;
 
     /**
      * The video object position for the participant.
@@ -277,7 +287,14 @@ const defaultStyles = (theme: Theme) => {
         },
 
         indicatorsBottomContainer: {
-            bottom: 0
+            bottom: 0,
+            transition: 'bottom .3s ease-in'
+        },
+
+        indicatorsBottomContainerElevated: {
+            '&.tile-view-mode': {
+                bottom: '96px'
+            }
         },
 
         indicatorsBackground: {
@@ -964,6 +981,7 @@ class Thumbnail extends Component<IProps, IState> {
             _shouldDisplayTintBackground,
             _thumbnailType,
             _videoTrack,
+            _shiftUp,
             filmstripType,
             t
         } = this.props;
@@ -1042,6 +1060,7 @@ class Thumbnail extends Component<IProps, IState> {
                 <div
                     className = { clsx(classes.indicatorsContainer,
                         classes.indicatorsBottomContainer,
+                        _shiftUp && _thumbnailType === THUMBNAIL_TYPE.TILE && classes.indicatorsBottomContainerElevated,
                         _thumbnailType === THUMBNAIL_TYPE.TILE && 'tile-view-mode'
                     ) }>
                     <ThumbnailBottomIndicators
@@ -1323,6 +1342,8 @@ function _mapStateToProps(state: IReduxState, ownProps: any): Object {
         _stageParticipantsVisible: _currentLayout === LAYOUTS.STAGE_FILMSTRIP_VIEW,
         _shouldDisplayTintBackground: !disableTintForeground && shouldDisplayTintBackground,
         _thumbnailType: tileType,
+        _toolboxVisible: state['features/toolbox'].visible,
+        _shiftUp: state['features/toolbox'].shiftUp,
         _videoObjectPosition: getVideoObjectPosition(state, participant?.id),
         _videoTrack,
         ...size,


### PR DESCRIPTION
Fixes #17617

### Description
In Tile View on web viewports (especially on narrow screens or with many toolbar buttons enabled), the bottom indicators container (which renders the participant display name badge) gets covered/obscured by the centered floating toolbox when it is visible.

While Jitsi Meet's `checkToolboxOverlap` detector successfully determines that the toolbox overlaps the indicators and sets `shiftUp` to true, this only shifts the toolbox itself, leaving the participant names underneath the shifted toolbox (or overlapping with it).

This PR reads the `_shiftUp` state inside `Thumbnail.tsx` and dynamically adds a new class `indicatorsBottomContainerElevated` which shifts the bottom indicators container up to `96px` (matching the spacing used for other floating videospace elements like subtitles and the dominant speaker badge) when the toolbox shifts up. This ensures participant names remain fully visible above the toolbox when active.

### Verification
- Verified that compiling the web target (`npm run tsc:web`) succeeds with 0 errors.
- Verified that ESLint (`npx eslint`) passes with 0 errors.
- Verified in local browser testing that:
  - When the toolbar becomes visible, the name tags smoothly slide up above the toolbar.
  - When the toolbar hides, the name tags slide back down to the bottom.
