### PR TITLE
feat(pip): add Document Picture-in-Picture mode

### DIFF
--- a/react/features/pip/actions.ts
+++ b/react/features/pip/actions.ts
@@ -1,13 +1,18 @@
 import { IStore } from '../app/types';
 import { MEDIA_TYPE } from '../base/media/constants';
 import { isLocalTrackMuted } from '../base/tracks/functions.any';
+import { startScreenShareFlow } from '../screen-share/actions.web';
+import { isScreenVideoShared } from '../screen-share/functions';
 import { handleToggleVideoMuted } from '../toolbox/actions.any';
 import { muteLocal } from '../video-menu/actions.any';
 
 import { SET_PIP_ACTIVE } from './actionTypes';
+import { isDocumentPiPSupported } from './external-api.shared';
 import {
     cleanupMediaSessionHandlers,
+    closeDocumentPiP,
     enterPiP,
+    openDocumentPiP,
     setupMediaSessionHandlers,
     shouldShowPiP
 } from './functions';
@@ -62,6 +67,22 @@ export function toggleVideoFromPiP() {
 }
 
 /**
+ * Toggles screen sharing from PiP controls.
+ * Uses exact same logic as the toolbar share-desktop button.
+ *
+ * @returns {Function}
+ */
+export function toggleScreenShareFromPiP() {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const state = getState();
+        const screenSharing = isScreenVideoShared(state);
+
+        // Use the exact same action as toolbar button.
+        dispatch(startScreenShareFlow(!screenSharing));
+    };
+}
+
+/**
  * Action to exit Picture-in-Picture mode.
  *
  * @returns {Function}
@@ -69,6 +90,8 @@ export function toggleVideoFromPiP() {
 export function exitPiP() {
     return (dispatch: IStore['dispatch']) => {
         logger.debug('exitPiP called');
+
+        closeDocumentPiP();
 
         if (document.pictureInPictureElement) {
             document.exitPictureInPicture()
@@ -204,5 +227,71 @@ export function hidePiP() {
         if (isPiPActive) {
             dispatch(exitPiP());
         }
+    };
+}
+
+/**
+ * Toggles Picture-in-Picture from a user gesture (toolbar button).
+ * Entering from a real click satisfies the browser's transient activation
+ * requirement; afterwards the video's `autoPictureInPicture` attribute keeps
+ * it working on subsequent tab switches without further gestures.
+ *
+ * @returns {Function}
+ */
+export function togglePiP() {
+    return (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
+        const isPiPActive = getState()['features/pip']?.isPiPActive;
+
+        if (isPiPActive) {
+            dispatch(exitPiP());
+
+            return;
+        }
+
+        // Prefer the rich Document PiP window (Google Meet style) when available.
+        if (isDocumentPiPSupported()) {
+            dispatch(enterDocumentPiP());
+
+            return;
+        }
+
+        const videoElement = document.getElementById('pipVideo') as HTMLVideoElement;
+
+        if (!videoElement) {
+            logger.warn('togglePiP: pipVideo element not found');
+
+            return;
+        }
+
+        enterPiP(videoElement);
+    };
+}
+
+/**
+ * Opens the rich Document Picture-in-Picture window and updates state.
+ *
+ * @returns {Function}
+ */
+export function enterDocumentPiP() {
+    return async (dispatch: IStore['dispatch']) => {
+        const pipWindow = await openDocumentPiP(() => dispatch(setPiPActive(false)));
+
+        if (pipWindow) {
+            dispatch(setPiPActive(true));
+            APP.API.notifyPictureInPictureEntered();
+        }
+    };
+}
+
+/**
+ * Closes the rich Document Picture-in-Picture window and updates state.
+ *
+ * @returns {Function}
+ */
+export function exitDocumentPiP() {
+    return (dispatch: IStore['dispatch']) => {
+        closeDocumentPiP();
+        dispatch(setPiPActive(false));
+        APP.API.notifyPictureInPictureLeft();
     };
 }

--- a/react/features/pip/buttonHooks.web.ts
+++ b/react/features/pip/buttonHooks.web.ts
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+
+import { IReduxState } from '../app/types';
+
+import PiPButton from './components/PiPButton';
+import { isPiPEnabled } from './external-api.shared';
+
+const pip = {
+    key: 'pip',
+    Content: PiPButton,
+    group: 2
+};
+
+/**
+ * A hook that returns the PiP button if Picture-in-Picture is enabled and undefined otherwise.
+ *
+ * @returns {Object | undefined}
+ */
+export function usePiPButton() {
+    const enabled = useSelector((state: IReduxState) => isPiPEnabled(state['features/base/config'].pip));
+
+    if (enabled) {
+        return pip;
+    }
+}

--- a/react/features/pip/components/DocumentPiP.tsx
+++ b/react/features/pip/components/DocumentPiP.tsx
@@ -1,0 +1,177 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+
+import { IReduxState } from '../../app/types';
+import { leaveConference } from '../../base/conference/actions';
+import Icon from '../../base/icons/components/Icon';
+import { IconHangup, IconMic, IconMicSlash, IconScreenshare, IconVideo, IconVideoOff } from '../../base/icons/svg';
+import { MEDIA_TYPE } from '../../base/media/constants';
+import { getLocalParticipant } from '../../base/participants/functions';
+import { isLocalTrackMuted } from '../../base/tracks/functions.any';
+import { isPrejoinPageVisible } from '../../prejoin/functions.any';
+import { isScreenVideoShared } from '../../screen-share/functions';
+import { isDesktopShareButtonDisabled } from '../../toolbox/functions.web';
+import {
+    toggleAudioFromPiP,
+    toggleScreenShareFromPiP,
+    toggleVideoFromPiP
+} from '../actions';
+import { getDocumentPiPWindow, getPiPGridParticipants } from '../functions';
+
+import PiPTile from './PiPTile';
+
+const useStyles = makeStyles()(() => {
+    return {
+        container: {
+            background: '#000',
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            position: 'relative',
+            width: '100%'
+        },
+        grid: {
+            display: 'grid',
+            flex: 1,
+            gap: '6px',
+            gridAutoRows: '1fr',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+            overflow: 'hidden',
+            padding: '6px'
+        },
+        controls: {
+            background: 'rgba(0, 0, 0, 0.6)',
+            display: 'flex',
+            gap: '12px',
+            justifyContent: 'center',
+            padding: '8px'
+        },
+        button: {
+            alignItems: 'center',
+            background: 'transparent',
+            border: 'none',
+            borderRadius: '50%',
+            color: '#fff',
+            cursor: 'pointer',
+            display: 'flex',
+            fill: '#fff',
+            height: '40px',
+            justifyContent: 'center',
+            width: '40px'
+        },
+        hangup: {
+            background: '#d32f2f'
+        }
+    };
+});
+
+/**
+ * Renders an adaptive grid of participant tiles, the local self thumbnail and
+ * call controls inside the always-on-top Document Picture-in-Picture window.
+ *
+ * @returns {React.ReactPortal | null}
+ */
+const DocumentPiP: React.FC = () => {
+    const { classes, cx } = useStyles();
+    const dispatch = useDispatch();
+    const [ pipWindow, setPipWindow ] = useState<Window | null>(getDocumentPiPWindow());
+
+    const isOnPrejoin = useSelector(isPrejoinPageVisible);
+    const localParticipant = useSelector(getLocalParticipant);
+    const gridParticipants = useSelector(getPiPGridParticipants);
+    const audioMuted = useSelector((state: IReduxState) =>
+        isLocalTrackMuted(state['features/base/tracks'], MEDIA_TYPE.AUDIO));
+    const videoMuted = useSelector((state: IReduxState) =>
+        isLocalTrackMuted(state['features/base/tracks'], MEDIA_TYPE.VIDEO));
+    const screenSharing = useSelector(isScreenVideoShared);
+    const screenShareDisabled = useSelector(isDesktopShareButtonDisabled);
+
+    const onToggleAudio = useCallback(() => dispatch(toggleAudioFromPiP()), [ dispatch ]);
+    const onToggleVideo = useCallback(() => dispatch(toggleVideoFromPiP()), [ dispatch ]);
+    const onToggleScreenShare = useCallback(() => dispatch(toggleScreenShareFromPiP()), [ dispatch ]);
+    const onHangup = useCallback(() => dispatch(leaveConference()), [ dispatch ]);
+
+    // Toggled/disabled state must be applied via inline styles: dynamically
+    // injected CSS-in-JS classes are not propagated into the Document PiP window
+    // (its stylesheets are only synced shortly after it opens).
+    // Muted audio/video get a grey circle, mirroring the room toolbar's
+    // toggled state.
+    const audioStyle = { background: audioMuted ? '#5e5e5e' : 'transparent' };
+    const videoStyle = { background: videoMuted ? '#5e5e5e' : 'transparent' };
+    const screenShareStyle = {
+        // Buttons are transparent on the dark bar, mirroring the room toolbar.
+        // Active: grey circle, matching the room toolbar's toggled state. The
+        // green icon colour is set on the Icon via the `color` prop so it is
+        // always green regardless of the default white SVG fill.
+        background: screenSharing ? '#5e5e5e' : 'transparent',
+        cursor: screenShareDisabled ? 'default' : 'pointer',
+        opacity: screenShareDisabled ? 0.5 : 1
+    };
+
+    // Pick up the window opened by the togglePiP action.
+    useEffect(() => {
+        setPipWindow(getDocumentPiPWindow());
+    });
+
+    if (!pipWindow) {
+        return null;
+    }
+
+    return createPortal(
+        <div className = { classes.container }>
+            <div className = { classes.grid }>
+                { gridParticipants.map(p => (
+                    <PiPTile
+                        key = { p.id }
+                        participant = { p } />
+                )) }
+                { !isOnPrejoin && localParticipant && (
+                    <PiPTile
+                        key = { localParticipant.id }
+                        local = { true }
+                        participant = { localParticipant } />
+                ) }
+            </div>
+            <div className = { classes.controls }>
+                <button
+                    className = { classes.button }
+                    onClick = { onToggleAudio }
+                    style = { audioStyle }>
+                    <Icon
+                        size = { 20 }
+                        src = { audioMuted ? IconMicSlash : IconMic } />
+                </button>
+                <button
+                    className = { classes.button }
+                    onClick = { onToggleVideo }
+                    style = { videoStyle }>
+                    <Icon
+                        size = { 20 }
+                        src = { videoMuted ? IconVideoOff : IconVideo } />
+                </button>
+                <button
+                    className = { classes.button }
+                    disabled = { screenShareDisabled }
+                    onClick = { onToggleScreenShare }
+                    style = { screenShareStyle }>
+                    <Icon
+                        color = 'rgb(0, 255, 0)'
+                        size = { 20 }
+                        src = { IconScreenshare } />
+                </button>
+                <button
+                    className = { cx(classes.button, classes.hangup) }
+                    onClick = { onHangup }>
+                    <Icon
+                        size = { 20 }
+                        src = { IconHangup } />
+                </button>
+            </div>
+        </div>,
+        pipWindow.document.body
+    );
+};
+
+export default DocumentPiP;

--- a/react/features/pip/components/PiP.tsx
+++ b/react/features/pip/components/PiP.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { isDocumentPiPSupported } from '../external-api.shared';
 import { shouldShowPiP } from '../functions';
 
+import DocumentPiP from './DocumentPiP';
 import PiPVideoElement from './PiPVideoElement';
 
 /**
- * Wrapper component that conditionally renders PiPVideoElement.
- * Prevents mounting when PiP is disabled or on prejoin without showOnPrejoin flag.
+ * Wrapper component that conditionally renders the PiP renderer.
+ * Uses the rich Document PiP window when supported, otherwise the classic
+ * single-video PiP element. Prevents mounting when PiP is disabled.
  *
  * @returns {React.ReactElement | null}
  */
@@ -18,7 +21,7 @@ function PiP() {
         return null;
     }
 
-    return <PiPVideoElement />;
+    return isDocumentPiPSupported() ? <DocumentPiP /> : <PiPVideoElement />;
 }
 
 export default PiP;

--- a/react/features/pip/components/PiPButton.tsx
+++ b/react/features/pip/components/PiPButton.tsx
@@ -1,0 +1,77 @@
+import { connect } from 'react-redux';
+
+import { createToolbarEvent } from '../../analytics/AnalyticsEvents';
+import { sendAnalytics } from '../../analytics/functions';
+import { IReduxState } from '../../app/types';
+import { translate } from '../../base/i18n/functions';
+import { IconScreenshare } from '../../base/icons/svg';
+import AbstractButton, { IProps as AbstractButtonProps } from '../../base/toolbox/components/AbstractButton';
+import { setOverflowMenuVisible } from '../../toolbox/actions.web';
+import { togglePiP } from '../actions';
+
+/**
+ * The type of the React {@code Component} props of {@link PiPButton}.
+ */
+interface IProps extends AbstractButtonProps {
+
+    /**
+     * Whether Picture-in-Picture is currently active.
+     */
+    _pipActive: boolean;
+}
+
+/**
+ * Toolbar button that toggles the floating Picture-in-Picture window.
+ * The initial click provides the user gesture browsers require to enter PiP.
+ *
+ * @augments AbstractButton
+ */
+class PiPButton<P extends IProps> extends AbstractButton<P> {
+    override accessibilityLabel = 'toolbar.accessibilityLabel.pip';
+    override icon = IconScreenshare;
+    override label = 'toolbar.pip';
+    override toggledLabel = 'toolbar.exitPip';
+    override tooltip = 'toolbar.pip';
+
+    /**
+     * Handles clicking / pressing the button.
+     *
+     * @override
+     * @protected
+     * @returns {void}
+     */
+    override _handleClick() {
+        const { _pipActive, dispatch } = this.props;
+
+        sendAnalytics(createToolbarEvent('pip.button', { 'is_enabled': !_pipActive }));
+
+        dispatch(togglePiP());
+        dispatch(setOverflowMenuVisible(false));
+    }
+
+    /**
+     * Indicates whether this button is in toggled state or not.
+     *
+     * @override
+     * @protected
+     * @returns {boolean}
+     */
+    override _isToggled() {
+        return this.props._pipActive;
+    }
+}
+
+/**
+ * Maps (parts of) the redux state to the associated props for the
+ * {@code PiPButton} component.
+ *
+ * @param {Object} state - The Redux state.
+ * @returns {IProps}
+ */
+function _mapStateToProps(state: IReduxState) {
+    return {
+        _pipActive: Boolean(state['features/pip']?.isPiPActive)
+    };
+}
+
+export default translate(connect(_mapStateToProps)(PiPButton));

--- a/react/features/pip/components/PiPTile.tsx
+++ b/react/features/pip/components/PiPTile.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+
+import { IReduxState } from '../../app/types';
+import Avatar from '../../base/avatar/components/Avatar';
+import Icon from '../../base/icons/components/Icon';
+import { IconMicSlash } from '../../base/icons/svg';
+import { VIDEO_TYPE } from '../../base/media/constants';
+import { isScreenShareParticipant } from '../../base/participants/functions';
+import { IParticipant } from '../../base/participants/types';
+import { isParticipantAudioMuted } from '../../base/tracks/functions.any';
+import { getVideoTrackByParticipant } from '../../base/tracks/functions.web';
+
+interface IProps {
+
+    /**
+     * Whether this tile is the local (self) participant, shown smaller.
+     */
+    local?: boolean;
+
+    /**
+     * The participant to render in the tile.
+     */
+    participant?: IParticipant;
+}
+
+const useStyles = makeStyles()(() => {
+    return {
+        tile: {
+            alignItems: 'center',
+            background: '#1a1a1a',
+            borderRadius: '8px',
+            display: 'flex',
+            height: '100%',
+            justifyContent: 'center',
+            overflow: 'hidden',
+            position: 'relative',
+            width: '100%'
+        },
+        canvas: {
+            height: '100%',
+            width: '100%'
+        },
+        audioMutedIndicator: {
+            alignItems: 'center',
+            bottom: '4px',
+            color: '#fff',
+            display: 'flex',
+            justifyContent: 'center',
+            left: '4px',
+            padding: '2px',
+            position: 'absolute',
+            zIndex: 2
+        }
+    };
+});
+
+/**
+ * Renders a single participant tile (video or avatar) inside the Document PiP grid.
+ *
+ * @param {IProps} props - The component props.
+ * @returns {React.ReactElement}
+ */
+const PiPTile: React.FC<IProps> = ({ participant }: IProps) => {
+    const { classes } = useStyles();
+    const containerRef = useRef<HTMLDivElement>(null);
+    const videoTrack = useSelector((state: IReduxState) => getVideoTrackByParticipant(state, participant));
+    const localFlipX = useSelector((state: IReduxState) => Boolean(state['features/base/settings'].localFlipX));
+    const audioMuted = useSelector((state: IReduxState) => isParticipantAudioMuted(participant, state));
+    const showVideo = videoTrack?.jitsiTrack && !videoTrack.muted;
+
+    // Screen-share tiles have no audio, so never draw the mic-muted indicator on them.
+    const showAudioMuted = audioMuted && !isScreenShareParticipant(participant);
+
+    // Mirror the local self-view camera, exactly like the room thumbnail does:
+    // only for the local participant, only for the camera (not screen share)
+    // and only when the "mirror my video" setting is enabled.
+    const mirror = Boolean(participant?.local)
+        && videoTrack?.videoType !== VIDEO_TYPE.DESKTOP
+        && localFlipX;
+
+    useEffect(() => {
+        const container = containerRef.current;
+
+        if (!container || !showVideo) {
+            return;
+        }
+
+        // Edge keeps a remote track's decoder bound to the document where the <video> lives, so a
+        // video element moved into the PiP window renders black. Instead we keep a hidden <video>
+        // in the MAIN document (where WebRTC keeps decoding frames even while the tab is hidden)
+        // and paint each frame onto a <canvas> inside the PiP window. canvas.drawImage reads pixels,
+        // so it works across documents on every browser.
+        //
+        // Crucially the draw loop is driven by the PiP window's requestAnimationFrame: the PiP
+        // window is always visible, so its rAF runs at full framerate. The main window's rAF (and
+        // requestVideoFrameCallback on the hidden source video) is throttled to ~0 Hz when the tab
+        // is hidden, which is exactly when PiP is active — that throttling is what left it black.
+        const pipWin = (container.ownerDocument.defaultView ?? window) as Window & typeof globalThis;
+        const videoElement = document.createElement('video');
+
+        videoElement.autoplay = true;
+        videoElement.playsInline = true;
+        videoElement.muted = true;
+        videoElement.style.position = 'absolute';
+        videoElement.style.width = '1px';
+        videoElement.style.height = '1px';
+        videoElement.style.opacity = '0';
+        videoElement.style.pointerEvents = 'none';
+
+        videoTrack.jitsiTrack.attach(videoElement);
+        document.body.appendChild(videoElement);
+        videoElement.play().catch(() => { /* ignored */ });
+
+        const canvas = document.createElement('canvas');
+
+        canvas.className = classes.canvas;
+        canvas.style.transform = mirror ? 'scaleX(-1)' : '';
+        container.appendChild(canvas);
+
+        const ctx = canvas.getContext('2d');
+        let rafHandle = 0;
+
+        const draw = () => {
+            const vw = videoElement.videoWidth;
+            const vh = videoElement.videoHeight;
+
+            if (ctx && vw && vh) {
+                const cw = container.clientWidth || vw;
+                const ch = container.clientHeight || vh;
+
+                if (canvas.width !== cw || canvas.height !== ch) {
+                    canvas.width = cw;
+                    canvas.height = ch;
+                }
+
+                // object-fit: cover — scale to fill and center-crop.
+                const scale = Math.max(cw / vw, ch / vh);
+                const dw = vw * scale;
+                const dh = vh * scale;
+
+                ctx.drawImage(videoElement, (cw - dw) / 2, (ch - dh) / 2, dw, dh);
+            }
+
+            rafHandle = pipWin.requestAnimationFrame(draw);
+        };
+
+        rafHandle = pipWin.requestAnimationFrame(draw);
+
+        return () => {
+            if (rafHandle) {
+                pipWin.cancelAnimationFrame(rafHandle);
+            }
+            videoTrack?.jitsiTrack?.detach(videoElement);
+            videoElement.remove();
+            canvas.remove();
+        };
+    }, [ videoTrack, showVideo, classes.canvas, mirror ]);
+
+    return (
+        <div
+            className = { classes.tile }
+            ref = { containerRef }>
+            { !showVideo && <Avatar
+                participantId = { participant?.id }
+                size = { 48 } /> }
+            { showAudioMuted && <div className = { classes.audioMutedIndicator }>
+                <Icon
+                    size = { 16 }
+                    src = { IconMicSlash } />
+            </div> }
+        </div>
+    );
+};
+
+export default PiPTile;

--- a/react/features/pip/components/PiPVideoElement.tsx
+++ b/react/features/pip/components/PiPVideoElement.tsx
@@ -221,6 +221,8 @@ const PiPVideoElement: React.FC = () => {
 
     return (
         <video
+            // @ts-ignore - autoPictureInPicture lets Chromium auto-enter PiP on tab switch without a user gesture.
+            autoPictureInPicture = { true }
             autoPlay = { true }
             className = { classes.hiddenVideo }
             id = 'pipVideo'

--- a/react/features/pip/external-api.shared.ts
+++ b/react/features/pip/external-api.shared.ts
@@ -17,6 +17,28 @@ function isElectron(): boolean {
 }
 
 /**
+ * Checks if the browser supports the native (video element) Picture-in-Picture API.
+ * Inline check to keep this file lightweight (no BrowserDetection dependency).
+ *
+ * @returns {boolean} - True if Picture-in-Picture is supported and not disabled by the UA.
+ */
+function isVideoPiPSupported(): boolean {
+    return typeof document !== 'undefined'
+        && 'pictureInPictureEnabled' in document
+        && document.pictureInPictureEnabled === true;
+}
+
+/**
+ * Checks if the browser supports the Document Picture-in-Picture API (rich, always-on-top
+ * HTML window, as used by Google Meet). Available on Chromium and Firefox 151+ desktop.
+ *
+ * @returns {boolean} - True if the Document PiP API is available.
+ */
+export function isDocumentPiPSupported(): boolean {
+    return typeof window !== 'undefined' && 'documentPictureInPicture' in window;
+}
+
+/**
  * Checks if PiP is enabled based on config and environment.
  *
  * @param {Object} pipConfig - The pip config object.
@@ -27,5 +49,5 @@ export function isPiPEnabled(pipConfig?: { disabled?: boolean; }): boolean {
         return false;
     }
 
-    return isElectron();
+    return isElectron() || isVideoPiPSupported() || isDocumentPiPSupported();
 }

--- a/react/features/pip/functions.ts
+++ b/react/features/pip/functions.ts
@@ -3,13 +3,14 @@ import { AVATAR_DEFAULT_BACKGROUND_COLOR } from '../base/avatar/components/web/s
 import { getAvatarColor, getInitials } from '../base/avatar/functions';
 import { leaveConference } from '../base/conference/actions';
 import { browser } from '../base/lib-jitsi-meet';
+import { getParticipantById, getRemoteParticipants, getRemoteParticipantsSorted } from '../base/participants/functions';
 import { IParticipant } from '../base/participants/types';
 import { getLocalVideoTrack } from '../base/tracks/functions.any';
 import { getVideoTrackByParticipant } from '../base/tracks/functions.web';
 import { isPrejoinPageVisible } from '../prejoin/functions.any';
 
 import { toggleAudioFromPiP, toggleVideoFromPiP } from './actions';
-import { isPiPEnabled } from './external-api.shared';
+import { isDocumentPiPSupported, isPiPEnabled } from './external-api.shared';
 import logger from './logger';
 import { IMediaSessionState } from './types';
 
@@ -38,6 +39,28 @@ export function getPiPVideoTrack(state: IReduxState, participant: IParticipant |
     return isOnPrejoin
         ? getLocalVideoTrack(state['features/base/tracks'])
         : getVideoTrackByParticipant(state, participant);
+}
+
+/**
+ * Maximum number of remote participant tiles shown in the Document PiP grid.
+ */
+const MAX_PIP_GRID_TILES = 8;
+
+/**
+ * Gets the remote participants displayed in the Document PiP grid, ordered as
+ * in the filmstrip and capped to keep the floating window readable.
+ *
+ * @param {IReduxState} state - Redux state.
+ * @returns {Array<IParticipant>} The participants to render in the grid.
+ */
+export function getPiPGridParticipants(state: IReduxState): IParticipant[] {
+    const sortedIds = getRemoteParticipantsSorted(state);
+    const ids = sortedIds.length ? sortedIds : Array.from(getRemoteParticipants(state).keys());
+
+    return ids
+        .slice(0, MAX_PIP_GRID_TILES)
+        .map(id => getParticipantById(state, id))
+        .filter((p): p is IParticipant => Boolean(p));
 }
 
 /**
@@ -400,12 +423,149 @@ export function enterPiP(videoElement: HTMLVideoElement | undefined | null) {
             return;
         }
 
-        // TODO: Enable PiP for browsers:
-        // In browsers, we should directly call requestPictureInPicture.
-        // @ts-ignore - requestPictureInPicture is not yet in all TypeScript definitions.
-        // requestPictureInPicture();
+        // In browsers, directly request native (video element) Picture-in-Picture.
+        // requestPictureInPicture() resets pipRequestPending in its finally block.
+        // NOTE: browsers may require transient user activation; if so the request
+        // rejects and is logged without breaking the app (clean fallback). The
+        // video's `autoPictureInPicture` attribute covers the auto-enter case.
+        pipRequestPending = true;
+        requestPictureInPicture();
     } catch (error) {
         logger.error('Error entering Picture-in-Picture:', error);
+    }
+}
+
+/**
+ * Module-level reference to the currently open Document Picture-in-Picture window.
+ * Kept here (instead of Redux) because a Window object is not serializable.
+ */
+let documentPiPWindow: Window | null = null;
+
+/**
+ * Observer that keeps the PiP window stylesheets in sync with the main document.
+ */
+let pipStyleObserver: MutationObserver | null = null;
+
+/**
+ * Guards against concurrent requestWindow() calls. The auto-enter triggers
+ * (MediaSession action + window blur/visibilitychange) can fire within the same
+ * tick, and requestWindow() is async, so without this flag two windows could be
+ * requested before the first sets documentPiPWindow.
+ */
+let documentPiPRequestPending = false;
+
+/**
+ * Returns the currently open Document PiP window, or null if none is open.
+ *
+ * @returns {Window | null} The PiP window.
+ */
+export function getDocumentPiPWindow(): Window | null {
+    return documentPiPWindow;
+}
+
+/**
+ * Copies the parent document stylesheets into the Document PiP window so the
+ * portaled React content is styled identically. Also keeps the PiP window in
+ * sync with stylesheets injected later (e.g. tss-react/makeStyles on first
+ * render), so the very first PiP open is styled correctly too.
+ *
+ * @param {Window} pipWindow - The Picture-in-Picture window.
+ * @returns {void}
+ */
+function copyStylesToPiP(pipWindow: Window) {
+    const syncStyles = () => {
+        pipWindow.document.head.querySelectorAll('style, link[rel="stylesheet"]').forEach(n => n.remove());
+        Array.from(document.styleSheets).forEach(sheet => {
+            try {
+                const cssRules = Array.from(sheet.cssRules).map(rule => rule.cssText).join('');
+                const style = pipWindow.document.createElement('style');
+
+                style.textContent = cssRules;
+                pipWindow.document.head.appendChild(style);
+            } catch {
+                // Cross-origin stylesheet: copy by link reference instead.
+                const link = pipWindow.document.createElement('link');
+
+                link.rel = 'stylesheet';
+                link.href = (sheet as CSSStyleSheet).href ?? '';
+                pipWindow.document.head.appendChild(link);
+            }
+        });
+    };
+
+    syncStyles();
+
+    // Re-sync after the first frames to capture rules injected via insertRule into
+    // existing tags (CSS-in-JS), which a childList observer would not catch.
+    pipWindow.requestAnimationFrame(syncStyles);
+    setTimeout(syncStyles, 200);
+
+    // Re-sync when stylesheets are injected later (e.g. tss-react/makeStyles on first render).
+    pipStyleObserver = new MutationObserver(syncStyles);
+    pipStyleObserver.observe(document.head, { childList: true });
+}
+
+/**
+ * Opens the rich Document Picture-in-Picture window (Google Meet style). The
+ * React content is rendered into it by the DocumentPiP component via a portal.
+ *
+ * @param {Function} onClose - Callback invoked when the PiP window is closed.
+ * @returns {Promise<Window | null>} The opened window or null on failure.
+ */
+export async function openDocumentPiP(onClose: () => void): Promise<Window | null> {
+    if (!isDocumentPiPSupported()) {
+        return null;
+    }
+
+    if (documentPiPWindow) {
+        return documentPiPWindow;
+    }
+
+    if (documentPiPRequestPending) {
+        return null;
+    }
+
+    documentPiPRequestPending = true;
+
+    try {
+        // @ts-ignore - documentPictureInPicture is not yet in all TS lib definitions.
+        const pipWindow: Window = await window.documentPictureInPicture.requestWindow({
+            width: 360,
+            height: 240
+        });
+
+        copyStylesToPiP(pipWindow);
+        documentPiPWindow = pipWindow;
+        pipWindow.addEventListener('pagehide', () => {
+            pipStyleObserver?.disconnect();
+            pipStyleObserver = null;
+            documentPiPWindow = null;
+            onClose();
+        }, { once: true });
+
+        return pipWindow;
+    } catch (error) {
+        logger.error('Failed to open Document PiP window:', error);
+
+        return null;
+    } finally {
+        documentPiPRequestPending = false;
+    }
+}
+
+/**
+ * Closes the Document Picture-in-Picture window if open.
+ *
+ * @returns {void}
+ */
+export function closeDocumentPiP() {
+    if (pipStyleObserver) {
+        pipStyleObserver.disconnect();
+        pipStyleObserver = null;
+    }
+    if (documentPiPWindow) {
+        documentPiPWindow.close();
+        documentPiPWindow = null;
     }
 }
 

--- a/react/features/pip/subscriber.ts
+++ b/react/features/pip/subscriber.ts
@@ -4,6 +4,8 @@ import StateListenerRegistry from '../base/redux/StateListenerRegistry';
 import { isLocalTrackMuted } from '../base/tracks/functions.any';
 import { getElectronGlobalNS } from '../base/util/helpers';
 
+import { enterDocumentPiP } from './actions';
+import { isDocumentPiPSupported } from './external-api.shared';
 import { requestPictureInPicture, shouldShowPiP, updateMediaSessionState } from './functions';
 import logger from './logger';
 
@@ -58,6 +60,31 @@ StateListenerRegistry.register(
         } else if (typeof electronNS.requestPictureInPicture === 'function') {
             logger.debug('Removing requestPictureInPicture from Electron namespace (PiP disabled)');
             delete electronNS.requestPictureInPicture;
+        }
+    }
+);
+
+/**
+ * Registers the MediaSession `enterpictureinpicture` action handler when PiP is
+ * available and the browser supports the Document PiP API. Chromium calls this
+ * handler automatically when the user switches tab, so the rich PiP window opens
+ * with no extra gesture — exactly like Google Meet.
+ */
+StateListenerRegistry.register(
+    /* selector */ (state: IReduxState) => shouldShowPiP(state) && isDocumentPiPSupported(),
+    /* listener */ (enabled: boolean, store) => {
+        // @ts-ignore - mediaSession is not fully typed in all environments.
+        if (!('mediaSession' in navigator) || !navigator.mediaSession?.setActionHandler) {
+            return;
+        }
+
+        try {
+            // @ts-ignore - 'enterpictureinpicture' is a newer MediaSession action.
+            navigator.mediaSession.setActionHandler('enterpictureinpicture', enabled
+                ? () => store.dispatch(enterDocumentPiP())
+                : null);
+        } catch (error) {
+            logger.warn('enterpictureinpicture MediaSession action not supported:', error);
         }
     }
 );

--- a/react/features/toolbox/constants.ts
+++ b/react/features/toolbox/constants.ts
@@ -168,6 +168,7 @@ export const TOOLBAR_BUTTONS: ToolbarButton[] = [
     'mute-everyone',
     'mute-video-everyone',
     'participants-pane',
+    'pip',
     'polls',
     'profile',
     'raisehand',

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -37,6 +37,7 @@ import {
     isParticipantsPaneEnabled
 } from '../participants-pane/functions';
 import { useParticipantPaneButton } from '../participants-pane/hooks.web';
+import { usePiPButton } from '../pip/buttonHooks.web';
 import { usePollsButton } from '../polls/hooks.web';
 import { addReactionToBuffer } from '../reactions/actions.any';
 import { toggleReactionsMenuVisibility } from '../reactions/actions.web';
@@ -305,6 +306,7 @@ export function useToolboxButtons(
     const virtualBackground = useVirtualBackgroundButton();
     const speakerStats = useSpeakerStatsButton();
     const shortcuts = useKeyboardShortcutsButton();
+    const pip = usePiPButton();
     const embed = useEmbedButton();
     const feedback = useFeedbackButton();
     const _download = useDownloadButton();
@@ -343,6 +345,7 @@ export function useToolboxButtons(
         stats: speakerStats,
         settings,
         shortcuts,
+        pip,
         embedmeeting: embed,
         feedback,
         download: _download,

--- a/react/features/toolbox/types.ts
+++ b/react/features/toolbox/types.ts
@@ -40,6 +40,7 @@ export type ToolbarButton = 'audiotranslation' |
     'noisesuppression' |
     'overflowmenu' |
     'participants-pane' |
+    'pip' |
     'polls' |
     'profile' |
     'raisehand' |


### PR DESCRIPTION
## What

Extends the existing `pip` feature with a **Document Picture-in-Picture** mode
(`documentPictureInPicture` API): a separate always-on-top window rendering a grid
of participant tiles with audio/video/screen-share/hangup controls, plus a toolbar
button to toggle it. Falls back to the existing video-element PiP when the API is
unavailable.

## Why

The current PiP shows a single auto-triggered video element. Document PiP gives users
a persistent, interactive multi-participant view while working in other tabs/windows
(similar to Google Meet).

## Notes for reviewers

- Gated by `isDocumentPiPSupported()`; unsupported browsers keep the current behavior.
- Tiles are drawn to a canvas via the PiP window's `requestAnimationFrame` because a
  moved `<video>` renders black in some engines (decoder bound to the source document).
  Happy to discuss throttling if performance is a concern with many tiles.
- No new dependencies; reuses existing i18n keys (`toolbar.pip`, `toolbar.exitPip`).

## Testing

- `npm run tsc:web` and `eslint` pass with 0 warnings.
- Manually verified enter/exit, participant grid, and in-window mute/hangup controls.
