### PR TITLE
fix(face-landmarks): clamp video object-position to a valid percentage

### DIFF
--- a/react/features/face-landmarks/functions.ts
+++ b/react/features/face-landmarks/functions.ts
@@ -143,7 +143,11 @@ export function getVideoObjectPosition(state: IReduxState, id?: string) {
         const { right, width } = faceBox;
 
         if (right && width) {
-            return `${right - (width / 2)}% 50%`;
+            const position = right - (width / 2);
+
+            if (Number.isFinite(position)) {
+                return `${Math.min(Math.max(position, 0), 100)}% 50%`;
+            }
         }
     }
 


### PR DESCRIPTION
Issue:
Sometimes, some videos seem to disappear from the screen, in certain screen sizes or arrangements. This was noted on Firefox.

Proposed solution:
The face box used for face-centering can come from a remote participant and is not guaranteed to be a valid percentage. Out-of-range or non-finite values produced an invalid CSS object-position (e.g. exponential notation like 2.349643e3%) that broke thumbnail rendering.

Guard against non-finite values and clamp the horizontal position to 0-100%.
