### PR TITLE
fix(chat): strip XML-invalid characters from outgoing messages

### DIFF
--- a/react/features/chat/functions.ts
+++ b/react/features/chat/functions.ts
@@ -74,6 +74,26 @@ const SLACK_EMOJI_REGEXP_ARRAY: Array<[RegExp, string]> = [];
 })();
 
 /**
+ * A regexp matching the characters that are not allowed in an XML 1.0 document.
+ * Sending such characters (e.g. the START OF TEXT control character U+0002)
+ * over XMPP produces a malformed stanza which makes the server terminate the
+ * stream, dropping everyone from the meeting.
+ */
+// eslint-disable-next-line no-control-regex
+const INVALID_XML_CHARS_REGEXP = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g;
+
+/**
+ * Removes the characters that are not allowed in an XML 1.0 document from the
+ * given string.
+ *
+ * @param {string} text - The text to be sanitized.
+ * @returns {string} The text with all XML-invalid characters removed.
+ */
+export function stripXMLInvalidChars(text: string): string {
+    return text.replace(INVALID_XML_CHARS_REGEXP, '');
+}
+
+/**
  * Replaces ASCII and other non-unicode emoticons with unicode emojis to let the emojis be rendered
  * by the platform native renderer.
  *

--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -73,7 +73,8 @@ import {
     getUnreadCount,
     isChatDisabled,
     isSendGroupChatDisabled,
-    isVisitorChatParticipant
+    isVisitorChatParticipant,
+    stripXMLInvalidChars
 } from './functions';
 import { INCOMING_MSG_SOUND_FILE } from './sounds';
 import './subscriber';
@@ -264,6 +265,12 @@ MiddlewareRegistry.register(store => next => action => {
     }
 
     case SEND_MESSAGE: {
+        // The message is transmitted over XMPP, so strip the characters that
+        // are not allowed in an XML 1.0 document. Sending them (e.g. the START
+        // OF TEXT character U+0002) produces a malformed stanza which makes the
+        // XMPP server terminate the stream and drops everyone from the meeting.
+        // See https://github.com/jitsi/jitsi-meet/issues/17267.
+        const message = stripXMLInvalidChars(action.message);
         const state = store.getState();
         const conference = getCurrentConference(state);
 
@@ -277,7 +284,7 @@ MiddlewareRegistry.register(store => next => action => {
 
                 if (participantExists || shouldSendPrivateMessageTo.isFromVisitor) {
                     dispatch(openDialog('ChatPrivacyDialog', ChatPrivacyDialog, {
-                        message: action.message,
+                        message,
                         participantID: shouldSendPrivateMessageTo.id,
                         isFromVisitor: shouldSendPrivateMessageTo.isFromVisitor,
                         displayName: shouldSendPrivateMessageTo.name
@@ -294,20 +301,20 @@ MiddlewareRegistry.register(store => next => action => {
                 = state['features/chat'];
 
             if (typeof APP !== 'undefined') {
-                APP.API.notifySendingChatMessage(action.message, Boolean(privateMessageRecipient));
+                APP.API.notifySendingChatMessage(message, Boolean(privateMessageRecipient));
             }
 
             if (isLobbyChatActive && lobbyMessageRecipient) {
                 conference.sendLobbyMessage({
                     type: LOBBY_CHAT_MESSAGE,
-                    message: action.message
+                    message
                 }, lobbyMessageRecipient.id);
-                _persistSentPrivateMessage(store, lobbyMessageRecipient, action.message, true);
+                _persistSentPrivateMessage(store, lobbyMessageRecipient, message, true);
             } else if (privateMessageRecipient) {
-                conference.sendPrivateTextMessage(privateMessageRecipient.id, action.message, 'body', isVisitorChatParticipant(privateMessageRecipient));
-                _persistSentPrivateMessage(store, privateMessageRecipient, action.message);
+                conference.sendPrivateTextMessage(privateMessageRecipient.id, message, 'body', isVisitorChatParticipant(privateMessageRecipient));
+                _persistSentPrivateMessage(store, privateMessageRecipient, message);
             } else {
-                conference.sendTextMessage(action.message);
+                conference.sendTextMessage(message);
             }
         }
         break;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->

Fixes #17267.

### What changed

Pasting a message containing a character that is not allowed in XML 1.0 (e.g. START OF TEXT, U+0002) into the chat input produces a malformed XMPP stanza. The server fails to parse it and terminates the stream, which drops **everyone** from the meeting.

This PR strips the XML-invalid characters from outgoing messages before they are sent:

- `stripXMLInvalidChars()` in `react/features/chat/functions.ts` removes the characters that are invalid in an XML 1.0 document (`[\\u0000-\\u0008 \\u000B \\u000C \\u000E-\\u001F \\uFFFE \\uFFFF]`).
- `react/features/chat/middleware.ts` applies it to the `SEND_MESSAGE` action so group messages, private messages and lobby messages all produce valid stanzas.

### Why this approach

Sanitizing at the middleware keeps every send path (group, private, lobby) covered from a single place, including messages routed through the external API (`notifySendingChatMessage`).

### Verification

- `npm run lint:ci` on the changed files passes.
- `npm run tsc:web` passes.
- `npm run lint:lang` passes (no translation changes).

@saghul would appreciate a review when you have a moment.