### PR TITLE
test(media) check that remote video is actually decoded after unmute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "js-md5": "0.6.1",
         "js-sha512": "0.8.0",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2194.0.0+2d91ec2a/lib-jitsi-meet.tgz",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2195.0.0+48c54c20/lib-jitsi-meet.tgz",
         "lodash-es": "4.18.1",
         "null-loader": "4.0.1",
         "optional-require": "1.0.3",
@@ -7590,9 +7590,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7610,9 +7607,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7630,9 +7624,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7650,9 +7641,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7670,9 +7658,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7690,9 +7675,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -18872,8 +18854,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2194.0.0+2d91ec2a/lib-jitsi-meet.tgz",
-      "integrity": "sha512-Ds+CILnqUfLY3nnj/7N0QrN5b5Y82ulL54avsYGnCAx0w98YVtqfN0yX3x32aCEx2SwCe4ahak4Ryc1+wDgdzw==",
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2195.0.0+48c54c20/lib-jitsi-meet.tgz",
+      "integrity": "sha512-NNvpAwvZ81jk619pZpMAlxSCwxN5TVpygFfj7UFrOt/gXCGLqOzgaKtbiO/HEunKeKilFFRRF6y9k7T9yg1BkQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "6.3.2",
@@ -40775,8 +40757,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2194.0.0+2d91ec2a/lib-jitsi-meet.tgz",
-      "integrity": "sha512-Ds+CILnqUfLY3nnj/7N0QrN5b5Y82ulL54avsYGnCAx0w98YVtqfN0yX3x32aCEx2SwCe4ahak4Ryc1+wDgdzw==",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2195.0.0+48c54c20/lib-jitsi-meet.tgz",
+      "integrity": "sha512-NNvpAwvZ81jk619pZpMAlxSCwxN5TVpygFfj7UFrOt/gXCGLqOzgaKtbiO/HEunKeKilFFRRF6y9k7T9yg1BkQ==",
       "requires": {
         "@jitsi/js-utils": "6.3.2",
         "@jitsi/logger": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "js-md5": "0.6.1",
     "js-sha512": "0.8.0",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2194.0.0+2d91ec2a/lib-jitsi-meet.tgz",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2195.0.0+48c54c20/lib-jitsi-meet.tgz",
     "lodash-es": "4.18.1",
     "null-loader": "4.0.1",
     "optional-require": "1.0.3",

--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -536,6 +536,26 @@ export class Participant {
     }
 
     /**
+     * Waits until the stats report a positive framerate for the video of the given remote endpoint, which means that
+     * frames from that endpoint are actually being decoded. Receiving data is not enough on its own, when the sender
+     * uses a payload type that was not negotiated the packets are received but not a single frame gets decoded.
+     *
+     * @param {string} endpointId - The endpoint ID of the participant whose video should be decoded.
+     * @param {number} timeout - Max time to wait in ms.
+     * @returns {Promise<boolean>}
+     */
+    async waitForRemoteVideoDecoding(endpointId: string, timeout = 15_000): Promise<boolean> {
+        return this.driver.waitUntil(() => this.execute(id => {
+            const framerates: { [ssrc: string]: number; } = APP?.conference?.getStats()?.framerate?.[id] ?? {};
+
+            return Object.values(framerates).some(fps => fps > 0);
+        }, endpointId), {
+            timeout,
+            timeoutMsg: `expected video of ${endpointId} to be decoded in ${timeout / 1000}s by ${this.name}`
+        });
+    }
+
+    /**
      * Waits until there are at least [number] participants that have at least one track.
      *
      * @param {number} number - The number of remote streams to wait for.

--- a/tests/pageobjects/Notifications.ts
+++ b/tests/pageobjects/Notifications.ts
@@ -78,7 +78,7 @@ export default class Notifications extends BasePageObject {
     dismissAnyJoinNotification() {
         return Promise.allSettled(
             [ `${JOIN_ONE_TEST_ID}-dismiss`, `${JOIN_TWO_TEST_ID}-dismiss`, `${JOIN_MULTIPLE_TEST_ID}-dismiss` ]
-                .map(id => this.participant.driver.$(`[data-testid="${id}"]`).click()));
+                .map(id => this.participant.driver.$(`#${id}"]`).click()));
     }
 
     /**

--- a/tests/pageobjects/Notifications.ts
+++ b/tests/pageobjects/Notifications.ts
@@ -78,7 +78,7 @@ export default class Notifications extends BasePageObject {
     dismissAnyJoinNotification() {
         return Promise.allSettled(
             [ `${JOIN_ONE_TEST_ID}-dismiss`, `${JOIN_TWO_TEST_ID}-dismiss`, `${JOIN_MULTIPLE_TEST_ID}-dismiss` ]
-                .map(id => this.participant.driver.$(`#${id}"]`).click()));
+                .map(id => this.participant.driver.$(`[data-testid="${id}"]`).click()));
     }
 
     /**

--- a/tests/specs/media/mute.spec.ts
+++ b/tests/specs/media/mute.spec.ts
@@ -142,4 +142,5 @@ async function muteP1BeforeP2JoinsAndScreenshare(p2p: boolean) {
     await p2.getParticipantsPane().assertVideoMuteIconIsDisplayed(p1);
     await unmuteVideoAndCheck(p1, p2);
     await p2.waitForRemoteVideo(await p1.getEndpointId());
+    await p2.waitForRemoteVideoDecoding(await p1.getEndpointId());
 }

--- a/tests/specs/media/stopVideo.spec.ts
+++ b/tests/specs/media/stopVideo.spec.ts
@@ -1,3 +1,4 @@
+import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { ensureTwoParticipants } from '../../helpers/participants';
 import { muteVideoAndCheck, unmuteVideoAndCheck } from '../helpers/mute';
@@ -11,7 +12,7 @@ describe('Stop video', () => {
 
     it('stop video and check', () => muteVideoAndCheck(ctx.p1, ctx.p2));
 
-    it('start video and check', () => unmuteVideoAndCheck(ctx.p1, ctx.p2));
+    it('start video and check', () => unmuteVideoAndCheckMedia(ctx.p1, ctx.p2));
 
     it('start video and check stream', async () => {
         await muteVideoAndCheck(ctx.p1, ctx.p2);
@@ -19,7 +20,7 @@ describe('Stop video', () => {
         // now participant2 should be on large video
         const largeVideoId = await ctx.p1.getLargeVideo().getId();
 
-        await unmuteVideoAndCheck(ctx.p1, ctx.p2);
+        await unmuteVideoAndCheckMedia(ctx.p1, ctx.p2);
 
         // check if video stream from second participant is still on large video
         expect(largeVideoId).toBe(await ctx.p1.getLargeVideo().getId());
@@ -27,7 +28,7 @@ describe('Stop video', () => {
 
     it('stop video on participant and check', () => muteVideoAndCheck(ctx.p2, ctx.p1));
 
-    it('start video on participant and check', () => unmuteVideoAndCheck(ctx.p2, ctx.p1));
+    it('start video on participant and check', () => unmuteVideoAndCheckMedia(ctx.p2, ctx.p1));
 
     it('stop video on before second joins', async () => {
         await ctx.p2.hangup();
@@ -42,6 +43,19 @@ describe('Stop video', () => {
 
         await p2.getParticipantsPane().assertVideoMuteIconIsDisplayed(p1);
 
-        await unmuteVideoAndCheck(p1, p2);
+        await unmuteVideoAndCheckMedia(p1, p2);
     });
 });
+
+/**
+ * Unmutes the video of testee and checks that observer sees it unmuted and that observer is decoding frames from it.
+ * The mute state alone is signalled over the presence, seeing it does not mean that any media is being received.
+ *
+ * @param testee The participant that unmutes its video.
+ * @param observer The participant that should receive and decode the video of testee.
+ */
+async function unmuteVideoAndCheckMedia(testee: Participant, observer: Participant): Promise<void> {
+    await unmuteVideoAndCheck(testee, observer);
+
+    await observer.waitForRemoteVideoDecoding(await testee.getEndpointId());
+}

--- a/tests/wdio.conf.ts
+++ b/tests/wdio.conf.ts
@@ -388,6 +388,14 @@ export const config: WebdriverIO.MultiremoteConfig = {
 
         console.log(`Running test: ${testName} via worker: ${cid} browser instances:${multiRemoteBrowser.instances.length}`);
 
+        // Log the browsers in use, the console logs of the participants are attached to the report only when a test
+        // fails, so this is the only place where a passing run records what it was executed against.
+        console.log(`Using browsers: ${multiRemoteBrowser.instances.map((instance: string) => {
+            const { browserName, browserVersion } = multiRemoteBrowser.getInstance(instance).capabilities;
+
+            return `${instance}:${browserName}/${browserVersion}`;
+        }).join(' ')}`);
+
         const globalAny: any = global;
 
         globalAny.ctx = {


### PR DESCRIPTION
Depends on https://github.com/jitsi/lib-jitsi-meet/pull/3095 (same branch name, so the PR test job picks up that fix).

### What

Adds `Participant.waitForRemoteVideoDecoding(endpointId)`, which waits until the stats report a positive framerate for a remote endpoint's video, and uses it after a camera unmute in `stopVideo.spec.ts` and in the p2p/jvb screenshare flow of `mute.spec.ts`.

### Why

`Mute › mute before join and screen share after in p2p` failed on the Firefox grid with `expected remote video for <id> to be received 15s by p2`. Firefox 154 was sending VP9 with a payload type that the munged SDP had removed, so Chrome received every packet and decoded nothing — fixed in lib-jitsi-meet#3095.

The interesting part for the tests is that almost nothing caught it:

* `ensureTwoParticipants` → `waitForSendReceiveData` only checks that the **bitrate** is positive, and it was (500 packets, 201 kB received, `framesDecoded: 0`).
* `unmuteVideoAndCheck` only checks the mute **icon**, which comes from the presence.
* `codecSelection.spec` checks `getLocalCameraEncoding()`, i.e. the **sender's** codec.

So a receiver that cannot decode a single frame looked healthy everywhere except the one assertion that happens to wait long enough for freeze detection to kick in. This adds an explicit check for the thing these specs are actually about: the observer receives *and decodes* the video.

The check reads `APP.conference.getStats().framerate[endpointId]`, which lib-jitsi-meet only populates for inbound streams whose framerate is above zero, and both Chrome and Firefox report `framesPerSecond` for inbound video.

### Notes

* It is deliberately not added to the shared `unmuteVideoAndCheck` helper: that one is also used in 3-4 participant specs where receive-side constraints decide which sources are being forwarded, so the invariant does not hold unconditionally there. Broadening it can be a follow-up.
* No decoding check was added around the screenshare tile in `mute.spec.ts` even though it is a false pass today for the same reason — a static desktop share produces close to no frames, so a framerate based check would be flaky there.

### Testing

`eslint` and `tsc --project tests/tsconfig.json` are clean for the touched files (the remaining `tests/` type errors are pre-existing). The specs themselves need a deployment, so they have not been run locally.
