### PR TITLE
ci(rnsdk): allow remote and git deps so npm 12 can install

### DIFF
--- a/.github/workflows/release-rnsdk.yml
+++ b/.github/workflows/release-rnsdk.yml
@@ -44,8 +44,9 @@ jobs:
           npm -v
           echo "Ref:    ${{ github.ref }}"
           echo "SHA:    ${{ github.sha }}"
+      # npm 12 blocks tarball-url and git dependencies by default; we have both.
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --allow-remote=all --allow-git=all
       - name: Set version
         if: ${{ inputs.version != '' }}
         working-directory: react-native-sdk


### PR DESCRIPTION
npm 12 blocks tarball-url and git dependencies by default, so `npm ci` fails with `EALLOWREMOTE` on `strophe.js` and the SDK release never gets to the publish step. Verified locally with npm 12.0.1: fails without the flags, installs all 2146 packages with them.