### PR TITLE
test(codec-selection): expect VP9 from Firefox 151+

### DIFF
--- a/tests/specs/media/codecSelection.spec.ts
+++ b/tests/specs/media/codecSelection.spec.ts
@@ -37,8 +37,8 @@ describe('Codec selection', () => {
         expect(await p2.execute(() => JitsiMeetJS.app.testing.isLargeVideoReceived())).toBe(true);
 
         // Check if p1 is sending VP9 and p2 is sending VP8 as per their codec preferences.
-        // Except on Firefox because it doesn't support VP9 encode.
-        const p1ExpectedCodec = p1.driver.isFirefox ? VP8 : VP9;
+        // Except on older versions of Firefox because they don't support VP9 encode.
+        const p1ExpectedCodec = supportsVp9Encode(p1) ? VP9 : VP8;
 
         await Promise.all([
             waitForCodec(p1, p1ExpectedCodec),
@@ -62,8 +62,8 @@ describe('Codec selection', () => {
         const majorVersion = parseInt(p1.driver.capabilities.browserVersion || '0', 10);
 
         // Check if p1 is encoding in VP9, p2 in VP8 and p3 in AV1 as per their codec preferences.
-        // Except on Firefox because it doesn't support VP9 encode.
-        const p1ExpectedCodec = p1.driver.isFirefox ? VP8 : VP9;
+        // Except on older versions of Firefox because they don't support VP9 encode.
+        const p1ExpectedCodec = supportsVp9Encode(p1) ? VP9 : VP8;
         const p3ExpectedCodec = (p1.driver.isFirefox && majorVersion < 136) ? VP9 : AV1;
 
         await Promise.all([
@@ -126,7 +126,21 @@ async function waitForCodec(p: Participant, codec: string) {
         () => p.execute(c => JitsiMeetJS.app.testing.getLocalCameraEncoding() === c, codec),
         {
             timeout: 10000,
-            timeoutMsg: `${p.name} failed to use VP8`
+            timeoutMsg: `${p.name} failed to use ${codec}`
         }
     );
+}
+
+/**
+ * Whether the given participant's browser is able to encode VP9. Firefox only supports VP9 encode on version 151 and
+ * above, see https://bugzilla.mozilla.org/show_bug.cgi?id=1633876.
+ *
+ * @param p The participant.
+ */
+function supportsVp9Encode(p: Participant) {
+    if (!p.driver.isFirefox) {
+        return true;
+    }
+
+    return parseInt(p.driver.capabilities.browserVersion || '0', 10) >= 151;
 }


### PR DESCRIPTION
## Problem

After the Selenium grid was updated to Firefox 154, `Codec selection > asymmetric codecs` started failing on **every** ff-chrome run with:

```
Error: p1 failed to use VP8
    at async waitForCodec (tests/specs/media/codecSelection.spec.ts:125:5)
```

Firefox supports VP9 encode from version 151 onwards ([bug 1633876](https://bugzilla.mozilla.org/show_bug.cgi?id=1633876)), which lib-jitsi-meet picks up in `BrowserCapabilities.supportsVP9()`. VP9 is therefore no longer pushed to the bottom of the codec preference order for Firefox:

```
User Agent: ... rv:154.0 Gecko/20100101 Firefox/154.0
[qc:CodecSelection] Codec preference order for jvb connection is vp9,vp8,h264,av1
```

p1 now legitimately encodes VP9, but the spec unconditionally expected VP8 on Firefox.

## Changes

- Gate the expected p1 codec on the Firefox major version (`>= 151` → VP9) in both `asymmetric codecs` and `asymmetric codecs with AV1`, via a small `supportsVp9Encode()` helper that mirrors the lib-jitsi-meet capability check.
- Interpolate the codec into the `waitForCodec` timeout message. It hardcoded `VP8`, which made a VP9 mismatch read as a VP8 failure and sent the investigation down the wrong path.

## Notes

- `codec switch over` still returns early on Firefox. That skip is arguably unnecessary now too, but enabling it would exercise Firefox VP9 simulcast switching for the first time, so I left it out of this change.
- This does **not** address the second consistent ff-chrome failure, `Mute > mute before join and screen share after in p2p`. That one has the same trigger (Firefox now encoding VP9, on the p2p connection) but is a genuine media issue rather than a stale expectation: Chrome receives RTP from Firefox while decoding zero frames (`remote video not decoding detected: ssrc=...` fires only when `bitrateDownload > 0 && framesPerSecond === 0`, followed by a stats-based freeze), so p1 renders as an avatar on p2. Tracking separately.