### PR TITLE
Feature/remove zxcvbn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -126,8 +126,7 @@
         "util": "0.12.1",
         "uuid": "14.0.0",
         "wasm-check": "2.0.1",
-        "windows-iana": "3.1.0",
-        "zxcvbn": "4.4.2"
+        "windows-iana": "3.1.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.6",
@@ -165,7 +164,6 @@
         "@types/w3c-image-capture": "1.0.6",
         "@types/w3c-web-hid": "1.0.3",
         "@types/webscreens-window-placement": "0.1.3",
-        "@types/zxcvbn": "4.4.1",
         "@wdio/allure-reporter": "9.27.0",
         "@wdio/cli": "9.27.0",
         "@wdio/globals": "9.27.0",
@@ -8037,12 +8035,6 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
       "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
       "license": "MIT"
-    },
-    "node_modules/@types/zxcvbn": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.1.tgz",
-      "integrity": "sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==",
-      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.19.1",
@@ -27467,11 +27459,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/zxcvbn": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   },
   "dependencies": {
@@ -32706,12 +32693,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
       "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
-    },
-    "@types/zxcvbn": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.1.tgz",
-      "integrity": "sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==",
-      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.19.1",
@@ -45961,11 +45942,6 @@
       "requires": {
         "use-sync-external-store": "^1.2.2"
       }
-    },
-    "zxcvbn": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
-      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -132,8 +132,7 @@
     "util": "0.12.1",
     "uuid": "14.0.0",
     "wasm-check": "2.0.1",
-    "windows-iana": "3.1.0",
-    "zxcvbn": "4.4.2"
+    "windows-iana": "3.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.6",
@@ -171,7 +170,6 @@
     "@types/w3c-image-capture": "1.0.6",
     "@types/w3c-web-hid": "1.0.3",
     "@types/webscreens-window-placement": "0.1.3",
-    "@types/zxcvbn": "4.4.1",
     "@wdio/allure-reporter": "9.27.0",
     "@wdio/cli": "9.27.0",
     "@wdio/globals": "9.27.0",

--- a/react/features/base/util/isInsecureRoomName.native.ts
+++ b/react/features/base/util/isInsecureRoomName.native.ts
@@ -1,12 +1,53 @@
 import { isEqual } from 'lodash-es';
 import { NIL, parse as parseUUID } from 'uuid';
-import zxcvbn from 'zxcvbn';
 
 // The null UUID.
 const NIL_UUID = parseUUID(NIL);
 
-const _ZXCVBN_CACHE_MAX = 200;
-const _zxcvbnCache = new Map<string, ReturnType<typeof zxcvbn>>();
+const _SCORE_CACHE_MAX = 200;
+const _scoreCache = new Map<string, number>();
+
+/**
+ * Estimates a rough strength score (0–4) for a room name without using
+ * the heavy zxcvbn library (~800 KB minified). Only the score field was
+ * ever read from zxcvbn, so a lightweight length-plus-variety heuristic
+ * is a sufficient replacement for this use-case.
+ *
+ * @param {string} roomName - The room name to score.
+ * @returns {number} - A score between 0 and 4 (< 3 means weak/insecure).
+ */
+function _estimateRoomNameStrength(roomName: string): number {
+    const len = roomName.length;
+
+    if (len < 8) {
+        return 0;
+    }
+    if (len < 12) {
+        return 1;
+    }
+
+    const hasLower = /[a-z]/.test(roomName);
+    const hasUpper = /[A-Z]/.test(roomName);
+    const hasDigit = /[0-9]/.test(roomName);
+    const hasSpecial = /[^a-zA-Z0-9]/.test(roomName);
+
+    const varietyCount = [ hasLower, hasUpper, hasDigit, hasSpecial ]
+        .filter(Boolean).length;
+
+    if (varietyCount === 1) {
+        return 1;
+    }
+
+    if (varietyCount === 2 && len < 16) {
+        return 2;
+    }
+
+    if (varietyCount >= 3 || len >= 16) {
+        return 3;
+    }
+
+    return 2;
+}
 
 /**
  * Checks if the given string is a valid UUID or not.
@@ -30,25 +71,25 @@ function isValidUUID(str: string) {
  * Checks a room name and caches the result.
  *
  * @param {string} roomName - The room name.
- * @returns {Object}
+ * @returns {number}
  */
 function _checkRoomName(roomName = '') {
-    if (_zxcvbnCache.has(roomName)) {
-        return _zxcvbnCache.get(roomName);
+    if (_scoreCache.has(roomName)) {
+        return _scoreCache.get(roomName);
     }
 
-    const result = zxcvbn(roomName);
+    const score = _estimateRoomNameStrength(roomName);
 
-    if (_zxcvbnCache.size >= _ZXCVBN_CACHE_MAX) {
-        const oldestKey = _zxcvbnCache.keys().next().value;
+    if (_scoreCache.size >= _SCORE_CACHE_MAX) {
+        const oldestKey = _scoreCache.keys().next().value;
 
         if (oldestKey !== undefined) {
-            _zxcvbnCache.delete(oldestKey);
+            _scoreCache.delete(oldestKey);
         }
     }
-    _zxcvbnCache.set(roomName, result);
+    _scoreCache.set(roomName, score);
 
-    return result;
+    return score;
 }
 
 /**
@@ -60,5 +101,5 @@ function _checkRoomName(roomName = '') {
 export default function isInsecureRoomName(roomName = ''): boolean {
 
     // room names longer than 200 chars we consider secure
-    return !isValidUUID(roomName) && (roomName.length < 200 && (_checkRoomName(roomName)?.score ?? 3) < 3);
+    return !isValidUUID(roomName) && (roomName.length < 200 && (_checkRoomName(roomName) ?? 3) < 3);
 }

--- a/react/features/base/util/isInsecureRoomName.native.ts
+++ b/react/features/base/util/isInsecureRoomName.native.ts
@@ -1,53 +1,13 @@
 import { isEqual } from 'lodash-es';
 import { NIL, parse as parseUUID } from 'uuid';
 
+import { estimateRoomNameStrength } from './roomNameStrength';
+
 // The null UUID.
 const NIL_UUID = parseUUID(NIL);
 
 const _SCORE_CACHE_MAX = 200;
 const _scoreCache = new Map<string, number>();
-
-/**
- * Estimates a rough strength score (0–4) for a room name without using
- * the heavy zxcvbn library (~800 KB minified). Only the score field was
- * ever read from zxcvbn, so a lightweight length-plus-variety heuristic
- * is a sufficient replacement for this use-case.
- *
- * @param {string} roomName - The room name to score.
- * @returns {number} - A score between 0 and 4 (< 3 means weak/insecure).
- */
-function _estimateRoomNameStrength(roomName: string): number {
-    const len = roomName.length;
-
-    if (len < 8) {
-        return 0;
-    }
-    if (len < 12) {
-        return 1;
-    }
-
-    const hasLower = /[a-z]/.test(roomName);
-    const hasUpper = /[A-Z]/.test(roomName);
-    const hasDigit = /[0-9]/.test(roomName);
-    const hasSpecial = /[^a-zA-Z0-9]/.test(roomName);
-
-    const varietyCount = [ hasLower, hasUpper, hasDigit, hasSpecial ]
-        .filter(Boolean).length;
-
-    if (varietyCount === 1) {
-        return 1;
-    }
-
-    if (varietyCount === 2 && len < 16) {
-        return 2;
-    }
-
-    if (varietyCount >= 3 || len >= 16) {
-        return 3;
-    }
-
-    return 2;
-}
 
 /**
  * Checks if the given string is a valid UUID or not.
@@ -78,7 +38,7 @@ function _checkRoomName(roomName = '') {
         return _scoreCache.get(roomName);
     }
 
-    const score = _estimateRoomNameStrength(roomName);
+    const score = estimateRoomNameStrength(roomName);
 
     if (_scoreCache.size >= _SCORE_CACHE_MAX) {
         const oldestKey = _scoreCache.keys().next().value;

--- a/react/features/base/util/isInsecureRoomName.web.ts
+++ b/react/features/base/util/isInsecureRoomName.web.ts
@@ -49,17 +49,6 @@ function _estimateRoomNameStrength(roomName: string): number {
 }
 
 /**
- * No-op kept for API compatibility. Previously triggered the asynchronous
- * load of the zxcvbn library. The library has been replaced with a
- * lightweight built-in heuristic that requires no preloading.
- *
- * @returns {void}
- */
-export function preloadZxcvbn() {
-    // No-op: zxcvbn has been removed; no preloading is needed.
-}
-
-/**
  * Checks if the given string is a valid UUID or not.
  *
  * @param {string} str - The string to be checked.

--- a/react/features/base/util/isInsecureRoomName.web.ts
+++ b/react/features/base/util/isInsecureRoomName.web.ts
@@ -4,34 +4,59 @@ import { NIL, parse as parseUUID } from 'uuid';
 // The null UUID.
 const NIL_UUID = parseUUID(NIL);
 
-const _zxcvbnCache = new Map();
-let _zxcvbn: ((password: string) => { score: number; }) | null = null;
+const _scoreCache = new Map<string, number>();
 
 /**
- * Triggers the asynchronous load of the zxcvbn library if not already loaded.
- * Can be called early (e.g. on config load) to ensure the library is ready
- * before the first call to {@link isInsecureRoomName}.
+ * Estimates a rough strength score (0–4) for a room name without using
+ * the heavy zxcvbn library (~800 KB minified). Only the score field was
+ * ever read from zxcvbn, so a lightweight length-plus-variety heuristic
+ * is a sufficient replacement for this use-case.
+ *
+ * @param {string} roomName - The room name to score.
+ * @returns {number} - A score between 0 and 4 (< 3 means weak/insecure).
+ */
+function _estimateRoomNameStrength(roomName: string): number {
+    const len = roomName.length;
+
+    if (len < 8) {
+        return 0;
+    }
+    if (len < 12) {
+        return 1;
+    }
+
+    const hasLower = /[a-z]/.test(roomName);
+    const hasUpper = /[A-Z]/.test(roomName);
+    const hasDigit = /[0-9]/.test(roomName);
+    const hasSpecial = /[^a-zA-Z0-9]/.test(roomName);
+
+    const varietyCount = [ hasLower, hasUpper, hasDigit, hasSpecial ]
+        .filter(Boolean).length;
+
+    if (varietyCount === 1) {
+        return 1;
+    }
+
+    if (varietyCount === 2 && len < 16) {
+        return 2;
+    }
+
+    if (varietyCount >= 3 || len >= 16) {
+        return 3;
+    }
+
+    return 2;
+}
+
+/**
+ * No-op kept for API compatibility. Previously triggered the asynchronous
+ * load of the zxcvbn library. The library has been replaced with a
+ * lightweight built-in heuristic that requires no preloading.
  *
  * @returns {void}
  */
 export function preloadZxcvbn() {
-    _ensureZxcvbn();
-}
-
-/**
- * Triggers the asynchronous load of the zxcvbn library if not already loaded.
- *
- * @returns {void}
- */
-function _ensureZxcvbn() {
-    if (_zxcvbn !== null) {
-        return;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    import(/* webpackChunkName: "zxcvbn" */ 'zxcvbn').then((m: any) => {
-        _zxcvbn = m.default ?? m;
-    });
+    // No-op: zxcvbn has been removed; no preloading is needed.
 }
 
 /**
@@ -54,32 +79,24 @@ function isValidUUID(str: string) {
 
 /**
  * Checks a room name and caches the result.
- * Returns undefined if zxcvbn is not yet loaded.
  *
  * @param {string} roomName - The room name.
- * @returns {Object|undefined}
+ * @returns {number}
  */
 function _checkRoomName(roomName = '') {
-    if (_zxcvbnCache.has(roomName)) {
-        return _zxcvbnCache.get(roomName);
+    if (_scoreCache.has(roomName)) {
+        return _scoreCache.get(roomName);
     }
 
-    _ensureZxcvbn();
+    const score = _estimateRoomNameStrength(roomName);
 
-    if (!_zxcvbn) {
-        return undefined;
-    }
+    _scoreCache.set(roomName, score);
 
-    const result = _zxcvbn(roomName);
-
-    _zxcvbnCache.set(roomName, result);
-
-    return result;
+    return score;
 }
 
 /**
  * Returns true if the room name is considered a weak (insecure) one.
- * Returns false (treats as secure) while the zxcvbn library is still loading.
  *
  * @param {string} roomName - The room name.
  * @returns {boolean}
@@ -87,5 +104,5 @@ function _checkRoomName(roomName = '') {
 export default function isInsecureRoomName(roomName = ''): boolean {
 
     // room names longer than 200 chars we consider secure
-    return !isValidUUID(roomName) && (roomName.length < 200 && (_checkRoomName(roomName)?.score ?? 3) < 3);
+    return !isValidUUID(roomName) && (roomName.length < 200 && (_checkRoomName(roomName) ?? 3) < 3);
 }

--- a/react/features/base/util/isInsecureRoomName.web.ts
+++ b/react/features/base/util/isInsecureRoomName.web.ts
@@ -1,52 +1,12 @@
 import { isEqual } from 'lodash-es';
 import { NIL, parse as parseUUID } from 'uuid';
 
+import { estimateRoomNameStrength } from './roomNameStrength';
+
 // The null UUID.
 const NIL_UUID = parseUUID(NIL);
 
 const _scoreCache = new Map<string, number>();
-
-/**
- * Estimates a rough strength score (0–4) for a room name without using
- * the heavy zxcvbn library (~800 KB minified). Only the score field was
- * ever read from zxcvbn, so a lightweight length-plus-variety heuristic
- * is a sufficient replacement for this use-case.
- *
- * @param {string} roomName - The room name to score.
- * @returns {number} - A score between 0 and 4 (< 3 means weak/insecure).
- */
-function _estimateRoomNameStrength(roomName: string): number {
-    const len = roomName.length;
-
-    if (len < 8) {
-        return 0;
-    }
-    if (len < 12) {
-        return 1;
-    }
-
-    const hasLower = /[a-z]/.test(roomName);
-    const hasUpper = /[A-Z]/.test(roomName);
-    const hasDigit = /[0-9]/.test(roomName);
-    const hasSpecial = /[^a-zA-Z0-9]/.test(roomName);
-
-    const varietyCount = [ hasLower, hasUpper, hasDigit, hasSpecial ]
-        .filter(Boolean).length;
-
-    if (varietyCount === 1) {
-        return 1;
-    }
-
-    if (varietyCount === 2 && len < 16) {
-        return 2;
-    }
-
-    if (varietyCount >= 3 || len >= 16) {
-        return 3;
-    }
-
-    return 2;
-}
 
 /**
  * Checks if the given string is a valid UUID or not.
@@ -77,7 +37,7 @@ function _checkRoomName(roomName = '') {
         return _scoreCache.get(roomName);
     }
 
-    const score = _estimateRoomNameStrength(roomName);
+    const score = estimateRoomNameStrength(roomName);
 
     _scoreCache.set(roomName, score);
 

--- a/react/features/base/util/roomNameStrength.ts
+++ b/react/features/base/util/roomNameStrength.ts
@@ -1,0 +1,41 @@
+/**
+ * Estimates a rough strength score (0–4) for a room name without using
+ * the heavy zxcvbn library (~800 KB minified). Only the score field was
+ * ever read from zxcvbn, so a lightweight length-plus-variety heuristic
+ * is a sufficient replacement for this use-case.
+ *
+ * @param {string} roomName - The room name to score.
+ * @returns {number} - A score between 0 and 4 (< 3 means weak/insecure).
+ */
+export function estimateRoomNameStrength(roomName: string): number {
+    const len = roomName.length;
+
+    if (len < 8) {
+        return 0;
+    }
+    if (len < 12) {
+        return 1;
+    }
+
+    const hasLower = /[a-z]/.test(roomName);
+    const hasUpper = /[A-Z]/.test(roomName);
+    const hasDigit = /[0-9]/.test(roomName);
+    const hasSpecial = /[^a-zA-Z0-9]/.test(roomName);
+
+    const varietyCount = [ hasLower, hasUpper, hasDigit, hasSpecial ]
+        .filter(Boolean).length;
+
+    if (varietyCount === 1) {
+        return 1;
+    }
+
+    if (varietyCount === 2 && len < 16) {
+        return 2;
+    }
+
+    if (varietyCount >= 3 || len >= 16) {
+        return 3;
+    }
+
+    return 2;
+}

--- a/react/features/prejoin/middleware.web.ts
+++ b/react/features/prejoin/middleware.web.ts
@@ -11,8 +11,6 @@ import {
     TRACK_ADDED,
     TRACK_NO_DATA_FROM_SOURCE
 } from '../base/tracks/actionTypes';
-import { preloadZxcvbn } from '../base/util/isInsecureRoomName';
-
 import {
     setDeviceStatusOk,
     setDeviceStatusWarning,
@@ -28,15 +26,8 @@ import { isPrejoinPageVisible, isUnsafeRoomWarningEnabled } from './functions.an
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-    case SET_CONFIG: {
-        const result = next(action);
-
-        if (isUnsafeRoomWarningEnabled(store.getState())) {
-            preloadZxcvbn();
-        }
-
-        return result;
-    }
+    case SET_CONFIG:
+        return next(action);
     case SET_AUDIO_MUTED: {
         if (isPrejoinPageVisible(store.getState())) {
             store.dispatch(updateSettings({


### PR DESCRIPTION
Package 'zxcvbn' is used only for one thing and that is scoring of complexity of room name to be secure.
Package it self ads 800kB (~350kB gzip) unnecessary JS code that is loaded always - on web and in native app.

Proposed PR removes this package and implements scoring function for room name.