### PR TITLE
feat(external-api): expose local participant property

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -918,6 +918,15 @@ export default {
     },
 
     /**
+     * Gets a local participant property.
+     * @param {string} name - The name of the property to retrieve.
+     * @returns {string|undefined} The value of the property if it exists, otherwise undefined.
+     */
+    getLocalParticipantProperty(name) {
+        return room && room.getLocalParticipantProperty(name);
+    },
+
+    /**
      * Returns the stats.
      */
     getStats() {

--- a/conference.js
+++ b/conference.js
@@ -918,15 +918,6 @@ export default {
     },
 
     /**
-     * Gets a local participant property.
-     * @param {string} name - The name of the property to retrieve.
-     * @returns {string|undefined} The value of the property if it exists, otherwise undefined.
-     */
-    getLocalParticipantProperty(name) {
-        return room && room.getLocalParticipantProperty(name);
-    },
-
-    /**
      * Returns the stats.
      */
     getStats() {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1175,6 +1175,12 @@ function initCommands() {
             callback(getRoomsInfo(APP.store.getState(), includeHidden));
             break;
         }
+        case 'get-local-participant-property': {
+            const { property } = request;
+
+            callback(APP.conference.getLocalParticipantProperty(property));
+            break;
+        }
         case 'get-shared-document-url': {
             const { etherpad } = APP.store.getState()['features/etherpad'];
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1177,8 +1177,9 @@ function initCommands() {
         }
         case 'get-local-participant-property': {
             const { property } = request;
+            const conference = APP.store.getState()['features/base/conference'].conference;
 
-            callback(APP.conference.getLocalParticipantProperty(property));
+            callback(conference?.getLocalParticipantProperty(property));
             break;
         }
         case 'get-shared-document-url': {

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -770,6 +770,19 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
     }
 
     /**
+     * Returns a local participant property.
+     *
+     * @param {string} property - The name of the property to retrieve.
+     * @returns {Promise<string|undefined>} The value of the property if it exists, otherwise undefined.
+     */
+    getLocalParticipantProperty(property) {
+        return this._transport.sendRequest({
+            name: 'get-local-participant-property',
+            property
+        });
+    }
+
+    /**
      * Returns the Shared Document Url of the conference.
      *
      * @returns {Promise<string>} Shared Document URL.


### PR DESCRIPTION
Adds `getLocalParticipantProperty(name)`, reading a local participant property through the iframe.
