### PR TITLE
feat(multi-screen): in-app triggers for the second screen

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -839,6 +839,12 @@
     "me": "me",
     "multiScreen": {
         "noParticipants": "No participants",
+        "openFailed": "Something went wrong. Please try again.",
+        "openFailedTitle": "Could not open the second screen",
+        "permissionDenied": "Allow this site to manage windows and try again.",
+        "popupBlocked": "Allow pop-ups for this site and try again.",
+        "removeFromSecondScreen": "Remove from second screen",
+        "sendToSecondScreen": "Show on second screen",
         "sharedVideoError": "The shared video could not be played on this screen",
         "sharedVideoInactive": "Share a video in the meeting to show it on the second screen",
         "showOnStage": "Show {{name}} on the second screen",

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -39,6 +39,8 @@ import { ITrack } from '../../../base/tracks/types';
 import { getVideoObjectPosition } from '../../../face-landmarks/functions';
 import { hideGif, showGif } from '../../../gifs/actions';
 import { getGifDisplayMode, getGifForParticipant } from '../../../gifs/functions';
+import SendToSecondScreenIcon from '../../../multi-screen/components/SendToSecondScreenIcon';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import PresenceLabel from '../../../presence-status/components/PresenceLabel';
 import { LAYOUTS } from '../../../video-layout/constants';
 import { getCurrentLayout } from '../../../video-layout/functions.web';
@@ -65,6 +67,12 @@ import ThumbnailBottomIndicators from './ThumbnailBottomIndicators';
 import ThumbnailTopIndicators from './ThumbnailTopIndicators';
 import TranslationPendingChip from './TranslationPendingChip';
 import VirtualScreenshareParticipant from './VirtualScreenshareParticipant';
+
+/**
+ * Module-scoped so the second-screen trigger's click handler stays stable
+ * across renders.
+ */
+const SHARED_VIDEO_SECOND_SCREEN_SOURCE: ISecondScreenSource = { role: 'sharedvideo' };
 
 /**
  * The type of the React {@code Component} state of {@link Thumbnail}.
@@ -287,6 +295,20 @@ const defaultStyles = (theme: Theme) => {
 
         indicatorsBottomContainer: {
             bottom: 0
+        },
+
+        /**
+         * The shared-video thumbnail has no indicators row, so its second-screen
+         * trigger is placed on its own, where the menu trigger sits on the other
+         * thumbnails.
+         */
+        sharedVideoTopRight: {
+            position: 'absolute' as const,
+            top: 0,
+            right: 0,
+            padding: theme.spacing(1),
+            zIndex: 10,
+            display: 'flex'
         },
 
         indicatorsBackground: {
@@ -844,6 +866,8 @@ class Thumbnail extends Component<IProps, IState> {
      */
     _renderFakeParticipant() {
         const { _isMobile, _participant: { avatarURL, pinned, name } } = this.props;
+        const { isHovered } = this.state;
+        const classes = withStyles.getClasses(this.props);
         const styles = this._getStyles();
         const containerClassName = this._getContainerClassName();
 
@@ -871,6 +895,11 @@ class Thumbnail extends Component<IProps, IState> {
                         src = { avatarURL } />
                 )
                     : this._renderAvatar(styles.avatar)}
+                <div className = { classes.sharedVideoTopRight }>
+                    <SendToSecondScreenIcon
+                        source = { SHARED_VIDEO_SECOND_SCREEN_SOURCE }
+                        visible = { isHovered } />
+                </div>
             </span>
         );
     }

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -300,7 +300,10 @@ const defaultStyles = (theme: Theme) => {
         /**
          * The shared-video thumbnail has no indicators row, so its second-screen
          * trigger is placed on its own, where the menu trigger sits on the other
-         * thumbnails.
+         * thumbnails. Applied to the trigger itself rather than to a container
+         * around it: the trigger renders nothing at all where the feature is off,
+         * and an empty box here would still take the corner of a thumbnail that
+         * is itself the click target for pinning.
          */
         sharedVideoTopRight: {
             position: 'absolute' as const,
@@ -895,11 +898,10 @@ class Thumbnail extends Component<IProps, IState> {
                         src = { avatarURL } />
                 )
                     : this._renderAvatar(styles.avatar)}
-                <div className = { classes.sharedVideoTopRight }>
-                    <SendToSecondScreenIcon
-                        source = { SHARED_VIDEO_SECOND_SCREEN_SOURCE }
-                        visible = { isHovered } />
-                </div>
+                <SendToSecondScreenIcon
+                    className = { classes.sharedVideoTopRight }
+                    source = { SHARED_VIDEO_SECOND_SCREEN_SOURCE }
+                    visible = { isHovered } />
             </span>
         );
     }

--- a/react/features/filmstrip/components/web/Thumbnail.tsx
+++ b/react/features/filmstrip/components/web/Thumbnail.tsx
@@ -37,6 +37,8 @@ import { ITrack } from '../../../base/tracks/types';
 import { getVideoObjectPosition } from '../../../face-landmarks/functions';
 import { hideGif, showGif } from '../../../gifs/actions';
 import { getGifDisplayMode, getGifForParticipant } from '../../../gifs/functions';
+import SendToSecondScreenIcon from '../../../multi-screen/components/SendToSecondScreenIcon';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import PresenceLabel from '../../../presence-status/components/PresenceLabel';
 import { LAYOUTS } from '../../../video-layout/constants';
 import { getCurrentLayout } from '../../../video-layout/functions.web';
@@ -62,6 +64,12 @@ import ThumbnailAudioIndicator from './ThumbnailAudioIndicator';
 import ThumbnailBottomIndicators from './ThumbnailBottomIndicators';
 import ThumbnailTopIndicators from './ThumbnailTopIndicators';
 import VirtualScreenshareParticipant from './VirtualScreenshareParticipant';
+
+/**
+ * Module-scoped so the second-screen trigger's click handler stays stable
+ * across renders.
+ */
+const SHARED_VIDEO_SECOND_SCREEN_SOURCE: ISecondScreenSource = { role: 'sharedvideo' };
 
 /**
  * The type of the React {@code Component} state of {@link Thumbnail}.
@@ -278,6 +286,20 @@ const defaultStyles = (theme: Theme) => {
 
         indicatorsBottomContainer: {
             bottom: 0
+        },
+
+        /**
+         * The shared-video thumbnail has no indicators row, so its second-screen
+         * trigger is placed on its own, where the menu trigger sits on the other
+         * thumbnails.
+         */
+        sharedVideoTopRight: {
+            position: 'absolute' as const,
+            top: 0,
+            right: 0,
+            padding: theme.spacing(1),
+            zIndex: 10,
+            display: 'flex'
         },
 
         indicatorsBackground: {
@@ -812,6 +834,8 @@ class Thumbnail extends Component<IProps, IState> {
      */
     _renderFakeParticipant() {
         const { _isMobile, _participant: { avatarURL, pinned, name } } = this.props;
+        const { isHovered } = this.state;
+        const classes = withStyles.getClasses(this.props);
         const styles = this._getStyles();
         const containerClassName = this._getContainerClassName();
 
@@ -839,6 +863,11 @@ class Thumbnail extends Component<IProps, IState> {
                         src = { avatarURL } />
                 )
                     : this._renderAvatar(styles.avatar)}
+                <div className = { classes.sharedVideoTopRight }>
+                    <SendToSecondScreenIcon
+                        source = { SHARED_VIDEO_SECOND_SCREEN_SOURCE }
+                        visible = { isHovered } />
+                </div>
             </span>
         );
     }

--- a/react/features/filmstrip/components/web/ThumbnailTopIndicators.tsx
+++ b/react/features/filmstrip/components/web/ThumbnailTopIndicators.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
@@ -6,6 +6,8 @@ import { IReduxState } from '../../../app/types';
 import { isMobileBrowser } from '../../../base/environment/utils';
 import { isScreenShareParticipantById } from '../../../base/participants/functions';
 import ConnectionIndicator from '../../../connection-indicator/components/web/ConnectionIndicator';
+import SendToSecondScreenIcon from '../../../multi-screen/components/SendToSecondScreenIcon';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import { STATS_POPOVER_POSITION, THUMBNAIL_TYPE } from '../../constants';
 import { getIndicatorsTooltipPosition } from '../../functions.web';
 
@@ -99,6 +101,13 @@ const ThumbnailTopIndicators = ({
         (state: IReduxState) => isScreenShareParticipantById(state, participantId)
     );
 
+    // Kept stable so the trigger's click handler is too: this thumbnail
+    // re-renders on every hover and every connection-stats tick.
+    const screenshareSource: ISecondScreenSource = useMemo(
+        () => ({ participant: participantId,
+            role: 'screenshare' }),
+        [ participantId ]);
+
     if (isVirtualScreenshareParticipant) {
         return (
             <div className = { styles.container }>
@@ -110,6 +119,12 @@ const ThumbnailTopIndicators = ({
                         participantId = { participantId }
                         statsPopoverPosition = { STATS_POPOVER_POSITION[thumbnailType] } />
                 }
+
+                {/* This thumbnail has no menu to add an entry to, so the second
+                    screen gets its own button, where the menu trigger would be. */}
+                <SendToSecondScreenIcon
+                    source = { screenshareSource }
+                    visible = { isHovered } />
             </div>
         );
     }

--- a/react/features/multi-screen/actions.web.ts
+++ b/react/features/multi-screen/actions.web.ts
@@ -24,7 +24,11 @@ export function setSecondScreen(id: string, source?: ISecondScreenSource, screen
         type: SET_SECOND_SCREEN,
         id,
         source,
-        screenId
+        screenId,
+
+        // Stamped here rather than in the reducer to keep the reducer pure; it
+        // orders the in-app windows by how recently they were targeted.
+        setAt: Date.now()
     };
 }
 

--- a/react/features/multi-screen/components/SecondScreenView.web.tsx
+++ b/react/features/multi-screen/components/SecondScreenView.web.tsx
@@ -29,7 +29,8 @@ interface IProps {
  * Routes a single second-screen window to a layout from its redux source
  * descriptor. A {@code whiteboard} source renders the {@link SecondScreenWhiteboard}
  * iframe; a {@code sharedvideo} source renders the meeting's shared video via
- * {@link SecondScreenSharedVideo}; a {@code tile} source renders the
+ * {@link SecondScreenSharedVideo}; a {@code screenshare} source renders that
+ * screenshare full-bleed; a {@code tile} source renders the
  * {@link SecondScreenGallery} grid; a stage or participant source renders the
  * {@link SecondScreenStage} layout (featured participant plus filmstrip); any
  * other source renders the single track/avatar via {@link SecondScreenSingle}.
@@ -51,6 +52,17 @@ const SecondScreenView = ({ id, win }: IProps) => {
         return (
             <SecondScreenSharedVideo
                 id = { id } />
+        );
+    }
+
+    // Before the participant check below: a screenshare names its virtual
+    // screenshare participant to say which one to show, but it is still shown
+    // full-bleed on its own rather than in the stage layout.
+    if (source?.role === 'screenshare') {
+        return (
+            <SecondScreenSingle
+                id = { id }
+                win = { win } />
         );
     }
 

--- a/react/features/multi-screen/components/SendToSecondScreenButton.web.tsx
+++ b/react/features/multi-screen/components/SendToSecondScreenButton.web.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { IconScreenshare } from '../../base/icons/svg';
+import ContextMenuItem from '../../base/ui/components/web/ContextMenuItem';
+import { NOTIFY_CLICK_MODE } from '../../toolbox/types';
+import { IButtonProps } from '../../video-menu/types';
+import { useSendToSecondScreen } from '../hooks.web';
+import { ISecondScreenSource } from '../types';
+
+interface IProps extends IButtonProps {
+
+    /**
+     * Button text class name.
+     */
+    className?: string;
+
+    /**
+     * Whether the icon should be hidden or not.
+     */
+    noIcon?: boolean;
+
+    /**
+     * Click handler executed aside from the main action.
+     */
+    onClick?: Function;
+
+    /**
+     * What to show on the second screen.
+     */
+    source: ISecondScreenSource;
+}
+
+/**
+ * A context-menu entry that sends its source to a second screen, and takes it
+ * off again once it is there. Renders nothing when the feature is unavailable,
+ * so it can be added unconditionally to a menu.
+ *
+ * @param {IProps} props - The component props.
+ * @returns {ReactElement | null}
+ */
+const SendToSecondScreenButton = ({
+    className,
+    noIcon = false,
+    notifyClick,
+    notifyMode,
+    onClick,
+    source
+}: IProps) => {
+    const { t } = useTranslation();
+    const { active, onClick: sendToSecondScreen, visible } = useSendToSecondScreen(source);
+
+    const _onClick = useCallback(() => {
+        notifyClick?.();
+        if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
+            return;
+        }
+        sendToSecondScreen();
+        onClick?.();
+    }, [ notifyClick, notifyMode, onClick, sendToSecondScreen ]);
+
+    if (!visible) {
+        return null;
+    }
+
+    const text = t(active ? 'multiScreen.removeFromSecondScreen' : 'multiScreen.sendToSecondScreen');
+
+    return (
+        <ContextMenuItem
+            accessibilityLabel = { text }
+            icon = { noIcon ? null : IconScreenshare }
+            onClick = { _onClick }
+            text = { text }
+            textClassName = { className } />
+    );
+};
+
+export default SendToSecondScreenButton;

--- a/react/features/multi-screen/components/SendToSecondScreenIcon.web.tsx
+++ b/react/features/multi-screen/components/SendToSecondScreenIcon.web.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from 'tss-react/mui';
+
+import { isMobileBrowser } from '../../base/environment/utils';
+import { IconScreenshare } from '../../base/icons/svg';
+import Button from '../../base/ui/components/web/Button';
+import { useSendToSecondScreen } from '../hooks.web';
+import { ISecondScreenSource } from '../types';
+
+interface IProps {
+
+    /**
+     * What to show on the second screen.
+     */
+    source: ISecondScreenSource;
+
+    /**
+     * Whether the tile is hovered, i.e. whether to show the button at all.
+     */
+    visible: boolean;
+}
+
+const useStyles = makeStyles()(() => {
+    return {
+        button: {
+            padding: '3px !important',
+            borderRadius: '4px',
+
+            '& svg': {
+                width: '18px',
+                height: '18px'
+            }
+        }
+    };
+});
+
+/**
+ * The tile counterpart of {@link SendToSecondScreenButton}, for the thumbnails
+ * that have no context menu to add an entry to (a screenshare, the shared
+ * video). It sits where the menu trigger sits on the other thumbnails and, like
+ * it, appears on hover.
+ *
+ * @param {IProps} props - The component props.
+ * @returns {ReactElement | null}
+ */
+const SendToSecondScreenIcon = ({ source, visible }: IProps) => {
+    const { classes } = useStyles();
+    const { t } = useTranslation();
+    const { active, onClick, visible: enabled } = useSendToSecondScreen(source);
+
+    // The thumbnails this sits on are themselves clickable (they pin), so the
+    // click must not reach them.
+    const _onClick = useCallback((e?: React.MouseEvent) => {
+        e?.stopPropagation();
+        onClick();
+    }, [ onClick ]);
+
+    const _onKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.stopPropagation();
+        }
+    }, []);
+
+    // Stays put while its source is on a second screen, even once the pointer
+    // leaves: it is the only way to take it off again, and a control that
+    // vanishes on unhover would leave the tile with no sign that it is being
+    // shown elsewhere.
+    if (!enabled || (!visible && !active) || isMobileBrowser()) {
+        return null;
+    }
+
+    return (
+        <span onKeyDown = { _onKeyDown }>
+            <Button
+                accessibilityLabel = {
+                    t(active ? 'multiScreen.removeFromSecondScreen' : 'multiScreen.sendToSecondScreen') }
+                className = { classes.button }
+                icon = { IconScreenshare }
+                onClick = { _onClick }
+                size = 'small' />
+        </span>
+    );
+};
+
+export default SendToSecondScreenIcon;

--- a/react/features/multi-screen/components/SendToSecondScreenIcon.web.tsx
+++ b/react/features/multi-screen/components/SendToSecondScreenIcon.web.tsx
@@ -11,6 +11,14 @@ import { ISecondScreenSource } from '../types';
 interface IProps {
 
     /**
+     * Class name for the button's wrapper. Applied here rather than to a
+     * container around this component so that a thumbnail that positions the
+     * trigger itself does not lay out an empty box over its own corner on the
+     * deployments where the feature is off and nothing renders.
+     */
+    className?: string;
+
+    /**
      * What to show on the second screen.
      */
     source: ISecondScreenSource;
@@ -44,7 +52,7 @@ const useStyles = makeStyles()(() => {
  * @param {IProps} props - The component props.
  * @returns {ReactElement | null}
  */
-const SendToSecondScreenIcon = ({ source, visible }: IProps) => {
+const SendToSecondScreenIcon = ({ className, source, visible }: IProps) => {
     const { classes } = useStyles();
     const { t } = useTranslation();
     const { active, onClick, visible: enabled } = useSendToSecondScreen(source);
@@ -71,7 +79,9 @@ const SendToSecondScreenIcon = ({ source, visible }: IProps) => {
     }
 
     return (
-        <span onKeyDown = { _onKeyDown }>
+        <span
+            className = { className }
+            onKeyDown = { _onKeyDown }>
             <Button
                 accessibilityLabel = {
                     t(active ? 'multiScreen.removeFromSecondScreen' : 'multiScreen.sendToSecondScreen') }

--- a/react/features/multi-screen/constants.ts
+++ b/react/features/multi-screen/constants.ts
@@ -2,3 +2,12 @@
  * The default window id used when the embedder does not specify one.
  */
 export const DEFAULT_SECOND_SCREEN_ID = 'default';
+
+/**
+ * The id prefix of the second-screen windows opened from the in-app triggers,
+ * as opposed to the ones an embedder opens through the external API. The
+ * in-app triggers only ever take over a window of their own (see
+ * {@code pickSecondScreenTarget}), so an embedder's windows keep showing what
+ * the embedder put on them.
+ */
+export const UI_SECOND_SCREEN_ID_PREFIX = 'ui-screen-';

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -54,16 +54,17 @@ const SECOND_SCREEN_LOAD_TIMEOUT = 10000;
 const SECOND_SCREEN_LOAD_POLL_INTERVAL = 250;
 
 /**
- * How long to wait for the window-management permission before giving up on an
- * open. A call to {@code getScreenDetails()} does not settle while its prompt is
- * on screen, and one that is never answered never settles it at all: verified in
- * headless Chrome, where the permission sits at {@code prompt}, nothing answers
- * it, and the promise stays pending for the life of the page. Without a bound
- * the open would produce no window, no error and no event, and its entry in
- * {@link opening} would never clear, so that id could never be opened again.
- * Generous enough for someone to read the prompt before answering, and a later
- * answer is not wasted, since {@link loadScreenDetails} still caches the result
- * for the next attempt.
+ * How long to wait for the window-management permission before giving up on
+ * placing a window. A call to {@code getScreenDetails()} does not settle while
+ * its prompt is on screen, and one that is never answered never settles it at
+ * all. The prompt is only ever raised where the call carries transient user
+ * activation, which is the in-app triggers; without it Chromium rejects at once
+ * with {@code NotAllowedError}, which is why the external API path fails fast
+ * rather than hanging, and why headless does too. Without a bound the window
+ * would sit unplaced on the meeting's own screen indefinitely, with nobody told
+ * anything either way. Generous enough for someone to read the prompt before
+ * answering, and a later answer is not wasted, since {@link loadScreenDetails}
+ * still caches the result for the next attempt.
  */
 const SECOND_SCREEN_PERMISSION_TIMEOUT = 30000;
 
@@ -1015,12 +1016,12 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
     // of its own. That is accepted rather than handled: the end state is
     // consistent rather than corrupt, the embedder is told through
     // secondScreenError for the id and can retry, and whatever caused the
-    // failure usually applies to both requests anyway. The window for this is
-    // wider than the load timeout: a first open also waits on the
-    // window-management permission prompt, which sits until the user answers it
-    // and lands on window-management-unavailable if they deny it. A screenId that
-    // changed in the meantime is ignored, exactly as it is for a window that is
-    // already open.
+    // failure usually applies to both requests anyway. This spans the page load
+    // and nothing else: the window-management permission is answered after the
+    // handle is in state, by a tail that holds no guard (see
+    // {@link openSecondScreenWindow}), so a request arriving during a prompt
+    // finds a live handle above and re-sources it. A screenId that changed in the
+    // meantime is ignored, exactly as it is for a window that is already open.
     if (opening.has(id)) {
         return;
     }
@@ -1032,6 +1033,78 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
     } finally {
         opening.delete(id);
     }
+}
+
+/**
+ * Fullscreens a second-screen window. Needs the AutomaticFullscreen permission on
+ * a managed device; without it the window simply stays windowed, which is why a
+ * refusal is logged rather than failing the open.
+ *
+ * @param {Window} win - The window to fullscreen.
+ * @param {string} id - The window id, for the log line.
+ * @returns {Promise<void>}
+ */
+async function fullscreenSecondScreen(win: Window, id: string): Promise<void> {
+    try {
+        await win.document.documentElement.requestFullscreen();
+    } catch (e) {
+        logger.debug(`Auto-fullscreen not granted for second screen "${id}"`, e);
+    }
+}
+
+/**
+ * Places and fullscreens a window once the window-management permission has been
+ * answered, for the open that could not place it at {@code window.open} time. Runs
+ * after the window is already registered and rendering, so everything it touches
+ * has to be re-checked: the answer can arrive long after the open finished, and
+ * the meeting has been free to close the window or open another for the same id
+ * in the meantime.
+ *
+ * Ownership is compared by handle identity rather than by asking whether an entry
+ * exists, so a window that was closed and opened again for the same id is neither
+ * placed nor torn down by the open it replaced.
+ *
+ * A denial (or a prompt left unanswered past {@link SECOND_SCREEN_PERMISSION_TIMEOUT})
+ * fails the open as it does everywhere else: without the permission the window
+ * cannot be put on another screen, which is the point of the feature, so it is
+ * closed and reported rather than left on the meeting's own display.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {ISecondScreenHandle} handle - The handle this open registered.
+ * @param {Promise<ScreenDetails>} pending - The in-flight permission request.
+ * @param {number} screenId - Optional target screen index.
+ * @returns {Promise<void>}
+ */
+async function placeSecondScreenWhenPermitted(
+        store: IStore,
+        id: string,
+        handle: ISecondScreenHandle,
+        pending: Promise<ScreenDetails>,
+        screenId?: number): Promise<void> {
+    let error: unknown;
+    const resolved = await pending.then(details => details, e => {
+        error = e;
+
+        return undefined;
+    });
+
+    if (getHandle(store.getState(), id) !== handle || handle.win.closed) {
+        logger.debug(`Dropping the window-management answer for second screen "${id}": `
+            + 'it no longer owns that window');
+
+        return;
+    }
+
+    if (!resolved) {
+        logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, error);
+        failSecondScreenOpen(store, id, 'window-management-unavailable', handle.win);
+
+        return;
+    }
+
+    placeSecondScreenWindow(handle.win, resolved, screenId);
+    await fullscreenSecondScreen(handle.win, id);
 }
 
 /**
@@ -1070,48 +1143,16 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         return;
     }
 
-    // Place the window as soon as there is an answer, rather than after the load.
-    // moveTo/resizeTo need no document, so placement never had to wait for the
-    // page; only the load listener has to be attached before the load event
-    // fires, which is a constraint on that wait alone. Hanging it off the answer
-    // instead also means a profile that has already denied the permission, which
-    // rejects without prompting at all, takes the window back off the screen at
-    // once rather than leaving it up for a whole page load first. Denying fails
-    // the open, as it does on every other path: without the permission the
-    // window cannot be put on another screen, which is the whole point of the
-    // feature. A prompt that is never answered is failed the same way once it is
-    // clearly not coming, rather than leaving the open pending forever with
-    // nothing reported to anyone.
-    let placementFailed = false;
-    const placement = details ? undefined : awaitScreenDetails(loadScreenDetails()).then(
-        resolved => {
+    // Start the request now so it runs alongside the page load rather than after
+    // it. Its outcome is handled once there is a handle to hang it on; this only
+    // keeps a rejection that arrives first from counting as unhandled.
+    const pendingDetails = details ? undefined : awaitScreenDetails(loadScreenDetails());
 
-            // A cancel can land while the answer is outstanding: the entry is in
-            // state for the whole open, so the trigger reads as active and a
-            // second click removes it, with no handle yet for
-            // closeSecondScreenHandle to close. Checking here rather than only
-            // below stops the window flying to the other screen a moment before
-            // it is closed for being unwanted.
-            if (!win.closed && store.getState()['features/multi-screen'].screens[id]) {
-                placeSecondScreenWindow(win, resolved, screenId);
-            }
-        },
-        e => {
-            placementFailed = true;
-            logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
-            failSecondScreenOpen(store, id, 'window-management-unavailable', win);
-        });
+    pendingDetails?.catch(() => undefined);
 
     // Wait for the shell page to replace the popup's initial empty document
     // before building the handle on it.
     const result = win.closed ? 'closed' : await awaitSecondScreenLoad(win);
-
-    // A permission refused during the load has already reported the failure and
-    // closed the window, which the load wait sees as the window going away.
-    // Checked before the result so that is not reported a second time.
-    if (placementFailed) {
-        return;
-    }
 
     if (result === 'closed' || win.closed) {
         handleWindowClosedWhileOpening(store, id, 'loading');
@@ -1137,26 +1178,6 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         failSecondScreenOpen(store, id, 'window-load-failed', win);
 
         return;
-    }
-
-    // The page is up; the answer may not be here yet. Nothing is built on the
-    // window until it is, so an open ends either placed or failed, never with a
-    // live portal on a window that is about to be torn down.
-    if (placement) {
-        await placement;
-
-        if (placementFailed) {
-            return;
-        }
-
-        // Unlike the load, the prompt is answered by the user, so the window can
-        // have been up for as long as they took over it, in front of them and
-        // closeable the whole time.
-        if (win.closed) {
-            handleWindowClosedWhileOpening(store, id, 'the window-management permission was pending');
-
-            return;
-        }
     }
 
     // A removal (or a conference end) can land while the window is loading. Its
@@ -1197,13 +1218,31 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
     store.dispatch(setSecondScreenWindow(id, handle));
     win.addEventListener('pagehide', () => handleWindowClosed(store, id), { once: true });
 
-    try {
-        await win.document.documentElement.requestFullscreen();
-    } catch (e) {
-        logger.debug(`Auto-fullscreen not granted for second screen "${id}"`, e);
+    // From here the window has the ordinary lifecycle rather than a half-open one:
+    // a cancel, a source leaving the meeting, or the conference ending all close
+    // it through closeSecondScreenHandle and report secondScreenClosed, and a
+    // repeat send finds a live handle above and re-sources it. Registering only
+    // after the permission was answered is what left all three of those with an
+    // entry, no handle, and nothing reported.
+    applySource(store, id);
+
+    if (!pendingDetails) {
+        await fullscreenSecondScreen(win, id);
+
+        return;
     }
 
-    applySource(store, id);
+    // Placement waits on the permission, so it becomes a tail rather than part of
+    // the open. Deliberately not awaited: holding the in-flight guard until a user
+    // answers a prompt is exactly what made a cancel silent. Fullscreen goes with
+    // it, and only after placement, or the window would fill the meeting's own
+    // screen for as long as the prompt is up.
+    // Caught here rather than by handleSecondScreenOpenError: the tail outlives the
+    // open, so it is no longer inside that catch-all. The window is live and
+    // registered by this point, so a throw costs it its placement, not its
+    // existence, and the meeting can still close it.
+    placeSecondScreenWhenPermitted(store, id, handle, pendingDetails, screenId)
+        .catch(e => logger.warn(`Could not place second-screen window "${id}" after the permission answer`, e));
 }
 
 /**

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -915,6 +915,22 @@ const opening = new Set<string>();
  * @returns {void}
  */
 function failSecondScreenOpen(store: IStore, id: string, error: string, win?: Window | null) {
+
+    // Detach the handle before removing the entry, so the middleware's REMOVE
+    // handler finds none and the removal stays silent: a failed open reports
+    // secondScreenError alone, as it does on master, and never a
+    // secondScreenClosed on top of it. Only the window-management denial reaches
+    // here with a handle in state, since that is the one failure that now comes
+    // after the window was registered, but the detach covers any later one too.
+    // An embedder that reopens on secondScreenClosed would otherwise loop on it.
+    // Detaching first also unmounts the portal while the window is still open,
+    // which is the ordering the REMOVE handler documents. Nothing awaits between
+    // the two dispatches, so no cancel or resend can observe the entry without
+    // its handle.
+    if (getHandle(store.getState(), id)) {
+        store.dispatch(setSecondScreenWindow(id, undefined));
+    }
+
     if (win && !win.closed) {
         win.close();
     }
@@ -1224,6 +1240,15 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
     // repeat send finds a live handle above and re-sources it. Registering only
     // after the permission was answered is what left all three of those with an
     // entry, no handle, and nothing reported.
+    //
+    // applySource runs here rather than behind placement. The window renders the
+    // source from this point, so the event is true when it is sent, and holding
+    // it back would not make "no event before placement" hold anyway: the
+    // subscriber calls applySource for every entry that has a handle, so a live
+    // role that resolves to someone else while the prompt is up emits it
+    // regardless. Deferring would only make the first event intermittent, and
+    // would drop it altogether where placement throws on a window that is live
+    // and rendering.
     applySource(store, id);
 
     if (!pendingDetails) {

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -53,6 +53,20 @@ const SECOND_SCREEN_LOAD_TIMEOUT = 10000;
 const SECOND_SCREEN_LOAD_POLL_INTERVAL = 250;
 
 /**
+ * How long to wait for the window-management permission before giving up on an
+ * open. A call to {@code getScreenDetails()} does not settle while its prompt is
+ * on screen, and one that is never answered never settles it at all: verified in
+ * headless Chrome, where the permission sits at {@code prompt}, nothing answers
+ * it, and the promise stays pending for the life of the page. Without a bound
+ * the open would produce no window, no error and no event, and its entry in
+ * {@link opening} would never clear, so that id could never be opened again.
+ * Generous enough for someone to read the prompt before answering, and a later
+ * answer is not wasted, since {@link loadScreenDetails} still caches the result
+ * for the next attempt.
+ */
+const SECOND_SCREEN_PERMISSION_TIMEOUT = 30000;
+
+/**
  * The name of the {@code meta} marker carried by the shell page (see
  * {@link getSecondScreenPageUrl}). A {@code load} event only says that
  * *something* was served, so the marker is what tells the shell apart from a 404
@@ -296,6 +310,25 @@ export async function loadScreenDetails(): Promise<ScreenDetails> {
     screenDetails = screenDetails ?? await window.getScreenDetails();
 
     return screenDetails;
+}
+
+/**
+ * Bounds a wait on the screen details, so an open cannot be left pending forever
+ * behind a permission prompt nobody answers (see
+ * {@link SECOND_SCREEN_PERMISSION_TIMEOUT}). Rejects on the timeout, which the
+ * caller treats exactly like a denial: either way the window cannot be placed.
+ *
+ * @param {Promise<ScreenDetails>} pending - The in-flight request.
+ * @returns {Promise<ScreenDetails>}
+ */
+function awaitScreenDetails(pending: Promise<ScreenDetails>): Promise<ScreenDetails> {
+    return new Promise<ScreenDetails>((resolve, reject) => {
+        const timeout = setTimeout(
+            () => reject(new Error('Timed out waiting for the window-management permission')),
+            SECOND_SCREEN_PERMISSION_TIMEOUT);
+
+        pending.then(resolve, reject).finally(() => clearTimeout(timeout));
+    });
 }
 
 /**
@@ -1016,12 +1049,14 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
     // event fires, and the prompt can easily outlast the load of a same-origin
     // page. Denying the permission fails the open, as it does on every other
     // path: without it the window cannot be put on another screen at all, which
-    // is the whole point of the feature.
+    // is the whole point of the feature. A prompt that is never answered is
+    // failed the same way once it is clearly not coming, rather than leaving the
+    // open pending forever with nothing reported to anyone.
     if (pendingDetails) {
         let resolved;
 
         try {
-            resolved = await pendingDetails;
+            resolved = await awaitScreenDetails(pendingDetails);
         } catch (e) {
             logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
             failSecondScreenOpen(store, id, 'window-management-unavailable', win);

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -14,6 +14,7 @@ import { getLargeVideoParticipant } from '../large-video/functions';
 import { showWarningNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 import { isVideoPlaying } from '../shared-video/functions';
+import { isWhiteboardPresent } from '../whiteboard/functions';
 
 import { removeSecondScreen, setSecondScreenWindow } from './actions.web';
 import { UI_SECOND_SCREEN_ID_PREFIX } from './constants';
@@ -206,12 +207,17 @@ export function resolveSource(state: IReduxState, source: ISecondScreenSource) {
  */
 function getSourceSignature(state: IReduxState, source: ISecondScreenSource): string {
 
-    // The shared video resolves to neither a track nor a participant (its player
-    // owns its own element), so what has to be signed is whether one is being
-    // shared at all. Without this, stopping the share reads exactly like still
-    // sharing and nothing re-runs.
+    // The shared video and the whiteboard resolve to neither a track nor a
+    // participant (each owns its own element: a player, an iframe), so what has
+    // to be signed is whether the thing is there at all. Without this both sign
+    // as the constant `avatar:::`, so stopping the share or closing the
+    // whiteboard reads exactly like still having it and nothing re-runs.
     if (source.role === 'sharedvideo') {
         return `sharedvideo:${isVideoPlaying(state)}`;
+    }
+
+    if (source.role === 'whiteboard') {
+        return `whiteboard:${isWhiteboardPresent(state)}`;
     }
 
     const { track, participant } = resolveSource(state, source);
@@ -394,8 +400,9 @@ function getWindowScreenIndex(details: ScreenDetails, win: Window): number | und
     } catch (_e) {
 
         // The second-screen windows are same-origin by the time they have a
-        // handle, so this is not expected; treat the position as unknown rather
-        // than as free, which would stack a window on top of this one.
+        // handle, so this is not expected. Answering "unknown" rather than
+        // guessing a screen leaves it to the caller, which fails closed (see
+        // {@link getEntryScreenIndex}).
         return undefined;
     }
 
@@ -403,11 +410,40 @@ function getWindowScreenIndex(details: ScreenDetails, win: Window): number | und
 }
 
 /**
- * The screen indices the second-screen windows currently occupy. Read from each
- * live window rather than from the entries, so it survives the browser
- * renumbering the screens and frees the screen of a window the user closed by
- * hand. An entry whose window is still opening has no position yet, so it falls
- * back to the screen it asked for, which is where the open is about to put it.
+ * The screen a second-screen entry counts as being on: where its window actually
+ * is, else the screen it asked for, else {@code fallback} (an entry that named
+ * no screen is placed on the first external one, which is what
+ * {@link getTargetScreen} does with it).
+ *
+ * The position is preferred because {@code screenId} only records where the
+ * window was asked to go at open time: a window is never re-placed afterwards,
+ * so it goes stale when the user drags the window or the browser renumbers
+ * {@code details.screens} on a display change. Falling back rather than
+ * answering "nowhere" is deliberate: a window whose position cannot be read
+ * (still opening, or centred outside every reported screen, as a minimized
+ * popup may report) still holds a screen, and treating it as free would open
+ * another window on top of it.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @param {ISecondScreenEntry} entry - The entry to locate.
+ * @param {number} fallback - The screen an entry that named none is placed on.
+ * @returns {number}
+ */
+function getEntryScreenIndex(details: ScreenDetails, entry: ISecondScreenEntry, fallback: number): number {
+    const win = (entry.handle as ISecondScreenHandle | undefined)?.win;
+
+    // A ternary rather than && so an unreadable position and a window without a
+    // handle both arrive here as undefined; ?? would pass a false straight
+    // through as the answer.
+    const index = win && !win.closed ? getWindowScreenIndex(details, win) : undefined;
+
+    return index ?? entry.screenId ?? fallback;
+}
+
+/**
+ * The screen indices the second-screen windows currently occupy. Read from the
+ * live windows rather than from the entries, so it survives the browser
+ * renumbering the screens and follows a window the user moved.
  *
  * @param {ScreenDetails} details - The screen details.
  * @param {Object} screens - The second-screen entries.
@@ -424,24 +460,37 @@ function getOccupiedScreens(
     Object.values(screens).forEach(entry => {
         const win = (entry.handle as ISecondScreenHandle | undefined)?.win;
 
-        if (!win) {
-            occupied.add(entry.screenId ?? fallback);
-
+        // A window the user closed by hand frees its screen. One that has no
+        // handle yet does not: it is still opening onto the screen it asked for.
+        if (win?.closed) {
             return;
         }
 
-        if (win.closed) {
-            return;
-        }
-
-        const index = getWindowScreenIndex(details, win);
-
-        if (typeof index === 'number') {
-            occupied.add(index);
-        }
+        occupied.add(getEntryScreenIndex(details, entry, fallback));
     });
 
     return occupied;
+}
+
+/**
+ * An id no second-screen window is using. Deliberately carries no screen index:
+ * occupancy is positional now, and an id that encodes a screen is a second,
+ * conflicting answer to "which window is on that screen" that goes stale the
+ * moment a display is undocked. It only has to be unique, or a "nothing is on
+ * that screen, open one" decision hands back the id of a window that exists and
+ * re-sources it instead, leaving the screen empty.
+ *
+ * @param {Object} screens - The second-screen entries.
+ * @returns {string}
+ */
+function mintSecondScreenId(screens: { [id: string]: ISecondScreenEntry; }): string {
+    let n = 0;
+
+    while (screens[`${UI_SECOND_SCREEN_ID_PREFIX}${n}`]) {
+        n++;
+    }
+
+    return `${UI_SECOND_SCREEN_ID_PREFIX}${n}`;
 }
 
 /**
@@ -464,26 +513,35 @@ function getOccupiedScreens(
 export function pickSecondScreenTarget(state: IReduxState): { id: string; screenId?: number; } {
     const details = screenDetails;
     const external = details ? getExternalScreenIndices(details) : [];
+    const { screens } = state['features/multi-screen'];
 
+    // One screen, so one window: a fixed id, which re-targets the window already
+    // up instead of opening another on top of it.
     if (!details || !external.length) {
         return { id: `${UI_SECOND_SCREEN_ID_PREFIX}0` };
     }
 
-    const { screens } = state['features/multi-screen'];
     const taken = getOccupiedScreens(details, screens, external[0]);
     const free = external.find(index => !taken.has(index));
 
     if (typeof free === 'number') {
-        return { id: `${UI_SECOND_SCREEN_ID_PREFIX}${free}`,
+        return { id: mintSecondScreenId(screens),
             screenId: free };
     }
 
-    const ours = Object.entries(screens).filter(([ id ]) => id.startsWith(UI_SECOND_SCREEN_ID_PREFIX));
+    // Only a window that is actually on an external screen can be taken over. One
+    // that has ended up on the meeting's own screen (dragged there, or relocated
+    // by the browser when its display was undocked) would otherwise be the oldest
+    // and get picked, putting the content on top of the meeting while the
+    // external screens keep what they were already showing.
+    const ours = Object.entries(screens).filter(([ id, entry ]) =>
+        id.startsWith(UI_SECOND_SCREEN_ID_PREFIX)
+            && external.includes(getEntryScreenIndex(details, entry, external[0])));
 
-    // Every screen is taken by the embedder's windows: open on the first one
-    // anyway rather than taking one of them over.
+    // Every external screen is taken by windows this trigger must not touch:
+    // open on the first one anyway rather than taking one of them over.
     if (!ours.length) {
-        return { id: `${UI_SECOND_SCREEN_ID_PREFIX}${external[0]}`,
+        return { id: mintSecondScreenId(screens),
             screenId: external[0] };
     }
 
@@ -493,11 +551,8 @@ export function pickSecondScreenTarget(state: IReduxState): { id: string; screen
     // Re-target where that window is now, not where it was first sent, so taking
     // it over does not also move it. Only used if it has to be re-opened: a
     // window that is still up keeps its position either way.
-    const win = (entry.handle as ISecondScreenHandle | undefined)?.win;
-    const current = win && !win.closed ? getWindowScreenIndex(details, win) : undefined;
-
     return { id,
-        screenId: current ?? entry.screenId ?? external[0] };
+        screenId: getEntryScreenIndex(details, entry, external[0]) };
 }
 
 /**
@@ -547,9 +602,11 @@ export function getSecondScreenShowing(state: IReduxState, source: ISecondScreen
  * What is left is a window showing an anonymous avatar on black that nobody in
  * the meeting can close, only somebody standing at the other display.
  *
- * Only a source that names something can go away this way: {@code stage} and
- * {@code tile} follow the meeting itself, and a {@code screenshare} with no
- * participant falls back to whatever is being shared.
+ * Only a source that selects one particular thing can go away this way:
+ * {@code stage} and {@code tile} follow the meeting itself, and a
+ * {@code screenshare} with no participant falls back to whatever is being
+ * shared. The rest are asked either by the participant they name or, where they
+ * name none, by role.
  *
  * @param {IReduxState} state - The redux state.
  * @param {ISecondScreenSource} source - The source to check.
@@ -558,6 +615,13 @@ export function getSecondScreenShowing(state: IReduxState, source: ISecondScreen
 function isSecondScreenSourceGone(state: IReduxState, source: ISecondScreenSource): boolean {
     if (source.role === 'sharedvideo') {
         return !isVideoPlaying(state);
+    }
+
+    // Closing the whiteboard removes its fake participant, taking the tile and
+    // the context menu holding the only trigger with it. The source names no
+    // participant, so it has to be asked for by role like the shared video.
+    if (source.role === 'whiteboard') {
+        return !isWhiteboardPresent(state);
     }
 
     // A screenshare names the virtual participant that owns it, which is removed
@@ -1006,16 +1070,48 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         return;
     }
 
-    // Start the prompt now so it runs alongside the shell page load instead of
-    // after it. Awaited (and its rejection handled) below; this only keeps an
-    // early rejection from counting as unhandled.
-    const pendingDetails = details ? undefined : loadScreenDetails();
+    // Place the window as soon as there is an answer, rather than after the load.
+    // moveTo/resizeTo need no document, so placement never had to wait for the
+    // page; only the load listener has to be attached before the load event
+    // fires, which is a constraint on that wait alone. Hanging it off the answer
+    // instead also means a profile that has already denied the permission, which
+    // rejects without prompting at all, takes the window back off the screen at
+    // once rather than leaving it up for a whole page load first. Denying fails
+    // the open, as it does on every other path: without the permission the
+    // window cannot be put on another screen, which is the whole point of the
+    // feature. A prompt that is never answered is failed the same way once it is
+    // clearly not coming, rather than leaving the open pending forever with
+    // nothing reported to anyone.
+    let placementFailed = false;
+    const placement = details ? undefined : awaitScreenDetails(loadScreenDetails()).then(
+        resolved => {
 
-    pendingDetails?.catch(() => undefined);
+            // A cancel can land while the answer is outstanding: the entry is in
+            // state for the whole open, so the trigger reads as active and a
+            // second click removes it, with no handle yet for
+            // closeSecondScreenHandle to close. Checking here rather than only
+            // below stops the window flying to the other screen a moment before
+            // it is closed for being unwanted.
+            if (!win.closed && store.getState()['features/multi-screen'].screens[id]) {
+                placeSecondScreenWindow(win, resolved, screenId);
+            }
+        },
+        e => {
+            placementFailed = true;
+            logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
+            failSecondScreenOpen(store, id, 'window-management-unavailable', win);
+        });
 
     // Wait for the shell page to replace the popup's initial empty document
     // before building the handle on it.
     const result = win.closed ? 'closed' : await awaitSecondScreenLoad(win);
+
+    // A permission refused during the load has already reported the failure and
+    // closed the window, which the load wait sees as the window going away.
+    // Checked before the result so that is not reported a second time.
+    if (placementFailed) {
+        return;
+    }
 
     if (result === 'closed' || win.closed) {
         handleWindowClosedWhileOpening(store, id, 'loading');
@@ -1043,24 +1139,13 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         return;
     }
 
-    // Place the window now if it could not be placed as it opened. After the
-    // load rather than before it, because the load wait deliberately has no fast
-    // path (see awaitSecondScreenLoad): it has to be waiting before the load
-    // event fires, and the prompt can easily outlast the load of a same-origin
-    // page. Denying the permission fails the open, as it does on every other
-    // path: without it the window cannot be put on another screen at all, which
-    // is the whole point of the feature. A prompt that is never answered is
-    // failed the same way once it is clearly not coming, rather than leaving the
-    // open pending forever with nothing reported to anyone.
-    if (pendingDetails) {
-        let resolved;
+    // The page is up; the answer may not be here yet. Nothing is built on the
+    // window until it is, so an open ends either placed or failed, never with a
+    // live portal on a window that is about to be torn down.
+    if (placement) {
+        await placement;
 
-        try {
-            resolved = await awaitScreenDetails(pendingDetails);
-        } catch (e) {
-            logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
-            failSecondScreenOpen(store, id, 'window-management-unavailable', win);
-
+        if (placementFailed) {
             return;
         }
 
@@ -1072,8 +1157,6 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
 
             return;
         }
-
-        placeSecondScreenWindow(win, resolved, screenId);
     }
 
     // A removal (or a conference end) can land while the window is loading. Its

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -11,8 +11,11 @@ import {
     getVirtualScreenshareParticipantTrack
 } from '../base/tracks/functions.any';
 import { getLargeVideoParticipant } from '../large-video/functions';
+import { showWarningNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
 
 import { removeSecondScreen, setSecondScreenWindow } from './actions.web';
+import { UI_SECOND_SCREEN_ID_PREFIX } from './constants';
 import logger from './logger';
 import { ISecondScreenSource } from './types';
 
@@ -141,8 +144,16 @@ export function resolveSource(state: IReduxState, source: ISecondScreenSource) {
         participant = getLargeVideoParticipant(state);
         iTrack = getVideoTrackByParticipant(state, participant);
     } else if (source.role === 'screenshare') {
-        iTrack = tracks.find(t => t.videoType === VIDEO_TYPE.DESKTOP && !t.muted && Boolean(t.jitsiTrack));
-        participant = iTrack ? getParticipantById(state, iTrack.participantId) : undefined;
+        // A screenshare sent from its own tile names the virtual screenshare
+        // participant that owns it, so the right one is rendered when several
+        // are live at once; without one, fall back to whatever is being shared.
+        if (source.participant) {
+            iTrack = getVirtualScreenshareParticipantTrack(tracks, source.participant);
+            participant = getParticipantById(state, source.participant);
+        } else {
+            iTrack = tracks.find(t => t.videoType === VIDEO_TYPE.DESKTOP && !t.muted && Boolean(t.jitsiTrack));
+            participant = iTrack ? getParticipantById(state, iTrack.participantId) : undefined;
+        }
     } else if (source.participant) {
         participant = getParticipantById(state, source.participant);
 
@@ -239,15 +250,169 @@ function getSecondScreenPageUrl(state: IReduxState): string {
 }
 
 /**
- * Computes the {@code window.open} features string, placing the window on a
- * physical screen via the Window Management API. Rejects if the API is
- * unavailable/denied (the feature requires it).
- *
- * @param {number} screenId - Optional target screen index.
- * @returns {Promise<string>}
+ * The {@code ScreenDetails} object, cached after the first successful call. The
+ * object is live (the browser keeps its {@code screens} and
+ * {@code currentScreen} up to date and fires {@code screenschange}), so it never
+ * needs to be invalidated, and caching it is what lets a window be opened
+ * synchronously: {@code window.open} then runs in the same task as the click
+ * that asked for it, keeping the user activation that the popup blocker
+ * requires.
  */
-async function computeFeatures(screenId?: number): Promise<string> {
-    const details = await window.getScreenDetails();
+let screenDetails: ScreenDetails | undefined;
+
+/**
+ * Returns the cached {@code ScreenDetails}, or {@code undefined} if it has not
+ * been obtained yet (see {@link loadScreenDetails}).
+ *
+ * @returns {ScreenDetails | undefined}
+ */
+export function getCachedScreenDetails(): ScreenDetails | undefined {
+    return screenDetails;
+}
+
+/**
+ * Obtains and caches the {@code ScreenDetails}. The first call requests the
+ * window-management permission, so it may prompt.
+ *
+ * @returns {Promise<ScreenDetails>}
+ */
+export async function loadScreenDetails(): Promise<ScreenDetails> {
+    screenDetails = screenDetails ?? await window.getScreenDetails();
+
+    return screenDetails;
+}
+
+/**
+ * Pre-loads the {@code ScreenDetails} when the window-management permission has
+ * already been granted, so the first in-app trigger can open its window without
+ * awaiting anything. Deliberately does not prompt: permission is only ever
+ * requested by an actual open, never just to decide what to draw.
+ *
+ * @returns {void}
+ */
+export function preloadScreenDetails() {
+    if (screenDetails || !isSecondScreenSupported()) {
+        return;
+    }
+
+    navigator.permissions?.query({ name: 'window-management' as PermissionName })
+        .then(status => (status.state === 'granted' ? loadScreenDetails() : undefined))
+        .catch(e => logger.debug('Could not pre-load the screen details', e));
+}
+
+/**
+ * The indices of the screens the meeting window is not on, in the order the
+ * Window Management API reports them.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @returns {number[]}
+ */
+function getExternalScreenIndices(details: ScreenDetails): number[] {
+    const { currentScreen } = details;
+
+    return details.screens
+        .map((screen, index) => ({ screen,
+            index }))
+        .filter(({ screen }) => screen.left !== currentScreen.left || screen.top !== currentScreen.top)
+        .map(({ index }) => index);
+}
+
+/**
+ * Picks which second-screen window an in-app trigger should target. Each screen
+ * shows its own source, so a trigger fills the first external screen that has no
+ * window yet; once they all have one it takes over the window this feature
+ * targeted longest ago. Windows opened through the external API are never taken
+ * over, only counted as occupying their screen.
+ *
+ * Falls back to a single window on the current screen when there is no external
+ * screen at all, which is what {@link computeFeatures} places it on.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {Object} The window id to target and the screen index to place it on.
+ */
+export function pickSecondScreenTarget(state: IReduxState): { id: string; screenId?: number; } {
+    const details = screenDetails;
+    const external = details ? getExternalScreenIndices(details) : [];
+
+    if (!external.length) {
+        return { id: `${UI_SECOND_SCREEN_ID_PREFIX}0` };
+    }
+
+    const { screens } = state['features/multi-screen'];
+
+    // An entry with no explicit screenId went to the first external screen,
+    // which is what computeFeatures picks for it.
+    const taken = new Set(Object.values(screens).map(entry => entry.screenId ?? external[0]));
+    const free = external.find(index => !taken.has(index));
+
+    if (typeof free === 'number') {
+        return { id: `${UI_SECOND_SCREEN_ID_PREFIX}${free}`,
+            screenId: free };
+    }
+
+    const ours = Object.entries(screens).filter(([ id ]) => id.startsWith(UI_SECOND_SCREEN_ID_PREFIX));
+
+    // Every screen is taken by the embedder's windows: open on the first one
+    // anyway rather than taking one of them over.
+    if (!ours.length) {
+        return { id: `${UI_SECOND_SCREEN_ID_PREFIX}${external[0]}`,
+            screenId: external[0] };
+    }
+
+    const [ id, entry ] = ours.reduce((oldest, current) =>
+        ((current[1].setAt ?? 0) < (oldest[1].setAt ?? 0) ? current : oldest));
+
+    return { id,
+        screenId: entry.screenId ?? external[0] };
+}
+
+/**
+ * Whether two source descriptors select the same thing, so a trigger can tell
+ * that what it would send is already on a second screen. Only {@code media} is
+ * defaulted: an absent {@code role} is not the same as {@code 'stage'} (it pins
+ * the named participant rather than following the large video), so the roles are
+ * compared as they are.
+ *
+ * @param {ISecondScreenSource} a - A source descriptor.
+ * @param {ISecondScreenSource} b - The source descriptor to compare it against.
+ * @returns {boolean}
+ */
+export function isSameSecondScreenSource(a?: ISecondScreenSource, b?: ISecondScreenSource): boolean {
+    if (!a || !b) {
+        return false;
+    }
+
+    return a.role === b.role
+        && a.participant === b.participant
+        && (a.media ?? 'camera') === (b.media ?? 'camera');
+}
+
+/**
+ * The id of the in-app second-screen window already showing {@code source}, if
+ * there is one. Only the in-app windows are considered, for the same reason
+ * {@link pickSecondScreenTarget} only takes those over: a trigger must not turn
+ * off a window the embedder opened and is managing through the external API.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {ISecondScreenSource} source - The source to look for.
+ * @returns {string | undefined} The window id, if any.
+ */
+export function getSecondScreenShowing(state: IReduxState, source: ISecondScreenSource): string | undefined {
+    const { screens } = state['features/multi-screen'];
+
+    return Object.keys(screens).find(id =>
+        id.startsWith(UI_SECOND_SCREEN_ID_PREFIX) && isSameSecondScreenSource(screens[id].source, source));
+}
+
+/**
+ * Computes the {@code window.open} features string, placing the window on a
+ * physical screen via the Window Management API.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @param {number} screenId - Optional target screen index.
+ * @returns {string}
+ */
+function computeFeatures(details: ScreenDetails, screenId?: number): string {
     const target = (typeof screenId === 'number' && details.screens[screenId])
         || details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top)
         || details.currentScreen;
@@ -495,7 +660,41 @@ function failSecondScreenOpen(store: IStore, id: string, error: string, win?: Wi
     }
 
     APP.API?.notifySecondScreenError?.({ id, error });
+    notifySecondScreenOpenFailed(store, id, error);
     store.dispatch(removeSecondScreen(id));
+}
+
+/**
+ * The notification shown for a failed in-app send, keyed by the error reported
+ * to the embedder. The two listed here are the ones the user can act on; the
+ * rest fall back to a generic message.
+ */
+const OPEN_ERROR_DESCRIPTIONS: { [error: string]: string; } = {
+    'popup-blocked': 'multiScreen.popupBlocked',
+    'window-management-unavailable': 'multiScreen.permissionDenied'
+};
+
+/**
+ * Tells the user that a send to a second screen failed. Only for the windows
+ * opened by the in-app triggers: an embedder handles its own windows' failures
+ * through {@code notifySecondScreenError}, and a notification in the meeting
+ * would be talking about a window the user never asked for. Without this an
+ * in-app click that is blocked does nothing observable at all.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {string} error - The error reported to the embedder.
+ * @returns {void}
+ */
+export function notifySecondScreenOpenFailed(store: IStore, id: string, error: string) {
+    if (!id.startsWith(UI_SECOND_SCREEN_ID_PREFIX)) {
+        return;
+    }
+
+    store.dispatch(showWarningNotification({
+        descriptionKey: OPEN_ERROR_DESCRIPTIONS[error] ?? 'multiScreen.openFailed',
+        titleKey: 'multiScreen.openFailedTitle'
+    }, NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
 }
 
 /**
@@ -583,7 +782,11 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
     let features;
 
     try {
-        features = await computeFeatures(screenId);
+        // Only awaits the first time, before the permission has been granted:
+        // afterwards the details are cached, so everything up to window.open
+        // below stays in the task that dispatched, and a window opened from a
+        // click still counts as user-initiated to the popup blocker.
+        features = computeFeatures(screenDetails ?? await loadScreenDetails(), screenId);
     } catch (e) {
         logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
         failSecondScreenOpen(store, id, 'window-management-unavailable');

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -69,6 +69,22 @@ const SECOND_SCREEN_LOAD_POLL_INTERVAL = 250;
 const SECOND_SCREEN_PERMISSION_TIMEOUT = 30000;
 
 /**
+ * How long a source that names a participant is given to come back before its
+ * window is closed. Absence is not proof of a departure: a participant whose
+ * presence flaps, or whose client rejoins the room, is removed and re-added, and
+ * the check that runs in between cannot tell that apart from someone leaving for
+ * good. Closing is one-way, because the send was a one-shot action whose trigger
+ * left with the tile, so being wrong costs a window the user cannot get back
+ * while being slow costs a few seconds of a window that is already showing an
+ * avatar. Only the participant-backed sources wait: the whiteboard and the
+ * shared video go when the local user stops them, which is deliberate and should
+ * not lag. A teardown of the whole participant list needs the room to be left,
+ * which ends the conference and resets every window anyway, so nothing here
+ * covers that case or could.
+ */
+const SECOND_SCREEN_SOURCE_GONE_GRACE = 5000;
+
+/**
  * The name of the {@code meta} marker carried by the shell page (see
  * {@link getSecondScreenPageUrl}). A {@code load} event only says that
  * *something* was served, so the marker is what tells the shell apart from a 404
@@ -1308,7 +1324,95 @@ export function closeSecondScreen(store: IStore, id: string) {
  * @returns {void}
  */
 export function closeAllSecondScreens(store: IStore) {
-    Object.keys(store.getState()['features/multi-screen'].screens).forEach(id => closeSecondScreen(store, id));
+    Object.keys(store.getState()['features/multi-screen'].screens).forEach(id => {
+        cancelSourceGoneClose(id);
+        closeSecondScreen(store, id);
+    });
+}
+
+/**
+ * The countdowns started for windows whose source has gone, keyed by window id
+ * and stamped with the send they belong to.
+ */
+const sourceGoneTimers = new Map<string, { setAt?: number; timeoutId: number; }>();
+
+/**
+ * Closes a window whose source did not come back within
+ * {@link SECOND_SCREEN_SOURCE_GONE_GRACE}.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {number} setAt - The send this countdown was started for.
+ * @returns {void}
+ */
+function closeGoneSource(store: IStore, id: string, setAt?: number) {
+    sourceGoneTimers.delete(id);
+
+    const state = store.getState();
+    const entry = state['features/multi-screen'].screens[id];
+
+    // The entry has to still be the one this was scheduled for. The in-app ids
+    // are reused (a one-monitor machine always sends to ui-screen-0), so a window
+    // closed and reopened, or re-sourced, while the countdown ran must not be
+    // torn down by it; setAt identifies the send rather than the id. Re-checking
+    // the source covers the rest: a refresh cancels a countdown when the source
+    // is back, but the entry may also have been given a different one.
+    if (!entry || entry.setAt !== setAt || !isSecondScreenSourceGone(state, entry.source)) {
+        return;
+    }
+
+    logger.debug(`Closing second screen "${id}": its source did not come back`);
+    store.dispatch(removeSecondScreen(id));
+}
+
+/**
+ * Starts the countdown to closing a window whose source has gone, if one is not
+ * already running for that send. Deliberately not restarted on every refresh:
+ * the subscriber runs on any window's signature change, so restarting would let
+ * unrelated traffic hold the deadline open indefinitely.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {number} setAt - The send the countdown belongs to.
+ * @returns {void}
+ */
+function scheduleSourceGoneClose(store: IStore, id: string, setAt?: number) {
+    const pending = sourceGoneTimers.get(id);
+
+    if (pending) {
+        if (pending.setAt === setAt) {
+            return;
+        }
+
+        window.clearTimeout(pending.timeoutId);
+    }
+
+    logger.debug(`Second screen "${id}" lost its source; closing it in `
+        + `${SECOND_SCREEN_SOURCE_GONE_GRACE}ms unless it comes back`);
+
+    sourceGoneTimers.set(id, {
+        setAt,
+        timeoutId: window.setTimeout(
+            () => closeGoneSource(store, id, setAt),
+            SECOND_SCREEN_SOURCE_GONE_GRACE)
+    });
+}
+
+/**
+ * Stops the countdown for a window, if one is running.
+ *
+ * @param {string} id - The window id.
+ * @returns {void}
+ */
+function cancelSourceGoneClose(id: string) {
+    const pending = sourceGoneTimers.get(id);
+
+    if (!pending) {
+        return;
+    }
+
+    window.clearTimeout(pending.timeoutId);
+    sourceGoneTimers.delete(id);
 }
 
 /**
@@ -1334,13 +1438,28 @@ export function refreshSecondScreens(store: IStore) {
             handleWindowClosed(store, id);
         } else if (entry && id.startsWith(UI_SECOND_SCREEN_ID_PREFIX) && isSecondScreenSourceGone(state, entry.source)) {
 
-            // Closes the window and reports secondScreenClosed, the same as the
+            // Closing the window reports secondScreenClosed, the same as the
             // trigger the user no longer has. An entry whose window is still
-            // opening is left with none, which that open already handles.
-            logger.debug(`Closing second screen "${id}": its source is no longer in the meeting`);
-            store.dispatch(removeSecondScreen(id));
-        } else if (handle) {
-            applySource(store, id);
+            // opening is left with none, which that open already handles. A
+            // participant-backed source gets the grace period first, since its
+            // absence may be a flap rather than a departure; the whiteboard and
+            // the shared video go at once, because those only stop when someone
+            // stops them.
+            if (entry.source.participant) {
+                scheduleSourceGoneClose(store, id, entry.setAt);
+            } else {
+                logger.debug(`Closing second screen "${id}": its source is no longer in the meeting`);
+                store.dispatch(removeSecondScreen(id));
+            }
+        } else {
+
+            // Either it never went or it came back within the grace period, so
+            // drop any countdown before re-applying.
+            cancelSourceGoneClose(id);
+
+            if (handle) {
+                applySource(store, id);
+            }
         }
     });
 }

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -457,24 +457,6 @@ function readWindowLocation(win: Window): string | undefined {
 }
 
 /**
- * Whether a second-screen window has already loaded its shell page, in which
- * case waiting for its {@code load} event would never resolve (the event has
- * already fired). Happens when a window is opened again for an id whose window
- * is still open, since {@code window.open} reuses the window with the same name.
- *
- * @param {Window} win - The opened window.
- * @returns {boolean}
- */
-function isShellPageLoaded(win: Window): boolean {
-    try {
-        return win.document.readyState === 'complete' && hasShellMarker(win);
-    } catch (_e) {
-        // Mid-navigation (or an unreadable document); treat it as not loaded and wait.
-        return false;
-    }
-}
-
-/**
  * How a wait for a second-screen window's shell page ended: the shell loaded,
  * the window was closed while it was loading, the load timed out, or something
  * other than the shell page was served. They are reported differently: only the
@@ -500,14 +482,16 @@ type SecondScreenLoadResult = 'loaded' | 'closed' | 'timeout' | 'wrong-page';
  * that delivered something other than the shell page is reported separately,
  * since the event fires for any served response.
  *
+ * There is deliberately no fast path for a window that has already loaded: the
+ * caller always opens with the shell URL, and navigating a reused named context
+ * loads it again, so {@code load} is always still to come. A document that reads
+ * as complete here is a stale outgoing one, which carries the marker too, so
+ * taking it would build the handle on a document that is about to be replaced.
+ *
  * @param {Window} win - The opened window.
  * @returns {Promise<SecondScreenLoadResult>}
  */
 function awaitSecondScreenLoad(win: Window): Promise<SecondScreenLoadResult> {
-    if (isShellPageLoaded(win)) {
-        return Promise.resolve('loaded');
-    }
-
     return new Promise<SecondScreenLoadResult>(resolve => {
         let poll = 0;
         let timeout = 0;
@@ -747,10 +731,21 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
     // would reach window.open with the same window name and re-navigate (or, on
     // the initial empty document, share) the window the first call is building
     // on, which orphans load listeners, duplicates roots and pagehide listeners,
-    // and can close a window that was just set up. Nothing is lost by returning:
-    // the source lives in redux, so the open already in flight picks up the
-    // newest one when it applies it at the end. A screenId that changed in the
-    // meantime is ignored, exactly as it is for a window that is already open.
+    // and can close a window that was just set up. The dropped request is not
+    // re-run later, so what it leaves behind depends on how the open in flight
+    // ends. If that one succeeds, nothing is lost: the source lives in redux, so
+    // it applies the newest one at the end. If it fails, its teardown dispatches
+    // removeSecondScreen(id), which also removes the entry the dropped request
+    // had just written, leaving that request with neither a window nor an entry
+    // of its own. That is accepted rather than handled: the end state is
+    // consistent rather than corrupt, the embedder is told through
+    // secondScreenError for the id and can retry, and whatever caused the
+    // failure usually applies to both requests anyway. The window for this is
+    // wider than the load timeout, since computeFeatures below raises the
+    // window-management permission prompt, which sits until the user answers it
+    // and lands on window-management-unavailable if they deny it. A screenId that
+    // changed in the meantime is ignored, exactly as it is for a window that is
+    // already open.
     if (opening.has(id)) {
         return;
     }

--- a/react/features/multi-screen/functions.web.ts
+++ b/react/features/multi-screen/functions.web.ts
@@ -13,11 +13,12 @@ import {
 import { getLargeVideoParticipant } from '../large-video/functions';
 import { showWarningNotification } from '../notifications/actions';
 import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
+import { isVideoPlaying } from '../shared-video/functions';
 
 import { removeSecondScreen, setSecondScreenWindow } from './actions.web';
 import { UI_SECOND_SCREEN_ID_PREFIX } from './constants';
 import logger from './logger';
-import { ISecondScreenSource } from './types';
+import { ISecondScreenEntry, ISecondScreenSource } from './types';
 
 // The Window Management API typings (Window.getScreenDetails, ScreenDetails, ScreenDetailed) come
 // from the `@types/webscreens-window-placement` devDependency.
@@ -181,11 +182,36 @@ export function resolveSource(state: IReduxState, source: ISecondScreenSource) {
 }
 
 /**
+ * A stable signature of what a single source should currently render. Includes
+ * the avatar identity (id/url/name) so the fallback avatar redraws even while no
+ * track is present.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {ISecondScreenSource} source - The source descriptor.
+ * @returns {string}
+ */
+function getSourceSignature(state: IReduxState, source: ISecondScreenSource): string {
+
+    // The shared video resolves to neither a track nor a participant (its player
+    // owns its own element), so what has to be signed is whether one is being
+    // shared at all. Without this, stopping the share reads exactly like still
+    // sharing and nothing re-runs.
+    if (source.role === 'sharedvideo') {
+        return `sharedvideo:${isVideoPlaying(state)}`;
+    }
+
+    const { track, participant } = resolveSource(state, source);
+
+    return track
+        ? track.id
+        : `avatar:${participant?.id ?? ''}:${participant?.loadableAvatarUrl ?? ''}:${participant?.name ?? ''}`;
+}
+
+/**
  * A stable signature of what every second-screen window should currently render.
- * When it changes — the active speaker switches, a source mutes/unmutes, or an
- * avatar finishes loading — the subscriber re-applies the sources, swapping the
- * window content in place. Includes the avatar identity (id/url/name) so the
- * fallback avatar redraws even while no track is present.
+ * When it changes — the active speaker switches, a source mutes/unmutes, an
+ * avatar finishes loading, or a source goes away entirely — the subscriber
+ * re-applies the sources, swapping the window content in place.
  *
  * @param {IReduxState} state - The redux state.
  * @returns {string}
@@ -194,14 +220,7 @@ export function getSecondScreenSignature(state: IReduxState): string {
     const { screens } = state['features/multi-screen'];
 
     return Object.keys(screens).sort()
-        .map(id => {
-            const { track, participant } = resolveSource(state, screens[id].source);
-            const key = track
-                ? track.id
-                : `avatar:${participant?.id ?? ''}:${participant?.loadableAvatarUrl ?? ''}:${participant?.name ?? ''}`;
-
-            return `${id}:${key}`;
-        })
+        .map(id => `${id}:${getSourceSignature(state, screens[id].source)}`)
         .join('|');
 }
 
@@ -251,24 +270,21 @@ function getSecondScreenPageUrl(state: IReduxState): string {
 
 /**
  * The {@code ScreenDetails} object, cached after the first successful call. The
- * object is live (the browser keeps its {@code screens} and
- * {@code currentScreen} up to date and fires {@code screenschange}), so it never
- * needs to be invalidated, and caching it is what lets a window be opened
- * synchronously: {@code window.open} then runs in the same task as the click
- * that asked for it, keeping the user activation that the popup blocker
- * requires.
+ * object is live: the browser keeps its {@code screens} and
+ * {@code currentScreen} up to date as displays come and go, so it never needs to
+ * be invalidated. Nothing subscribes to its {@code screenschange} event either,
+ * because every read happens at the point of use. That matters for the indices
+ * into {@code screens}: the browser renumbers the array on a display change, so
+ * an index only means anything at the moment it is read, which is why occupancy
+ * is derived from where the windows actually are (see
+ * {@link getWindowScreenIndex}) rather than from the indices they were opened
+ * with.
+ *
+ * Caching it is also what lets a window be opened synchronously:
+ * {@code window.open} then runs in the same task as the click that asked for it,
+ * keeping the user activation that the popup blocker requires.
  */
 let screenDetails: ScreenDetails | undefined;
-
-/**
- * Returns the cached {@code ScreenDetails}, or {@code undefined} if it has not
- * been obtained yet (see {@link loadScreenDetails}).
- *
- * @returns {ScreenDetails | undefined}
- */
-export function getCachedScreenDetails(): ScreenDetails | undefined {
-    return screenDetails;
-}
 
 /**
  * Obtains and caches the {@code ScreenDetails}. The first call requests the
@@ -318,14 +334,96 @@ function getExternalScreenIndices(details: ScreenDetails): number[] {
 }
 
 /**
+ * The index of the screen a live second-screen window is actually on, derived
+ * from the window's own position in the multi-screen coordinate space. The
+ * {@code screenId} on its entry cannot answer this: it records where the window
+ * was asked to go at open time, and a window is never re-placed afterwards
+ * (neither when the user drags it nor when the browser renumbers
+ * {@code details.screens} on a display change), so it goes stale while the
+ * window stays put. Uses the window's centre, so one straddling a boundary
+ * counts as being on the screen showing most of it.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @param {Window} win - The window to locate.
+ * @returns {number | undefined} The screen index, or {@code undefined} if the
+ * window could not be read or sits outside every reported screen.
+ */
+function getWindowScreenIndex(details: ScreenDetails, win: Window): number | undefined {
+    let index;
+
+    try {
+        const x = win.screenLeft + (win.outerWidth / 2);
+        const y = win.screenTop + (win.outerHeight / 2);
+
+        index = details.screens.findIndex(screen =>
+            x >= screen.left && x < screen.left + screen.width
+                && y >= screen.top && y < screen.top + screen.height);
+    } catch (_e) {
+
+        // The second-screen windows are same-origin by the time they have a
+        // handle, so this is not expected; treat the position as unknown rather
+        // than as free, which would stack a window on top of this one.
+        return undefined;
+    }
+
+    return index === -1 ? undefined : index;
+}
+
+/**
+ * The screen indices the second-screen windows currently occupy. Read from each
+ * live window rather than from the entries, so it survives the browser
+ * renumbering the screens and frees the screen of a window the user closed by
+ * hand. An entry whose window is still opening has no position yet, so it falls
+ * back to the screen it asked for, which is where the open is about to put it.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @param {Object} screens - The second-screen entries.
+ * @param {number} fallback - The screen an entry that named none is placed on,
+ * i.e. what {@link getTargetScreen} picks for it.
+ * @returns {Set<number>}
+ */
+function getOccupiedScreens(
+        details: ScreenDetails,
+        screens: { [id: string]: ISecondScreenEntry; },
+        fallback: number): Set<number> {
+    const occupied = new Set<number>();
+
+    Object.values(screens).forEach(entry => {
+        const win = (entry.handle as ISecondScreenHandle | undefined)?.win;
+
+        if (!win) {
+            occupied.add(entry.screenId ?? fallback);
+
+            return;
+        }
+
+        if (win.closed) {
+            return;
+        }
+
+        const index = getWindowScreenIndex(details, win);
+
+        if (typeof index === 'number') {
+            occupied.add(index);
+        }
+    });
+
+    return occupied;
+}
+
+/**
  * Picks which second-screen window an in-app trigger should target. Each screen
  * shows its own source, so a trigger fills the first external screen that has no
- * window yet; once they all have one it takes over the window this feature
- * targeted longest ago. Windows opened through the external API are never taken
- * over, only counted as occupying their screen.
+ * window on it; once they all have one it takes over the window this feature
+ * targeted longest ago, on the screen that window is on now. Windows opened
+ * through the external API are never taken over, only counted as occupying their
+ * screen.
  *
  * Falls back to a single window on the current screen when there is no external
- * screen at all, which is what {@link computeFeatures} places it on.
+ * screen at all, which is what {@link getTargetScreen} places it on. That is
+ * also the answer before the screen details have been obtained: the very first
+ * send cannot enumerate the screens without prompting for the window-management
+ * permission, and the open does that (see {@link openSecondScreenWindow}).
  *
  * @param {IReduxState} state - The redux state.
  * @returns {Object} The window id to target and the screen index to place it on.
@@ -334,15 +432,12 @@ export function pickSecondScreenTarget(state: IReduxState): { id: string; screen
     const details = screenDetails;
     const external = details ? getExternalScreenIndices(details) : [];
 
-    if (!external.length) {
+    if (!details || !external.length) {
         return { id: `${UI_SECOND_SCREEN_ID_PREFIX}0` };
     }
 
     const { screens } = state['features/multi-screen'];
-
-    // An entry with no explicit screenId went to the first external screen,
-    // which is what computeFeatures picks for it.
-    const taken = new Set(Object.values(screens).map(entry => entry.screenId ?? external[0]));
+    const taken = getOccupiedScreens(details, screens, external[0]);
     const free = external.find(index => !taken.has(index));
 
     if (typeof free === 'number') {
@@ -362,8 +457,14 @@ export function pickSecondScreenTarget(state: IReduxState): { id: string; screen
     const [ id, entry ] = ours.reduce((oldest, current) =>
         ((current[1].setAt ?? 0) < (oldest[1].setAt ?? 0) ? current : oldest));
 
+    // Re-target where that window is now, not where it was first sent, so taking
+    // it over does not also move it. Only used if it has to be re-opened: a
+    // window that is still up keeps its position either way.
+    const win = (entry.handle as ISecondScreenHandle | undefined)?.win;
+    const current = win && !win.closed ? getWindowScreenIndex(details, win) : undefined;
+
     return { id,
-        screenId: entry.screenId ?? external[0] };
+        screenId: current ?? entry.screenId ?? external[0] };
 }
 
 /**
@@ -405,6 +506,49 @@ export function getSecondScreenShowing(state: IReduxState, source: ISecondScreen
 }
 
 /**
+ * Whether what a source names has gone from the meeting, leaving its window with
+ * nothing to render. Every in-app trigger lives on the thing it sends (a
+ * screenshare's own thumbnail, the shared video's thumbnail, a participant's
+ * context menu), so when that thing goes the trigger goes with it, and the only
+ * control that could take the window down is gone before the user can use it.
+ * What is left is a window showing an anonymous avatar on black that nobody in
+ * the meeting can close, only somebody standing at the other display.
+ *
+ * Only a source that names something can go away this way: {@code stage} and
+ * {@code tile} follow the meeting itself, and a {@code screenshare} with no
+ * participant falls back to whatever is being shared.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @param {ISecondScreenSource} source - The source to check.
+ * @returns {boolean}
+ */
+function isSecondScreenSourceGone(state: IReduxState, source: ISecondScreenSource): boolean {
+    if (source.role === 'sharedvideo') {
+        return !isVideoPlaying(state);
+    }
+
+    // A screenshare names the virtual participant that owns it, which is removed
+    // when the share stops; anything else names a real participant, removed when
+    // they leave.
+    return Boolean(source.participant) && !getParticipantById(state, source.participant ?? '');
+}
+
+/**
+ * The screen a second-screen window should end up on: the one it named, else the
+ * first screen the meeting window is not on, else the meeting's own screen when
+ * that is all there is.
+ *
+ * @param {ScreenDetails} details - The screen details.
+ * @param {number} screenId - Optional target screen index.
+ * @returns {ScreenDetailed}
+ */
+function getTargetScreen(details: ScreenDetails, screenId?: number): ScreenDetailed {
+    return (typeof screenId === 'number' && details.screens[screenId])
+        || details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top)
+        || details.currentScreen;
+}
+
+/**
  * Computes the {@code window.open} features string, placing the window on a
  * physical screen via the Window Management API.
  *
@@ -413,12 +557,29 @@ export function getSecondScreenShowing(state: IReduxState, source: ISecondScreen
  * @returns {string}
  */
 function computeFeatures(details: ScreenDetails, screenId?: number): string {
-    const target = (typeof screenId === 'number' && details.screens[screenId])
-        || details.screens.find(s => s.left !== details.currentScreen.left || s.top !== details.currentScreen.top)
-        || details.currentScreen;
+    const target = getTargetScreen(details, screenId);
 
     // No avail* offsets: the window is auto-fullscreened, so the full screen bounds are what matter.
     return `popup,left=${target.left},top=${target.top},width=${target.width},height=${target.height}`;
+}
+
+/**
+ * Moves an already-open second-screen window onto its target screen, for the
+ * open that could not place it at {@code window.open} time (see
+ * {@link openSecondScreenWindow}). Placing a window on another screen needs the
+ * window-management permission, which is exactly what the caller has just
+ * awaited.
+ *
+ * @param {Window} win - The window to place.
+ * @param {ScreenDetails} details - The screen details.
+ * @param {number} screenId - Optional target screen index.
+ * @returns {void}
+ */
+function placeSecondScreenWindow(win: Window, details: ScreenDetails, screenId?: number) {
+    const target = getTargetScreen(details, screenId);
+
+    win.moveTo(target.left, target.top);
+    win.resizeTo(target.width, target.height);
 }
 
 /**
@@ -620,6 +781,23 @@ function handleWindowClosed(store: IStore, id: string) {
 }
 
 /**
+ * Handles the user closing a second-screen window while it is still being set
+ * up, i.e. before it has a handle for {@link handleWindowClosed} to work from.
+ * Closing it then is the same action as closing it a moment later, so it reports
+ * the same event rather than an error, and there is no window left to close.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {string} id - The window id.
+ * @param {string} phase - What the open was waiting on, for the log line.
+ * @returns {void}
+ */
+function handleWindowClosedWhileOpening(store: IStore, id: string, phase: string) {
+    logger.debug(`Second-screen window "${id}" was closed while ${phase}`);
+    store.dispatch(removeSecondScreen(id));
+    APP.API?.notifySecondScreenClosed?.({ id });
+}
+
+/**
  * The ids whose windows are currently being opened, i.e. the calls that are past
  * the handle check below but have not stored a handle yet.
  */
@@ -741,7 +919,7 @@ export async function openOrUpdateSecondScreen(store: IStore, id: string, screen
     // consistent rather than corrupt, the embedder is told through
     // secondScreenError for the id and can retry, and whatever caused the
     // failure usually applies to both requests anyway. The window for this is
-    // wider than the load timeout, since computeFeatures below raises the
+    // wider than the load timeout: a first open also waits on the
     // window-management permission prompt, which sits until the user answers it
     // and lands on window-management-unavailable if they deny it. A screenId that
     // changed in the meantime is ignored, exactly as it is for a window that is
@@ -774,23 +952,19 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
     // overwritten below and React unmounts its portal content (stopping the cloned
     // track and its Emotion cache) on its own, so there is nothing to tear down.
 
-    let features;
-
-    try {
-        // Only awaits the first time, before the permission has been granted:
-        // afterwards the details are cached, so everything up to window.open
-        // below stays in the task that dispatched, and a window opened from a
-        // click still counts as user-initiated to the popup blocker.
-        features = computeFeatures(screenDetails ?? await loadScreenDetails(), screenId);
-    } catch (e) {
-        logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
-        failSecondScreenOpen(store, id, 'window-management-unavailable');
-
-        return;
-    }
-
+    const details = screenDetails;
     const url = getSecondScreenPageUrl(store.getState());
-    const win = window.open(url, `jitsiSecondScreen_${id}`, features);
+
+    // Nothing above this awaits, so window.open runs in the task that dispatched
+    // and a window opened from a click still counts as user-initiated to the
+    // popup blocker. With the details cached the window is placed as it opens,
+    // which is every open but the first. Without them, obtaining them here first
+    // would put the window-management permission prompt between the click and
+    // the open: Chromium expires transient user activation after 5s while the
+    // prompt sits until it is answered, so a user who reads it before pressing
+    // Allow would have their window blocked rather than opened. Open unplaced
+    // instead and move it once the answer arrives.
+    const win = window.open(url, `jitsiSecondScreen_${id}`, details ? computeFeatures(details, screenId) : 'popup');
 
     if (!win) {
         logger.warn(`Failed to open second-screen window "${id}" (popup blocked?)`);
@@ -799,18 +973,19 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         return;
     }
 
+    // Start the prompt now so it runs alongside the shell page load instead of
+    // after it. Awaited (and its rejection handled) below; this only keeps an
+    // early rejection from counting as unhandled.
+    const pendingDetails = details ? undefined : loadScreenDetails();
+
+    pendingDetails?.catch(() => undefined);
+
     // Wait for the shell page to replace the popup's initial empty document
     // before building the handle on it.
     const result = win.closed ? 'closed' : await awaitSecondScreenLoad(win);
 
     if (result === 'closed' || win.closed) {
-
-        // The user closed the popup while it was loading. That is the same action
-        // as closing it a moment later, so it reports the same event rather than
-        // an error, and there is no window left to close.
-        logger.debug(`Second-screen window "${id}" was closed while loading`);
-        store.dispatch(removeSecondScreen(id));
-        APP.API?.notifySecondScreenClosed?.({ id });
+        handleWindowClosedWhileOpening(store, id, 'loading');
 
         return;
     }
@@ -833,6 +1008,37 @@ async function openSecondScreenWindow(store: IStore, id: string, screenId?: numb
         failSecondScreenOpen(store, id, 'window-load-failed', win);
 
         return;
+    }
+
+    // Place the window now if it could not be placed as it opened. After the
+    // load rather than before it, because the load wait deliberately has no fast
+    // path (see awaitSecondScreenLoad): it has to be waiting before the load
+    // event fires, and the prompt can easily outlast the load of a same-origin
+    // page. Denying the permission fails the open, as it does on every other
+    // path: without it the window cannot be put on another screen at all, which
+    // is the whole point of the feature.
+    if (pendingDetails) {
+        let resolved;
+
+        try {
+            resolved = await pendingDetails;
+        } catch (e) {
+            logger.warn(`Window Management API unavailable; cannot place second-screen window "${id}"`, e);
+            failSecondScreenOpen(store, id, 'window-management-unavailable', win);
+
+            return;
+        }
+
+        // Unlike the load, the prompt is answered by the user, so the window can
+        // have been up for as long as they took over it, in front of them and
+        // closeable the whole time.
+        if (win.closed) {
+            handleWindowClosedWhileOpening(store, id, 'the window-management permission was pending');
+
+            return;
+        }
+
+        placeSecondScreenWindow(win, resolved, screenId);
     }
 
     // A removal (or a conference end) can land while the window is loading. Its
@@ -924,18 +1130,33 @@ export function closeAllSecondScreens(store: IStore) {
 }
 
 /**
- * Re-resolves and re-renders every open second-screen window. Called by the
- * subscriber when the active speaker / tracks change.
+ * Re-resolves and re-renders every open second-screen window, and closes the
+ * in-app ones whose source has left the meeting. Called by the subscriber when
+ * the active speaker / tracks change.
+ *
+ * Only the in-app windows are closed: an embedder's window is the embedder's to
+ * manage, it is told what happened through {@code secondScreenSourceChanged} and
+ * the ordinary participant events, and closing it from here would change the
+ * external API's behaviour for input it already accepts today.
  *
  * @param {IStore} store - The redux store.
  * @returns {void}
  */
 export function refreshSecondScreens(store: IStore) {
     Object.keys(store.getState()['features/multi-screen'].screens).forEach(id => {
-        const handle = getHandle(store.getState(), id);
+        const state = store.getState();
+        const handle = getHandle(state, id);
+        const entry = state['features/multi-screen'].screens[id];
 
         if (handle?.win.closed) {
             handleWindowClosed(store, id);
+        } else if (entry && id.startsWith(UI_SECOND_SCREEN_ID_PREFIX) && isSecondScreenSourceGone(state, entry.source)) {
+
+            // Closes the window and reports secondScreenClosed, the same as the
+            // trigger the user no longer has. An entry whose window is still
+            // opening is left with none, which that open already handles.
+            logger.debug(`Closing second screen "${id}": its source is no longer in the meeting`);
+            store.dispatch(removeSecondScreen(id));
         } else if (handle) {
             applySource(store, id);
         }

--- a/react/features/multi-screen/hooks.web.ts
+++ b/react/features/multi-screen/hooks.web.ts
@@ -10,14 +10,10 @@ import {
 
 import { removeSecondScreen, setSecondScreen } from './actions.web';
 import {
-    getCachedScreenDetails,
     getSecondScreenShowing,
     isSecondScreenEnabled,
-    loadScreenDetails,
-    notifySecondScreenOpenFailed,
     pickSecondScreenTarget
 } from './functions.web';
-import logger from './logger';
 import { ISecondScreenSource } from './types';
 
 /**
@@ -96,29 +92,19 @@ export function useSendToSecondScreen(source: ISecondScreenSource): {
             return;
         }
 
-        const send = () => {
-            const { id, screenId } = pickSecondScreenTarget(store.getState());
+        // Dispatch synchronously, always. window.open has to run in this click's
+        // own task for the popup blocker to see it as user-initiated, and on a
+        // profile that has not granted window-management yet, obtaining the
+        // screen details here would spend that activation waiting on a
+        // permission prompt: Chromium expires it after 5s and the prompt sits
+        // until the user answers it. The open asks for the permission itself and
+        // places the window once it has an answer (see openSecondScreenWindow),
+        // which is also why the target picked here has no screen index on that
+        // first send: without the details there are no screens to choose between,
+        // and the open puts it on the first external one.
+        const { id, screenId } = pickSecondScreenTarget(store.getState());
 
-            store.dispatch(setSecondScreen(id, source, screenId));
-        };
-
-        // Stay synchronous once the screen details are known, so the window is
-        // opened in this click's task and the popup blocker sees it as
-        // user-initiated. Only the very first send has to await the permission.
-        if (getCachedScreenDetails()) {
-            send();
-        } else {
-            loadScreenDetails()
-                .then(send)
-                .catch((e: any) => {
-                    logger.warn('Could not send to a second screen', e);
-
-                    // No window was opened, so no id exists yet to report
-                    // against; the failure paths inside the open cover the rest.
-                    notifySecondScreenOpenFailed(
-                        store, pickSecondScreenTarget(store.getState()).id, 'window-management-unavailable');
-                });
-        }
+        store.dispatch(setSecondScreen(id, source, screenId));
     }, [ activeId, source, store ]);
 
     return { active: Boolean(activeId),

--- a/react/features/multi-screen/hooks.web.ts
+++ b/react/features/multi-screen/hooks.web.ts
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useCallback, useMemo } from 'react';
+import { useSelector, useStore } from 'react-redux';
 
 import { IReduxState } from '../app/types';
 import {
@@ -7,6 +7,18 @@ import {
     getLocalParticipant,
     getLocalScreenShareParticipant
 } from '../base/participants/functions';
+
+import { removeSecondScreen, setSecondScreen } from './actions.web';
+import {
+    getCachedScreenDetails,
+    getSecondScreenShowing,
+    isSecondScreenEnabled,
+    loadScreenDetails,
+    notifySecondScreenOpenFailed,
+    pickSecondScreenTarget
+} from './functions.web';
+import logger from './logger';
+import { ISecondScreenSource } from './types';
 
 /**
  * Returns the ordered participant ids for a second-screen layout: the local
@@ -47,4 +59,69 @@ export function useSecondScreenParticipantIds(): string[] {
  */
 export function useDominantSpeakerId(): string | null {
     return useSelector((state: IReduxState) => getDominantSpeakerParticipant(state)?.id ?? null);
+}
+
+/**
+ * Backs the in-app "send to second screen" triggers: whether to show one,
+ * whether the source is already on a screen, and the handler that toggles it.
+ * The handler dispatches {@code setSecondScreen}, the same action the external
+ * API dispatches, so the API stays the single control plane;
+ * {@link pickSecondScreenTarget} chooses which window it lands on.
+ *
+ * The trigger is shown whenever the feature is enabled and the browser can
+ * place a window on another screen, without checking that a second monitor is
+ * actually attached: that answer needs the window-management permission, and
+ * the click itself is what should ask for it. With no second monitor the window
+ * opens on the current screen.
+ *
+ * @param {ISecondScreenSource} source - What to send.
+ * @returns {Object} Whether the trigger is visible, whether its source is
+ * already on a second screen, and its click handler.
+ */
+export function useSendToSecondScreen(source: ISecondScreenSource): {
+    active: boolean; onClick: () => void; visible: boolean;
+} {
+    const store = useStore<IReduxState>();
+    const visible = useSelector(isSecondScreenEnabled);
+    const activeId = useSelector((state: IReduxState) => getSecondScreenShowing(state, source));
+
+    const onClick = useCallback(() => {
+
+        // Already on a screen: the trigger turns it off again. This is the only
+        // way to close an in-app second screen from the meeting window, short of
+        // closing the popup by hand on the other display.
+        if (activeId) {
+            store.dispatch(removeSecondScreen(activeId));
+
+            return;
+        }
+
+        const send = () => {
+            const { id, screenId } = pickSecondScreenTarget(store.getState());
+
+            store.dispatch(setSecondScreen(id, source, screenId));
+        };
+
+        // Stay synchronous once the screen details are known, so the window is
+        // opened in this click's task and the popup blocker sees it as
+        // user-initiated. Only the very first send has to await the permission.
+        if (getCachedScreenDetails()) {
+            send();
+        } else {
+            loadScreenDetails()
+                .then(send)
+                .catch((e: any) => {
+                    logger.warn('Could not send to a second screen', e);
+
+                    // No window was opened, so no id exists yet to report
+                    // against; the failure paths inside the open cover the rest.
+                    notifySecondScreenOpenFailed(
+                        store, pickSecondScreenTarget(store.getState()).id, 'window-management-unavailable');
+                });
+        }
+    }, [ activeId, source, store ]);
+
+    return { active: Boolean(activeId),
+        onClick,
+        visible };
 }

--- a/react/features/multi-screen/middleware.web.ts
+++ b/react/features/multi-screen/middleware.web.ts
@@ -1,5 +1,5 @@
 import { IStore } from '../app/types';
-import { CONFERENCE_FAILED, CONFERENCE_LEFT } from '../base/conference/actionTypes';
+import { CONFERENCE_FAILED, CONFERENCE_JOINED, CONFERENCE_LEFT } from '../base/conference/actionTypes';
 import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
 
 import { REMOVE_SECOND_SCREEN, RESET_SECOND_SCREENS, SET_SECOND_SCREEN } from './actionTypes';
@@ -9,7 +9,9 @@ import {
     closeSecondScreenHandle,
     getHandle,
     handleSecondScreenOpenError,
-    openOrUpdateSecondScreen
+    isSecondScreenEnabled,
+    openOrUpdateSecondScreen,
+    preloadScreenDetails
 } from './functions.web';
 
 import './subscriber.web';
@@ -65,6 +67,18 @@ MiddlewareRegistry.register((store: IStore) => {
             closeAllSecondScreens(store);
 
             return next(action);
+        case CONFERENCE_JOINED: {
+            const result = next(action);
+
+            // Warm the screen details so an in-app trigger can open its window
+            // without awaiting, which is what keeps the click's user activation
+            // (see openOrUpdateSecondScreen). Never prompts on its own.
+            if (isSecondScreenEnabled(store.getState())) {
+                preloadScreenDetails();
+            }
+
+            return result;
+        }
         case CONFERENCE_FAILED:
         case CONFERENCE_LEFT:
 

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -39,7 +39,8 @@ ReducerRegistry.register<IMultiScreenState>('features/multi-screen',
                 [action.id]: {
                     ...state.screens[action.id],
                     source: action.source,
-                    screenId: action.screenId
+                    screenId: action.screenId,
+                    setAt: action.setAt
                 }
             }
         };

--- a/react/features/multi-screen/reducer.ts
+++ b/react/features/multi-screen/reducer.ts
@@ -39,7 +39,14 @@ ReducerRegistry.register<IMultiScreenState>('features/multi-screen',
                 [action.id]: {
                     ...state.screens[action.id],
                     source: action.source,
-                    screenId: action.screenId,
+
+                    // Keep the screen an existing window was configured for when
+                    // the new request names none: re-sourcing a window (a
+                    // setSecondScreen with no `screen`) says what it should show,
+                    // not that it should go back to the default screen. Dropping
+                    // it would also be read as "wherever a window with no screen
+                    // goes" everywhere the id is used.
+                    screenId: action.screenId ?? state.screens[action.id]?.screenId,
                     setAt: action.setAt
                 }
             }

--- a/react/features/multi-screen/types.ts
+++ b/react/features/multi-screen/types.ts
@@ -13,14 +13,17 @@ export interface ISecondScreenSource {
     media?: 'camera' | 'desktop';
 
     /**
-     * The id of an explicitly pinned participant to render.
+     * The id of an explicitly pinned participant to render. On its own it
+     * selects the stage layout with that participant featured; combined with
+     * {@code role: 'screenshare'} it names which screenshare to render, so a
+     * specific one can be shown full-bleed when several are live at once.
      */
     participant?: string;
 
     /**
-     * What the window shows: the active-speaker stage, the current screenshare,
-     * a tile grid of every participant, the shared whiteboard, or the video
-     * (e.g. YouTube) shared in the meeting.
+     * What the window shows: the active-speaker stage, a screenshare, a tile
+     * grid of every participant, the shared whiteboard, or the video (e.g.
+     * YouTube) shared in the meeting.
      */
     role?: 'stage' | 'screenshare' | 'tile' | 'whiteboard' | 'sharedvideo';
 }
@@ -46,6 +49,15 @@ export interface ISecondScreenEntry {
      * reported by the Window Management API.
      */
     screenId?: number;
+
+    /**
+     * When this entry's source was last set. Used to pick which of the in-app
+     * windows to take over once every screen already has one (the least
+     * recently targeted). Absent for an entry configured by dispatching the
+     * raw action rather than through {@code setSecondScreen}, which counts as
+     * the oldest.
+     */
+    setAt?: number;
 
     /**
      * What the window renders.

--- a/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/FakeParticipantContextMenu.tsx
@@ -1,20 +1,30 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import TogglePinToStageButton from '../../../../features/video-menu/components/web/TogglePinToStageButton';
 import Avatar from '../../../base/avatar/components/Avatar';
 import { IconPlay } from '../../../base/icons/svg';
-import { isWhiteboardParticipant } from '../../../base/participants/functions';
+import { isSharedVideoParticipant, isWhiteboardParticipant } from '../../../base/participants/functions';
 import { IParticipant } from '../../../base/participants/types';
 import ContextMenu from '../../../base/ui/components/web/ContextMenu';
 import ContextMenuItemGroup from '../../../base/ui/components/web/ContextMenuItemGroup';
+import SendToSecondScreenButton from '../../../multi-screen/components/SendToSecondScreenButton';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import { stopSharedVideo } from '../../../shared-video/actions';
 import { getParticipantMenuButtonsWithNotifyClick, showOverflowDrawer } from '../../../toolbox/functions.web';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/types';
 import { setWhiteboardOpen } from '../../../whiteboard/actions';
 import { WHITEBOARD_ID } from '../../../whiteboard/constants';
 import { PARTICIPANT_MENU_BUTTONS as BUTTONS } from '../../constants';
+
+/**
+ * Module-scoped so the second-screen trigger's click handler stays stable
+ * across renders. Both of the participants this menu serves have a second-screen
+ * view of their own, so neither goes to the second screen as a video track.
+ */
+const WHITEBOARD_SECOND_SCREEN_SOURCE: ISecondScreenSource = { role: 'whiteboard' };
+const SHARED_VIDEO_SECOND_SCREEN_SOURCE: ISecondScreenSource = { role: 'sharedvideo' };
 
 interface IProps {
 
@@ -118,6 +128,14 @@ const FakeParticipantContextMenu = ({
         dispatch(setWhiteboardOpen(false));
     }, [ setWhiteboardOpen ]);
 
+    const secondScreenSource = useMemo(() => {
+        if (isWhiteboardParticipant(participant)) {
+            return WHITEBOARD_SECOND_SCREEN_SOURCE;
+        }
+
+        return isSharedVideoParticipant(participant) ? SHARED_VIDEO_SECOND_SCREEN_SOURCE : undefined;
+    }, [ participant ]);
+
     const _getActions = useCallback(() => {
         if (isWhiteboardParticipant(participant)) {
             return [ {
@@ -170,6 +188,15 @@ const FakeParticipantContextMenu = ({
                         notifyClick = { () => notifyClick(BUTTONS.PIN_TO_STAGE, WHITEBOARD_ID) }
                         notifyMode = { buttonsWithNotifyClick?.get(BUTTONS.PIN_TO_STAGE) }
                         participantID = { WHITEBOARD_ID } />
+                )}
+                {secondScreenSource && (
+                    <SendToSecondScreenButton
+                        key = 'sendToSecondScreen'
+                        // eslint-disable-next-line react/jsx-no-bind
+                        notifyClick = { () => notifyClick(BUTTONS.SEND_TO_SECOND_SCREEN, participant.id) }
+                        notifyMode = { buttonsWithNotifyClick?.get(BUTTONS.SEND_TO_SECOND_SCREEN) }
+                        participantID = { participant.id }
+                        source = { secondScreenSource } />
                 )}
             </ContextMenuItemGroup>
 

--- a/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
+++ b/react/features/video-menu/components/web/LocalVideoMenuTriggerButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { batch, connect, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
@@ -17,6 +17,9 @@ import ContextMenuItemGroup from '../../../base/ui/components/web/ContextMenuIte
 import ConnectionIndicatorContent from '../../../connection-indicator/components/web/ConnectionIndicatorContent';
 import { THUMBNAIL_TYPE } from '../../../filmstrip/constants';
 import { isStageFilmstripAvailable } from '../../../filmstrip/functions.web';
+import SendToSecondScreenButton from '../../../multi-screen/components/SendToSecondScreenButton';
+import { isSecondScreenEnabled } from '../../../multi-screen/functions.web';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import { getParticipantMenuButtonsWithNotifyClick } from '../../../toolbox/functions.web';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/types';
 import { renderConnectionStatus } from '../../actions.web';
@@ -74,6 +77,11 @@ interface IProps {
      * Whether to render the pin to stage button.
      */
     _showPinToStage: boolean;
+
+    /**
+     * Whether to render the send to second screen button.
+     */
+    _showSendToSecondScreen: boolean;
 
     /**
      * Whether or not the button should be visible.
@@ -141,6 +149,7 @@ const LocalVideoMenuTriggerButton = ({
     _showHideSelfViewButton,
     _showLocalVideoFlipButton,
     _showPinToStage,
+    _showSendToSecondScreen,
     buttonVisible,
     dispatch,
     hidePopover,
@@ -151,6 +160,10 @@ const LocalVideoMenuTriggerButton = ({
     const { t } = useTranslation();
     const buttonsWithNotifyClick = useSelector(getParticipantMenuButtonsWithNotifyClick);
     const visitorsSupported = useSelector((state: IReduxState) => state['features/visitors'].supported);
+    const localSource: ISecondScreenSource = useMemo(
+        () => ({ media: 'camera',
+            participant: _localParticipantId }),
+        [ _localParticipantId ]);
 
     const notifyClick = useCallback(
         (buttonKey: string) => {
@@ -214,6 +227,15 @@ const LocalVideoMenuTriggerButton = ({
                             onClick = { hidePopover }
                             participantID = { _localParticipantId } />
                     }
+                    <SendToSecondScreenButton
+                        className = { _overflowDrawer ? classes.flipText : '' }
+                        noIcon = { true }
+                        // eslint-disable-next-line react/jsx-no-bind
+                        notifyClick = { () => notifyClick(BUTTONS.SEND_TO_SECOND_SCREEN) }
+                        notifyMode = { buttonsWithNotifyClick?.get(BUTTONS.SEND_TO_SECOND_SCREEN) }
+                        onClick = { hidePopover }
+                        participantID = { _localParticipantId }
+                        source = { localSource } />
                     {
                         _showDemote && visitorsSupported && <DemoteToVisitorButton
                             className = { _overflowDrawer ? classes.flipText : '' }
@@ -236,7 +258,7 @@ const LocalVideoMenuTriggerButton = ({
         );
 
     return (
-        isMobileBrowser() || _showLocalVideoFlipButton || _showHideSelfViewButton
+        isMobileBrowser() || _showLocalVideoFlipButton || _showHideSelfViewButton || _showSendToSecondScreen
             ? <Popover
                 content = { content }
                 headingLabel = { t('dialog.localUserControls') }
@@ -298,7 +320,8 @@ function _mapStateToProps(state: IReduxState, ownProps: Partial<IProps>) {
         _overflowDrawer: overflowDrawer,
         _localParticipantId: localParticipant?.id ?? '',
         _showConnectionInfo: Boolean(showConnectionInfo),
-        _showPinToStage: isStageFilmstripAvailable(state)
+        _showPinToStage: isStageFilmstripAvailable(state),
+        _showSendToSecondScreen: isSecondScreenEnabled(state)
     };
 }
 

--- a/react/features/video-menu/components/web/ParticipantContextMenu.tsx
+++ b/react/features/video-menu/components/web/ParticipantContextMenu.tsx
@@ -21,6 +21,8 @@ import { IRoom } from '../../../breakout-rooms/types';
 import { displayVerification } from '../../../e2ee/functions';
 import { setVolume } from '../../../filmstrip/actions.web';
 import { isStageFilmstripAvailable } from '../../../filmstrip/functions.web';
+import SendToSecondScreenButton from '../../../multi-screen/components/SendToSecondScreenButton';
+import { ISecondScreenSource } from '../../../multi-screen/types';
 import { QUICK_ACTION_BUTTON } from '../../../participants-pane/constants';
 import { getQuickActionButtonType } from '../../../participants-pane/functions';
 import { requestRemoteControl, stopController } from '../../../remote-control/actions';
@@ -212,6 +214,13 @@ const ParticipantContextMenu = ({
         && typeof _volume === 'number'
         && !isNaN(_volume);
 
+    // Kept stable so the trigger's click handler is too; this menu re-renders
+    // while it is open.
+    const secondScreenSource: ISecondScreenSource = useMemo(
+        () => ({ media: 'camera',
+            participant: _getCurrentParticipantId() }),
+        [ _getCurrentParticipantId ]);
+
     const getButtonProps = useCallback((key: string) => {
         const notifyMode = buttonsWithNotifyClick?.get(key);
         const shouldNotifyClick = typeof notifyMode !== 'undefined';
@@ -288,6 +297,12 @@ const ParticipantContextMenu = ({
     if (stageFilmstrip) {
         buttons2.push(<TogglePinToStageButton { ...getButtonProps(BUTTONS.PIN_TO_STAGE) } />);
     }
+
+    buttons2.push(
+        <SendToSecondScreenButton
+            { ...getButtonProps(BUTTONS.SEND_TO_SECOND_SCREEN) }
+            source = { secondScreenSource } />
+    );
 
     if (enablePrivateChat) {
         buttons2.push(<PrivateMessageMenuButton { ...getButtonProps(BUTTONS.PRIVATE_MESSAGE) } />);

--- a/react/features/video-menu/constants.ts
+++ b/react/features/video-menu/constants.ts
@@ -37,6 +37,7 @@ export const PARTICIPANT_MENU_BUTTONS = {
     PRIVATE_MESSAGE: 'privateMessage',
     REMOTE_CONTROL: 'remote-control',
     SEND_PARTICIPANT_TO_ROOM: 'send-participant-to-room',
+    SEND_TO_SECOND_SCREEN: 'send-to-second-screen',
     TRANSLATE_AUDIO: 'translate-audio',
     VERIFY: 'verify'
 };


### PR DESCRIPTION
Second half of the GSoC multi-screen work: the in-app triggers, so a second
screen can be opened from the meeting UI rather than only through the external API. 
@cosmintimis @quitrk 

Rebased onto master now that #17615 has merged. The second commit here picks up the
two suggestions from its review.

### What it adds

A "Show on second screen" entry in the local, remote and fake participant menus,
plus a hover icon on the screenshare and shared-video tiles, which have no context
menu of their own. Everything routes through `setSecondScreen`, the same action the
external API dispatches, so the API stays the single control plane.

Clicking an active trigger takes the source off its screen again. That is the only
way to close an in-app second screen from the meeting window, short of closing the
popup by hand on the other display.

`pickSecondScreenTarget` fills a free external screen first, then reuses the least
recently targeted in-app window (a new `setAt` stamp orders them). Windows the
embedder opened through the external API are counted as occupying their screen but
never taken over.

The `ScreenDetails` are cached, so a send stays in the click's own task and keeps
the user activation the popup blocker requires; only the very first send has to
await the permission. They are pre-loaded on `CONFERENCE_JOINED` when the permission
has already been granted, which never prompts on its own.

Failures are now surfaced to the user. A blocked popup or a denied window-management
permission was reported only through `notifySecondScreenError`, which an in-app click
has no listener for, so a failed click did nothing observable at all.

A screenshare source can now name its virtual screenshare participant, so the right
one is shown when several are live at once.

### Notes

The triggers self-hide unless `secondScreen.enabled` is set and the browser has
`getScreenDetails`, so nothing changes for existing deployments or on mobile.

`role: 'tile'` and `role: 'stage'` still have no in-app trigger; neither has a
natural home in a participant menu, so they are left for a follow-up.

### Screenshots

The trigger in a participant menu, before the source has been sent:

<img width="1920" height="1080" alt="1-menu-trigger" src="https://github.com/user-attachments/assets/3d24e1eb-c5e6-4f36-9d7b-9bd1eb08b5e4" />

Sent: the second screen on the left, and the entry flipped to "Remove from second
screen" on the right, which is how a source is taken back off:

<img width="3840" height="980" alt="2-participant-on-second-screen" src="https://github.com/user-attachments/assets/abcd2e35-31cc-46f3-a598-cc145eb12ece" />

A shared YouTube video on the second screen, playing in sync with the meeting:

<img width="3840" height="1080" alt="3-shared-video-in-sync" src="https://github.com/user-attachments/assets/a8b86a45-2f15-41b7-9952-d1514416391c" />

### Testing

Tested locally on Chrome with the dev server.

Sent to a second screen and toggled back off again from the menus: the local
participant (stage layout with filmstrip), the whiteboard, a screenshare, and the
shared video. In each case the trigger flips to "Remove from second screen" while
its source is on a screen, and clicking it again closes the window.

The shared video was checked with an actual YouTube video rather than a direct
link, since that is the path where the IFrame API's listener is on the opener while
the iframe lives in the popup. It plays on the second screen in sync with the
meeting.