### PR TITLE
fix(base/tracks) prevent back camera preview from being mirrored

### DIFF
--- a/react/features/base/tracks/middleware.any.ts
+++ b/react/features/base/tracks/middleware.any.ts
@@ -90,7 +90,7 @@ MiddlewareRegistry.register(store => next => action => {
 
             // Don't mirror the video of the back/environment-facing camera.
             const mirror
-                = jitsiTrack.getCameraFacingMode() === CAMERA_FACING_MODE.USER;
+                = store.getState()['features/base/media'].video.facingMode !== CAMERA_FACING_MODE.USER;
 
             store.dispatch({
                 type: TRACK_UPDATED,

--- a/react/features/base/tracks/middleware.any.ts
+++ b/react/features/base/tracks/middleware.any.ts
@@ -78,6 +78,7 @@ MiddlewareRegistry.register(store => next => action => {
         break;
 
     case TOGGLE_CAMERA_FACING_MODE: {
+        const result = next(action);
         const localTrack = _getLocalTrack(store, MEDIA_TYPE.VIDEO);
         let jitsiTrack;
 
@@ -90,7 +91,7 @@ MiddlewareRegistry.register(store => next => action => {
 
             // Don't mirror the video of the back/environment-facing camera.
             const mirror
-                = store.getState()['features/base/media'].video.facingMode !== CAMERA_FACING_MODE.USER;
+                = store.getState()['features/base/media']?.video?.facingMode === CAMERA_FACING_MODE.USER;
 
             store.dispatch({
                 type: TRACK_UPDATED,
@@ -100,7 +101,8 @@ MiddlewareRegistry.register(store => next => action => {
                 }
             });
         }
-        break;
+
+        return result;
     }
     }
 


### PR DESCRIPTION
Fixes #17569

### Description
When users switch to the back/environment-facing camera on mobile devices (Android/iOS), the camera preview in self-view remains mirrored, making it counterintuitive to point and frame objects. 

This happens because the camera-facing mode toggle in `tracks/middleware.any.ts` checks `jitsiTrack.getCameraFacingMode()` right after switching cameras. However, `_switchCamera` is a native React Native WebRTC track method that switches the device under the hood without immediately mutating the JS track object properties inside `lib-jitsi-meet`, causing `getCameraFacingMode()` to return the stale/old value (`USER`), resulting in the mirror flag always evaluating to `true`.

This PR resolves the issue by calculating the `mirror` flag state dynamically based on the toggled `facingMode` state fetched directly from the Redux store (`state['features/base/media'].video.facingMode`).

### Verification
- Verified that both web and native typechecks (`npm run tsc:ci`) succeed.
- Verified that ESLint (`npx eslint`) passes with 0 errors.
