### PR TITLE
fix(android): honor LIBRE_BUILD in the autolinking manifest

### DIFF
--- a/android/sdk/build.gradle
+++ b/android/sdk/build.gradle
@@ -68,7 +68,7 @@ android {
 def jitsiAutolinkOutDir = layout.buildDirectory.dir('generated/autolinking/src/main/jni')
 def jitsiGenerateAutolinking = tasks.register('jitsiGenerateAutolinkingNewArchitectureFiles',
         com.facebook.react.tasks.GenerateAutolinkingNewArchitecturesFileTask) {
-    autolinkInputFile.set(rootProject.file('build/generated/autolinking/autolinking.json'))
+    autolinkInputFile.set(gradle.ext.autolinkingManifest)
     generatedOutputDirectory.set(jitsiAutolinkOutDir)
 }
 
@@ -114,17 +114,9 @@ dependencies {
         (':react-native-device-info')                 : ['com.google.firebase', 'com.google.android.gms', 'com.android.installreferrer'],
         (':react-native-google-signin-google-signin') : ['com.google.android.gms', 'androidx']
     ]
-    // Only add these packages if we are NOT doing a LIBRE_BUILD
-    def rnLibreExcluded = [
-        ':amplitude-analytics-react-native',
-        ':giphy-react-native-sdk',
-        ':react-native-google-signin-google-signin'
-    ]
 
+    // LIBRE_BUILD exclusions happen in settings.gradle.
     (gradle.ext.autolinkedProjects ?: []).each { path ->
-        if (rootProject.ext.libreBuild && rnLibreExcluded.contains(path)) {
-            return
-        }
         def conf = rnApiModules.contains(path) ? 'api' : 'implementation'
         dependencies.add(conf, project(path)) {
             rnModuleExcludes.getOrDefault(path, []).each { grp -> exclude group: grp }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,18 @@
+import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
 include ':app', ':sdk'
 
 includeBuild('../node_modules/@react-native/gradle-plugin')
 
-// Project paths of every autolinked RN module included below.
-// sdk/build.gradle consumes this instead of hardcoding names that can drift.
+// Non-free RN modules, excluded when LIBRE_BUILD is set.
+def libreExcludedModules = [
+    '@amplitude/analytics-react-native',
+    '@giphy/react-native-sdk',
+    '@react-native-google-signin/google-signin'
+]
+
+// Autolinked RN module paths, consumed by sdk/build.gradle.
 gradle.ext.autolinkedProjects = []
 
 def autolinkingJson = file('build/generated/autolinking/autolinking.json')
@@ -15,6 +22,22 @@ if (!autolinkingJson.exists()) {
 }
 
 def json = new JsonSlurper().parseText(autolinkingJson.text)
+
+// Filtered here so the includes below and sdk/build.gradle's codegen agree.
+def autolinkingManifest = autolinkingJson
+if ((System.env.LIBRE_BUILD ?: 'false').toBoolean()) {
+    // Fail loudly if the list above was patched away.
+    if (libreExcludedModules.isEmpty()) {
+        throw new IllegalStateException('LIBRE_BUILD is set but libreExcludedModules is empty.')
+    }
+
+    libreExcludedModules.each { json.dependencies.remove(it) }
+
+    autolinkingManifest = file('build/generated/autolinking/autolinking-libre.json')
+    autolinkingManifest.text = JsonOutput.toJson(json)
+}
+gradle.ext.autolinkingManifest = autolinkingManifest
+
 json.dependencies.each { name, config ->
     if (config.platforms?.android?.sourceDir) {
 


### PR DESCRIPTION
`LIBRE_BUILD=true` dropped the non-free RN modules from the SDK's Gradle dependencies, but the new-architecture autolinking codegen kept reading the unfiltered `autolinking.json`. Giphy, Amplitude and Google Sign-In still landed in the generated `Android-autolinking.cmake` and `autolinking.cpp`, so a libre AAR shipped their native specs inside `libjitsisdkmodules.so`.

Separately, since b3cab7d3 replaced the hardcoded `include` lines with autolinking-driven ones, downstream packagers lost the only switch they had. F-Droid's recipe still does `sed -i -e '/amplitude/d' -e '/giphy/d' -e '/google-signin/d' ../settings.gradle`, which no longer matches anything — see #17505.

`LIBRE_BUILD` now filters the manifest once in `settings.gradle`, and both the Gradle project includes and the codegen read the filtered result. The per-module exclusion list in `sdk/build.gradle` is gone, so one list governs both. A guard fails the build if that list is patched empty, rather than silently shipping the non-free modules.

### Testing

`LIBRE_BUILD=true` configures 25 projects instead of 28, and `:sdk:externalNativeBuildRelease` succeeds for all four ABIs. Symbols in the linked `libjitsisdkmodules.so`:

| symbol | libre |
|---|---|
| `Giphy` | 0 |
| `RTNGiphy` | 0 |
| `Amplitude` | 0 |
| `GoogleSignin` | 0 |
| `AsyncStorage` (control) | 156 |
| `RNSVG` (control) | 15240 |

Default (non-libre) builds are unaffected — no filtered copy is written and the original manifest is used, so the generated output is unchanged.

Note for packagers: these packages must stay in `package.json`. The JS bundle imports `@giphy/react-native-sdk` unconditionally; at runtime `_cleanupConfig` forces `giphy.enabled = false` under `LIBRE_BUILD`, so nothing giphy is configured or rendered. The `settings.gradle` sed should be dropped in favour of `export LIBRE_BUILD=true`.

Related to #17505 
