### PR TITLE
fix(api): regression in background toggle command

### DIFF
--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -966,7 +966,7 @@ function initCommands() {
             APP.store.dispatch(overwriteConfig(whitelistedConfig));
         },
         'toggle-virtual-background': () => {
-            APP.store.dispatch(toggleDialog(SettingsDialog, {
+            APP.store.dispatch(toggleDialog('SettingsDialog', SettingsDialog, {
                 defaultTab: SETTINGS_TABS.VIRTUAL_BACKGROUND }));
         },
         'end-conference': () => {


### PR DESCRIPTION
Commit [1aca8ab98](https://github.com/jitsi/jitsi-meet/commit/1aca8ab98) added a leading name parameter to all dialogues intended for logging. `toggle-virtual-background` lacks this parameter, leading to:

```
Error: Minified React error #130; visit https://react.dev/errors/130?args[]=object&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings. [object Object]: https://meet.example.com/libs/app.bundle.min.js?v=9268 +2
```

followed by an instant XMPP disconnect.