### PR TITLE
feat(android): add instantiateReactNative and destroyReactNative APIs

### DIFF
--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
@@ -16,6 +16,7 @@
 package org.jitsi.meet.sdk;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -82,14 +83,17 @@ public class JitsiMeet {
      * Starts the React Native runtime if it's not already running. Optional
      * warm-up after {@link #destroyReactNative()}; joining a conference also
      * restarts it on demand.
+     *
+     * @param context - Any {@link Context}; its application context is used.
      */
-    public static void instantiateReactNative() {
-        ReactHostHolder.instantiateReactNative();
+    public static void instantiateReactNative(Context context) {
+        ReactHostHolder.initReactHost((Application) context.getApplicationContext());
     }
 
     /**
      * Destroys the React Native runtime, freeing its resources. Teardown is
-     * asynchronous. Every {@link JitsiMeetView} must be disposed first.
+     * asynchronous. Every {@link JitsiMeetView} must be disposed first; the
+     * next {@link JitsiMeetView} join() re-creates the runtime.
      */
     public static void destroyReactNative() {
         ReactHostHolder.destroyReactHost();

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeet.java
@@ -78,6 +78,23 @@ public class JitsiMeet {
         }
     }
 
+    /**
+     * Starts the React Native runtime if it's not already running. Optional
+     * warm-up after {@link #destroyReactNative()}; joining a conference also
+     * restarts it on demand.
+     */
+    public static void instantiateReactNative() {
+        ReactHostHolder.instantiateReactNative();
+    }
+
+    /**
+     * Destroys the React Native runtime, freeing its resources. Teardown is
+     * asynchronous. Every {@link JitsiMeetView} must be disposed first.
+     */
+    public static void destroyReactNative() {
+        ReactHostHolder.destroyReactHost();
+    }
+
     public static boolean isCrashReportingDisabled(Context context) {
         SharedPreferences preferences = context.getSharedPreferences("jitsi-default-preferences", Context.MODE_PRIVATE);
         String value = preferences.getString("isCrashReportingDisabled", "");

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -17,7 +17,6 @@
 package org.jitsi.meet.sdk;
 
 import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.AttributeSet;
@@ -195,7 +194,7 @@ public class JitsiMeetView extends FrameLayout {
         if (reactHost == null) {
             // Rebuild the host after destroyReactNative().
             JitsiMeetLogger.w("ReactHost not initialized, re-creating");
-            ReactHostHolder.initReactHost((Application) getContext().getApplicationContext());
+            JitsiMeet.instantiateReactNative(getContext());
             reactHost = ReactHostHolder.getReactHost();
         }
         if (reactHost == null) {

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -190,13 +190,10 @@ public class JitsiMeetView extends FrameLayout {
             props = new Bundle();
         }
 
+        // No-op while running; rebuilds the host after destroyReactNative().
+        JitsiMeet.instantiateReactNative(getContext());
+
         ReactHost reactHost = ReactHostHolder.getReactHost();
-        if (reactHost == null) {
-            // Rebuild the host after destroyReactNative().
-            JitsiMeetLogger.w("ReactHost not initialized, re-creating");
-            JitsiMeet.instantiateReactNative(getContext());
-            reactHost = ReactHostHolder.getReactHost();
-        }
         if (reactHost == null) {
             JitsiMeetLogger.w("Cannot create surface, ReactHost is not initialized");
             return;

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/JitsiMeetView.java
@@ -17,6 +17,7 @@
 package org.jitsi.meet.sdk;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
 import android.util.AttributeSet;
@@ -191,6 +192,12 @@ public class JitsiMeetView extends FrameLayout {
         }
 
         ReactHost reactHost = ReactHostHolder.getReactHost();
+        if (reactHost == null) {
+            // Rebuild the host after destroyReactNative().
+            JitsiMeetLogger.w("ReactHost not initialized, re-creating");
+            ReactHostHolder.initReactHost((Application) getContext().getApplicationContext());
+            reactHost = ReactHostHolder.getReactHost();
+        }
         if (reactHost == null) {
             JitsiMeetLogger.w("Cannot create surface, ReactHost is not initialized");
             return;

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
@@ -62,11 +62,6 @@ class ReactHostHolder {
      */
     private static ReactHost reactHost;
 
-    /**
-     * Application reference kept for re-creating the host after destroy.
-     */
-    private static Application application;
-
     private static List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> nativeModules
             = new ArrayList<>(Arrays.<NativeModule>asList(
@@ -217,8 +212,6 @@ class ReactHostHolder {
             return;
         }
 
-        application = app;
-
         // Initialize the WebRTC module options.
         WebRTCModuleOptions options = WebRTCModuleOptions.getInstance();
         options.enableMediaProjectionService = true;
@@ -234,9 +227,8 @@ class ReactHostHolder {
 
         JitsiMeetLogger.d(TAG + " initializing RN");
 
-        // Same construction DefaultReactHost.getDefaultReactHost does internally,
-        // minus its never-cleared static cache, so the host can be rebuilt after
-        // destroyReactHost().
+        // Same construction getDefaultReactHost() does, minus its private static cache
+        // that only an internal invalidate() clears — a destroyed host is never replaced.
         JSBundleLoader bundleLoader
             = JSBundleLoader.createAssetLoader(app, "assets://index.android.bundle", true);
 
@@ -270,18 +262,6 @@ class ReactHostHolder {
             BuildConfig.DEBUG       /* useDevSupport */);
 
         reactHost.start();
-    }
-
-    /**
-     * Starts the React Native runtime if it's not already running.
-     */
-    static void instantiateReactNative() {
-        if (application == null) {
-            JitsiMeetLogger.w(TAG + " Cannot instantiate RN, SDK is not initialized");
-            return;
-        }
-
-        initReactHost(application);
     }
 
     /**

--- a/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
+++ b/android/sdk/src/main/java/org/jitsi/meet/sdk/ReactHostHolder.java
@@ -22,12 +22,18 @@ import androidx.annotation.Nullable;
 
 import com.facebook.react.ReactHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.RetryableMountingLayerException;
-import com.facebook.react.defaults.DefaultReactHost;
+import com.facebook.react.defaults.DefaultComponentsRegistry;
+import com.facebook.react.defaults.DefaultReactHostDelegate;
+import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate;
+import com.facebook.react.fabric.ComponentFactory;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.runtime.ReactHostImpl;
+import com.facebook.react.runtime.hermes.HermesInstance;
 import com.facebook.react.uimanager.ViewManager;
 import com.oney.WebRTCModule.EglUtils;
 import com.oney.WebRTCModule.WebRTCModuleOptions;
@@ -55,6 +61,11 @@ class ReactHostHolder {
      * bridgeless (Fabric + TurboModules) mode.
      */
     private static ReactHost reactHost;
+
+    /**
+     * Application reference kept for re-creating the host after destroy.
+     */
+    private static Application application;
 
     private static List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> nativeModules
@@ -206,6 +217,8 @@ class ReactHostHolder {
             return;
         }
 
+        application = app;
+
         // Initialize the WebRTC module options.
         WebRTCModuleOptions options = WebRTCModuleOptions.getInstance();
         options.enableMediaProjectionService = true;
@@ -219,17 +232,20 @@ class ReactHostHolder {
             }
         }
 
-        JitsiMeetLogger.d(TAG, "initializing RN");
+        JitsiMeetLogger.d(TAG + " initializing RN");
 
-        reactHost = DefaultReactHost.getDefaultReactHost(
-            app,
+        // Same construction DefaultReactHost.getDefaultReactHost does internally,
+        // minus its never-cleared static cache, so the host can be rebuilt after
+        // destroyReactHost().
+        JSBundleLoader bundleLoader
+            = JSBundleLoader.createAssetLoader(app, "assets://index.android.bundle", true);
+
+        DefaultReactHostDelegate delegate = new DefaultReactHostDelegate(
+            "index.android",        /* jsMainModulePath */
+            bundleLoader,
             getReactNativePackages(),
-            "index.android",       /* jsMainModulePath */
-            "index.android.bundle", /* jsBundleAssetPath */
-            null,                   /* jsBundleFilePath */
-            null,                   /* jsRuntimeFactory (defaults to Hermes) */
-            BuildConfig.DEBUG, /* useDevSupport */
-            Collections.emptyList(), /* cxxReactPackageProviders */
+            new HermesInstance(),
+            null,                   /* bindingsInstaller */
             e -> {
                 // Backport of react-native #57181: ignore the benign missing-viewState
                 // mount race. Remove once RN ships the fix.
@@ -240,11 +256,47 @@ class ReactHostHolder {
                     throw new RuntimeException(e);
                 }
                 return kotlin.Unit.INSTANCE;
-            }, /* exceptionHandler */
-            null                    /* bindingsInstaller */
-        );
+            },                      /* exceptionHandler */
+            new DefaultTurboModuleManagerDelegate.Builder());
+
+        ComponentFactory componentFactory = new ComponentFactory();
+        DefaultComponentsRegistry.register(componentFactory);
+
+        reactHost = new ReactHostImpl(
+            app,
+            delegate,
+            componentFactory,
+            true,                   /* allowPackagerServerAccess */
+            BuildConfig.DEBUG       /* useDevSupport */);
 
         reactHost.start();
+    }
+
+    /**
+     * Starts the React Native runtime if it's not already running.
+     */
+    static void instantiateReactNative() {
+        if (application == null) {
+            JitsiMeetLogger.w(TAG + " Cannot instantiate RN, SDK is not initialized");
+            return;
+        }
+
+        initReactHost(application);
+    }
+
+    /**
+     * Destroys the React Native runtime and drops the host reference so a
+     * new one can be built. Teardown is asynchronous.
+     */
+    static void destroyReactHost() {
+        if (reactHost == null) {
+            return;
+        }
+
+        JitsiMeetLogger.d(TAG + " destroying RN");
+
+        reactHost.invalidate();
+        reactHost = null;
     }
 
     // Matches the missing-viewState mount race fixed upstream in react-native #57181.


### PR DESCRIPTION
Adds public `JitsiMeet.instantiateReactNative()` / `JitsiMeet.destroyReactNative()` on Android, mirroring the existing iOS `-instantiateReactNative` / `-destroyReactNative`, so embedders can free the React Native runtime when no conference is active and bring it back later.

## Why the host construction moved

`DefaultReactHost.getDefaultReactHost()` caches the host in a private static field that is only cleared by an `internal` (Kotlin-only) `invalidate()`, unreachable from Java. Once a host built that way is destroyed it can never be replaced — every later call returns the dead instance.

`ReactHostHolder` now performs the same construction `getDefaultReactHost` does internally (`JSBundleLoader.createAssetLoader`, `DefaultReactHostDelegate`, `ComponentFactory` + `DefaultComponentsRegistry.register`, `ReactHostImpl`) without that cache, so destroy + rebuild works. Behaviour on the normal path is unchanged.

- `destroyReactNative()` — `reactHost.invalidate()` and drop the reference; teardown is asynchronous.
- `instantiateReactNative()` — re-runs the construction using the stored `Application`.
- `JitsiMeetView` self-heals: a `join()` after a destroy rebuilds the host, so calling `instantiateReactNative()` is optional.

Also fixes two `JitsiMeetLogger.d(TAG, "...")` calls that matched `d(String message, Object... args)`, making the message a silently dropped format argument — they only ever logged `ReactHostHolder`. They now use the codebase's `TAG + " ..."` convention.

## Testing

Verified on a Pixel 6 Pro against the Java SDK sample, with the runtime destroyed on hangup and re-created on join:

- 3 consecutive join → hangup cycles: each built a fresh host (`ReactHost{0}` → `{1}` → `{2}`) and reached `CONFERENCE_JOINED`.
- Destroy after hangup: full teardown logged, no crash.
- Join after destroy, both with an explicit `instantiateReactNative()` and without it (exercising the `JitsiMeetView` rebuild path).
- Destroy followed by an immediate re-join ~1s later, while the previous host's teardown was still in flight.

No `FATAL EXCEPTION` or ANR in any log buffer across the run.

Related to #17676 