### PR TITLE
fix(tests): switch to main frame before navigating away in hangup()

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -792,6 +792,12 @@ export class Participant {
         );
         console.log(`Hung up (${this.name})`);
 
+        // If the driver is currently focused on an iframe (iFrameApi mode), switch back to the
+        // top-level context before navigating away. Otherwise driver.url() targets the iframe
+        // browsing context instead of the outer page, which leaves the outer page still at the
+        // conference URL and puts the driver in a broken state for any subsequent ensureOneParticipant call.
+        await this.switchToMainFrame();
+
         await this.driver.url('/base.html')
 
             // This was fixed in wdio v9.9.1, we can drop once we update to that version

--- a/tests/helpers/participants.ts
+++ b/tests/helpers/participants.ts
@@ -212,21 +212,27 @@ async function joinParticipant( // eslint-disable-line max-params
     const p = ctx[participantOptions.name] as Participant;
 
     if (p) {
-        if (participantOptions.iFrameApi) {
-            await p.switchToIFrame();
-        }
+        // Skip the isInMuc check (and the iframe context switch it requires) when the participant
+        // is already on base.html — they cannot be in the MUC and there is no iframe to switch into.
+        const alreadyOnBasePage = (await p.driver.getUrl()).endsWith('/base.html');
 
-        if (await p.isInMuc()) {
-            return p;
-        }
+        if (!alreadyOnBasePage) {
+            if (participantOptions.iFrameApi) {
+                await p.switchToIFrame();
+            }
 
-        if (participantOptions.iFrameApi) {
-            // when loading url make sure we are on the top page context or strange errors may occur
-            await p.switchToMainFrame();
-        }
+            if (await p.isInMuc()) {
+                return p;
+            }
 
-        // Change the page so we can reload same url if we need to, base.html is supposed to be empty or close to empty
-        await p.driver.url('/base.html');
+            if (participantOptions.iFrameApi) {
+                // when loading url make sure we are on the top page context or strange errors may occur
+                await p.switchToMainFrame();
+            }
+
+            // Change the page so we can reload same url if we need to, base.html is supposed to be empty or close to empty
+            await p.driver.url('/base.html');
+        }
     }
 
     const newParticipant = new Participant(participantOptions);


### PR DESCRIPTION
## Summary

- `Participant.hangup()` called `driver.url('/base.html')` while the WebDriver was still focused on the iframe browsing context (left there by a prior `switchToIFrame()` call in the same test suite).
- In BiDi mode this either navigates the *iframe* instead of the outer page, or throws a suppressed error (the pre-WDIO v9.9.1 bug the existing `.catch` guards against). Either way the outer page is never taken to `/base.html`, `_inMainFrame` stays `false`, and the subsequent `ensureOneParticipant` rejoin silently skips `switchToIFrame()`.
- This leaves `config.prejoinConfig?.enabled === false` executing against the outer page where `config` is undefined, causing a script-execution timeout and a 180 s test failure in `setMeetingTimer > ignores the command when the feature is disabled`.
- Fix: call `switchToMainFrame()` before `driver.url('/base.html')` so the navigation always targets the top-level browsing context.

## Test plan

- [ ] Confirm `setMeetingTimer iframe API command > ignores the command when the feature is disabled` passes on CI
- [ ] Confirm no regressions in other iframe specs (`kick`, `participantsPresence`, `chat`, `setMeetingTimer`)