### PR TITLE
fix(audio-settings): dispose audio tracks on picker close to prevent Bluetooth profile leak

### DIFF
--- a/react/features/settings/components/web/audio/AudioSettingsContent.tsx
+++ b/react/features/settings/components/web/audio/AudioSettingsContent.tsx
@@ -147,6 +147,10 @@ const AudioSettingsContent = ({
         };
     }));
     const microphoneDevicesRef = useRef(microphoneDevices);
+    const audioTracksRef = useRef(audioTracks);
+
+    audioTracksRef.current = audioTracks;
+
     const { t } = useTranslation();
 
     /**
@@ -268,7 +272,7 @@ const AudioSettingsContent = ({
 
         return () => {
             _componentWasUnmounted.current = true;
-            _disposeTracks(audioTracks);
+            _disposeTracks(audioTracksRef.current);
         };
     }, []);
 


### PR DESCRIPTION
## Problem

When opening the audio device picker, Bluetooth devices (e.g. AirPods) switch from A2DP (48 kHz) to HFP/HSP (24 kHz) and never revert after closing the picker, even though the conference already has its own separate mic track.

## Root cause

`AudioSettingsContent` creates a live `getUserMedia` track for each microphone (to power the VU meters). The cleanup `useEffect` has an **empty dependency array** (`[]`), so the closure captures the **initial** value of `audioTracks` where every `jitsiTrack` is `null`.

When the tracks are later populated via `setAudioTracks(...)`, the cleanup still holds the stale reference. So `_disposeTracks(audioTracks)` iterates over null `jitsiTrack` values, the real `JitsiLocalTrack` objects are never `.dispose()`d, and the underlying `MediaStreamTrack`s keep the microphone hardware active — locking the Bluetooth device in HFP/HSP mode.

## Fix

Use a `ref` that always holds the latest `audioTracks` value, so the cleanup disposes the actual tracks on close:

```js
const audioTracksRef = useRef(audioTracks);
audioTracksRef.current = audioTracks;

// in the useEffect cleanup:
_disposeTracks(audioTracksRef.current);
```
This ensures the MediaStreamTracks are .stop()ed when the picker closes → macOS releases the microphone → the Bluetooth device switches back to A2DP (48 kHz).

## Testing

Tested on macOS with AirPods Pro 3, after the fix, the device correctly reverts to 48 kHz when closing the audio device picker.

## Context
Community discussion: https://community.jitsi.org/t/bluetooth-audio-quality-degrades-when-opening-audio-device-settings/142471