### PR TITLE
fix(whiteboard): prevent reopening closed whiteboard on unrelated metadata updates

### DIFF
--- a/react/features/whiteboard/middleware.any.ts
+++ b/react/features/whiteboard/middleware.any.ts
@@ -41,10 +41,15 @@ MiddlewareRegistry.register((store: IStore) => next => action => {
 
     case UPDATE_CONFERENCE_METADATA: {
         const { metadata } = action;
+        const newCollabDetails = metadata?.[WHITEBOARD_ID]?.collabDetails;
 
-        if (metadata?.[WHITEBOARD_ID]) {
+        // Only react when a *new* whiteboard collaboration session is announced. Otherwise unrelated
+        // metadata updates (e.g. toggling the lobby) would re-open a whiteboard the user had closed.
+        const previousCollabDetails = state['features/base/conference'].metadata?.[WHITEBOARD_ID]?.collabDetails;
+
+        if (newCollabDetails && newCollabDetails.roomId !== previousCollabDetails?.roomId) {
             store.dispatch(setupWhiteboard({
-                collabDetails: metadata[WHITEBOARD_ID].collabDetails,
+                collabDetails: newCollabDetails,
                 collabServerUrl: generateCollabServerUrl(store.getState())
             }));
 


### PR DESCRIPTION
### Problem

Unrelated conference metadata updates (e.g. toggling the lobby) triggered the
`UPDATE_CONFERENCE_METADATA` handler in the whiteboard middleware, which
re-opened a whiteboard that the user had previously closed. On mobile this also
caused an extra `navigate()` call that reloaded the WebView and disconnected the
active collaboration session.

### Fix

The middleware now sets up / opens the whiteboard only when a *new* collaboration
session is announced, by comparing the incoming `collabDetails.roomId` with the
one already present in `features/base/conference` metadata. Unrelated metadata
updates no longer re-open a closed whiteboard.

### Testing

- `npm run lint:ci` — passes with 0 warnings
- `npm run tsc:ci` — passes (web + native)
- Manually verified the whiteboard stays closed after unrelated metadata updates
  (e.g. toggling the lobby) and still opens when a new collab session starts.