### PR TITLE
fix(audio-mode): don't change the audio mode with low bandwidth mode

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/AudioModeModule.java
@@ -46,13 +46,9 @@ import java.util.concurrent.Executors;
  * Module implementing a simple API to select the appropriate audio device for a
  * conference call.
  *
- * Audio calls should use {@code AudioModeModule.AUDIO_CALL}, which uses the
- * builtin earpiece, wired headset or bluetooth headset. The builtin earpiece is
+ * Calls should use {@code AudioModeModule.IN_CALL}, which uses the builtin
+ * speaker, earpiece, wired headset or bluetooth headset. The builtin speaker is
  * the default audio device.
- *
- * Video calls should should use {@code AudioModeModule.VIDEO_CALL}, which uses
- * the builtin speaker, earpiece, wired headset or bluetooth headset. The
- * builtin speaker is the default audio device.
  *
  * Before a call has started and after it has ended the
  * {@code AudioModeModule.DEFAULT} mode should be used.
@@ -65,14 +61,11 @@ class AudioModeModule extends ReactContextBaseJavaModule {
      * Constants representing the audio mode.
      * - DEFAULT: Used before and after every call. It represents the default
      *   audio routing scheme.
-     * - AUDIO_CALL: Used for audio only calls. It will use the earpiece by
-     *   default, unless a wired or Bluetooth headset is connected.
-     * - VIDEO_CALL: Used for video calls. It will use the speaker by default,
+     * - IN_CALL: Used while in a call. It will use the speaker by default,
      *   unless a wired or Bluetooth headset is connected.
      */
-    static final int DEFAULT    = 0;
-    static final int AUDIO_CALL = 1;
-    static final int VIDEO_CALL = 2;
+    static final int DEFAULT = 0;
+    static final int IN_CALL = 1;
 
     /**
      * The {@code Log} tag {@code AudioModeModule} is to log messages with.
@@ -175,9 +168,8 @@ class AudioModeModule extends ReactContextBaseJavaModule {
         Map<String, Object> constants = new HashMap<>();
 
         constants.put("DEVICE_CHANGE_EVENT", DEVICE_CHANGE_EVENT);
-        constants.put("AUDIO_CALL", AUDIO_CALL);
         constants.put("DEFAULT", DEFAULT);
-        constants.put("VIDEO_CALL", VIDEO_CALL);
+        constants.put("IN_CALL", IN_CALL);
 
         return constants;
     }
@@ -324,7 +316,7 @@ class AudioModeModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        if (mode < DEFAULT || mode > VIDEO_CALL) {
+        if (mode < DEFAULT || mode > IN_CALL) {
             promise.reject("setMode", "Invalid audio mode " + mode);
             return;
         }

--- a/ios/sdk/src/AudioMode.m
+++ b/ios/sdk/src/AudioMode.m
@@ -27,8 +27,7 @@
 // Audio mode
 typedef enum {
     kAudioModeDefault,
-    kAudioModeAudioCall,
-    kAudioModeVideoCall
+    kAudioModeInCall
 } JitsiMeetAudioMode;
 
 // Events
@@ -52,8 +51,7 @@ static NSString * const kDeviceTypeUnknown    = @"UNKNOWN";
 @implementation AudioMode {
     JitsiMeetAudioMode activeMode;
     RTCAudioSessionConfiguration *defaultConfig;
-    RTCAudioSessionConfiguration *audioCallConfig;
-    RTCAudioSessionConfiguration *videoCallConfig;
+    RTCAudioSessionConfiguration *inCallConfig;
     RTCAudioSessionConfiguration *earpieceConfig;
     BOOL audioDisabled;
     BOOL forceSpeaker;
@@ -75,9 +73,8 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport {
     return @{
         @"DEVICE_CHANGE_EVENT": kDevicesChanged,
-        @"AUDIO_CALL" : [NSNumber numberWithInt: kAudioModeAudioCall],
-        @"DEFAULT"    : [NSNumber numberWithInt: kAudioModeDefault],
-        @"VIDEO_CALL" : [NSNumber numberWithInt: kAudioModeVideoCall]
+        @"DEFAULT" : [NSNumber numberWithInt: kAudioModeDefault],
+        @"IN_CALL" : [NSNumber numberWithInt: kAudioModeInCall]
     };
 };
 
@@ -95,15 +92,10 @@ RCT_EXPORT_MODULE();
         defaultConfig.categoryOptions = 0;
         defaultConfig.mode = AVAudioSessionModeDefault;
 
-        audioCallConfig = [[RTCAudioSessionConfiguration alloc] init];
-        audioCallConfig.category = AVAudioSessionCategoryPlayAndRecord;
-        audioCallConfig.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionDefaultToSpeaker;
-        audioCallConfig.mode = AVAudioSessionModeVoiceChat;
-
-        videoCallConfig = [[RTCAudioSessionConfiguration alloc] init];
-        videoCallConfig.category = AVAudioSessionCategoryPlayAndRecord;
-        videoCallConfig.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth;
-        videoCallConfig.mode = AVAudioSessionModeVideoChat;
+        inCallConfig = [[RTCAudioSessionConfiguration alloc] init];
+        inCallConfig.category = AVAudioSessionCategoryPlayAndRecord;
+        inCallConfig.categoryOptions = AVAudioSessionCategoryOptionAllowBluetooth;
+        inCallConfig.mode = AVAudioSessionModeVideoChat;
 
         // Manually routing audio to the earpiece doesn't quite work unless one disables BT (weird, I know).
         earpieceConfig = [[RTCAudioSessionConfiguration alloc] init];
@@ -336,12 +328,10 @@ RCT_EXPORT_METHOD(updateDeviceList) {
     }
 
     switch (mode) {
-        case kAudioModeAudioCall:
-            return audioCallConfig;
         case kAudioModeDefault:
             return defaultConfig;
-        case kAudioModeVideoCall:
-            return videoCallConfig;
+        case kAudioModeInCall:
+            return inCallConfig;
         default:
             return nil;
     }

--- a/react/features/mobile/audio-mode/middleware.ts
+++ b/react/features/mobile/audio-mode/middleware.ts
@@ -12,7 +12,6 @@ import { getCurrentConference } from '../../base/conference/functions';
 import { SET_CONFIG } from '../../base/config/actionTypes';
 import { AUDIO_FOCUS_DISABLED } from '../../base/flags/constants';
 import { getFeatureFlag } from '../../base/flags/functions';
-import { SET_LOW_BANDWIDTH_MODE } from '../../base/low-bandwidth-mode/actionTypes';
 import MiddlewareRegistry from '../../base/redux/MiddlewareRegistry';
 import { parseURIString } from '../../base/util/uri';
 
@@ -24,8 +23,7 @@ const AudioModeEmitter = new NativeEventEmitter(AudioMode);
 
 /**
  * Middleware that captures conference actions and sets the correct audio mode
- * based on the type of conference. Audio-only conferences don't use the speaker
- * by default, and video conferences do.
+ * based on whether we are in a conference or not.
  *
  * @param {Store} store - The redux store.
  * @returns {Function}
@@ -59,7 +57,6 @@ MiddlewareRegistry.register(store => next => action => {
     * conference after the password prompt appears.
     */
     case CONFERENCE_JOINED:
-    case SET_LOW_BANDWIDTH_MODE:
         return _updateAudioMode(store, next, action);
 
     case SET_CONFIG: {
@@ -159,13 +156,12 @@ function _updateAudioMode({ getState }: IStore, next: Function, action: AnyActio
     const result = next(action);
     const state = getState();
     const conference = getCurrentConference(state);
-    const { enabled: audioOnly } = state['features/base/low-bandwidth-mode'];
     let mode: string;
 
     if (getFeatureFlag(state, AUDIO_FOCUS_DISABLED, false)) {
         return result;
     } else if (conference) {
-        mode = audioOnly ? AudioMode.AUDIO_CALL : AudioMode.VIDEO_CALL;
+        mode = AudioMode.IN_CALL;
     } else {
         mode = AudioMode.DEFAULT;
     }

--- a/react/features/mobile/call-integration/middleware.ts
+++ b/react/features/mobile/call-integration/middleware.ts
@@ -352,10 +352,8 @@ function _handleConnectionServiceFailure(state: IReduxState) {
         if (AudioMode.setUseConnectionService) {
             AudioMode.setUseConnectionService(false);
 
-            const hasVideo = !isVideoMutedByLowBandwidthMode(state);
-
             // Set the desired audio mode, since we just reset the whole thing.
-            AudioMode.setMode(hasVideo ? AudioMode.VIDEO_CALL : AudioMode.AUDIO_CALL);
+            AudioMode.setMode(AudioMode.IN_CALL);
         }
     }
 }


### PR DESCRIPTION
Toggling low bandwidth mode reconfigured the native audio session
(AUDIO_CALL vs VIDEO_CALL), which on iOS meant re-applying the audio
session category mid-call for no functional gain, and on Android meant
nothing at all since both modes resolved to MODE_IN_COMMUNICATION with
the same route selection.

Since there is now a single in-call mode, drop AUDIO_CALL and rename
VIDEO_CALL to IN_CALL, keeping the former VIDEO_CALL configuration. Also
fix the stale documentation claiming AUDIO_CALL defaults to the earpiece.
