### PR TITLE
fix(breakout-rooms): reply with an error for an invalid breakout room

### DIFF
--- a/resources/prosody-plugins/mod_muc_breakout_rooms.lua
+++ b/resources/prosody-plugins/mod_muc_breakout_rooms.lua
@@ -381,6 +381,16 @@ function on_breakout_room_pre_create(event)
         breakout_room:set_subject(breakout_room.jid, main_room._data.breakout_rooms[breakout_room.jid]);
     else
         module:log('debug', 'Invalid breakout room %s will not be created.', breakout_room.jid);
+
+        -- Tell the client that the join failed. Without this reply the join presence is
+        -- dropped without an answer, and the client waits until its own timeout.
+        -- Prosody sends an error for restrict_room_creation, but that handler and this one
+        -- both use the default priority, so the order between the two is not defined.
+        if event.origin and event.stanza then
+            event.origin.send(st.error_reply(
+                event.stanza, 'cancel', 'item-not-found', 'Breakout room is invalid.'));
+        end
+
         breakout_room:destroy(main_room_jid, 'Breakout room is invalid.');
         return true;
     end


### PR DESCRIPTION
`on_breakout_room_pre_create` destroyed the room and returned `true` without a reply when the breakout room was not registered in the main room. The join presence of the client got no answer at all, so the client waited until its own timeout instead of receiving an error. This is reachable in production whenever a client joins a breakout room JID that is stale or was removed.

Prosody sends an error of its own for `restrict_room_creation`, but that handler (`plugins/muc/mod_muc.lua`) and this one both use the default priority on `muc-room-pre-create`. `util.events` builds the handler list from a table keyed by the handler function, then sorts by priority only, and that sort is not stable. The order of the two handlers is therefore not defined, and it can differ for each prosody process. So the client sometimes got the error from prosody and sometimes got nothing.

The same cause made the integration test `access control > non-admin cannot create rooms on the breakout component (restrict_room_creation)` intermittent, which is why it failed once in CI on an unrelated pull request.

### Verification

Repeated runs of `mod_muc_breakout_rooms_spec.js`:

| code | runs | result |
| --- | --- | --- |
| before | 20 | 11 failed |
| before, module handler forced to priority 1 | 3 | 3 failed |
| before, module handler forced to priority -1 | 3 | 3 passed |
| after this change | 20 | 20 passed |

The two forced-priority runs confirm that the hook order alone decides the outcome. The failure was always the same: no presence of any kind reached the client, and the join timed out after 15 seconds.
