### PR TITLE
Add enableIceRestart config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -693,6 +693,11 @@ var config = {
     // the bridge going down.
     // enableForcedReload: true,
 
+    // Enables in-place ICE restarts of the bridge connection (e.g. after a network change), instead of the
+    // legacy recovery flow which re-creates the whole media session. Requires support in jitsi-videobridge
+    // (default: disabled).
+    // enableIceRestart: false,
+
     // Use TURN/UDP servers for the jitsi-videobridge connection (by default
     // we filter out TURN/UDP because it is usually not needed since the
     // bridge itself is reachable via UDP)

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -421,6 +421,7 @@ export interface IConfig {
     enableEmailInStats?: boolean;
     enableEncodedTransformSupport?: boolean;
     enableForcedReload?: boolean;
+    enableIceRestart?: boolean;
     enableInsecureRoomNameWarning?: boolean;
     /**
      * @deprecated Use `lobby.enableChat` instead.


### PR DESCRIPTION
## Summary

Adds the `enableIceRestart` config option, consumed by lib-jitsi-meet to gate in-place ICE restarts of
the bridge connection. Disabled by default.

Companion change: jitsi/lib-jitsi-meet#3080 (same branch name, `ice-restart`).
