### PR TITLE
fix(base/popover): check contextMenuRef in outside click handler (#15559)

### DIFF
--- a/react/features/base/popover/components/Popover.web.tsx
+++ b/react/features/base/popover/components/Popover.web.tsx
@@ -238,8 +238,10 @@ class Popover extends Component<IProps, IState> {
      * @param {MouseEvent} e - The click event.
      * @returns {void}
      */
-    _onOutsideClick(e: React.MouseEvent) {
-        if (!this._containerRef?.current?.contains(e.target as Node) && this.props.visible) {
+    _onOutsideClick(e: MouseEvent) {
+        if (!this._containerRef?.current?.contains(e.target as Node)
+            && !this._contextMenuRef?.contains?.(e.target as Node)
+            && this.props.visible) {
             this._onHideDialog();
         }
     }


### PR DESCRIPTION
Fixes #15559

### Summary
Fixes an issue on iPad and touch browsers where tapping any item inside the toolbar "More Actions" (`...`) context menu caused the menu to immediately disappear without executing the item's action.

---

### 🔍 Cause
The context menu content is rendered via `DialogPortal` into `document.body` (referenced by `this._contextMenuRef`), which is outside the popover's trigger container (`this._containerRef`). 

While `_onOutsideTouchStart` correctly checked `!this._contextMenuRef?.contains?.(event.target)`, `_onOutsideClick` only checked `!this._containerRef?.current?.contains(e.target)`. When a menu item was clicked/tapped on iPad, the synthesized click bubbling to `window` was treated as an outside click, immediately dismissing the dialog before the action could be performed.

---

### 🛠️ Solution
Added `!this._contextMenuRef?.contains?.(e.target as Node)` to `_onOutsideClick` in `Popover.web.tsx` so clicks originating inside the portaled context menu are recognized as internal clicks.

---

### ✅ Verification
- Verified click event containment logic against portal reference `_contextMenuRef`.
- Ensured consistent behavior across touch and mouse event listeners.
