### PR TITLE
fix(prosody): do not rate limit s2s sessions

### DIFF
--- a/resources/prosody-plugins/mod_rate_limit.lua
+++ b/resources/prosody-plugins/mod_rate_limit.lua
@@ -197,8 +197,13 @@ local function on_login(session, ip)
 end
 
 local function filter_hook(session)
-    -- ignore outgoing sessions (s2s)
-    if session.outgoing then
+    -- ignore s2s sessions, in both directions. s2s is restricted to the hosts in
+    -- s2s_whitelist, so a rate limit adds no protection, but it can throttle a legitimate
+    -- burst of stanzas from a trusted node.
+    -- Use base_type, not type. util.session sets base_type when it creates the session and
+    -- never changes it. It sets type to 's2sin_unauthed' first, then to 's2sin' after the
+    -- session authenticates.
+    if session.base_type == 's2sin' or session.base_type == 's2sout' then
         return;
     end
 


### PR DESCRIPTION
`mod_rate_limit` exempted only outgoing s2s sessions, through `session.outgoing`. Incoming s2s sessions were rate limited.

`mod_visitors` sends one presence stanza for each main participant when it connects a visitor node. In a conference with more than four main participants, that burst passes `rate_limit_presence_rate` (4 per second). The visitor prosody then throttles the full s2s link from the main prosody to `rate_limit_session_rate` for `rate_limit_timeout`. A visitor that joins during the throttle gets an incomplete MUC roster, and the client can show a tile only for an occupant it knows about. This was seen on beta: a visitor saw 4 tiles in a conference with 6 main participants.

s2s is restricted to the hosts in `s2s_whitelist`, so a rate limit gives no protection on such a link.

The new check uses `session.base_type`. `util.session` sets that field when it creates the session, and never changes it. It covers both directions of s2s. A check on `session.type` does not work here, because the filter hook runs at connect time, before the session authenticates, when the value is still `s2sin_unauthed`. The old check was also unreliable, because `mod_s2s_bidi` sets `session.outgoing` on incoming bidi sessions.

### Related

Parts of the same fix:

- jitsi/jitsi-meet#17739 - do not rate limit s2s sessions
- jitsi/docker-jitsi-meet#2309 - add `::1` to the whitelist in the prosody templates
- jitsi/infra-configuration#944 - add `::1` to the ansible default whitelist
- jitsi/infra-provisioning#1139 - set the session rate on the visitor node task
