### PR TITLE
fix(rn-sdk): drop reference to removed NAT64AddrInfoModule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,9 +101,10 @@ tsconfig.json
 # React Native SDK
 #
 react-native-sdk/*.tgz
-react-native-sdk/android/src
+react-native-sdk/android/src/**
+!react-native-sdk/android/src/**/
 !react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JitsiMeetReactNativePackage.java
-!react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JitsiMeetOngoingConferenceService.java
+!react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JMOngoingConferenceService.java
 !react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JMOngoingConferenceModule.java
 !react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/RNOngoingNotification.java
 react-native-sdk/images

--- a/react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JitsiMeetReactNativePackage.java
+++ b/react-native-sdk/android/src/main/java/org/jitsi/meet/sdk/JitsiMeetReactNativePackage.java
@@ -25,8 +25,7 @@ public class JitsiMeetReactNativePackage implements ReactPackage {
                 new LocaleDetector(reactContext),
                 new LogBridgeModule(reactContext),
                 new PictureInPictureModule(reactContext),
-                new ProximityModule(reactContext),
-                new org.jitsi.meet.sdk.net.NAT64AddrInfoModule(reactContext)
+                new ProximityModule(reactContext)
                 ));
         return modules;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
