### PR TITLE
fix(chat): strip XML-invalid characters from outgoing messages

### DIFF
--- a/react/features/chat/functions.ts
+++ b/react/features/chat/functions.ts
@@ -74,6 +74,26 @@ const SLACK_EMOJI_REGEXP_ARRAY: Array<[RegExp, string]> = [];
 })();
 
 /**
+ * A regexp matching the characters that are not allowed in an XML 1.0 document.
+ * Sending such characters (e.g. the START OF TEXT control character U+0002)
+ * over XMPP produces a malformed stanza which makes the server terminate the
+ * stream, dropping everyone from the meeting.
+ */
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_CHARS_REGEXP = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g;
+
+/**
+ * Removes the characters that are not allowed in an XML 1.0 document from the
+ * given string.
+ *
+ * @param {string} text - The text to be sanitized.
+ * @returns {string} The text with all XML-invalid characters removed.
+ */
+export function stripXMLInvalidChars(text: string): string {
+    return text.replace(INVALID_XML_CHARS_REGEXP, '');
+}
+
+/**
  * Replaces ASCII and other non-unicode emoticons with unicode emojis to let the emojis be rendered
  * by the platform native renderer.
  *

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -73,7 +73,8 @@ import {
     getUnreadCount,
     isChatDisabled,
     isSendGroupChatDisabled,
-    isVisitorChatParticipant
+    isVisitorChatParticipant,
+    stripXMLInvalidChars
 } from './functions';
 import { INCOMING_MSG_SOUND_FILE } from './sounds';
 import './subscriber';
@@ -264,6 +265,12 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case SEND_MESSAGE: {
+        // The message is transmitted over XMPP, so strip the characters that
+        // are not allowed in an XML 1.0 document. Sending them (e.g. the START
+        // OF TEXT character U+0002) produces a malformed stanza which makes the
+        // XMPP server terminate the stream and drops everyone from the meeting.
+        // See https://github.com/jitsi/jitsi-meet/issues/17267.
+        const message = stripXMLInvalidChars(action.message);
         const state = store.getState();
         const conference = getCurrentConference(state);
 
@@ -277,7 +284,7 @@ MiddlewareRegistry.register(store => next => action => {
 
                 if (participantExists || shouldSendPrivateMessageTo.isFromVisitor) {
                     dispatch(openDialog('ChatPrivacyDialog', ChatPrivacyDialog, {
-                        message: action.message,
+                        message,
                         participantID: shouldSendPrivateMessageTo.id,
                         isFromVisitor: shouldSendPrivateMessageTo.isFromVisitor,
                         displayName: shouldSendPrivateMessageTo.name
@@ -294,20 +301,20 @@ MiddlewareRegistry.register(store => next => action => {
                 = state['features/chat'];
 
             if (typeof APP !== 'undefined') {
-                APP.API.notifySendingChatMessage(action.message, Boolean(privateMessageRecipient));
+                APP.API.notifySendingChatMessage(message, Boolean(privateMessageRecipient));
             }
 
             if (isLobbyChatActive && lobbyMessageRecipient) {
                 conference.sendLobbyMessage({
                     type: LOBBY_CHAT_MESSAGE,
-                    message: action.message
+                    message
                 }, lobbyMessageRecipient.id);
-                _persistSentPrivateMessage(store, lobbyMessageRecipient, action.message, true);
+                _persistSentPrivateMessage(store, lobbyMessageRecipient, message, true);
             } else if (privateMessageRecipient) {
-                conference.sendPrivateTextMessage(privateMessageRecipient.id, action.message, 'body', isVisitorChatParticipant(privateMessageRecipient));
-                _persistSentPrivateMessage(store, privateMessageRecipient, action.message);
+                conference.sendPrivateTextMessage(privateMessageRecipient.id, message, 'body', isVisitorChatParticipant(privateMessageRecipient));
+                _persistSentPrivateMessage(store, privateMessageRecipient, message);
             } else {
-                conference.sendTextMessage(action.message);
+                conference.sendTextMessage(message);
             }
         }
         break;


### PR DESCRIPTION
**Fixes #17267**

## What

Pasting a message that contains a character not allowed in XML 1.0 (e.g. the START OF TEXT control character `U+0002`) into the chat input crashes the session — the WebSocket closes unexpectedly and everyone gets dropped from the meeting.

## Root cause

Chat messages are transmitted over XMPP as the text content of a stanza. Characters such as `U+0002` are invalid in XML 1.0. The browser's `XMLSerializer` embeds the raw character into the serialized stanza, producing malformed XML. The XMPP server (Prosody) fails to parse the stanza and terminates the stream, which is exactly the `Websocket closed unexpectedly` error from the report.

I verified this with a headless-browser round-trip: a stanza built with `textContent = 'hello\u0002world'` serializes with the raw control character and fails to re-parse as XML, while the same text without it parses fine.

## Fix

Strip the characters that are not allowed in XML 1.0 from the outgoing message in the `SEND_MESSAGE` middleware before it reaches the XMPP layer. This covers all send paths (group chat, private chat, lobby chat) on both web and native.

```ts
const INVALID_XML_CHARS_REGEXP = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g;
```

Valid characters (tab, LF, CR, all normal Unicode incl. emoji) are preserved.

## Validation
- `npm run lint:ci` — 0 warnings
- `npm run tsc:ci` — web + native pass
- Sanitizer unit-checked against C0 controls, emoji, tab/LF/CR, non-ASCII
- Browser round-trip confirms sanitized stanzas parse as valid XML

@damencho could you please take a look?