### PR TITLE
test(multi-screen): fix flaky close-window guard in secondScreen spec

### DIFF
--- a/tests/specs/iframe/secondScreen.spec.ts
+++ b/tests/specs/iframe/secondScreen.spec.ts
@@ -178,11 +178,16 @@ describe('setSecondScreen iframe API command', () => {
         const changed = await p1.getIframeAPI().getEventResult('secondScreenSourceChanged');
 
         if (!changed) {
-            // No window was opened in this environment, which the previous test
-            // has already accounted for. Skip rather than return: headless
-            // cannot grant the window-management permission, so this would
-            // otherwise report green without ever touching the payload it is
-            // named for.
+            // secondScreenSourceChanged never fired, so no window was ever
+            // opened/registered in this environment. Skip rather than return:
+            // headless cannot grant the window-management permission, so this
+            // would otherwise report green without ever touching the payload
+            // it is named for.
+            //
+            // When changed is truthy the window may since have closed itself
+            // (see the next test) - that does not matter here, since this only
+            // checks the shape of the payload already recorded, not that a
+            // window is still open.
             // eslint-disable-next-line @typescript-eslint/no-invalid-this
             this.skip();
         }
@@ -196,17 +201,17 @@ describe('setSecondScreen iframe API command', () => {
     it('closes an open window and reports it', async function() {
         const { p1 } = ctx;
 
-        const changed = await p1.getIframeAPI().getEventResult('secondScreenSourceChanged');
-        const handles = await p1.driver.getWindowHandles();
-
-        if (!changed || handles.length === 1) {
-            // Nothing to close: either no window was opened in this environment
-            // (same reason as above), or it already closed itself asynchronously
-            // (e.g. a window-management-unavailable failure resolving shortly
-            // after secondScreenSourceChanged had already fired) before this
-            // test got a chance to close it. The cached event alone cannot tell
-            // the two apart from "still open", so the live handle count is
-            // checked too.
+        if ((await p1.driver.getWindowHandles()).length === 1) {
+            // Nothing to close: either no window was ever opened in this
+            // environment, or it already closed itself asynchronously (e.g. a
+            // window-management-unavailable failure resolving shortly after
+            // secondScreenSourceChanged had already fired) before this test
+            // got a chance to close it. The live handle count is the direct
+            // signal for "is there a window to close", unlike the cached event
+            // above, which stays truthy even once that window is long gone -
+            // that is what makes this a skip rather than a pass in practice on
+            // every environment CI runs today; see secondScreen.manual.md for
+            // the coverage that would otherwise exercise this path.
             // eslint-disable-next-line @typescript-eslint/no-invalid-this
             this.skip();
         }

--- a/tests/specs/iframe/secondScreen.spec.ts
+++ b/tests/specs/iframe/secondScreen.spec.ts
@@ -196,9 +196,17 @@ describe('setSecondScreen iframe API command', () => {
     it('closes an open window and reports it', async function() {
         const { p1 } = ctx;
 
-        if (!await p1.getIframeAPI().getEventResult('secondScreenSourceChanged')) {
-            // Nothing to close, for the same reason as above, and for the same
-            // reason it is a skip rather than a pass.
+        const changed = await p1.getIframeAPI().getEventResult('secondScreenSourceChanged');
+        const handles = await p1.driver.getWindowHandles();
+
+        if (!changed || handles.length === 1) {
+            // Nothing to close: either no window was opened in this environment
+            // (same reason as above), or it already closed itself asynchronously
+            // (e.g. a window-management-unavailable failure resolving shortly
+            // after secondScreenSourceChanged had already fired) before this
+            // test got a chance to close it. The cached event alone cannot tell
+            // the two apart from "still open", so the live handle count is
+            // checked too.
             // eslint-disable-next-line @typescript-eslint/no-invalid-this
             this.skip();
         }


### PR DESCRIPTION
## Summary
- CI run failed on `tests/specs/iframe/secondScreen.spec.ts` in the `closes an open window and reports it` test with `Error: secondScreenClosed was not received`.
- Root cause: #17666 registers the window handle and fires `secondScreenSourceChanged` (via `applySource`) as soon as the shell page loads, before the window-management placement permission is answered. In headless Chrome that permission rejects within milliseconds, tearing the window (and its redux entry) down again via the `window-management-unavailable` failure path almost immediately after `secondScreenSourceChanged` was recorded. `closes an open window and reports it` only checked that cached event to decide whether a window was still open, so it sent a close command for a window that was already gone; the middleware's `REMOVE_SECOND_SCREEN` handler correctly no-ops when there's no live handle, so `secondScreenClosed` never arrives and the test times out.
- This is a test premise invalidated by a legitimate ordering change in #17666, not a bug in the second-screen feature itself, and not a timing race in the usual flaky-test sense.

## Fix
- The skip-guard in `closes an open window and reports it` now checks the live browser window-handle count instead of the stale cached event, so the test correctly skips once the window has already closed itself. Following review feedback, the cached-event check was dropped entirely (the handle count is the direct, sufficient signal) and the neighboring test's misleading comment was corrected.
- Note: with this fix, `closes an open window and reports it` skips on every environment CI currently runs (headless Chrome always hits the fast permission rejection), same as before #17666 landed. The window-closes-and-reports-it path is covered by the manual checklist in `secondScreen.manual.md` instead.

## Test plan
- [x] `npx tsc` on the tests project shows no new errors for the changed file.
- [x] Reviewed and reproduced locally by @cosmintimis; confirmed the failure is deterministic (not flaky) and was affecting other open PRs against the same suite.