### PR TITLE
fix(breakout-rooms): don't clear jitsi_breakout_main_jid on smacks resume

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -159,6 +159,21 @@ local function anonymous(self, message)
 
 sasl.registerMechanism("ANONYMOUS", {"anonymous"}, anonymous);
 
+-- Fired by Prosody's sessionmanager.update_session() during smacks (XEP-0198) session
+-- resumption. The naming can be counter-intuitive:
+--   event.session      (session)      – the OLD hibernating session being kept alive.
+--                                       It holds all MUC state, auth state, and custom
+--                                       fields accumulated during the call.
+--   event.from_session (from_session) – the NEW incoming TCP session being absorbed and
+--                                       then retired.  It has JWT fields freshly extracted
+--                                       from the reconnect URL by mod_jitsi_session, but
+--                                       no MUC state (it never joined a room).
+-- The copies below refresh the old session's JWT claims with the latest values from the
+-- new connection (useful when the client reconnects with a rotated token).  Fields that
+-- represent runtime MUC state (e.g. jitsi_breakout_main_jid, set by
+-- mod_muc_breakout_rooms when the session joins the main room) must NOT be copied here —
+-- from_session will have nil for those, which would silently overwrite the valid value
+-- on the old session.
 module:hook_global('c2s-session-updated', function (event)
     local session, from_session = event.session, event.from_session;
 
@@ -201,5 +216,4 @@ module:hook_global('c2s-session-updated', function (event)
     session.jitsi_meet_str_tenant = from_session.jitsi_meet_str_tenant;
     session.jitsi_meet_domain = from_session.jitsi_meet_domain;
     session.jitsi_meet_tenant_mismatch = from_session.jitsi_meet_tenant_mismatch;
-    session.jitsi_breakout_main_jid = from_session.jitsi_breakout_main_jid;
 end, 1);


### PR DESCRIPTION
## Summary

During XEP-0198 (smacks) session resumption, Prosody calls `sessionmanager.update_session(original_session, new_tcp_session)` which fires `c2s-session-updated` with a counter-intuitive naming:

- `event.session` = the **OLD hibernating session** (kept alive, holds all MUC state)
- `event.from_session` = the **NEW TCP session** (absorbed then retired, has only JWT fields from the reconnect URL)

The `c2s-session-updated` handler in `mod_auth_token.lua` copies JWT fields from the new session onto the old one (correct — refreshes claims from the latest token). However, it also unconditionally copied `jitsi_breakout_main_jid`, which is a MUC runtime flag set by `mod_muc_breakout_rooms` when a session joins the main room. The new TCP session never joins a room, so this field is `nil`, silently overwriting the valid value on the old session.

**Symptom:** participants who had moved to a breakout room (or were about to) received `<not-allowed/>` after a network reconnect mid-call, even though they were legitimate main-room participants.

**Root cause confirmed via:**
- Prosody logs: old session `c2sb9c6bf0f7aa0` hibernated at 20:52:15, no MUC events until the rejection at 21:11:07 — session was preserved, not replaced
- Browser logs: `Strophe: Websocket closed unexpectedly` at 20:52:15, stats events resuming 21s later with no `doLeave` or new conference-request — confirms smacks resume, not a full reconnect

## Fix

Remove the `jitsi_breakout_main_jid` copy from the handler. Add a comment explaining the session naming and the rule that MUC runtime state must not be copied here.

## Test plan

- [ ] Reproduce: join a call with 2+ participants, move to a breakout room, simulate a network drop and smacks resume, verify the breakout join is no longer rejected
- [ ] Verify participants who never joined the main room are still rejected from breakout rooms