### PR TITLE
dep(react-native-worklets-core): update to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "react-native-video": "6.19.1",
         "react-native-webrtc": "124.0.8",
         "react-native-webview": "13.16.0",
-        "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
+        "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8b20145466186a369d13dd38e979642035a9bda1",
         "react-native-youtube-iframe": "2.3.0",
         "react-redux": "7.2.9",
         "react-textarea-autosize": "8.3.0",
@@ -22826,8 +22826,8 @@
     },
     "node_modules/react-native-worklets-core": {
       "version": "1.6.2",
-      "resolved": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
-      "integrity": "sha512-FjdqVkN1nvkVCs+Zhl0pvJe2MpkCGaNGAEEWVKepjvmA6+/MiejEDJRdCVoIB1P3SYTP+iBe6qgrnK6cXPOlcg==",
+      "resolved": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#8b20145466186a369d13dd38e979642035a9bda1",
+      "integrity": "sha512-CqTjd1IR3t1V1QhRRL9jT1eHzllzrhp1HOeTH2fAYr6L/WYte3yMW13DjefSuUaRIPhDnM4tR9m+aaNfjUohRg==",
       "license": "MIT",
       "dependencies": {
         "string-hash-64": "^1.0.3"
@@ -42795,9 +42795,9 @@
       }
     },
     "react-native-worklets-core": {
-      "version": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
-      "integrity": "sha512-FjdqVkN1nvkVCs+Zhl0pvJe2MpkCGaNGAEEWVKepjvmA6+/MiejEDJRdCVoIB1P3SYTP+iBe6qgrnK6cXPOlcg==",
-      "from": "react-native-worklets-core@https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
+      "version": "git+ssh://git@github.com/jitsi/react-native-worklets-core.git#8b20145466186a369d13dd38e979642035a9bda1",
+      "integrity": "sha512-CqTjd1IR3t1V1QhRRL9jT1eHzllzrhp1HOeTH2fAYr6L/WYte3yMW13DjefSuUaRIPhDnM4tR9m+aaNfjUohRg==",
+      "from": "react-native-worklets-core@https://github.com/jitsi/react-native-worklets-core.git#8b20145466186a369d13dd38e979642035a9bda1",
       "requires": {
         "string-hash-64": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "react-native-video": "6.19.1",
     "react-native-webrtc": "124.0.8",
     "react-native-webview": "13.16.0",
-    "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#02ef759e6555051949b68a0e5867d3114eae114a",
+    "react-native-worklets-core": "https://github.com/jitsi/react-native-worklets-core.git#8b20145466186a369d13dd38e979642035a9bda1",
     "react-native-youtube-iframe": "2.3.0",
     "react-redux": "7.2.9",
     "react-textarea-autosize": "8.3.0",


### PR DESCRIPTION
Fix for iOS 

RNWorklet::JsiWorkletContext map __erase_unique — EXC_BAD_ACCESS (KERN_INVALID_ADDRESS) 

repetitive crash.