### PR TITLE
feat(external-api): add set-participant-properties command

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -948,6 +948,22 @@ export default {
     },
 
     /**
+     * Sets multiple properties for the local participant in a single presence update.
+     *
+     * @param {Object} properties - Object of property names to values.
+     * @returns {void}
+     */
+    setLocalParticipantProperties(properties) {
+        if (!room) {
+            logger.warn('Not setting participant properties, conference not initialized');
+
+            return;
+        }
+
+        room.setLocalParticipantProperties(properties);
+    },
+
+    /**
      * Exposes a Command(s) API on this instance. It is necessitated by (1) the
      * desire to keep room private to this instance and (2) the need of other
      * modules to send and receive commands to and from participants.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -426,6 +426,27 @@ function initCommands() {
             sendAnalytics(createApiEvent('largevideo.participant.set'));
             dispatch(selectParticipantInLargeVideo(participant.id));
         },
+        'set-participant-properties': properties => {
+            const room = APP.conference._room?.room;
+
+            if (!room) {
+                logger.warn('Not setting participant properties, room not initialized');
+
+                return;
+            }
+
+            let changed = false;
+
+            for (const key of Object.keys(properties)) {
+                const wasChanged = room.addOrReplaceInPresence(`jitsi_participant_${key}`, { value: properties[key] });
+
+                changed = changed || wasChanged;
+            }
+
+            if (changed) {
+                room.sendPresence();
+            }
+        },
         'set-participant-volume': (participantId, volume) => {
             APP.store.dispatch(setVolume(participantId, volume));
         },

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -427,25 +427,7 @@ function initCommands() {
             dispatch(selectParticipantInLargeVideo(participant.id));
         },
         'set-participant-properties': properties => {
-            const room = APP.conference._room?.room;
-
-            if (!room) {
-                logger.warn('Not setting participant properties, room not initialized');
-
-                return;
-            }
-
-            let changed = false;
-
-            for (const key of Object.keys(properties)) {
-                const wasChanged = room.addOrReplaceInPresence(`jitsi_participant_${key}`, { value: properties[key] });
-
-                changed = changed || wasChanged;
-            }
-
-            if (changed) {
-                room.sendPresence();
-            }
+            APP.conference.setLocalParticipantProperties(properties);
         },
         'set-participant-volume': (participantId, volume) => {
             APP.store.dispatch(setVolume(participantId, volume));

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -69,6 +69,7 @@ const commands = {
     setMediaEncryptionKey: 'set-media-encryption-key',
     setMeetingTimer: 'set-meeting-timer',
     setNoiseSuppressionEnabled: 'set-noise-suppression-enabled',
+    setParticipantProperties: 'set-participant-properties',
     setParticipantVolume: 'set-participant-volume',
     setSecondScreen: 'set-second-screen',
     setSubtitles: 'set-subtitles',


### PR DESCRIPTION
Adds a `setParticipantProperties` command that sets multiple presence properties in one call

Depends on: https://github.com/jitsi/lib-jitsi-meet/pull/3071