### PR TITLE
fix(lobby): let authenticated owners bypass the lobby join gate

### DIFF
--- a/resources/prosody-plugins/mod_muc_lobby_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_lobby_rooms.lua
@@ -117,6 +117,29 @@ load_config();
 local lobby_muc_service;
 local main_muc_service;
 
+-- Returns true when the joining session is an authenticated owner/moderator that
+-- must bypass the lobby. Their JWT still proves ownership, so a moderator who
+-- created the room, enabled the lobby and then reconnected after a dropped
+-- connection is routed straight in instead of being trapped in the lobby (their
+-- stored affiliation is gone, but the token isn't). Mirrors the owner detection
+-- in mod_token_affiliation.
+local function is_authenticated_owner(session)
+    if not session or not session.auth_token then
+        return false;
+    end
+
+    local context_user = session.jitsi_meet_context_user;
+    if not context_user then
+        return false;
+    end
+
+    return context_user.affiliation == 'owner'
+        or context_user.affiliation == 'moderator'
+        or context_user.affiliation == 'teacher'
+        or context_user.moderator == 'true'
+        or context_user.moderator == true;
+end
+
 function broadcast_json_msg(room, from, json_msg)
     json_msg.type = NOTIFY_JSON_MESSAGE_TYPE;
 
@@ -623,6 +646,17 @@ process_host_module(main_muc_component_config, function(host_module, host)
             if valid_affiliations[affiliation or 'none'] >= valid_affiliations.member and not password then
                 join:tag('password', { xmlns = MUC_NS }):text(room:get_password());
             end
+        end
+
+        -- An authenticated owner/moderator (proven by their JWT) must bypass the
+        -- lobby entirely, so a moderator who owns the room is never trapped in it
+        -- after a reconnect. Grant the owner affiliation and let the join proceed.
+        if is_authenticated_owner(event.origin) then
+            occupant.role = 'moderator';
+            room:set_affiliation(true, invitee_bare_jid, 'owner');
+            room:save_occupant(occupant);
+
+            return;
         end
 
         -- Check for display name if missing return an error

--- a/tests/prosody/mod_muc_lobby_rooms_spec.js
+++ b/tests/prosody/mod_muc_lobby_rooms_spec.js
@@ -256,7 +256,11 @@ describe('mod_muc_lobby_rooms', () => {
     // -------------------------------------------------------------------------
     describe('token_affiliation interaction', () => {
 
-        it('moderator token holder is blocked by lobby, not bypassed by affiliation grant', async () => {
+        it('authenticated moderator token holder bypasses the lobby', async () => {
+            // Regression test: a moderator who owns the room (proven by their JWT)
+            // must be routed straight in even when the lobby is enabled and they
+            // hold no stored affiliation — e.g. the moderator who created the room,
+            // enabled the lobby and then reconnected after a dropped connection.
             const r = room();
             const roomName = r.split('@')[0];
 
@@ -268,16 +272,15 @@ describe('mod_muc_lobby_rooms', () => {
             const c = await connect({ params: { token } });
             const presence = await c.joinRoom(r, undefined, { displayName: 'TokenMod' });
 
-            assert.equal(presence.attrs.type, 'error',
-                'moderator token user must be blocked by lobby');
+            assert.notEqual(presence.attrs.type, 'error',
+                'authenticated moderator token user must bypass the lobby');
 
-            const error = presence.getChild('error');
+            const { role, affiliation } = getRoleAndAffiliation(presence);
 
-            assert.ok(error, 'error element must be present');
-            assert.ok(
-                error.getChild('registration-required'),
-                'error condition must be registration-required'
-            );
+            assert.equal(affiliation, 'owner',
+                'moderator token user must join with owner affiliation');
+            assert.equal(role, 'moderator',
+                'moderator token user must join with moderator role');
         });
 
         it('non-moderator token holder is blocked by lobby', async () => {
@@ -308,7 +311,7 @@ describe('mod_muc_lobby_rooms', () => {
         // lobby + room password
         // ---------------------------------------------------------------------
 
-        it('moderator token user admitted from lobby joins directly without password prompt', async () => {
+        it('moderator token user bypasses lobby and room password without a prompt', async () => {
             const r = room();
             const roomName = r.split('@')[0];
             const focus = await focusJoin(r);
@@ -320,32 +323,19 @@ describe('mod_muc_lobby_rooms', () => {
                 context: { user: { moderator: true } } });
             const c = await connect({ params: { token } });
 
-            // First attempt — blocked by lobby
-            const blocked = await c.joinRoom(r, undefined, { displayName: 'TokenMod' });
-
-            assert.equal(blocked.attrs.type, 'error', 'first join must be blocked by lobby');
-            assert.ok(
-                blocked.getChild('error')?.getChild('registration-required'),
-                'must be blocked with registration-required'
-            );
-
-            // Simulate moderator approval
-            const userBareJid = c.jid.split('/')[0];
-
-            await setAffiliation(r, userBareJid, 'member');
-
-            // Second attempt — admitted user must join directly as moderator, no password required
+            // An authenticated moderator owns the room: they are routed straight in,
+            // without knocking and without being asked for the room password.
             const presence = await c.joinRoom(r, undefined, { displayName: 'TokenMod' });
 
             assert.notEqual(presence.attrs.type, 'error',
-                'admitted user must not be asked for password');
+                'authenticated moderator must not be blocked by lobby or password');
 
             const { role, affiliation } = getRoleAndAffiliation(presence);
 
             assert.equal(affiliation, 'owner',
-                'admitted moderator token user must get owner affiliation');
+                'moderator token user must join with owner affiliation');
             assert.equal(role, 'moderator',
-                'admitted moderator token user must get moderator role');
+                'moderator token user must join with moderator role');
         });
 
         it('moderator token user who bypasses lobby with room password gets moderator role', async () => {


### PR DESCRIPTION
Fixes #7561

## What & why

A moderator who creates a room in a secure domain, enables the lobby (no password) and then disconnects while guests remain was permanently locked out of their own room.

The members-only join gate in `mod_muc_lobby_rooms` (`muc-occupant-pre-join`, priority -4) rejects any joiner whose **stored** affiliation is `none`. On reconnect the moderator's affiliation is gone, so they were redirected to the lobby to knock — but with only guests inside, nobody could admit them. Permanent lockout.

## Change

Fix the join gate itself rather than papering over it with a client-side re-login prompt. Before emitting the 407, recognise a session whose JWT still proves ownership (`context.user` affiliation of `owner`/`moderator`/`teacher`, or `moderator == true`) and route it straight in, granting the `owner` affiliation. Guests without such a claim keep knocking exactly as before.

Ownership detection (`is_authenticated_owner`) mirrors the existing owner logic in `mod_token_affiliation`. Note that `mod_token_affiliation` intentionally *defers* while the lobby is active, so the lobby gate is the correct place to grant this bypass. Ordering holds: `token_affiliation` (-3.5) defers → this gate (-4) grants owner and passes through → built-in members-only check (-5) admits the owner.

## Tests

`tests/prosody/mod_muc_lobby_rooms_spec.js`: the two cases that asserted a moderator token holder is *blocked* by the lobby now assert the *bypass* (direct join as `owner`/`moderator`, past both lobby and room password). The first of these doubles as the regression test for this bug (moderator token, no stored affiliation, lobby enabled → routed straight in). The non-moderator-token and anonymous cases remain blocked.

These run against the Prosody docker harness (`tests/prosody`).

## Reviewer notes

- The bypass keys off the **JWT owner/moderator claim**, not "PLAIN-authenticated on `muc_mapper_domain_base`". A host-based clause would false-positive in the test harness, where `muc_domain_base` is `localhost` and also hosts anonymous/empty-token users. If PLAIN secure-domain (non-JWT) deployments should also be covered, that clause needs a separate guest domain to be distinguished safely — happy to add it if desired.
- No client-side changes; the fix is entirely at the XMPP backend so a brief reconnect routes the owner back in silently, with no re-authentication step.
