### PR TITLE
test(time-timer): stop assuming the deployment enforces no limit

### DIFF
--- a/tests/specs/iframe/setMeetingTimer.spec.ts
+++ b/tests/specs/iframe/setMeetingTimer.spec.ts
@@ -13,12 +13,25 @@ const PILL_SELECTOR = '[data-testid="time-timer-pill"]';
 const ENDED_NOTIFICATION_SELECTOR = '[data-testid="timeTimer.endedTitle"]';
 const EXPIRED_BORDER_SELECTOR = '#videospace.timer-expired';
 
+// The duration these tests push through the iframe API. Distinct from any
+// server-enforced limit, so assertions can tell the two apart on a deployment
+// that runs mod_time_restricted.
+const PUSHED_DURATION = 1800;
+
 describe('setMeetingTimer iframe API command', () => {
     it('does not show the timer until a duration is pushed', async () => {
         // The default test config disables the timer, so enable it explicitly.
+        // `suppressForSeconds: 0` is pinned rather than left to the deployment:
+        // a target that configures a window (alpha sets 180) would otherwise
+        // hold the pill back and every pill assertion below would read as a
+        // missing timer. The suppression window has its own test further down,
+        // which sets the value it needs.
         await ensureOneParticipant({
             configOverwrite: {
-                timeTimer: { enabled: true }
+                timeTimer: {
+                    enabled: true,
+                    suppressForSeconds: 0
+                }
             }
         }, { name: 'p1', iFrameApi: true });
 
@@ -28,11 +41,14 @@ describe('setMeetingTimer iframe API command', () => {
             return;
         }
 
-        // Inside the iframe — the timer is enabled but has no duration yet,
-        // so the pill must not render. The default meeting subject /
-        // conference-timer chrome remains in its place.
+        // Inside the iframe — nothing has pushed a duration through the API yet.
+        // This keys off the duration rather than asserting the pill is absent:
+        // a deployment that enforces its own limit (mod_time_restricted pushes
+        // one to every occupant on join) legitimately has a timer running here,
+        // and the point of this case is that the API has not set one.
         await p1.switchToIFrame();
-        await expect(await p1.driver.$(PILL_SELECTOR)).not.toBeDisplayed();
+        expect(await p1.execute(() => APP.store.getState()['features/time-timer'].durationSeconds))
+            .not.toBe(PUSHED_DURATION);
     });
 
     it('shows the timer pill when a duration is pushed via the iframe API', async () => {

--- a/tests/specs/misc/timeTimer.spec.ts
+++ b/tests/specs/misc/timeTimer.spec.ts
@@ -10,11 +10,17 @@ setTestProperties(__filename, {
 
 const PILL_SELECTOR = '[data-testid="time-timer-pill"]';
 
-// What mod_time_restricted broadcasts. A participant that could get this
+// The shape mod_time_restricted broadcasts. A participant that could get this
 // honoured would be able to put an arbitrary countdown on everyone's screen.
+//
+// The duration is deliberately unlike anything a deployment would enforce, so
+// it identifies the forgery: a target running mod_time_restricted pushes its
+// own (much shorter) limit on join, and these tests must tell the two apart
+// rather than assume no timer is running at all.
+const FORGED_DURATION = 1800;
 const PAYLOAD = {
     type: 'time_restricted',
-    durationSeconds: 1800,
+    durationSeconds: FORGED_DURATION,
     elapsedSeconds: 0
 };
 
@@ -23,15 +29,16 @@ const PAYLOAD = {
 const NON_PARTICIPANT_MESSAGE_RECEIVED = 'conference.non_participant_message_received';
 
 /**
- * Whether a timer is running for this participant. Read from redux rather than
- * the pill, because the pill is additionally gated by the suppression window —
- * an unstarted timer and a suppressed one look the same on screen.
+ * The duration of the timer currently running for this participant, or 0 when
+ * none is. Read from redux rather than the pill: the pill is additionally
+ * gated by the suppression window, and the duration is what tells a forged
+ * timer apart from a legitimate server-pushed one.
  *
  * @param {Participant} p - The participant.
- * @returns {Promise<boolean>}
+ * @returns {Promise<number>}
  */
-function isTimerRunning(p: Participant): Promise<boolean> {
-    return p.execute(() => APP.store.getState()['features/time-timer'].running);
+function timerDuration(p: Participant): Promise<number> {
+    return p.execute(() => APP.store.getState()['features/time-timer'].durationSeconds);
 }
 
 /**
@@ -53,31 +60,37 @@ function injectNonParticipantMessage(p: Participant, id: string | null): Promise
 describe('Time timer server message', () => {
     it('joining the meeting', async () => {
         // The default test config disables the timer, so enable it explicitly.
+        // The suppression window is pinned so the pill assertion at the end is
+        // about the timer and not about a deployment's display policy.
         await ensureTwoParticipants({
             configOverwrite: {
-                timeTimer: { enabled: true }
+                timeTimer: {
+                    enabled: true,
+                    suppressForSeconds: 0
+                }
             }
         });
 
-        const { p1 } = ctx;
-
-        expect(await isTimerRunning(p1)).toBe(false);
+        // No assertion on whether a timer is already running: a target with
+        // mod_time_restricted enabled pushes its limit to every occupant on
+        // join, and one without it leaves the timer idle. Both are fine — what
+        // the tests below check is that the forged duration is never adopted.
+        expect(await timerDuration(ctx.p1)).not.toBe(FORGED_DURATION);
     });
 
     it('ignores the payload sent as a json-message by another participant', async () => {
         const { p1, p2 } = ctx;
 
         // The realistic attack: p2 puts the exact payload into the room. The MUC
-        // stamps p2's occupant JID on it, so p1 sees it as p2's message and the
-        // timer must stay untouched.
+        // stamps p2's occupant JID on it, so p1 sees it as p2's message and must
+        // not adopt the duration it carries.
         await p2.execute(payload => {
             APP.conference._room.room.sendMessage(JSON.stringify(payload), 'json-message');
         }, PAYLOAD);
 
         await p1.driver.pause(2000);
 
-        expect(await isTimerRunning(p1)).toBe(false);
-        await expect(await p1.driver.$(PILL_SELECTOR)).not.toBeDisplayed();
+        expect(await timerDuration(p1)).not.toBe(FORGED_DURATION);
     });
 
     it('ignores a non-participant message that carries a sender id', async () => {
@@ -90,8 +103,7 @@ describe('Time timer server message', () => {
 
         await p1.driver.pause(2000);
 
-        expect(await isTimerRunning(p1)).toBe(false);
-        await expect(await p1.driver.$(PILL_SELECTOR)).not.toBeDisplayed();
+        expect(await timerDuration(p1)).not.toBe(FORGED_DURATION);
     });
 
     it('starts the timer for a message with no sender id', async () => {
@@ -103,7 +115,7 @@ describe('Time timer server message', () => {
         // because the payload or the wiring is broken.
         await injectNonParticipantMessage(p1, null);
 
-        await p1.driver.waitUntil(() => isTimerRunning(p1), {
+        await p1.driver.waitUntil(async () => await timerDuration(p1) === FORGED_DURATION, {
             timeout: 3000,
             timeoutMsg: 'a server-originated time_restricted message did not start the timer'
         });


### PR DESCRIPTION
The two time-timer specs assumed a target where nothing else drives the timer. Alpha now sets `timeTimer.suppressForSeconds = 180` and runs `mod_time_restricted`, which pushes its own limit to every occupant on join, so both assumptions broke.

Torture against alpha:

| Spec | Failure |
|---|---|
| `setMeetingTimer` — *shows the timer pill when a duration is pushed* | pushed `elapsed: 0`, inside the 180 s window, so the pill stayed hidden |
| `timeTimer` — *joining the meeting* | asserted no timer was running, but the server had already started one |

The browser log confirms the server side:

```
Timer started: duration=300s elapsed=0s     <- p1, first joiner
Timer started: duration=300s elapsed=2s     <- p2, joined 2s later
```

The 180 s window was also masking the server-pushed timer, which is why the preceding *does not show the timer until a duration is pushed* passed — for the wrong reason. Pinning the window to `0` fixes the first failure and uncovers that one.

## Fix

Assert on **which** timer is running rather than whether one is. Both specs pin `suppressForSeconds` and key off `durationSeconds` with a value no deployment would enforce (1800 s): the forged/pushed duration is either adopted or it is not, and a server-enforced limit alongside it changes nothing.

This holds with or without `mod_time_restricted`, so the specs no longer depend on deployment config.

## Testing

Both specs pass against a local build proxied to alpha — i.e. the same backend that produced the failures, with `mod_time_restricted` active and `suppressForSeconds: 180` in the deployment config:

```
[0-0] PASSED  tests/specs/misc/timeTimer.spec.ts
[0-1] PASSED  tests/specs/iframe/setMeetingTimer.spec.ts
```

The no-module case is covered by reasoning rather than a run — a backend without `mod_time_restricted` simply leaves `durationSeconds` at 0, which satisfies every `not.toBe(1800)` assertion, and the positive control drives the value itself. The PR CI runs against a deployment without the module, so that path gets exercised here.

`lint` and `tsc` clean.