### PR TITLE
feat(breakout-rooms): add participant mute flags

### DIFF
--- a/react/features/base/participants/types.ts
+++ b/react/features/base/participants/types.ts
@@ -95,8 +95,10 @@ export interface IJitsiParticipant {
     getProperty: (name: string) => any;
     getRole: () => string;
     getSources: () => Map<string, Map<string, ISourceInfo>>;
+    isAudioMuted: () => boolean;
     isHidden: () => boolean;
     isHiddenFromRecorder: () => boolean;
+    isVideoMuted: () => boolean;
 }
 
 export type ParticipantFeaturesKey = keyof IParticipantFeatures;

--- a/react/features/breakout-rooms/functions.ts
+++ b/react/features/breakout-rooms/functions.ts
@@ -100,7 +100,9 @@ export const getRoomsInfo = (stateful: IStateful, includeHidden = false) => {
                                 id: participantItem.getId(),
                                 userContext: storeParticipant?.userContext,
                                 isJigasi: participantItem.getProperty('features_jigasi') === true,
-                                isJibri: participantItem.isHidden() || participantItem.isHiddenFromRecorder()
+                                isJibri: participantItem.isHidden() || participantItem.isHiddenFromRecorder(),
+                                audioMuted: participantItem.isAudioMuted(),
+                                videoMuted: participantItem.isVideoMuted()
                             } as IRoomInfoParticipant;
                         }) ]
                     : [ localParticipantInfo ]

--- a/react/features/breakout-rooms/types.ts
+++ b/react/features/breakout-rooms/types.ts
@@ -33,6 +33,7 @@ export interface IRoomsInfo {
 }
 
 export interface IRoomInfoParticipant {
+    audioMuted?: boolean;
     avatarUrl: string;
     displayName: string;
     id: string;
@@ -45,4 +46,5 @@ export interface IRoomInfoParticipant {
         id?: string;
         name?: string;
     };
+    videoMuted?: boolean;
 }


### PR DESCRIPTION
Adds `audioMuted`/`videoMuted` booleans to `getRoomsInfo()`'s main room participant objects, read from `JitsiParticipant.isAudioMuted()`/`isVideoMuted()`