### PR TITLE
feat(virtual-background): default to V2 engine unless explicitly disabled

### DIFF
--- a/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
+++ b/react/features/stream-effects/virtual-background/JitsiStreamBackgroundEffect.ts
@@ -38,12 +38,13 @@ export interface IV2EffectInit {
 /**
  * Virtual background stream effect.
  *
- * When {@code enableV2} is false (default), the class behaves identically to the original V1
+ * When {@code enableV2} is false, the class behaves identically to the original V1
  * engine: main-thread TFLite WASM inference, Canvas 2D compositing, TimerWorker frame driver.
  *
- * When {@code enableV2} is true, the constructor delegates to the pipeline/backend/compositor
- * abstraction: Worker-based inference, WebGL compositing, and insertable streams (with
- * captureStream fallback). The captureStream fallback reuses the shared video/canvas/timer.
+ * When {@code enableV2} is true (default), the constructor delegates to the
+ * pipeline/backend/compositor abstraction: Worker-based inference, WebGL compositing, and
+ * insertable streams (with captureStream fallback). The captureStream fallback reuses the
+ * shared video/canvas/timer.
  */
 export default class JitsiStreamBackgroundEffect {
     _backend: WorkerSegmentationBackend | null = null;

--- a/react/features/stream-effects/virtual-background/index.ts
+++ b/react/features/stream-effects/virtual-background/index.ts
@@ -38,8 +38,12 @@ export async function createVirtualBackgroundEffect(virtualBackground: IVirtualB
     }
     const fullVbConfig = APP.store.getState()['features/base/config'].virtualBackground;
 
-    if (fullVbConfig?.enableV2) {
-        const vbConfig = fullVbConfig.advanced;
+    // V2 is the default engine. V1 is only used when enableV2 is explicitly set to false.
+    // (The type of enableV2 is `boolean | undefined` per IConfig, so `undefined` picks V2.)
+    const useV2Engine = fullVbConfig?.enableV2 !== false;
+
+    if (useV2Engine) {
+        const vbConfig = fullVbConfig?.advanced;
         const capabilities = await detectDeviceTier(vbConfig);
 
         logger.info(


### PR DESCRIPTION
## Summary

Flips the default virtual background engine from V1 → V2. The V2 engine (Worker-based inference + WebGL compositing + insertable streams, with captureStream fallback) has been the opt-in path via `config.virtualBackground.enableV2 = true`; this makes it the default.

Semantics:
- `config.virtualBackground.enableV2 === false` → use V1
- everything else (unset, `true`, missing config block) → use V2

Existing deployments that want V1 can opt out by setting `enableV2: false` explicitly.

## Follow-ups

- [ ] docker-jitsi-meet PR #2270 default should be updated to match (`ENABLE_VIRTUAL_BACKGROUND_V2` currently defaults to `"false"` on that PR; will flip to `"true"` once this lands).

## Test plan

- [x] `tsc:web` clean
- [x] `eslint` clean
