### PR TITLE
fix(chat): render chat messages in a semantic list

### DIFF
--- a/css/_chat.scss
+++ b/css/_chat.scss
@@ -58,6 +58,12 @@
     padding: 0 16px 24px;
 }
 
+.chat-message-list {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
 #chat-input {
     display: flex;
     align-items: flex-end;

--- a/lang/main.json
+++ b/lang/main.json
@@ -128,6 +128,7 @@
         "message": "Message",
         "messageAccessibleTitle": "{{user}} says:",
         "messageAccessibleTitleMe": "me says:",
+        "messageListLabel": "Chat messages",
         "messageTo": "Private message to {{recipient}}",
         "messagebox": "Type a message",
         "newMessages": "New messages",

--- a/react/features/chat/components/web/Chat.tsx
+++ b/react/features/chat/components/web/Chat.tsx
@@ -484,7 +484,8 @@ const Chat = ({
                     tabIndex = { 0 }>
                     <MessageContainer
                         isVisible = { _focusedTab === ChatTabs.CHAT }
-                        messages = { _messages } />
+                        messages = { _messages }
+                        t = { t } />
                     <MessageRecipient />
                     {isPrivateChatAllowed && (
                         <Select

--- a/react/features/chat/components/web/ChatMessage.tsx
+++ b/react/features/chat/components/web/ChatMessage.tsx
@@ -38,7 +38,10 @@ const useStyles = makeStyles()((theme: Theme) => {
             overflow: 'hidden'
         },
         chatMessageWrapper: {
-            maxWidth: '100%'
+            listStyleType: 'none',
+            margin: 0,
+            maxWidth: '100%',
+            padding: 0
         },
         chatMessage: {
             display: 'inline-flex',
@@ -348,7 +351,7 @@ const ChatMessage = ({
     }, [ message?.reactions, isHovered, isReactionsOpen ]);
 
     return (
-        <div
+        <li
             className = { cx(classes.chatMessageWrapper, className) }
             id = { message.messageId }
             onMouseEnter = { handleMouseEnter }
@@ -439,7 +442,7 @@ const ChatMessage = ({
                     </div>
                 )}
             </div>
-        </div>
+        </li>
     );
 };
 

--- a/react/features/chat/components/web/ChatMessageGroup.tsx
+++ b/react/features/chat/components/web/ChatMessageGroup.tsx
@@ -25,7 +25,10 @@ const useStyles = makeStyles()(theme => {
         messageGroup: {
             display: 'flex',
             flexDirection: 'column',
+            listStyleType: 'none',
+            margin: 0,
             maxWidth: '100%',
+            padding: 0,
 
             '&.remote, &.file': {
                 maxWidth: 'calc(100% - 40px)' // 100% - avatar and margin
@@ -34,6 +37,9 @@ const useStyles = makeStyles()(theme => {
 
         groupContainer: {
             display: 'flex',
+            listStyleType: 'none',
+            margin: 0,
+            padding: 0,
 
             '&.local': {
                 justifyContent: 'flex-end',
@@ -63,12 +69,12 @@ const ChatMessageGroup = ({ className = '', messages }: IProps) => {
     }
 
     return (
-        <div className = { clsx(classes.groupContainer, className) }>
+        <li className = { clsx(classes.groupContainer, className) }>
             <Avatar
                 className = { clsx(classes.avatar, 'avatar') }
                 participantId = { messages[0].participantId }
                 size = { 32 } />
-            <div className = { `${classes.messageGroup} chat-message-group ${className}` }>
+            <ul className = { `${classes.messageGroup} chat-message-group ${className}` }>
                 {messages.map((message, i) => (
                     <ChatMessage
                         className = { className }
@@ -77,8 +83,8 @@ const ChatMessageGroup = ({ className = '', messages }: IProps) => {
                         showDisplayName = { i === 0 }
                         showTimestamp = { i === messages.length - 1 } />
                 ))}
-            </div>
-        </div>
+            </ul>
+        </li>
     );
 };
 

--- a/react/features/chat/components/web/MessageContainer.tsx
+++ b/react/features/chat/components/web/MessageContainer.tsx
@@ -1,5 +1,6 @@
 import { throttle } from 'lodash-es';
 import React, { Component, RefObject } from 'react';
+import { WithTranslation } from 'react-i18next';
 import { scrollIntoView } from 'seamless-scroll-polyfill';
 
 import { groupMessagesBySender } from '../../../base/util/messageGrouping';
@@ -18,6 +19,11 @@ interface IProps {
      */
     isVisible?: boolean;
     messages: IMessage[];
+
+    /**
+     * The translation function.
+     */
+    t: WithTranslation['t'];
 }
 
 interface IState {
@@ -109,6 +115,7 @@ export default class MessageContainer extends Component<IProps, IState> {
      * @inheritdoc
      */
     override render() {
+        const { t } = this.props;
         const groupedMessages = this._getMessagesGroupedBySender();
         const content = groupedMessages.map((group, index) => {
             const { messages } = group;
@@ -131,7 +138,11 @@ export default class MessageContainer extends Component<IProps, IState> {
                     ref = { this._messageListRef }
                     role = 'log'
                     tabIndex = { 0 }>
-                    { content }
+                    <ul
+                        aria-label = { t('chat.messageListLabel') }
+                        className = 'chat-message-list'>
+                        { content }
+                    </ul>
 
                     { !this.state.isScrolledToBottom && this.state.hasNewMessages
                         && <NewMessagesButton

--- a/react/features/lobby/components/AbstractLobbyScreen.tsx
+++ b/react/features/lobby/components/AbstractLobbyScreen.tsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { WithTranslation } from 'react-i18next';
 
 import { IReduxState, IStore } from '../../app/types';
 import { conferenceWillJoin } from '../../base/conference/actions.any';
@@ -105,7 +106,7 @@ export interface IProps {
     /**
      * Function to be used to translate i18n labels.
      */
-    t: Function;
+    t: WithTranslation['t'];
 }
 
 interface IState {

--- a/react/features/lobby/components/web/LobbyScreen.tsx
+++ b/react/features/lobby/components/web/LobbyScreen.tsx
@@ -135,7 +135,8 @@ class LobbyScreen extends AbstractLobbyScreen<IProps> {
                 </div>
                 <MessageContainer
                     messages = { _lobbyChatMessages }
-                    ref = { this._messageContainerRef } />
+                    ref = { this._messageContainerRef }
+                    t = { t } />
                 <ChatInput onSend = { this._onSendMessage } />
             </div>
         );


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Addresses #5789 (confirmed accessibility issue, open since 2020).

### What changed

The chat history is currently a flat sequence of `<div>`s with no semantic structure, so screen reader users cannot navigate between messages using list shortcuts. This PR exposes the messages as a proper list:

- `MessageContainer` now renders the history inside a `<ul>` labelled `aria-label="Chat messages"`.
- Each message group (`ChatMessageGroup`) is an `<li>`, with its messages inside a nested `<ul>`.
- Each message (`ChatMessage`) is an `<li>` containing the sender, timestamp and body.
- List marker/indent styles are reset so the visual layout is unchanged (`css/_chat.scss`).
- The lobby chat reuses the same `MessageContainer`, so the translation function is threaded through there too.

### Why it matters

Screen readers (NVDA, VoiceOver, TalkBack) expose list shortcuts (e.g. `L` in NVDA) that let users jump between messages. Without a real `<ul>`/`<li>` structure, the entire chat history is announced as one flat block of text.

### Verification

- `npm run lint:ci` on the changed files passes.
- `npm run tsc:web` and `npm run tsc:native` pass (the lobby change is shared with the native abstract component).
- `npm run lint:lang` passes for the new `chat.messageListLabel` key.

@saghul would appreciate a review when you have a moment.