### PR TITLE
fix: safari pip open with avatar show on video mute

### DIFF
--- a/react/features/pip/components/PiPVideoElement.tsx
+++ b/react/features/pip/components/PiPVideoElement.tsx
@@ -82,8 +82,6 @@ const PiPVideoElement: React.FC = () => {
     const fontFamily = (avatarFont as any).fontFamily ?? 'Inter, sans-serif';
     const initialsColor = getAvatarInitialsColor(theme);
     const displayNameColor = getDisplayNameColor(theme);
-
-    // Determine if we should show avatar instead of video.
     const shouldShowAvatar = shouldShowPiPAvatar(videoTrack);
 
     const { canvasStreamRef, publishFrame } = useCanvasAvatar({

--- a/react/features/pip/components/PiPVideoElement.tsx
+++ b/react/features/pip/components/PiPVideoElement.tsx
@@ -6,14 +6,13 @@ import { IReduxState, IStore } from '../../app/types';
 import { getAvatarFont, getAvatarInitialsColor } from '../../base/avatar/components/web/styles';
 import { browser } from '../../base/lib-jitsi-meet';
 import { getLocalParticipant, getParticipantDisplayName } from '../../base/participants/functions';
-import { isTrackStreamingStatusActive } from '../../connection-indicator/functions';
 import { getDisplayNameColor } from '../../display-name/components/web/styles';
 import { getThumbnailBackgroundColor } from '../../filmstrip/functions.web';
 import { getLargeVideoParticipant } from '../../large-video/functions';
 import { isPrejoinPageVisible } from '../../prejoin/functions.any';
 import { handlePiPLeaveEvent, handlePipEnterEvent, handleWindowBlur, handleWindowFocus } from '../actions';
 import { FOCUS_CHECK_DELAY_MS } from '../constants';
-import { getPiPVideoTrack } from '../functions';
+import { getPiPVideoTrack, shouldShowPiPAvatar } from '../functions';
 import { useCanvasAvatar } from '../hooks';
 import logger from '../logger';
 import type { IWebKitPictureInPictureVideoElement } from '../types';
@@ -85,11 +84,9 @@ const PiPVideoElement: React.FC = () => {
     const displayNameColor = getDisplayNameColor(theme);
 
     // Determine if we should show avatar instead of video.
-    const shouldShowAvatar = !videoTrack
-        || videoTrack.muted
-        || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
+    const shouldShowAvatar = shouldShowPiPAvatar(videoTrack);
 
-    const { canvasStreamRef } = useCanvasAvatar({
+    const { canvasStreamRef, publishFrame } = useCanvasAvatar({
         participant,
         displayName,
         customAvatarBackgrounds,
@@ -97,7 +94,7 @@ const PiPVideoElement: React.FC = () => {
         fontFamily,
         initialsColor,
         displayNameColor,
-        isAvatarVisible: shouldShowAvatar
+        shouldShowAvatar
     });
 
     /**
@@ -129,6 +126,7 @@ const PiPVideoElement: React.FC = () => {
             // Only set srcObject if it's different to avoid interrupting playback.
             if (canvasStream && videoElement.srcObject !== canvasStream) {
                 videoElement.srcObject = canvasStream;
+                publishFrame();
             }
         } else if (videoTrack?.jitsiTrack) {
             // Attach real video track.
@@ -150,7 +148,7 @@ const PiPVideoElement: React.FC = () => {
                 }
             }
         };
-    }, [ videoTrack, shouldShowAvatar ]);
+    }, [ videoTrack, shouldShowAvatar, publishFrame ]);
 
     /**
      * Effect: Use WebKit presentation modes to enter and leave Video PiP on tab switches.

--- a/react/features/pip/components/PiPVideoElement.tsx
+++ b/react/features/pip/components/PiPVideoElement.tsx
@@ -83,6 +83,12 @@ const PiPVideoElement: React.FC = () => {
     const fontFamily = (avatarFont as any).fontFamily ?? 'Inter, sans-serif';
     const initialsColor = getAvatarInitialsColor(theme);
     const displayNameColor = getDisplayNameColor(theme);
+
+    // Determine if we should show avatar instead of video.
+    const shouldShowAvatar = !videoTrack
+        || videoTrack.muted
+        || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
+
     const { canvasStreamRef } = useCanvasAvatar({
         participant,
         displayName,
@@ -90,13 +96,9 @@ const PiPVideoElement: React.FC = () => {
         backgroundColor: getThumbnailBackgroundColor(theme),
         fontFamily,
         initialsColor,
-        displayNameColor
+        displayNameColor,
+        isAvatarVisible: shouldShowAvatar
     });
-
-    // Determine if we should show avatar instead of video.
-    const shouldShowAvatar = !videoTrack
-        || videoTrack.muted
-        || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
 
     /**
      * Effect: Handle switching between real video track and canvas avatar stream.

--- a/react/features/pip/components/web/DocumentPiPView.tsx
+++ b/react/features/pip/components/web/DocumentPiPView.tsx
@@ -5,7 +5,6 @@ import { makeStyles } from 'tss-react/mui';
 import { IReduxState } from '../../../app/types';
 import Avatar from '../../../base/avatar/components/Avatar';
 import { getLocalParticipant, getParticipantDisplayName } from '../../../base/participants/functions';
-import { isTrackStreamingStatusActive } from '../../../connection-indicator/functions';
 import DisplayNameBadge from '../../../display-name/components/web/DisplayNameBadge';
 import { getStageParticipantTypography } from '../../../display-name/components/web/styles';
 import { getLargeVideoParticipant } from '../../../large-video/functions';
@@ -13,7 +12,7 @@ import { isPrejoinPageVisible } from '../../../prejoin/functions.any';
 import HangupButton from '../../../toolbox/components/HangupButton';
 import AudioMuteButton from '../../../toolbox/components/web/AudioMuteButton';
 import VideoMuteButton from '../../../toolbox/components/web/VideoMuteButton';
-import { getPiPVideoTrack } from '../../functions';
+import { getPiPVideoTrack, shouldShowPiPAvatar } from '../../functions';
 import logger from '../../logger';
 
 const useStyles = makeStyles<void, 'controls'>()((theme, _params, classes) => {
@@ -120,9 +119,7 @@ export function DocumentPiPView() {
     const videoTrack = useSelector((state: IReduxState) => getPiPVideoTrack(state, participant));
     const participantName = useSelector((state: IReduxState) =>
         participant?.id ? getParticipantDisplayName(state, participant.id) : '');
-    const shouldShowAvatar = !videoTrack
-        || videoTrack.muted
-        || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
+    const shouldShowAvatar = shouldShowPiPAvatar(videoTrack);
 
     useEffect(() => {
         const video = videoRef.current;

--- a/react/features/pip/functions.ts
+++ b/react/features/pip/functions.ts
@@ -6,6 +6,8 @@ import { browser } from '../base/lib-jitsi-meet';
 import { IParticipant } from '../base/participants/types';
 import { getLocalVideoTrack } from '../base/tracks/functions.any';
 import { getVideoTrackByParticipant } from '../base/tracks/functions.web';
+import { ITrack } from '../base/tracks/types';
+import { isTrackStreamingStatusActive } from '../connection-indicator/functions';
 import { isPrejoinPageVisible } from '../prejoin/functions.any';
 
 import { toggleAudioFromPiP, toggleVideoFromPiP } from './actions';
@@ -67,6 +69,18 @@ export function getPiPVideoTrack(state: IReduxState, participant: IParticipant |
     return isOnPrejoin
         ? getLocalVideoTrack(state['features/base/tracks'])
         : getVideoTrackByParticipant(state, participant);
+}
+
+/**
+ * Returns whether PiP should show an avatar instead of the selected video track.
+ *
+ * @param {ITrack | undefined} videoTrack - The selected PiP video track.
+ * @returns {boolean} Whether the avatar should be shown.
+ */
+export function shouldShowPiPAvatar(videoTrack: ITrack | undefined): boolean {
+    return !videoTrack
+        || videoTrack.muted
+        || (!videoTrack.local && !isTrackStreamingStatusActive(videoTrack));
 }
 
 /**

--- a/react/features/pip/hooks.ts
+++ b/react/features/pip/hooks.ts
@@ -45,17 +45,18 @@ interface IUseCanvasAvatarOptions {
     displayNameColor: string;
     fontFamily: string;
     initialsColor: string;
-    isAvatarVisible: boolean;
     participant: IParticipant | undefined;
+    shouldShowAvatar: boolean;
 }
 
 /**
  * Result returned by the useCanvasAvatar hook.
- * Returns a ref object so consumers can access .current inside effects
- * (the stream is created in an effect and won't be available at render time).
+ * The stream ref is populated in an effect, while publishFrame lets consumers
+ * explicitly deliver the current canvas after attaching it to a video element.
  */
 interface IUseCanvasAvatarResult {
     canvasStreamRef: React.MutableRefObject<MediaStream | null>;
+    publishFrame: () => void;
 }
 
 /**
@@ -92,10 +93,11 @@ function createDefaultIconImage(): HTMLImageElement {
 /**
  * Custom hook that manages canvas-based avatar rendering for Picture-in-Picture.
  * Creates and maintains a canvas element with a MediaStream that can be used
- * as a video source when the participant's video is unavailable.
+ * as a video source when the participant's video is unavailable. Avatar rendering
+ * is gated by shouldShowAvatar, while hidden content is cleared to avoid stale identity frames.
  *
  * @param {IUseCanvasAvatarOptions} options - The hook options.
- * @returns {IUseCanvasAvatarResult} The canvas stream for use as video source.
+ * @returns {IUseCanvasAvatarResult} The canvas stream and frame publication callback.
  */
 export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAvatarResult {
     const {
@@ -106,15 +108,13 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
         fontFamily,
         initialsColor,
         displayNameColor,
-        isAvatarVisible
+        shouldShowAvatar
     } = options;
 
     const refs = useRef<ICanvasRefs>({
         canvas: null,
         defaultIcon: null
     });
-
-    const shouldSkipAvatarRender = !browser.isElectron() && !isAvatarVisible;
 
     // Separate ref for the stream to return to consumers.
     // This allows consumers to access .current inside their effects.
@@ -124,6 +124,20 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
     // To fix this, we could return an additional state flag like `streamReady` that
     // changes when the stream is set, and consumers would add it to their effect deps.
     const streamRef = useRef<MediaStream | null>(null);
+
+    /**
+     * Publishes the canvas's current contents to its on-demand capture stream.
+     *
+     * @returns {void}
+     */
+    const publishFrame = useCallback(() => {
+        const track = streamRef.current?.getVideoTracks()[0] as MediaStreamTrack & { requestFrame?: () => void; };
+
+        if (track?.requestFrame) {
+            track.requestFrame();
+            logger.log('Canvas frame requested');
+        }
+    }, []);
 
     /**
      * Initialize canvas, stream, and default icon on mount.
@@ -157,12 +171,12 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
     }, []);
 
     /**
-     * Re-render avatar when participant or display name changes.
+     * Renders the avatar when it should be shown and clears stale participant content otherwise.
      */
     useEffect(() => {
         const { canvas, defaultIcon } = refs.current;
 
-        if (!canvas || shouldSkipAvatarRender) {
+        if (!canvas) {
             return;
         }
 
@@ -171,6 +185,14 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
         if (!ctx) {
             logger.error('Failed to get canvas 2D context');
 
+            return;
+        }
+
+        // Clear participant identity synchronously before the canvas can be attached to a new sink.
+        ctx.fillStyle = backgroundColor;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        if (!shouldShowAvatar) {
             return;
         }
 
@@ -185,20 +207,13 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
             fontFamily,
             initialsColor,
             displayNameColor
-        ).then(() => {
-            // Request a frame capture after drawing.
-            // For captureStream(0), we need to manually trigger frame capture.
-            const track = streamRef.current?.getVideoTracks()[0] as MediaStreamTrack & { requestFrame?: () => void; };
-
-            if (track?.requestFrame) {
-                track.requestFrame();
-                logger.log('Canvas frame requested after render');
-            }
-        }).catch((error: Error) => logger.error('Error rendering avatar on canvas:', error));
-    }, [ participant?.loadableAvatarUrl, participant?.loadableAvatarUrlUseCORS, participant?.name, displayName, customAvatarBackgrounds, backgroundColor, fontFamily, initialsColor, displayNameColor, shouldSkipAvatarRender ]);
+        ).then(publishFrame)
+            .catch((error: Error) => logger.error('Error rendering avatar on canvas:', error));
+    }, [ participant?.loadableAvatarUrl, participant?.loadableAvatarUrlUseCORS, participant?.name, displayName, customAvatarBackgrounds, backgroundColor, fontFamily, initialsColor, displayNameColor, shouldShowAvatar, publishFrame ]);
 
     return {
-        canvasStreamRef: streamRef
+        canvasStreamRef: streamRef,
+        publishFrame
     };
 }
 

--- a/react/features/pip/hooks.ts
+++ b/react/features/pip/hooks.ts
@@ -45,6 +45,7 @@ interface IUseCanvasAvatarOptions {
     displayNameColor: string;
     fontFamily: string;
     initialsColor: string;
+    isAvatarVisible: boolean;
     participant: IParticipant | undefined;
 }
 
@@ -104,13 +105,16 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
         backgroundColor,
         fontFamily,
         initialsColor,
-        displayNameColor
+        displayNameColor,
+        isAvatarVisible
     } = options;
 
     const refs = useRef<ICanvasRefs>({
         canvas: null,
         defaultIcon: null
     });
+
+    const shouldSkipAvatarRender = !browser.isElectron() && !isAvatarVisible;
 
     // Separate ref for the stream to return to consumers.
     // This allows consumers to access .current inside their effects.
@@ -158,7 +162,7 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
     useEffect(() => {
         const { canvas, defaultIcon } = refs.current;
 
-        if (!canvas) {
+        if (!canvas || shouldSkipAvatarRender) {
             return;
         }
 
@@ -191,7 +195,7 @@ export function useCanvasAvatar(options: IUseCanvasAvatarOptions): IUseCanvasAva
                 logger.log('Canvas frame requested after render');
             }
         }).catch((error: Error) => logger.error('Error rendering avatar on canvas:', error));
-    }, [ participant?.loadableAvatarUrl, participant?.name, displayName, customAvatarBackgrounds, backgroundColor, fontFamily, initialsColor, displayNameColor ]);
+    }, [ participant?.loadableAvatarUrl, participant?.loadableAvatarUrlUseCORS, participant?.name, displayName, customAvatarBackgrounds, backgroundColor, fontFamily, initialsColor, displayNameColor, shouldSkipAvatarRender ]);
 
     return {
         canvasStreamRef: streamRef


### PR DESCRIPTION
rendering avatar and opening pip when video is in mute state in safari

<img width="1096" height="514" alt="image" src="https://github.com/user-attachments/assets/ff48825c-c399-4c6f-a5f8-ca4abc3db3de" />
