### PR TITLE
feat(rayo): limit transcription dials to one per room per 10 seconds

### DIFF
--- a/resources/prosody-plugins/mod_filter_iq_rayo.lua
+++ b/resources/prosody-plugins/mod_filter_iq_rayo.lua
@@ -79,6 +79,12 @@ local OUT_ROOM_PASS_ATTR_NAME = 'JvbRoomPassword';
 local OUTGOING_CALLS_THROTTLE_INTERVAL = 60; -- if max_number_outgoing_calls is enabled it will be
                                              -- the max number of outgoing calls a user can try for a minute
 
+-- Per-room throttle for transcription dials: at most 1 allowed per this interval (seconds).
+-- Burst requests within the window after a successful dial are dropped so that
+-- only one Jigasi transcriber is started per conference.
+local TRANSCRIPTION_THROTTLE_INTERVAL = 10;
+local transcription_room_throttles = {};
+
 -- filters rayo iq in case of requested from not jwt authenticated sessions
 -- or if the session has features in user context and it doesn't mention
 -- feature "outbound-call" to be enabled
@@ -156,6 +162,22 @@ module:hook("pre-iq/full", function(event)
                 then
                     module:log("warn",
                         "Filtering stanza dial, stanza:%s, outgoing calls limit reached", tostring(stanza));
+                    measure_drop(1);
+                    session.send(st.error_reply(stanza, "cancel", "resource-constraint"));
+                    return true;
+                end
+            end
+
+            -- Per-room throttle for transcription: drop burst dials so only one
+            -- Jigasi transcriber is dispatched per conference per interval.
+            if feature == 'transcription' then
+                if not transcription_room_throttles[room_real_jid] then
+                    transcription_room_throttles[room_real_jid] = new_throttle(1, TRANSCRIPTION_THROTTLE_INTERVAL);
+                end
+                if not transcription_room_throttles[room_real_jid]:poll(1) then
+                    module:log("warn",
+                        "Filtering transcription dial for room %s - per-room throttle hit (limit: 1 per %ds)",
+                        room_real_jid, TRANSCRIPTION_THROTTLE_INTERVAL);
                     measure_drop(1);
                     session.send(st.error_reply(stanza, "cancel", "resource-constraint"));
                     return true;
@@ -254,6 +276,12 @@ function process_main_muc_loaded(main_muc, host_module)
     module:log('debug', 'Main muc loaded');
 
     main_muc_service = main_muc;
+
+    -- Clean up the per-room throttle entry when a room is destroyed so the
+    -- table does not grow without bound across many short-lived conferences.
+    host_module:hook('muc-room-destroyed', function(event)
+        transcription_room_throttles[event.room.jid] = nil;
+    end);
 end
 
 process_host_module(main_muc_component_host, function(host_module, host)

--- a/tests/prosody/mod_filter_iq_rayo_spec.js
+++ b/tests/prosody/mod_filter_iq_rayo_spec.js
@@ -190,6 +190,81 @@ describe('mod_filter_iq_rayo (feature-based authorization)', () => {
         });
     });
 
+    // ─── Per-room transcription throttle ────────────────────────────────────
+
+    describe('transcription per-room throttle', () => {
+        const transcribeOpts = { dialTo: 'jitsi_meet_transcribe' };
+
+        it('allows the first transcription dial in a room', async () => {
+            const { client: c, room } = await setup({ context: { features: { transcription: true } } });
+            const iqs = await sendAndCollect(c, room, transcribeOpts);
+
+            assert.strictEqual(iqs.length, 1, 'first dial should reach the MUC');
+            assert.strictEqual(iqs[0].dial_to, 'jitsi_meet_transcribe');
+        });
+
+        it('drops a second transcription dial to the same room within 10 s', async () => {
+            const { client: c, room } = await setup({ context: { features: { transcription: true } } });
+
+            const first = await sendAndCollect(c, room, transcribeOpts);
+
+            assert.strictEqual(first.length, 1, 'first dial should reach the MUC');
+
+            // Second dial: throttle budget exhausted, should be blocked
+            const second = await sendAndCollect(c, room, transcribeOpts);
+
+            assert.strictEqual(second.length, 0, 'second dial within 10 s should be throttled');
+        });
+
+        it('allows only one transcription dial when multiple are sent concurrently', async () => {
+            const { client: c, room } = await setup({ context: { features: { transcription: true } } });
+
+            await clearDialIqs();
+
+            // Fire three dials before Prosody has processed any of them
+            await Promise.all([
+                c.sendRayoIq(room, transcribeOpts),
+                c.sendRayoIq(room, transcribeOpts),
+                c.sendRayoIq(room, transcribeOpts)
+            ]);
+
+            await new Promise(r => setTimeout(r, 500));
+
+            const iqs = await getDialIqs();
+
+            assert.strictEqual(iqs.length, 1, 'exactly one concurrent transcription dial should pass');
+        });
+
+        it('does not apply the throttle across different rooms', async () => {
+            const { client: c1, room: room1 } = await setup({ context: { features: { transcription: true } } });
+            const { client: c2, room: room2 } = await setup({ context: { features: { transcription: true } } });
+
+            // First dial to room1 consumes room1's throttle budget
+            const iqs1 = await sendAndCollect(c1, room1, transcribeOpts);
+
+            assert.strictEqual(iqs1.length, 1, 'first dial to room1 should pass');
+
+            // First dial to room2 has its own independent throttle bucket
+            const iqs2 = await sendAndCollect(c2, room2, transcribeOpts);
+
+            assert.strictEqual(iqs2.length, 1, 'first dial to room2 should pass independently');
+        });
+
+        it('does not throttle outbound-call dials', async () => {
+            const { client: c, room } = await setup({ context: { features: { 'outbound-call': true } } });
+
+            const first = await sendAndCollect(c, room);
+
+            assert.strictEqual(first.length, 1, 'first outbound-call should pass');
+
+            // A second outbound-call to the same room must not be caught by the
+            // transcription throttle (which only applies to jitsi_meet_transcribe dials)
+            const second = await sendAndCollect(c, room);
+
+            assert.strictEqual(second.length, 1, 'second outbound-call should also pass');
+        });
+    });
+
     // ─── Header stripping ───────────────────────────────────────────────────
 
     describe('header stripping', () => {


### PR DESCRIPTION
## Summary

- Adds a per-room throttle in `mod_filter_iq_rayo` that allows at most one Jigasi transcriber dial to pass per conference every 10 seconds
- Burst requests within the window are dropped with a `resource-constraint` error, ensuring only one transcriber is dispatched regardless of how many concurrent dial requests arrive
- The throttle table is cleaned up on `muc-room-destroyed` to prevent unbounded memory growth

## Test plan

- [ ] First transcription dial in a room passes
- [ ] Second transcription dial to the same room within 10 s is blocked
- [ ] Multiple concurrent transcription dials allow exactly one through
- [ ] Different rooms have independent throttle buckets (first dial to each room passes)
- [ ] Outbound-call dials are unaffected by the transcription throttle