### PR TITLE
fix(recording): decouple transcription from live stream and local recording visibility

### DIFF
--- a/react/features/recording/components/LiveStream/AbstractLiveStreamButton.ts
+++ b/react/features/recording/components/LiveStream/AbstractLiveStreamButton.ts
@@ -5,7 +5,6 @@ import { isJwtFeatureEnabled } from '../../../base/jwt/functions';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../../base/toolbox/components/AbstractButton';
 import { isInBreakoutRoom } from '../../../breakout-rooms/functions';
 import { maybeShowPremiumFeatureDialog } from '../../../jaas/actions';
-import { isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { isCloudRecordingRunning, isLiveStreamingButtonVisible, isLiveStreamingRunning } from '../../functions';
 
 import { getLiveStreaming } from './functions';
@@ -137,8 +136,8 @@ export function _mapStateToProps(state: IReduxState, ownProps: IProps) {
         });
     }
 
-    // disable the button if the recording is running.
-    if (visible && (isCloudRecordingRunning(state) || isRecorderTranscriptionsRunning(state))) {
+    // disable the button if cloud recording is running.
+    if (visible && isCloudRecordingRunning(state)) {
         _disabled = true;
         _tooltip = 'dialog.liveStreamingDisabledBecauseOfActiveRecordingTooltip';
     }

--- a/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/AbstractStartRecordingDialogContent.tsx
@@ -13,7 +13,7 @@ import { authorizeDropbox, updateDropboxToken } from '../../../dropbox/actions';
 import { isVpaasMeeting } from '../../../jaas/functions';
 import { canAddTranscriber, isRecorderTranscriptionsRunning } from '../../../transcribing/functions';
 import { RECORDING_TYPES } from '../../constants';
-import { hasRecordingOrTranscriptionFeature, supportsLocalRecording } from '../../functions';
+import { hasRecordingOrTranscriptionFeature, isLiveStreamingRunning, supportsLocalRecording } from '../../functions';
 
 /**
  * The type of the React {@code Component} props of
@@ -41,6 +41,11 @@ export interface IProps extends WithTranslation {
      * Whether to hide the storage warning or not.
      */
     _hideStorageWarning: boolean;
+
+    /**
+     * Whether a live stream session is currently active.
+     */
+    _isLiveStreamRunning: boolean;
 
     /**
      * Whether the local participant is a moderator.
@@ -500,6 +505,7 @@ export function mapStateToProps(state: IReduxState) {
         isVpaas: isVpaasMeeting(state),
         _canManageRecordingOrTranscription: canManageRecordingOrTranscription,
         _canStartTranscribing: canAddTranscriber(state),
+        _isLiveStreamRunning: isLiveStreamingRunning(state),
         _hideStorageWarning: Boolean(recordingService?.hideStorageWarning),
         _isModerator: isLocalParticipantModerator(state),
         _renderRecording: isJwtFeatureEnabled(state, MEET_FEATURES.RECORDING, false),

--- a/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
+++ b/react/features/recording/components/Recording/web/StartRecordingDialogContent.tsx
@@ -39,6 +39,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
      */
     _renderSessionToggles() {
         const {
+            _isLiveStreamRunning,
             _localRecordingRunning,
             _renderRecording,
             shouldRecordAudioAndVideo,
@@ -48,7 +49,8 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
 
         // A participant who started a local recording must always be able to stop it,
         // even without the JWT recording feature that _renderRecording reflects.
-        const renderRecordingToggle = _renderRecording || _localRecordingRunning;
+        // Cloud recording (Jibri) cannot run alongside an active live stream.
+        const renderRecordingToggle = (!_isLiveStreamRunning && _renderRecording) || _localRecordingRunning;
 
         return (
             <>
@@ -88,6 +90,7 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
     override render() {
         const {
             _canStartTranscribing,
+            _isLiveStreamRunning,
             _renderRecording,
             _transcriptionRunning,
             fileRecordingsServiceEnabled,
@@ -113,14 +116,18 @@ class StartRecordingDialogContent extends AbstractStartRecordingDialogContent {
                 <Container className = 'recording-dialog'>
                     { this._renderFileSharingContent() }
                     { this._renderSessionToggles() }
+                    { /* _renderSessionToggles already covers local recording when !_renderRecording */ }
+                    { _renderRecording && this._renderLocalRecordingContent() }
                 </Container>
             );
         }
 
-        // Cloud recording is only usable when a service (file recording or integration) is available;
-        // the JWT recording feature alone doesn't imply one. Transcription nests under the cloud
-        // options when it's supported, otherwise it shows standalone.
-        const supportsCloudRecording = _renderRecording && (fileRecordingsServiceEnabled || integrationsEnabled);
+        // Cloud recording is only usable when a service (file recording or integration) is available,
+        // the JWT recording feature alone doesn't imply one, and it cannot run alongside an active live
+        // stream (both require Jibri). Transcription nests under the cloud options when supported,
+        // otherwise it shows standalone.
+        const supportsCloudRecording = _renderRecording && (fileRecordingsServiceEnabled || integrationsEnabled)
+            && !_isLiveStreamRunning;
         const showTranscription = _canStartTranscribing && !supportsCloudRecording;
 
         return (

--- a/react/features/recording/functions.ts
+++ b/react/features/recording/functions.ts
@@ -269,7 +269,7 @@ export function getRecordButtonProps(state: IReduxState) {
     // a button can be disabled/enabled if enableFeaturesBasedOnToken
     // is on or if the livestreaming is running.
     let disabled = false;
-    let tooltip = isRecordingRunning(state) ? 'dialog.stopRecording' : 'dialog.startRecording';
+    const tooltip = isRecordingRunning(state) ? 'dialog.stopRecording' : 'dialog.startRecording';
 
     // If the containing component provides the visible prop, that is one
     // above all, but if not, the button should be autonomus and decide on
@@ -295,12 +295,6 @@ export function getRecordButtonProps(state: IReduxState) {
         // Self-hosted without JWT: fall back to server config so moderators
         // see the button when recordingService.enabled or transcription.enabled.
         visible = recordingEnabled || transcriptionEnabled;
-    }
-
-    // disable the button if the livestreaming is running.
-    if (visible && isLiveStreamingRunning(state)) {
-        disabled = true;
-        tooltip = 'dialog.recordingDisabledBecauseOfActiveLiveStreamingTooltip';
     }
 
     // disable the button if we are in a breakout room.


### PR DESCRIPTION
## Summary

Fixes two related issues where transcription state incorrectly affected unrelated recording controls:

- **Fixes #17732** — Live streaming was disabled whenever transcription was active. Transcription and live streaming are independent (transcription doesn't exclusively occupy Jibri the way cloud recording does), so `isRecorderTranscriptionsRunning` has been removed from the live stream button's disable condition.

- **Fixes #17731** — The local recording option disappeared from the Record & Transcribe dialog when transcription was running. The `isTranscriptionOnlySession` render path was missing the `_renderLocalRecordingContent()` call that the normal render path always includes. Local recording is browser-side and has no dependency on Jibri or the JWT recording feature flag.

## Changes

- `AbstractLiveStreamButton.ts` — remove `isRecorderTranscriptionsRunning` from the disable guard (and its now-unused import)
- `StartRecordingDialogContent.tsx` — add `_renderLocalRecordingContent()` to the transcription-only session render path; `_renderSessionToggles()` itself is unchanged so the cloud-recording-running path is unaffected

## Test plan

- [ ] Start transcription → live stream button should be enabled and startable
- [ ] Start live stream → Record & Transcribe should remain accessible
- [ ] Start transcription (no recording) → reopen Record & Transcribe → local recording option should be visible
- [ ] Start cloud recording → local recording option in session manage view should behave as before (hidden when JWT recording feature is enabled)