### PR TITLE
feat(breakout-rooms): add isHidden field to getRoomsInfo response

### DIFF
--- a/react/features/breakout-rooms/functions.ts
+++ b/react/features/breakout-rooms/functions.ts
@@ -57,6 +57,7 @@ export const getRoomsInfo = (stateful: IStateful, includeHidden = false) => {
     };
     const breakoutRooms = getBreakoutRooms(stateful);
     const conference = getCurrentConference(stateful);
+    const { iAmRecorder } = state['features/base/config'];
 
     const initialRoomsInfo = {
         rooms: []
@@ -101,6 +102,9 @@ export const getRoomsInfo = (stateful: IStateful, includeHidden = false) => {
                                 userContext: storeParticipant?.userContext,
                                 isJigasi: participantItem.getProperty('features_jigasi') === true,
                                 isJibri: participantItem.isHidden() || participantItem.isHiddenFromRecorder(),
+                                // A participant can be hidden because it's a transcriber or Jibri using
+                                // the hidden domain, or it can be a user hidden from the recorder.
+                                isHidden: participantItem.isHidden() || (iAmRecorder && participantItem.isHiddenFromRecorder()),
                                 audioMuted: participantItem.isAudioMuted(),
                                 videoMuted: participantItem.isVideoMuted()
                             } as IRoomInfoParticipant;

--- a/react/features/breakout-rooms/functions.ts
+++ b/react/features/breakout-rooms/functions.ts
@@ -101,7 +101,6 @@ export const getRoomsInfo = (stateful: IStateful, includeHidden = false) => {
                                 id: participantItem.getId(),
                                 userContext: storeParticipant?.userContext,
                                 isJigasi: participantItem.getProperty('features_jigasi') === true,
-                                isJibri: participantItem.isHidden() || participantItem.isHiddenFromRecorder(),
                                 // A participant can be hidden because it's a transcriber or Jibri using
                                 // the hidden domain, or it can be a user hidden from the recorder.
                                 isHidden: participantItem.isHidden() || (iAmRecorder && participantItem.isHiddenFromRecorder()),

--- a/react/features/breakout-rooms/types.ts
+++ b/react/features/breakout-rooms/types.ts
@@ -38,7 +38,6 @@ export interface IRoomInfoParticipant {
     displayName: string;
     id: string;
     isHidden?: boolean;
-    isJibri?: boolean;
     isJigasi?: boolean;
     jid: string;
     role: string;

--- a/react/features/breakout-rooms/types.ts
+++ b/react/features/breakout-rooms/types.ts
@@ -37,6 +37,7 @@ export interface IRoomInfoParticipant {
     avatarUrl: string;
     displayName: string;
     id: string;
+    isHidden?: boolean;
     isJibri?: boolean;
     isJigasi?: boolean;
     jid: string;

--- a/tests/prosody/mod_trace_spec.js
+++ b/tests/prosody/mod_trace_spec.js
@@ -75,7 +75,7 @@ describe('mod_trace', () => {
             const cm = iq.getChild('conference-modify', 'jitsi:colibri2');
 
             assert.ok(!cm.getChild('traceparent'),
-                'no traceparent should be added when the sender did not include one' );
+                'no traceparent should be added when the sender did not include one');
 
             // Give Prosody a moment to (not) export before asserting the negative.
             await new Promise(r => setTimeout(r, 300));


### PR DESCRIPTION
Adds `isHidden`, avoiding `isJibri`'s false positive on visible sip-jibri participants.