### PR TITLE
fix(conference): leave meeting when JWT authentication fails

### DIFF
--- a/react/features/base/conference/middleware.web.ts
+++ b/react/features/base/conference/middleware.web.ts
@@ -7,7 +7,7 @@ import {
 } from '../../prejoin/actions.web';
 import { isPrejoinPageVisible } from '../../prejoin/functions';
 import { iAmVisitor } from '../../visitors/functions';
-import { CONNECTION_DISCONNECTED, CONNECTION_ESTABLISHED } from '../connection/actionTypes';
+import { CONNECTION_DISCONNECTED, CONNECTION_ESTABLISHED, CONNECTION_FAILED } from '../connection/actionTypes';
 import { hangup } from '../connection/actions.web';
 import { JitsiConferenceErrors, JitsiConnectionErrors, browser } from '../lib-jitsi-meet';
 import { gumPending, setInitialGUMPromise } from '../media/actions';
@@ -191,6 +191,19 @@ MiddlewareRegistry.register(store => next => action => {
 
         if (initialGUMPromise) {
             store.dispatch(setInitialGUMPromise());
+        }
+
+        break;
+    }
+    case CONNECTION_FAILED: {
+        const { error } = action;
+        const { jwt } = getState()['features/base/jwt'];
+
+        // A JWT authentication failure is not recoverable, so leave the meeting
+        // and notify the user via a dialog (like when someone is kicked out),
+        // instead of leaving them stuck in the (never joined) conference.
+        if (error?.name === JitsiConnectionErrors.PASSWORD_REQUIRED && jwt && !error.recoverable) {
+            dispatch(hangup(true, i18next.t('dialog.tokenAuthFailedTitle'), true));
         }
 
         break;


### PR DESCRIPTION
Fixes #14242

## Summary

When joining with an invalid JWT (e.g. `nbf` in the future or `exp` in the past), the server rejects the authentication and the connection fails with a `PASSWORD_REQUIRED` error. The web app only showed an "Authentication failed" notification but never left the meeting, leaving the participant stuck in the (never joined) conference screen with no way out other than manually navigating back.

This change makes the web app leave the meeting the same way a kicked participant is handled — showing the "Authentication failed" dialog and returning the participant to the welcome page.

## Changes

In `react/features/base/conference/middleware.web.ts`, a new `CONNECTION_FAILED` handler mirrors the existing `CONFERENCE_DESTROYED` / `KICKED_OUT` handling:

```ts
case CONNECTION_FAILED: {
    const { error } = action;
    const { jwt } = getState()['features/base/jwt'];

    // A JWT authentication failure is not recoverable, so leave the meeting
    // and notify the user via a dialog (like when someone is kicked out),
    // instead of leaving them stuck in the (never joined) conference.
    if (error?.name === JitsiConnectionErrors.PASSWORD_REQUIRED && jwt && !error.recoverable) {
        dispatch(hangup(true, i18next.t('dialog.tokenAuthFailedTitle'), true));
    }

    break;
}
```

- The `hangup(true, ...)` call is the same primitive used for `KICKED_OUT` (`react/features/conference/middleware.web.ts`) and `CONFERENCE_DESTROYED`, so the user gets the familiar "reason" dialog (with the detailed `nbf`/`exp` reasons still shown in the sticky notification) followed by a redirect to the welcome page.
- It is scoped to web: native already surfaces unrecoverable connection errors through the page-reload dialog in `react/features/overlay/middleware.ts`, whereas web had no recovery path for this case.
- Gated on `!error.recoverable` — the `PASSWORD_REQUIRED` case without a JWT (recoverable, prompts for credentials) is unaffected.

## Testing

- `npm run tsc:web` passes.
- `eslint` passes on the changed file.

Manual verification (web):
1. Configure a deployment with token auth and a short-lived token.
2. Open a meeting URL with `?jwt=<expired token>`.
3. Before: "Authentication failed" notification, stuck on the meeting screen.
4. After: "Authentication failed" dialog is shown; clicking OK returns to the welcome page.
