### PR TITLE
feat: Add enableIceRestart config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -693,6 +693,11 @@ var config = {
     // the bridge going down.
     // enableForcedReload: true,
 
+    // Enables in-place ICE restarts of the bridge connection (e.g. after a network change), instead of the
+    // legacy recovery flow which re-creates the whole media session. Requires support in jitsi-videobridge
+    // (default: disabled).
+    // enableIceRestart: false,
+
     // Use TURN/UDP servers for the jitsi-videobridge connection (by default
     // we filter out TURN/UDP because it is usually not needed since the
     // bridge itself is reachable via UDP)

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -421,6 +421,7 @@ export interface IConfig {
     enableEmailInStats?: boolean;
     enableEncodedTransformSupport?: boolean;
     enableForcedReload?: boolean;
+    enableIceRestart?: boolean;
     enableInsecureRoomNameWarning?: boolean;
     /**
      * @deprecated Use `lobby.enableChat` instead.

--- a/react/features/base/config/configWhitelist.ts
+++ b/react/features/base/config/configWhitelist.ts
@@ -142,6 +142,7 @@ export default [
     'enableDisplayNameInStats',
     'enableEmailInStats',
     'enableEncodedTransformSupport',
+    'enableIceRestart',
     'enableInsecureRoomNameWarning',
     'enableLobbyChat',
     'enableOpusRed',


### PR DESCRIPTION
Adds the `enableIceRestart` config flag, which gates in-place ICE restarts of the bridge connection in lib-jitsi-meet. When enabled, a network change is recovered by rotating the ICE credentials in place, keeping the same DTLS session, SSRCs and RTP state, instead of the legacy flow which re-creates the whole media session.

Disabled by default (commented out), and requires support in jitsi-videobridge and jicofo.

Part of a multi-repo change; all PRs share the `in-place-ice-restart` branch name so CI tests them together:

- jitsi-xmpp-extensions: https://github.com/jitsi/jitsi-xmpp-extensions/pull/148
- jitsi-videobridge: https://github.com/jitsi/jitsi-videobridge/pull/2438
- jicofo: https://github.com/jitsi/jicofo/pull/1299
- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3083
