### PR TITLE
chore: hide pip trigger buttons from toolbox in electron

### DIFF
--- a/react/features/pip/hooks.ts
+++ b/react/features/pip/hooks.ts
@@ -15,6 +15,7 @@ import {
     shouldShowPiP,
 } from './functions';
 import logger from './logger';
+import { browser } from '../base/lib-jitsi-meet';
 
 /**
  * Canvas dimensions for PiP avatar rendering.
@@ -274,7 +275,7 @@ export function usePipToggleButton() {
     const visible = useSelector((state: IReduxState) =>
         state['features/base/config'].pip?.showToolbarButton !== false && shouldShowPiP(state));
 
-    return visible && (isDocumentPiPSupported() || Boolean(document.pictureInPictureEnabled))
+    return !browser.isElectron() && visible && (isDocumentPiPSupported() || Boolean(document.pictureInPictureEnabled))
         ? togglePiP
         : undefined;
 }

--- a/react/features/pip/hooks.ts
+++ b/react/features/pip/hooks.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { IReduxState, IStore } from '../app/types';
 import IconUserSVG from '../base/icons/svg/user.svg?raw';
+import { browser } from '../base/lib-jitsi-meet';
 import { IParticipant } from '../base/participants/types';
 import { TILE_ASPECT_RATIO } from '../filmstrip/constants';
 
@@ -15,7 +16,6 @@ import {
     shouldShowPiP,
 } from './functions';
 import logger from './logger';
-import { browser } from '../base/lib-jitsi-meet';
 
 /**
  * Canvas dimensions for PiP avatar rendering.


### PR DESCRIPTION
hides action buttons in electron