### PR TITLE
fix(av-moderation): send reject before mute request

### DIFF
--- a/react/features/av-moderation/actions.ts
+++ b/react/features/av-moderation/actions.ts
@@ -2,7 +2,7 @@ import { batch } from 'react-redux';
 
 import { IStore } from '../app/types';
 import { getConferenceState } from '../base/conference/functions';
-import { getParticipantById, isParticipantModerator } from '../base/participants/functions';
+import { getParticipantById } from '../base/participants/functions';
 import { IParticipant } from '../base/participants/types';
 
 import {
@@ -23,7 +23,7 @@ import {
     REQUEST_ENABLE_VIDEO_MODERATION
 } from './actionTypes';
 import { MEDIA_TYPE, type MediaType } from './constants';
-import { isEnabledFromState, isForceMuted } from './functions';
+import { canRejectParticipant, isEnabledFromState, isForceMuted } from './functions';
 
 /**
  * Action used by moderator to approve audio for a participant.
@@ -106,13 +106,9 @@ export const approveParticipant = (id: string) => (dispatch: IStore['dispatch'])
 export const rejectParticipantAudio = (id: string) => (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
     const state = getState();
     const { conference } = getConferenceState(state);
-    const audioModeration = isEnabledFromState(MEDIA_TYPE.AUDIO, state);
-
     const participant = getParticipantById(state, id);
-    const isAudioForceMuted = isForceMuted(participant, MEDIA_TYPE.AUDIO, state);
-    const isModerator = isParticipantModerator(participant);
 
-    if (audioModeration && !isAudioForceMuted && !isModerator) {
+    if (canRejectParticipant(participant, MEDIA_TYPE.AUDIO, state)) {
         conference?.avModerationReject(MEDIA_TYPE.AUDIO, id);
     }
 };
@@ -126,13 +122,9 @@ export const rejectParticipantAudio = (id: string) => (dispatch: IStore['dispatc
 export const rejectParticipantDesktop = (id: string) => (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
     const state = getState();
     const { conference } = getConferenceState(state);
-    const desktopModeration = isEnabledFromState(MEDIA_TYPE.DESKTOP, state);
-
     const participant = getParticipantById(state, id);
-    const isDesktopForceMuted = isForceMuted(participant, MEDIA_TYPE.DESKTOP, state);
-    const isModerator = isParticipantModerator(participant);
 
-    if (desktopModeration && !isDesktopForceMuted && !isModerator) {
+    if (canRejectParticipant(participant, MEDIA_TYPE.DESKTOP, state)) {
         conference?.avModerationReject(MEDIA_TYPE.DESKTOP, id);
     }
 };
@@ -146,13 +138,9 @@ export const rejectParticipantDesktop = (id: string) => (dispatch: IStore['dispa
 export const rejectParticipantVideo = (id: string) => (dispatch: IStore['dispatch'], getState: IStore['getState']) => {
     const state = getState();
     const { conference } = getConferenceState(state);
-    const videoModeration = isEnabledFromState(MEDIA_TYPE.VIDEO, state);
-
     const participant = getParticipantById(state, id);
-    const isVideoForceMuted = isForceMuted(participant, MEDIA_TYPE.VIDEO, state);
-    const isModerator = isParticipantModerator(participant);
 
-    if (videoModeration && !isVideoForceMuted && !isModerator) {
+    if (canRejectParticipant(participant, MEDIA_TYPE.VIDEO, state)) {
         conference?.avModerationReject(MEDIA_TYPE.VIDEO, id);
     }
 };

--- a/react/features/av-moderation/functions.ts
+++ b/react/features/av-moderation/functions.ts
@@ -157,6 +157,24 @@ export const shouldShowModeratedNotification = (mediaType: MediaType, state: IRe
     && !isLocalParticipantApprovedFromState(mediaType, state);
 
 /**
+ * Checks whether rejecting a participant for a media type has an effect. The mute state that a participant
+ * reports in presence is not used, because a participant can report a state that is not correct.
+ *
+ * @param {IParticipant|undefined} participant - The participant.
+ * @param {MediaType} mediaType - The media type.
+ * @param {IReduxState} state - The redux state.
+ * @returns {boolean}
+ */
+export function canRejectParticipant(participant: IParticipant | undefined, mediaType: MediaType,
+        state: IReduxState) {
+    // Moderators are never subject to A/V moderation, and a participant that is already force muted has nothing
+    // left to reject.
+    return isEnabledFromState(mediaType, state)
+        && !isParticipantModerator(participant)
+        && !isForceMuted(participant, mediaType, state);
+}
+
+/**
  * Checks if a participant is force muted.
  *
  * @param {IParticipant|undefined} participant - The participant.

--- a/react/features/participants-pane/components/web/ParticipantQuickAction.tsx
+++ b/react/features/participants-pane/components/web/ParticipantQuickAction.tsx
@@ -6,14 +6,11 @@ import { makeStyles } from 'tss-react/mui';
 import {
     approveParticipantAudio,
     approveParticipantDesktop,
-    approveParticipantVideo,
-    rejectParticipantAudio,
-    rejectParticipantDesktop,
-    rejectParticipantVideo
+    approveParticipantVideo
 } from '../../../av-moderation/actions';
 import { MEDIA_TYPE } from '../../../base/media/constants';
 import Button from '../../../base/ui/components/web/Button';
-import { muteRemote } from '../../../video-menu/actions.web';
+import { muteRemoteAndReject } from '../../../video-menu/actions.web';
 import { QUICK_ACTION_BUTTON } from '../../constants';
 
 interface IProps {
@@ -80,18 +77,15 @@ const ParticipantQuickAction = ({
     }, [ dispatch, participantID ]);
 
     const muteAudio = useCallback(() => {
-        dispatch(muteRemote(participantID, MEDIA_TYPE.AUDIO));
-        dispatch(rejectParticipantAudio(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.AUDIO));
     }, [ dispatch, participantID ]);
 
     const stopDesktop = useCallback(() => {
-        dispatch(muteRemote(participantID, MEDIA_TYPE.SCREENSHARE));
-        dispatch(rejectParticipantDesktop(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.SCREENSHARE));
     }, [ dispatch, participantID ]);
 
     const stopVideo = useCallback(() => {
-        dispatch(muteRemote(participantID, MEDIA_TYPE.VIDEO));
-        dispatch(rejectParticipantVideo(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.VIDEO));
     }, [ dispatch, participantID ]);
 
     switch (buttonType) {

--- a/react/features/participants-pane/functions.ts
+++ b/react/features/participants-pane/functions.ts
@@ -1,6 +1,7 @@
 import { IReduxState } from '../app/types';
 import { MEDIA_TYPE as AVM_MEDIA_TYPE } from '../av-moderation/constants';
 import {
+    canRejectParticipant,
     isForceMuted,
     isSupported
 } from '../av-moderation/functions';
@@ -130,9 +131,13 @@ export function getQuickActionButtonType(participant: IParticipant | undefined, 
     const isVideoMuted = isParticipantVideoMuted(participant, state);
     const isDesktopForceMuted = isForceMuted(participant, AVM_MEDIA_TYPE.DESKTOP, state);
     const isVideoForceMuted = isForceMuted(participant, AVM_MEDIA_TYPE.VIDEO, state);
+    const canRejectAudio = canRejectParticipant(participant, AVM_MEDIA_TYPE.AUDIO, state);
     const isParticipantSilent = participant?.isSilent ?? false;
 
-    if (!isAudioMuted && !isParticipantSilent) {
+    // The mute state that a participant reports can be incorrect. If the participant can be removed from the A/V
+    // moderation whitelist, keep the mute action available, because it is the action that mutes the participant on
+    // the bridge.
+    if ((!isAudioMuted || canRejectAudio) && !isParticipantSilent) {
         return QUICK_ACTION_BUTTON.MUTE;
     }
 

--- a/react/features/video-menu/actions.any.ts
+++ b/react/features/video-menu/actions.any.ts
@@ -77,6 +77,33 @@ export function muteRemote(participantId: string, mediaType: MediaType) {
 }
 
 /**
+ * Mutes the remote participant with the given ID, and removes it from the A/V moderation whitelist.
+ *
+ * The order of the two operations is important. Jicofo mutes a participant on the bridge only if the participant
+ * is not allowed to unmute when jicofo receives the mute request. Jicofo does not calculate the mute state again
+ * when the whitelist changes. If the mute request is sent first, the participant is still on the whitelist, thus
+ * jicofo only forwards the mute request to the participant. A participant that does not obey the mute request
+ * continues to send media until the moderator mutes it a second time.
+ *
+ * @param {string} participantId - ID of the participant to mute.
+ * @param {MEDIA_TYPE} mediaType - The type of the media channel to mute.
+ * @returns {Function}
+ */
+export function muteRemoteAndReject(participantId: string, mediaType: MediaType) {
+    return (dispatch: IStore['dispatch']) => {
+        if (mediaType === MEDIA_TYPE.AUDIO) {
+            dispatch(rejectParticipantAudio(participantId));
+        } else if (mediaType === MEDIA_TYPE.VIDEO) {
+            dispatch(rejectParticipantVideo(participantId));
+        } else if (mediaType === MEDIA_TYPE.SCREENSHARE) {
+            dispatch(rejectParticipantDesktop(participantId));
+        }
+
+        dispatch(muteRemote(participantId, mediaType));
+    };
+}
+
+/**
  * Mutes all participants.
  *
  * @param {Array<string>} exclude - Array of participant IDs to not mute.
@@ -92,14 +119,7 @@ export function muteAllParticipants(exclude: Array<string>, mediaType: MediaType
                 return;
             }
 
-            dispatch(muteRemote(id, mediaType));
-            if (mediaType === MEDIA_TYPE.AUDIO) {
-                dispatch(rejectParticipantAudio(id));
-            } else if (mediaType === MEDIA_TYPE.VIDEO) {
-                dispatch(rejectParticipantVideo(id));
-            } else if (mediaType === MEDIA_TYPE.SCREENSHARE) {
-                dispatch(rejectParticipantDesktop(id));
-            }
+            dispatch(muteRemoteAndReject(id, mediaType));
         });
     };
 }

--- a/react/features/video-menu/components/AbstractMuteButton.ts
+++ b/react/features/video-menu/components/AbstractMuteButton.ts
@@ -1,12 +1,14 @@
 import { createRemoteVideoMenuButtonEvent } from '../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../analytics/functions';
 import { IReduxState } from '../../app/types';
-import { rejectParticipantAudio } from '../../av-moderation/actions';
+import { MEDIA_TYPE as AVM_MEDIA_TYPE } from '../../av-moderation/constants';
+import { canRejectParticipant } from '../../av-moderation/functions';
 import { IconMicSlash } from '../../base/icons/svg';
 import { MEDIA_TYPE } from '../../base/media/constants';
+import { getParticipantById } from '../../base/participants/functions';
 import AbstractButton, { IProps as AbstractButtonProps } from '../../base/toolbox/components/AbstractButton';
 import { isRemoteTrackMuted } from '../../base/tracks/functions.any';
-import { muteRemote } from '../actions.any';
+import { muteRemoteAndReject } from '../actions.any';
 
 export interface IProps extends AbstractButtonProps {
 
@@ -15,6 +17,11 @@ export interface IProps extends AbstractButtonProps {
      * not.
      */
     _audioTrackMuted: boolean;
+
+    /**
+     * Boolean to indicate if the participant can be removed from the A/V moderation whitelist.
+     */
+    _canReject: boolean;
 
     /**
      * The ID of the participant object that this button is supposed to
@@ -47,8 +54,7 @@ export default class AbstractMuteButton extends AbstractButton<IProps> {
                 'participant_id': participantID
             }));
 
-        dispatch(muteRemote(participantID, MEDIA_TYPE.AUDIO));
-        dispatch(rejectParticipantAudio(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.AUDIO));
     }
 
     /**
@@ -57,7 +63,7 @@ export default class AbstractMuteButton extends AbstractButton<IProps> {
      * @inheritdoc
      */
     override _isDisabled() {
-        return this.props._audioTrackMuted;
+        return this._isMuted();
     }
 
     /**
@@ -66,7 +72,19 @@ export default class AbstractMuteButton extends AbstractButton<IProps> {
      * @inheritdoc
      */
     override _isToggled() {
-        return this.props._audioTrackMuted;
+        return this._isMuted();
+    }
+
+    /**
+     * Tells if the participant must be shown as muted. A participant that can be removed from the A/V moderation
+     * whitelist is not shown as muted, because the mute state that the participant reports can be incorrect. The
+     * moderator must be able to mute the participant on the bridge.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _isMuted() {
+        return this.props._audioTrackMuted && !this.props._canReject;
     }
 }
 
@@ -77,14 +95,17 @@ export default class AbstractMuteButton extends AbstractButton<IProps> {
  * @param {Object} ownProps - Properties of component.
  * @private
  * @returns {{
- *      _audioTrackMuted: boolean
+ *      _audioTrackMuted: boolean,
+ *      _canReject: boolean
  *  }}
  */
 export function _mapStateToProps(state: IReduxState, ownProps: any) {
     const tracks = state['features/base/tracks'];
+    const participant = getParticipantById(state, ownProps.participantID);
 
     return {
         _audioTrackMuted: isRemoteTrackMuted(
-            tracks, MEDIA_TYPE.AUDIO, ownProps.participantID)
+            tracks, MEDIA_TYPE.AUDIO, ownProps.participantID),
+        _canReject: canRejectParticipant(participant, AVM_MEDIA_TYPE.AUDIO, state)
     };
 }

--- a/react/features/video-menu/components/AbstractMuteEveryoneDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteEveryoneDialog.ts
@@ -90,12 +90,18 @@ export default class AbstractMuteEveryoneDialog<P extends IProps> extends Compon
             exclude
         } = this.props;
 
-        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.AUDIO));
+        // Change the moderation state before the participants are muted. Jicofo mutes a participant on the bridge
+        // only if the participant is not allowed to unmute when jicofo receives the mute request. If the mute
+        // requests are sent first, jicofo does not know yet that moderation is enabled, thus it only forwards the
+        // mute requests to the participants. A participant that does not obey the mute request continues to send
+        // audio until the moderator mutes it a second time.
         if (this.state.audioModerationEnabled) {
             dispatch(requestEnableAudioModeration());
         } else if (this.state.audioModerationEnabled !== undefined) {
             dispatch(requestDisableAudioModeration());
         }
+
+        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.AUDIO));
 
         return true;
     }

--- a/react/features/video-menu/components/AbstractMuteEveryonesDesktopDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteEveryonesDesktopDialog.ts
@@ -90,12 +90,15 @@ export default class AbstractMuteEveryonesDesktopDialog<P extends IProps>
             exclude
         } = this.props;
 
-        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.SCREENSHARE));
+        // Change the moderation state before the participants are muted. See AbstractMuteEveryoneDialog for the
+        // reason.
         if (this.state.moderationEnabled) {
             dispatch(requestEnableDesktopModeration());
         } else if (this.state.moderationEnabled !== undefined) {
             dispatch(requestDisableDesktopModeration());
         }
+
+        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.SCREENSHARE));
 
         return true;
     }

--- a/react/features/video-menu/components/AbstractMuteEveryonesVideoDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteEveryonesVideoDialog.ts
@@ -90,12 +90,15 @@ export default class AbstractMuteEveryonesVideoDialog<P extends IProps>
             exclude
         } = this.props;
 
-        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.VIDEO));
+        // Change the moderation state before the participants are muted. See AbstractMuteEveryoneDialog for the
+        // reason.
         if (this.state.moderationEnabled) {
             dispatch(requestEnableVideoModeration());
         } else if (this.state.moderationEnabled !== undefined) {
             dispatch(requestDisableVideoModeration());
         }
+
+        dispatch(muteAllParticipants(exclude, MEDIA_TYPE.VIDEO));
 
         return true;
     }

--- a/react/features/video-menu/components/AbstractMuteRemoteParticipantsDesktopDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteRemoteParticipantsDesktopDialog.ts
@@ -2,11 +2,10 @@ import { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
 
 import { IReduxState, IStore } from '../../app/types';
-import { rejectParticipantDesktop } from '../../av-moderation/actions';
 import { MEDIA_TYPE as AVM_MEDIA_TYPE } from '../../av-moderation/constants';
 import { isEnabledFromState } from '../../av-moderation/functions';
 import { MEDIA_TYPE } from '../../base/media/constants';
-import { muteRemote } from '../actions';
+import { muteRemoteAndReject } from '../actions';
 
 /**
  * The type of the React {@code Component} props of
@@ -59,8 +58,7 @@ export default class AbstractMuteRemoteParticipantsDesktopDialog<P extends IProp
     _onSubmit() {
         const { dispatch, participantID } = this.props;
 
-        dispatch(muteRemote(participantID, MEDIA_TYPE.SCREENSHARE));
-        dispatch(rejectParticipantDesktop(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.SCREENSHARE));
 
         return true;
     }

--- a/react/features/video-menu/components/AbstractMuteRemoteParticipantsVideoDialog.ts
+++ b/react/features/video-menu/components/AbstractMuteRemoteParticipantsVideoDialog.ts
@@ -2,11 +2,10 @@ import { Component } from 'react';
 import { WithTranslation } from 'react-i18next';
 
 import { IReduxState, IStore } from '../../app/types';
-import { rejectParticipantVideo } from '../../av-moderation/actions';
 import { MEDIA_TYPE as AVM_MEDIA_TYPE } from '../../av-moderation/constants';
 import { isEnabledFromState } from '../../av-moderation/functions';
 import { MEDIA_TYPE } from '../../base/media/constants';
-import { muteRemote } from '../actions';
+import { muteRemoteAndReject } from '../actions';
 
 /**
  * The type of the React {@code Component} props of
@@ -59,8 +58,7 @@ export default class AbstractMuteRemoteParticipantsVideoDialog<P extends IProps 
     _onSubmit() {
         const { dispatch, participantID } = this.props;
 
-        dispatch(muteRemote(participantID, MEDIA_TYPE.VIDEO));
-        dispatch(rejectParticipantVideo(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.VIDEO));
 
         return true;
     }

--- a/react/features/video-menu/components/web/MuteButton.tsx
+++ b/react/features/video-menu/components/web/MuteButton.tsx
@@ -5,13 +5,15 @@ import { useDispatch, useSelector } from 'react-redux';
 import { createRemoteVideoMenuButtonEvent } from '../../../analytics/AnalyticsEvents';
 import { sendAnalytics } from '../../../analytics/functions';
 import { IReduxState } from '../../../app/types';
-import { rejectParticipantAudio } from '../../../av-moderation/actions';
+import { MEDIA_TYPE as AVM_MEDIA_TYPE } from '../../../av-moderation/constants';
+import { canRejectParticipant } from '../../../av-moderation/functions';
 import { IconMicSlash } from '../../../base/icons/svg';
 import { MEDIA_TYPE } from '../../../base/media/constants';
+import { getParticipantById } from '../../../base/participants/functions';
 import { isRemoteTrackMuted } from '../../../base/tracks/functions.any';
 import ContextMenuItem from '../../../base/ui/components/web/ContextMenuItem';
 import { NOTIFY_CLICK_MODE } from '../../../toolbox/types';
-import { muteRemote } from '../../actions.any';
+import { muteRemoteAndReject } from '../../actions.any';
 import { IButtonProps } from '../../types';
 
 /**
@@ -33,6 +35,12 @@ const MuteButton = ({
         [ isRemoteTrackMuted, participantID, tracks ]
     );
 
+    // The mute state that a participant reports can be incorrect. If the participant can be removed from the A/V
+    // moderation whitelist, keep the mute action available, because it is the action that mutes the participant on
+    // the bridge.
+    const canReject = useSelector((state: IReduxState) =>
+        canRejectParticipant(getParticipantById(state, participantID), AVM_MEDIA_TYPE.AUDIO, state));
+
     const handleClick = useCallback(() => {
         notifyClick?.();
         if (notifyMode === NOTIFY_CLICK_MODE.PREVENT_AND_NOTIFY) {
@@ -44,11 +52,10 @@ const MuteButton = ({
                 'participant_id': participantID
             }));
 
-        dispatch(muteRemote(participantID, MEDIA_TYPE.AUDIO));
-        dispatch(rejectParticipantAudio(participantID));
+        dispatch(muteRemoteAndReject(participantID, MEDIA_TYPE.AUDIO));
     }, [ dispatch, notifyClick, notifyMode, participantID, sendAnalytics ]);
 
-    if (audioTrackMuted) {
+    if (audioTrackMuted && !canReject) {
         return null;
     }
 

--- a/tests/pageobjects/ParticipantsPane.ts
+++ b/tests/pageobjects/ParticipantsPane.ts
@@ -274,6 +274,18 @@ export default class ParticipantsPane extends BasePageObject {
     }
 
     /**
+     * Waits for the mute audio action of a participant to be available.
+     * @param participant
+     */
+    async waitForMuteAudioAction(participant: Participant) {
+        const participantId = await participant.getEndpointId();
+
+        await this.participant.driver.$(`#participant-item-${participantId}`).moveTo();
+
+        await this.participant.driver.$(`button[data-testid="mute-audio-${participantId}"]`).waitForDisplayed();
+    }
+
+    /**
      * Mutes the audio of a participant.
      * @param participant
      */

--- a/tests/pageobjects/ParticipantsPane.ts
+++ b/tests/pageobjects/ParticipantsPane.ts
@@ -278,6 +278,10 @@ export default class ParticipantsPane extends BasePageObject {
      * @param participant
      */
     async waitForMuteAudioAction(participant: Participant) {
+        if (!await this.isOpen()) {
+            await this.open();
+        }
+
         const participantId = await participant.getEndpointId();
 
         await this.participant.driver.$(`#participant-item-${participantId}`).moveTo();

--- a/tests/specs/media/audioVideoModeration.spec.ts
+++ b/tests/specs/media/audioVideoModeration.spec.ts
@@ -247,7 +247,6 @@ describe('Audio/video moderation', () => {
         await p2.getToolbar().clickAudioMuteButton();
         await p1.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
 
-        await p1ParticipantsPane.open();
         await p1ParticipantsPane.waitForMuteAudioAction(p2);
         await p1ParticipantsPane.muteAudio(p2);
         await p1ParticipantsPane.close();

--- a/tests/specs/media/audioVideoModeration.spec.ts
+++ b/tests/specs/media/audioVideoModeration.spec.ts
@@ -231,6 +231,35 @@ describe('Audio/video moderation', () => {
 
         await tryToAudioUnmuteAndCheck(p2, p1);
     });
+    it('mute a participant that reports muted', async () => {
+        await hangupAllParticipants();
+
+        await ensureTwoParticipants();
+
+        const { p1, p2 } = ctx;
+        const p1ParticipantsPane = p1.getParticipantsPane();
+
+        // Enable moderation and let p2 unmute. This puts p2 on the whitelist.
+        await unmuteByModerator(p1, p2, true, false);
+
+        // p2 mutes itself. The mute state that p2 reports is not reliable, thus p1 must keep the mute action. The
+        // mute action is the action that removes p2 from the whitelist and mutes p2 on the bridge.
+        await p2.getToolbar().clickAudioMuteButton();
+        await p1.getFilmstrip().assertAudioMuteIconIsDisplayed(p2);
+
+        await p1ParticipantsPane.open();
+        await p1ParticipantsPane.waitForMuteAudioAction(p2);
+        await p1ParticipantsPane.muteAudio(p2);
+        await p1ParticipantsPane.close();
+
+        // p2 is not on the whitelist any more, thus p2 cannot unmute.
+        await tryToAudioUnmuteAndCheck(p2, p1);
+
+        await p1ParticipantsPane.clickContextMenuButton();
+        await p1ParticipantsPane.getAVModerationMenu().clickStopAudioModeration();
+        await p1ParticipantsPane.getAVModerationMenu().clickStopVideoModeration();
+        await p1ParticipantsPane.close();
+    });
 });
 
 /**


### PR DESCRIPTION
Jicofo mutes a participant on the bridge only if the participant is not allowed to unmute when jicofo receives the mute request. Jicofo does not calculate the mute state again when the moderation whitelist changes.

The client sent the mute request before it removed the participant from the A/V moderation whitelist. Jicofo received the mute request while the participant was still on the whitelist, thus it only forwarded the mute request to the participant. A participant that does not obey the mute request continued to send audio until the moderator muted it a second time.

## Changes

- New `muteRemoteAndReject` action. It sends the reject first, then the mute request. It keeps the order in one place, for all mute actions: mute all, the participants pane quick action, the web and native context menu, and the video and desktop dialogs.
- The mute-everyone dialogs change the moderation state before they mute the participants, for the same reason.
- New `canRejectParticipant` function. The moderator UI used the mute state that a participant reports in presence to hide the mute action. A participant can report a state that is not correct, which removed the only action that mutes the participant on the bridge. The mute action now stays available while the participant can be removed from the whitelist. The three reject actions use the same function, thus the action is shown only when it has an effect.
- New test in `audioVideoModeration.spec.ts`. A participant mutes itself while it is on the whitelist. The moderator must keep the mute action, and the participant cannot unmute after the moderator uses it.

## Remaining work

The order now depends on the order of the stanzas that jicofo receives. A full guarantee needs a change in jicofo: recalculate the bridge mute state when a whitelist change makes a participant not allowed to unmute.
