### PR TITLE
fix(deep-linking): hide join in app on iOS without a custom scheme

### DIFF
--- a/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
+++ b/react/features/deep-linking/components/DeepLinkingMobilePage.web.tsx
@@ -10,6 +10,7 @@ import { sendAnalytics } from '../../analytics/functions';
 import { IReduxState } from '../../app/types';
 import { IDeeplinkingConfig, IDeeplinkingMobileConfig } from '../../base/config/configType';
 import { isSupportedMobileBrowser } from '../../base/environment/environment';
+import { isIosMobileBrowser } from '../../base/environment/utils';
 import { translate } from '../../base/i18n/functions';
 import Platform from '../../base/react/Platform.web';
 import Button from '../../base/ui/components/web/Button';
@@ -104,6 +105,12 @@ const DeepLinkingMobilePage: React.FC<WithTranslation> = ({ t }) => {
     const dispatch = useDispatch();
     const { classes: styles } = useStyles();
 
+    const showOpenAppButton = useMemo(() => {
+        const iosAppScheme = deeplinkingCfg?.ios?.appScheme;
+
+        return !isIosMobileBrowser() || Boolean(iosAppScheme && !/^https?$/i.test(iosAppScheme));
+    }, [ deeplinkingCfg ]);
+
     const generateDownloadURL = useCallback(() => {
         const { downloadLink }
             = (deeplinkingCfg?.[Platform.OS as keyof typeof deeplinkingCfg] || {}) as IDeeplinkingMobileConfig;
@@ -170,16 +177,18 @@ const DeepLinkingMobilePage: React.FC<WithTranslation> = ({ t }) => {
 
                 <div className = { styles.launchingMeetingLabel }>{ t(`${_TNS}.launchMeetingLabel`) }</div>
                 <div className = ''>{room}</div>
-                <a
-                    { ...onOpenLinkProperties }
-                    className = { styles.joinMeetWrapper }
-                    href = { deepLinkingUrl }
-                    onClick = { onOpenApp }
-                    target = '_top'>
-                    <Button
-                        fullWidth = { true }
-                        label = { t(`${_TNS}.joinInAppNew`) } />
-                </a>
+                {showOpenAppButton && (
+                    <a
+                        { ...onOpenLinkProperties }
+                        className = { styles.joinMeetWrapper }
+                        href = { deepLinkingUrl }
+                        onClick = { onOpenApp }
+                        target = '_top'>
+                        <Button
+                            fullWidth = { true }
+                            label = { t(`${_TNS}.joinInAppNew`) } />
+                    </a>
+                )}
                 <div className = { styles.labelDescription }>{ t(`${_TNS}.noMobileApp`) }</div>
                 <a
                     { ...onOpenLinkProperties }


### PR DESCRIPTION
On iOS the deep linking page's "Join in app" button only works when the deployment
configures a custom app scheme. When `deeplinking.ios.appScheme` is `http`/`https`,
`generateDeepLinkingURL` returns the URL the page is already served from, and iOS
suppresses Universal Links for same-domain in-browser navigations, so tapping the
button just reloads the deep linking page.

Hide the button in that case, leaving the download link and "Join in browser"
fallbacks. Deployments with a real custom scheme are unaffected: `org.jitsi.meet`
is the value `_setDeeplinkingDefaults` applies when none is configured and the one
meet.jit.si serves, so the button keeps rendering and opening the app there.

Android is untouched — it uses the `intent://…;package=…` path, which works with
`appScheme: "https"`.

## On replacing the button with a smart app banner

Deployments that drop their custom scheme (custom schemes are hijackable — there is
no ownership verification, and Apple's recommended mitigation is Universal Links)
lose their only in-app route on iOS with this change. The replacement is Safari's
native Smart App Banner via an `apple-itunes-app` meta tag, which is keyed to the
App Store ID rather than a claimable scheme and works same-domain because the OS,
not the page, performs the app launch. That belongs in the deployment's served HTML,
so it is out of scope here.

Deliberately not included: an in-page HTML banner as a cross-browser stand-in.
`apple-itunes-app` is drawn by the Safari app itself, so Chrome, Brave and Firefox
on iOS ignore it, and a banner we render ourselves would have to navigate to the
same-domain URL — which those browsers suppress exactly like Safari does. It would
look like a smart banner while behaving like the button this PR removes. Making a
tap actually open the app in a non-Safari iOS browser requires a cross-host redirect
(a different domain or subdomain that 302s to the meeting URL), since same-domain is
the condition that triggers the suppression.

So on `appScheme: "https"` deployments: Safari users get the native banner once the
meta tag is served, and other iOS browsers keep the download / join-in-browser
fallbacks.