### PR TITLE
feat(android): Add CHANGE_NETWORK_STATE, so WebRTC can hold cellular open

### DIFF
--- a/android/sdk/src/main/AndroidManifest.xml
+++ b/android/sdk/src/main/AndroidManifest.xml
@@ -3,6 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools">
     <!-- XXX ACCESS_NETWORK_STATE is required by WebRTC. -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- XXX CHANGE_NETWORK_STATE lets WebRTC's own NetworkMonitorAutoDetect call
+         ConnectivityManager#requestNetwork for a cellular network. Without it that call throws
+         SecurityException (silently caught by WebRTC), the cellular interface never comes up
+         while wifi is active, and the client gathers only one ICE candidate pair - so a wifi
+         drop has no established backup pair to fail over to. -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
## Summary

- WebRTC's `NetworkMonitorAutoDetect` already calls `ConnectivityManager#requestNetwork` for `TRANSPORT_CELLULAR` on its own, to keep the mobile data interface up even while wifi is the active network. That call needs `CHANGE_NETWORK_STATE`, which jitsi-meet never declared, so it has been throwing `SecurityException` (caught and logged by WebRTC) the whole time.
- Without a cellular interface, WebRTC gathers only one ICE candidate for a JVB session, so only one candidate pair ever forms. A bridge running `keep-alive-strategy = all_succeeded` has nothing to fail over to, and losing wifi means recovering from a torn-down session rather than switching to an already-established path.
- `CHANGE_NETWORK_STATE` is protection level `normal` — granted at install time, no runtime prompt, no user-facing change.

Measured on a Pixel against a single bridge, wifi disabled mid-call:

| | outage |
|---|---|
| before | 17.35 s, recovered by a full session restart |
| after | ~1.2 s, recovered by WebRTC's own pair switch |

Reconnecting to wifi measured no gap above 0.3 s.
