### PR TITLE
test(prosody): add integration tests for mod_muc_breakout_rooms + SMACKS resume regression

### DIFF
--- a/resources/prosody-plugins/mod_auth_token.lua
+++ b/resources/prosody-plugins/mod_auth_token.lua
@@ -182,7 +182,11 @@ module:hook_global('c2s-session-updated', function (event)
     end
 
     -- we care to handle sessions from other hosts (anonymous hosts)
-    if module.host ~= event.from_session.host then
+    -- Skip if from_session was already authenticated by its own token-auth module
+    -- (indicated by _jitsi_auth_done=true), to avoid a second module instance
+    -- on a different VirtualHost (e.g. hs256.localhost) incorrectly re-verifying
+    -- a token signed for the original host and then closing the session.
+    if module.host ~= event.from_session.host and not from_session._jitsi_auth_done then
         -- Handle session updates (e.g., when a session is resumed on some anonymous host with a token we need to do all the checks here)
         session.auth_token = event.from_session.auth_token;
 

--- a/tests/prosody/docker/cfg/components.cfg.lua
+++ b/tests/prosody/docker/cfg/components.cfg.lua
@@ -8,6 +8,16 @@ Component "lobby.conference.localhost" "muc"
     muc_room_locking = false
     muc_room_default_public_jids = true
 
+-- Breakout MUC component for mod_muc_breakout_rooms tests.
+-- Only Prosody admins (focus@auth.localhost) may create rooms here; the module
+-- creates them programmatically. Joining an unregistered UUID room triggers
+-- on_breakout_room_pre_create which destroys it and returns an error.
+Component "breakout.conference.localhost" "muc"
+    storage = "memory"
+    restrict_room_creation = true
+    muc_room_locking = false
+    muc_room_default_public_jids = true
+
 -- Internal MUC used by mod_muc_jigasi_invite: the module resolves the Jigasi
 -- brewery room from this component via process_host_module. Without this
 -- component main_muc_service would remain nil and requests that reach the

--- a/tests/prosody/docker/cfg/components.cfg.lua
+++ b/tests/prosody/docker/cfg/components.cfg.lua
@@ -9,9 +9,10 @@ Component "lobby.conference.localhost" "muc"
     muc_room_default_public_jids = true
 
 -- Breakout MUC component for mod_muc_breakout_rooms tests.
--- Only Prosody admins (focus@auth.localhost) may create rooms here; the module
--- creates them programmatically. Joining an unregistered UUID room triggers
--- on_breakout_room_pre_create which destroys it and returns an error.
+-- Only Prosody admins (focus@auth.localhost) may create rooms here, matching
+-- real-life behaviour where Jicofo creates breakout rooms on behalf of the
+-- moderator. The on_breakout_room_pre_create hook then enforces that the UUID
+-- is registered in the main room before admitting non-admin occupants.
 Component "breakout.conference.localhost" "muc"
     storage = "memory"
     restrict_room_creation = true

--- a/tests/prosody/docker/cfg/virtualhosts.cfg.lua
+++ b/tests/prosody/docker/cfg/virtualhosts.cfg.lua
@@ -42,6 +42,7 @@ VirtualHost "localhost"
         "system_chat_message";
         -- test-only
         "muc_password_check";
+        "muc_breakout_rooms";
     }
 
     -- mod_muc_password_check: verify Bearer tokens with the login ASAP key server.
@@ -67,8 +68,10 @@ VirtualHost "localhost"
 
     -- Required by mod_conference_duration to find the MUC component.
     -- Required by mod_muc_lobby_rooms.
+    -- Required by mod_muc_breakout_rooms.
     main_muc = "conference.localhost"
     lobby_muc = "lobby.conference.localhost"
+    breakout_rooms_muc = "breakout.conference.localhost"
 
     -- Clients on whitelist.localhost bypass the lobby.
     muc_lobby_whitelist = { "whitelist.localhost" }

--- a/tests/prosody/helpers/xmpp_client.js
+++ b/tests/prosody/helpers/xmpp_client.js
@@ -1040,6 +1040,31 @@ export async function createXmppClient({ host = 'localhost', domain, params, use
         },
 
         /**
+         * Sends a <breakout_rooms> control message to the breakout rooms component.
+         * The session must have jitsi_web_query_room set (connect with
+         * params: { room: '<roomname>' }) and the sender must be a moderator
+         * occupant of the main room for the module to process the message.
+         *
+         * @param {string} componentJid  e.g. 'breakout.conference.localhost'
+         * @param {string} type          operation type, e.g. 'features/breakout-rooms/add'
+         * @param {object} [extraAttrs]  extra attributes on the <breakout_rooms> element,
+         *                              e.g. { subject: 'Group A' } or { breakoutRoomJid: '...' }
+         */
+        sendBreakoutRoomsMessage(componentJid, type, extraAttrs = {}) {
+            return xmpp.send(
+                xml('message', {
+                    to: componentJid,
+                    id: `br-${++_counter}`
+                },
+                    xml('breakout_rooms', {
+                        type,
+                        ...extraAttrs
+                    })
+                )
+            );
+        },
+
+        /**
          * Sends a raw file-sharing message. Use this to test malformed payloads
          * or non-standard message types (e.g. type='error').
          *

--- a/tests/prosody/helpers/xmpp_client.js
+++ b/tests/prosody/helpers/xmpp_client.js
@@ -1108,15 +1108,103 @@ export async function createXmppClient({ host = 'localhost', domain, params, use
         },
 
         /**
-         * Abruptly closes the underlying WebSocket without sending a stream
-         * close. Prosody will put the session into smacks hibernation, keeping
-         * it in full_sessions so mod_auth_jitsi-anonymous can find it by
-         * resumption_token on the next connect.
+         * Abruptly terminates the underlying WebSocket without a close
+         * handshake.  Prosody sees an unclean disconnect and hibernates the
+         * SMACKS session.  On reconnect the library sends <resume>, which
+         * triggers Prosody's c2s-session-updated hook (where the
+         * breakout-rooms bug manifested).
+         *
+         * Jitsi's SMACKS resume flow (mod_auth_token.lua + mod_smacks.lua):
+         *   1. Client reconnects with ?previd=<smacks-id> in the WebSocket URL.
+         *   2. mod_jitsi_session.lua sets session.previd from the URL param.
+         *   3. SASL runs; mod_auth_token.lua's get_username_from_token finds
+         *      the hibernating session whose resumption_token == session.previd
+         *      and copies its username, preserving the original UUID.
+         *   4. Post-auth features include <sm>; @xmpp/stream-management sends
+         *      <resume previd='...'>.  mod_smacks looks up the session with
+         *      registry key "uuid@host/smacks_id" — which now matches because
+         *      step 3 preserved the UUID — and resumes successfully.
+         *   5. sessionmanager.update_session fires c2s-session-updated.
+         *
+         * Without ?previd in the URL, step 3 assigns a fresh UUID, the key
+         * doesn't match, mod_smacks falls back to a new session, and the
+         * regression is never exercised.
+         *
+         * IMPORTANT: must use ws.terminate() (TCP RST, no close frame), NOT
+         * ws.close() / Socket.end().  A clean WebSocket close (code 1000)
+         * causes Prosody to destroy the SMACKS session rather than hibernate it.
+         *
+         * xmpp.socket           – @xmpp/websocket Socket wrapper
+         * xmpp.socket.socket    – underlying ws.WebSocket instance with terminate()
          */
         dropConnection() {
+            // Patch the reconnect URL to carry ?previd=<smacks-id> so that
+            // mod_jitsi_session.lua sets session.previd and mod_auth_token.lua
+            // can preserve session.username across the SASL exchange, allowing
+            // mod_smacks.lua's registry lookup to succeed.
+            const smId = xmpp.streamManagement?.id;
+
+            if (smId) {
+                try {
+                    const serviceUrl = new URL(xmpp.options.service);
+
+                    serviceUrl.searchParams.set('previd', smId);
+                    xmpp.options.service = serviceUrl.toString();
+                } catch { /* ignore */ }
+            }
             try {
-                xmpp.websocket?.socket?.end();
+                const ws = xmpp.socket?.socket;
+
+                if (ws?.terminate) {
+                    ws.terminate();
+                } else {
+                    xmpp.socket?.end();
+                }
             } catch { /* ignore */ }
+        },
+
+        /**
+         * Resolves when the SMACKS (XEP-0198) session resume is fully complete
+         * after a dropConnection().  Set up this listener BEFORE calling
+         * dropConnection() to avoid a race with a very fast reconnect.
+         *
+         * The @xmpp/reconnect 'reconnected' event fires after entity.open()
+         * resolves, which happens on the stream-open header — BEFORE stream
+         * features are processed and therefore BEFORE SMACKS sends <resume>
+         * and receives <resumed>.  The SMACKS handler then sets entity.status
+         * = 'online' directly (no event emitted).  We poll that field after
+         * 'reconnected' to detect the moment the resume is complete, so that
+         * any stanza sent afterwards is processed on the fully-resumed session.
+         *
+         * @param {number} [timeout=10000]
+         */
+        waitForReconnect(timeout = 10000) {
+            return new Promise((resolve, reject) => {
+                let done = false;
+                const timer = setTimeout(() => {
+                    if (!done) {
+                        done = true;
+                        reject(new Error('Timeout waiting for session to reconnect'));
+                    }
+                }, timeout);
+
+                xmpp.reconnect.once('reconnected', () => {
+                    const checkOnline = () => {
+                        if (done) {
+                            return;
+                        }
+                        if (xmpp.status === 'online') {
+                            done = true;
+                            clearTimeout(timer);
+                            resolve();
+                        } else {
+                            setTimeout(checkOnline, 50);
+                        }
+                    };
+
+                    checkOnline();
+                });
+            });
         }
     };
 }

--- a/tests/prosody/mod_muc_breakout_rooms_spec.js
+++ b/tests/prosody/mod_muc_breakout_rooms_spec.js
@@ -1,0 +1,305 @@
+import assert from 'assert';
+
+import { mintAsapToken } from './helpers/jwt.js';
+import { createXmppClient, joinWithFocus } from './helpers/xmpp_client.js';
+
+const CONFERENCE = 'conference.localhost';
+const BREAKOUT_MUC = 'breakout.conference.localhost';
+const JITMEET_NS = 'http://jitsi.org/jitmeet';
+
+// JSON message type constants (must match mod_muc_breakout_rooms.lua)
+const BREAKOUT_ROOMS_TYPE = 'breakout_rooms';
+const EVENT_UPDATE = 'features/breakout-rooms/update';
+const OP_ADD = 'features/breakout-rooms/add';
+const OP_REMOVE = 'features/breakout-rooms/remove';
+const OP_RENAME = 'features/breakout-rooms/rename';
+
+let _roomCounter = 0;
+
+const nextRoomName = () => `br-test-${++_roomCounter}`;
+const roomJid = name => `${name}@${CONFERENCE}`;
+
+/**
+ * Parses the JSON payload from a <json-message xmlns="http://jitsi.org/jitmeet"> stanza.
+ * Returns null if the stanza has no such child or the body is not valid JSON.
+ *
+ * @param {object} stanza
+ * @returns {object|null}
+ */
+function parseJsonMessage(stanza) {
+    const jm = stanza.getChild('json-message', JITMEET_NS);
+
+    if (!jm) {
+        return null;
+    }
+    try {
+        return JSON.parse(jm.getText());
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Waits for a breakout_rooms update broadcast on the given client.
+ * Resolves with the parsed JSON payload.
+ *
+ * mod_muc_breakout_rooms broadcasts only to non-admin occupants, so always
+ * wait on a JWT moderator client, never on the focus (admin) client.
+ *
+ * @param {object} client
+ * @param {number} [timeout=6000]  ms — must exceed BROADCAST_ROOMS_INTERVAL (300 ms)
+ * @returns {Promise<object>}
+ */
+async function waitForBreakoutUpdate(client, timeout = 6000) {
+    const stanza = await client.waitForMessage(s => {
+        const p = parseJsonMessage(s);
+
+        return p?.type === BREAKOUT_ROOMS_TYPE && p?.event === EVENT_UPDATE;
+    }, timeout);
+
+    return parseJsonMessage(stanza);
+}
+
+/**
+ * Creates a conference room with focus and an authenticated moderator.
+ *
+ * Focus joins first to satisfy the mod_muc_meeting_id jicofo lock so that
+ * regular clients can join. The moderator connects with ?room=name so that
+ * mod_jitsi_session sets jitsi_web_query_room, which mod_muc_breakout_rooms
+ * uses to look up the main room. The JWT token carries context.user.moderator=true
+ * so mod_token_affiliation promotes the client to moderator on join.
+ *
+ * mod_muc_breakout_rooms excludes Prosody admins (focus) from update broadcasts,
+ * so the moderator — who is NOT a Prosody admin — acts as the broadcast receiver
+ * in tests.
+ *
+ * @param {string} name  bare room name, e.g. 'br-test-1'
+ * @returns {Promise<{focus: object, moderator: object}>}
+ */
+async function createRoom(name) {
+    const jid = roomJid(name);
+    const focus = await joinWithFocus(jid);
+    const token = mintAsapToken({
+        room: name,
+        context: { user: { moderator: true } }
+    });
+    const moderator = await createXmppClient({ params: { room: name,
+        token } });
+
+    await moderator.joinRoom(jid);
+
+    return { focus,
+        moderator };
+}
+
+describe('mod_muc_breakout_rooms', () => {
+
+    let clients;
+
+    beforeEach(() => {
+        clients = [];
+    });
+
+    afterEach(async () => {
+        await Promise.all(clients.map(c => c.disconnect()));
+    });
+
+    // -------------------------------------------------------------------------
+    // breakout room creation
+    // -------------------------------------------------------------------------
+    describe('create breakout room', () => {
+
+        it('moderator receives an update broadcast after creating a breakout room', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Group 1' });
+
+            const payload = await waitForBreakoutUpdate(moderator);
+
+            assert.equal(payload.type, BREAKOUT_ROOMS_TYPE);
+            assert.equal(payload.event, EVENT_UPDATE);
+        });
+
+        it('update payload contains the main room and the new breakout room', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Group A' });
+
+            const payload = await waitForBreakoutUpdate(moderator);
+            const rooms = Object.values(payload.rooms);
+
+            assert.equal(rooms.length, 2, 'payload must contain main room + one breakout room');
+
+            const mainRoom = rooms.find(r => r.isMainRoom);
+            const breakoutRoom = rooms.find(r => !r.isMainRoom);
+
+            assert.ok(mainRoom, 'one room must be flagged as the main room');
+            assert.ok(breakoutRoom, 'one room must be the breakout room');
+            assert.equal(breakoutRoom.name, 'Group A');
+            assert.ok(
+                breakoutRoom.jid.endsWith(`@${BREAKOUT_MUC}`),
+                `breakout room JID must be on ${BREAKOUT_MUC}`
+            );
+        });
+
+        it('all non-admin occupants of the main room receive the update broadcast', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            // A second non-admin participant.
+            const participant = await createXmppClient({ params: { room: name } });
+
+            clients.push(focus, moderator, participant);
+            await participant.joinRoom(roomJid(name));
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Team Room' });
+
+            const [ modPayload, partPayload ] = await Promise.all([
+                waitForBreakoutUpdate(moderator),
+                waitForBreakoutUpdate(participant)
+            ]);
+
+            assert.equal(modPayload.event, EVENT_UPDATE, 'moderator must receive the update');
+            assert.equal(partPayload.event, EVENT_UPDATE, 'regular participant must receive the update');
+        });
+
+        it('roomCounter increments with each created breakout room', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Room 1' });
+            const first = await waitForBreakoutUpdate(moderator);
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Room 2' });
+            const second = await waitForBreakoutUpdate(moderator);
+
+            assert.ok(second.roomCounter > first.roomCounter, 'roomCounter must increase');
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // breakout room removal
+    // -------------------------------------------------------------------------
+    describe('remove breakout room', () => {
+
+        it('moderator can remove a breakout room and receives an update', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            // Create
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Temp Room' });
+            const createPayload = await waitForBreakoutUpdate(moderator);
+
+            const breakoutJid = Object.values(createPayload.rooms)
+                .find(r => !r.isMainRoom)?.jid;
+
+            assert.ok(breakoutJid, 'breakout room JID must be present in create update');
+
+            // Remove
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_REMOVE, {
+                breakoutRoomJid: breakoutJid
+            });
+
+            const removePayload = await waitForBreakoutUpdate(moderator);
+            const rooms = Object.values(removePayload.rooms);
+
+            assert.equal(rooms.length, 1, 'only the main room must remain after removal');
+            assert.ok(rooms[0].isMainRoom, 'remaining room must be the main room');
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // breakout room rename
+    // -------------------------------------------------------------------------
+    describe('rename breakout room', () => {
+
+        it('moderator can rename a breakout room and receives an update with the new name', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Original Name' });
+            const createPayload = await waitForBreakoutUpdate(moderator);
+
+            const breakoutJid = Object.values(createPayload.rooms)
+                .find(r => !r.isMainRoom)?.jid;
+
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_RENAME, {
+                breakoutRoomJid: breakoutJid,
+                subject: 'Renamed Room'
+            });
+
+            const renamePayload = await waitForBreakoutUpdate(moderator);
+            const renamedRoom = Object.values(renamePayload.rooms).find(r => !r.isMainRoom);
+
+            assert.ok(renamedRoom, 'breakout room must still exist after rename');
+            assert.equal(renamedRoom.name, 'Renamed Room');
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // access control
+    // -------------------------------------------------------------------------
+    describe('access control', () => {
+
+        it('non-admin cannot create rooms on the breakout component (restrict_room_creation)', async () => {
+            // Any anonymous or JWT-authenticated client that is NOT a Prosody
+            // admin (i.e. not focus@auth.localhost) should receive a <forbidden/>
+            // or similar error when trying to create a new room on the breakout
+            // MUC component.  restrict_room_creation=true on the component is the
+            // first line of defence; on_breakout_room_pre_create is the second.
+            const name = nextRoomName();
+            const user = await createXmppClient({ params: { room: name } });
+
+            clients.push(user);
+
+            const fakeBreakoutJid = `00000000-0000-0000-0000-000000000000@${BREAKOUT_MUC}`;
+            const presence = await user.joinRoom(fakeBreakoutJid);
+
+            assert.equal(
+                presence.attrs.type,
+                'error',
+                'non-admin must receive an error when attempting to create a breakout room'
+            );
+        });
+
+        it('ignores create requests from non-moderator participants', async () => {
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            // Anonymous participant — no moderator token means participant role.
+            const participant = await createXmppClient({ params: { room: name } });
+
+            clients.push(focus, moderator, participant);
+            await participant.joinRoom(roomJid(name));
+
+            // Participant sends a create request — the module must ignore it.
+            await participant.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, {
+                subject: 'Unauthorized Room'
+            });
+
+            // A broadcast would only arrive if the room was actually created.
+            await assert.rejects(
+                waitForBreakoutUpdate(participant, 1500),
+                /Timeout/,
+                'no broadcast must be received when a non-moderator attempts to create a room'
+            );
+        });
+
+    });
+
+});

--- a/tests/prosody/mod_muc_breakout_rooms_spec.js
+++ b/tests/prosody/mod_muc_breakout_rooms_spec.js
@@ -252,6 +252,74 @@ describe('mod_muc_breakout_rooms', () => {
     });
 
     // -------------------------------------------------------------------------
+    // smacks regression: eb43cf601
+    // -------------------------------------------------------------------------
+    describe('smacks session resume', () => {
+
+        it('participant can join breakout room after smacks session resume', async () => {
+            // Regression test for eb43cf601:
+            // mod_auth_token.lua's c2s-session-updated handler used to copy
+            // jitsi_breakout_main_jid from the fresh TCP session (which never
+            // joined a room, so the field is nil) onto the old hibernating
+            // session, silently overwriting the valid value set when the user
+            // originally joined the main room.  Without the fix, the subsequent
+            // on_occupant_pre_join_or_change check
+            //   origin.jitsi_breakout_main_jid ~= main_room.jid
+            // fails with nil ~= main_room_jid → not-allowed error.
+            const name = nextRoomName();
+            const { focus, moderator } = await createRoom(name);
+
+            clients.push(focus, moderator);
+
+            // Register a breakout room via the OP_ADD message flow and capture its JID.
+            await moderator.sendBreakoutRoomsMessage(BREAKOUT_MUC, OP_ADD, { subject: 'Breakout 1' });
+            const createPayload = await waitForBreakoutUpdate(moderator);
+            const breakoutJid = Object.values(createPayload.rooms).find(r => !r.isMainRoom)?.jid;
+
+            assert.ok(breakoutJid, 'breakout room JID must be in the create broadcast');
+
+            // Focus (jicofo) joins the breakout room first to physically create it,
+            // matching the real-life flow where Jicofo creates the room on the
+            // breakout component (which has restrict_room_creation=true, so only
+            // Prosody admins like focus@auth.localhost can create rooms here).
+            const focusBreakoutPresence = await focus.joinRoom(breakoutJid, 'focus');
+
+            assert.notEqual(
+                focusBreakoutPresence.attrs.type,
+                'error',
+                'focus must be able to join (create) the breakout room'
+            );
+
+            // Arm the reconnect listener BEFORE dropping so we cannot miss the
+            // 'reconnected' event even if the reconnect is very fast.
+            const reconnected = moderator.waitForReconnect();
+
+            // Snap the WebSocket.  @xmpp/client schedules a reconnect after ~1 s;
+            // on reconnect it sends <resume> which triggers Prosody's
+            // c2s-session-updated — the event where the bug cleared jitsi_breakout_main_jid.
+            moderator.dropConnection();
+
+            // Wait until SMACKS resume is fully complete (entity.status === 'online').
+            // waitForReconnect() polls entity.status after the @xmpp/reconnect
+            // 'reconnected' event, because that event fires on stream-open which
+            // is before stream features (including SMACKS) are negotiated.
+            await reconnected;
+
+            // The moderator now tries to join the breakout room.
+            // With the bug:   jitsi_breakout_main_jid is nil → not-allowed error.
+            // With the fix:   jitsi_breakout_main_jid is preserved → join succeeds.
+            const presence = await moderator.joinRoom(breakoutJid);
+
+            assert.notEqual(
+                presence.attrs.type,
+                'error',
+                'participant must be able to join breakout room after smacks session resume'
+            );
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
     // access control
     // -------------------------------------------------------------------------
     describe('access control', () => {
@@ -268,7 +336,7 @@ describe('mod_muc_breakout_rooms', () => {
             clients.push(user);
 
             const fakeBreakoutJid = `00000000-0000-0000-0000-000000000000@${BREAKOUT_MUC}`;
-            const presence = await user.joinRoom(fakeBreakoutJid);
+            const presence = await user.joinRoom(fakeBreakoutJid, undefined, { timeout: 15000 });
 
             assert.equal(
                 presence.attrs.type,


### PR DESCRIPTION
## Summary

- Adds 9 Mocha integration tests for `mod_muc_breakout_rooms` using a Dockerised Prosody instance (testcontainers).
- Adds a regression test for eb43cf601 that verifies a moderator can join a breakout room after a SMACKS (XEP-0198) session resume.
- Fixes a latent bug in `mod_auth_token.lua`'s `c2s-session-updated` handler that caused SMACKS resume to fail when multiple JWT-authenticated VirtualHosts are configured.

## What the tests cover

| Test | Description |
|---|---|
| create breakout room × 3 | Moderator creates a room; payload contents; broadcast to all occupants; roomCounter increments |
| remove breakout room | Moderator removes a room and receives an update |
| rename breakout room | Moderator renames a room and receives an update with the new name |
| **smacks session resume** | Regression for eb43cf601 — moderator joins breakout room after SMACKS resume |
| access control × 2 | Non-admin cannot create rooms (`restrict_room_creation=true`); non-moderator create requests are ignored |

## SMACKS regression test details

The test exercises the exact bug scenario from eb43cf601:

1. Focus (jicofo) joins the main room first, then the breakout room, to physically create it — `restrict_room_creation=true` is preserved on the breakout component, matching real deployments where only Prosody admins can create breakout rooms.
2. The moderator's WebSocket is killed with `ws.terminate()` (TCP RST → SMACKS hibernation).
3. The reconnect URL carries `?previd=<smacks-id>` so `mod_auth_token.lua` preserves the session UUID across SASL, allowing `mod_smacks.lua`'s registry lookup to succeed and produce a true `<resumed>`.
4. The moderator then joins the breakout room. Without eb43cf601, `jitsi_breakout_main_jid` is nil and the join returns `not-allowed`.

## Bug fix in mod_auth_token.lua

The `c2s-session-updated` hook is registered globally (`module:hook_global`), so it fires in **every** VirtualHost instance of `mod_auth_token` — including `hs256.localhost` in the test environment. When a `localhost` session was resumed via SMACKS, the `hs256.localhost` instance entered the cross-host branch (since `module.host ≠ from_session.host`), attempted to verify the RS256 ASAP token with its HS256 verifier, failed, and called `event.session:close()` — destroying the resumed session before `<resumed>` could be sent.

Fix: skip the cross-host verification when `from_session._jitsi_auth_done` is already `true`, meaning the session was fully authenticated by its own VirtualHost's module. Anonymous-host sessions (which never set this flag) are unaffected.

## Test plan

- [x] Run `npx mocha --grep "mod_muc_breakout_rooms"` — all 9 tests pass
- [x] Verify SMACKS test fails when eb43cf601 is reverted (the bug re-appears)
- [x] Verify SMACKS test passes with eb43cf601 in place