### PR TITLE
test(media) check that remote video is actually decoded after unmute

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -536,6 +536,26 @@ export class Participant {
     }
 
     /**
+     * Waits until the stats report a positive framerate for the video of the given remote endpoint, which means that
+     * frames from that endpoint are actually being decoded. Receiving data is not enough on its own, when the sender
+     * uses a payload type that was not negotiated the packets are received but not a single frame gets decoded.
+     *
+     * @param {string} endpointId - The endpoint ID of the participant whose video should be decoded.
+     * @param {number} timeout - Max time to wait in ms.
+     * @returns {Promise<boolean>}
+     */
+    async waitForRemoteVideoDecoding(endpointId: string, timeout = 15_000): Promise<boolean> {
+        return this.driver.waitUntil(() => this.execute(id => {
+            const framerates: { [ssrc: string]: number; } = APP?.conference?.getStats()?.framerate?.[id] ?? {};
+
+            return Object.values(framerates).some(fps => fps > 0);
+        }, endpointId), {
+            timeout,
+            timeoutMsg: `expected video of ${endpointId} to be decoded in ${timeout / 1000}s by ${this.name}`
+        });
+    }
+
+    /**
      * Waits until there are at least [number] participants that have at least one track.
      *
      * @param {number} number - The number of remote streams to wait for.

--- a/tests/specs/media/mute.spec.ts
+++ b/tests/specs/media/mute.spec.ts
@@ -142,4 +142,5 @@ async function muteP1BeforeP2JoinsAndScreenshare(p2p: boolean) {
     await p2.getParticipantsPane().assertVideoMuteIconIsDisplayed(p1);
     await unmuteVideoAndCheck(p1, p2);
     await p2.waitForRemoteVideo(await p1.getEndpointId());
+    await p2.waitForRemoteVideoDecoding(await p1.getEndpointId());
 }

--- a/tests/specs/media/stopVideo.spec.ts
+++ b/tests/specs/media/stopVideo.spec.ts
@@ -1,3 +1,4 @@
+import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { ensureTwoParticipants } from '../../helpers/participants';
 import { muteVideoAndCheck, unmuteVideoAndCheck } from '../helpers/mute';
@@ -11,7 +12,7 @@ describe('Stop video', () => {
 
     it('stop video and check', () => muteVideoAndCheck(ctx.p1, ctx.p2));
 
-    it('start video and check', () => unmuteVideoAndCheck(ctx.p1, ctx.p2));
+    it('start video and check', () => unmuteVideoAndCheckMedia(ctx.p1, ctx.p2));
 
     it('start video and check stream', async () => {
         await muteVideoAndCheck(ctx.p1, ctx.p2);
@@ -19,7 +20,7 @@ describe('Stop video', () => {
         // now participant2 should be on large video
         const largeVideoId = await ctx.p1.getLargeVideo().getId();
 
-        await unmuteVideoAndCheck(ctx.p1, ctx.p2);
+        await unmuteVideoAndCheckMedia(ctx.p1, ctx.p2);
 
         // check if video stream from second participant is still on large video
         expect(largeVideoId).toBe(await ctx.p1.getLargeVideo().getId());
@@ -27,7 +28,7 @@ describe('Stop video', () => {
 
     it('stop video on participant and check', () => muteVideoAndCheck(ctx.p2, ctx.p1));
 
-    it('start video on participant and check', () => unmuteVideoAndCheck(ctx.p2, ctx.p1));
+    it('start video on participant and check', () => unmuteVideoAndCheckMedia(ctx.p2, ctx.p1));
 
     it('stop video on before second joins', async () => {
         await ctx.p2.hangup();
@@ -42,6 +43,19 @@ describe('Stop video', () => {
 
         await p2.getParticipantsPane().assertVideoMuteIconIsDisplayed(p1);
 
-        await unmuteVideoAndCheck(p1, p2);
+        await unmuteVideoAndCheckMedia(p1, p2);
     });
 });
+
+/**
+ * Unmutes the video of testee and checks that observer sees it unmuted and that observer is decoding frames from it.
+ * The mute state alone is signalled over the presence, seeing it does not mean that any media is being received.
+ *
+ * @param testee The participant that unmutes its video.
+ * @param observer The participant that should receive and decode the video of testee.
+ */
+async function unmuteVideoAndCheckMedia(testee: Participant, observer: Participant): Promise<void> {
+    await unmuteVideoAndCheck(testee, observer);
+
+    await observer.waitForRemoteVideoDecoding(await testee.getEndpointId());
+}


### PR DESCRIPTION
### What

Adds `Participant.waitForRemoteVideoDecoding(endpointId)`, which waits until the stats report a positive framerate for a remote endpoint's video, and uses it after a camera unmute in `stopVideo.spec.ts` and in the p2p/jvb screenshare flow of `mute.spec.ts`.

### Why

`Mute › mute before join and screen share after in p2p` failed on the Firefox grid with `expected remote video for <id> to be received 15s by p2`. Firefox 154 was sending VP9 with a payload type that the munged SDP had removed, so Chrome received every packet and decoded nothing — fixed in https://github.com/jitsi/lib-jitsi-meet/pull/3095.

The interesting part for the tests is that almost nothing caught it:

* `ensureTwoParticipants` → `waitForSendReceiveData` only checks that the **bitrate** is positive, and it was (500 packets, 201 kB received, `framesDecoded: 0`).
* `unmuteVideoAndCheck` only checks the mute **icon**, which comes from the presence.
* `codecSelection.spec` checks `getLocalCameraEncoding()`, i.e. the **sender's** codec.

So a receiver that cannot decode a single frame looked healthy everywhere except the one assertion that happens to wait long enough for freeze detection to kick in. This adds an explicit check for the thing these specs are actually about: the observer receives *and decodes* the video.

The check reads `APP.conference.getStats().framerate[endpointId]`, which lib-jitsi-meet only populates for inbound streams whose framerate is above zero, and both Chrome and Firefox report `framesPerSecond` for inbound video.

### Notes

* It is deliberately not added to the shared `unmuteVideoAndCheck` helper: that one is also used in 3-4 participant specs where receive-side constraints decide which sources are being forwarded, so the invariant does not hold unconditionally there. Broadening it can be a follow-up.
* No decoding check was added around the screenshare tile in `mute.spec.ts` even though it is a false pass today for the same reason — a static desktop share produces close to no frames, so a framerate based check would be flaky there.

### Testing

`eslint` and `tsc --project tests/tsconfig.json` are clean for the touched files (the remaining `tests/` type errors are pre-existing). The specs themselves need a deployment, so they have not been run locally — Jenkins should exercise them on both grids, and the Firefox grid is expected to keep failing `mute.spec` until lib-jitsi-meet#3095 is merged and picked up.
