### PR TITLE
fix(breakout-rooms): Add admin user to prosody configuration example

### DIFF
--- a/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
+++ b/doc/debian/jitsi-meet-prosody/prosody.cfg.lua-jvb.example
@@ -75,6 +75,7 @@ VirtualHost "jitmeet.example.com"
     breakout_rooms_muc = "breakout.jitmeet.example.com"
     main_muc = "conference.jitmeet.example.com"
     -- muc_lobby_whitelist = { "recorder.jitmeet.example.com" } -- Here we can whitelist jibri to enter lobby enabled rooms
+    admins = { "focusUser@auth.jitmeet.example.com" }
 
 Component "conference.jitmeet.example.com" "muc"
     restrict_room_creation = true


### PR DESCRIPTION
Fix for #17290

Explination here: https://github.com/jitsi/jitsi-meet/issues/17290#issuecomment-4248074065

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
