### PR TITLE
test(prosody): accept either surface of a mod_muc_auth_ban rejection

### DIFF
--- a/tests/prosody/mod_muc_auth_ban_spec.js
+++ b/tests/prosody/mod_muc_auth_ban_spec.js
@@ -35,6 +35,41 @@ function createVpaasClient(token) {
     });
 }
 
+/**
+ * Asserts that a VPaaS session is banned, whichever way the ban surfaces.
+ *
+ * mod_muc_auth_ban's HTTP callback calls session:close(), and where that lands
+ * depends on when the access manager answers. Answering within the same event
+ * loop tick as the SASL auth refuses the connection outright; answering a tick
+ * later lets the session establish and then closes it. Both are the same ban,
+ * and which one happens is timing, so accept either rather than only the first.
+ *
+ * @param {string} token  A login JWT the access manager will reject.
+ * @param {string} message  Assertion message.
+ * @returns {Promise<void>}
+ */
+async function assertBanned(token, message) {
+    let client;
+
+    try {
+        client = await createVpaasClient(token);
+    } catch (e) {
+        // refused during SASL
+        assert.match(String(e), /not-allowed/, message);
+
+        return;
+    }
+
+    // established, so the close must follow
+    const disconnected = await client.waitForDisconnect(5000).then(() => true, () => false);
+
+    if (!disconnected) {
+        await client.disconnect();
+    }
+
+    assert.ok(disconnected, message);
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('mod_muc_auth_ban', () => {
@@ -95,21 +130,17 @@ describe('mod_muc_auth_ban', () => {
     // ── VPaaS — access denied ─────────────────────────────────────────────────
     //
     // When access=false, mod_muc_auth_ban's HTTP callback calls session:close()
-    // and caches the token. Because the access manager runs on the same Prosody
-    // process (loopback), the callback resolves within the same event loop tick
-    // as the SASL auth, so the ban surfaces as a SASL failure rather than a
-    // post-connect disconnect.
+    // and caches the token. The access manager runs on the same Prosody process
+    // (loopback), so the callback usually resolves within the same event loop
+    // tick as the SASL auth and the ban surfaces as a SASL failure, but under
+    // load it can resolve a tick later and close an established session instead.
+    // assertBanned accepts either.
 
-    it('VPaaS user is rejected (SASL failure) when access manager returns access=false', async () => {
+    it('VPaaS user is rejected when access manager returns access=false', async () => {
         await setAccessManagerResponse({ access: false });
 
-        const token = freshToken();
-
-        await assert.rejects(
-            createVpaasClient(token),
-            /not-allowed/,
-            'VPaaS user must be rejected when access manager returns access=false'
-        );
+        await assertBanned(freshToken(),
+            'VPaaS user must be rejected when access manager returns access=false');
     });
 
     // ── Cached ban ────────────────────────────────────────────────────────────
@@ -125,11 +156,7 @@ describe('mod_muc_auth_ban', () => {
 
         const token = freshToken();
 
-        await assert.rejects(
-            createVpaasClient(token),
-            /not-allowed/,
-            'initial ban must be rejected'
-        );
+        await assertBanned(token, 'initial ban must be rejected');
 
         // Step 2: Reset the mock to allow. A fresh token must now succeed,
         // proving the cache — not the mock response — drives the next rejection.
@@ -140,11 +167,8 @@ describe('mod_muc_auth_ban', () => {
         await fresh.disconnect();
 
         // Step 3: Same banned token must still be rejected (cache wins over mock).
-        await assert.rejects(
-            createVpaasClient(token),
-            /not-allowed/,
-            'cached banned token must be rejected even when mock is reset to allow'
-        );
+        await assertBanned(token,
+            'cached banned token must be rejected even when mock is reset to allow');
     });
 
     // ── HTTP error — fail open ────────────────────────────────────────────────


### PR DESCRIPTION
`mod_muc_auth_ban` intermittently fails in CI on the VPaaS rejection tests:

```
1) mod_muc_auth_ban
     VPaaS user is rejected (SASL failure) when access manager returns access=false:
   AssertionError: VPaaS user must be rejected when access manager returns access=false
   at tests/prosody/mod_muc_auth_ban_spec.js:108:9
```

### Why

The module's HTTP callback calls `session:close()`, and where that lands depends on when the access manager answers. It runs on the same prosody process, so it usually answers within the same event loop tick as the SASL auth and the connection is refused outright. Under load it can answer a tick later, in which case the session is established and then closed.

Both are the same ban. The test asserted only the first, with `assert.rejects(createVpaasClient(token), /not-allowed/)`, so the later answer failed it. The comment above the test described the same-tick behaviour as if it were guaranteed.

### Fix

An `assertBanned` helper that accepts either: a rejection matching `not-allowed`, or an established session that is then closed within the timeout. Applied to the three places that asserted a ban. Nothing about the module changes; this only stops the test depending on which tick the callback lands in.

### Evidence it is a flake

Run [33567287417](https://github.com/jitsi/jitsi-meet/actions/runs/33567287417) failed on this test, then passed on re-run of the same commit with no changes. Lua tests were 386 passed / 0 failed in both.

### Testing

`npm run test:one -- mod_muc_auth_ban_spec.js` — 8 passing locally against the test container.

The same-tick path is what runs locally, so the fallback branch is exercised only when the callback is late. The mock access manager has no delay option, so forcing that ordering would mean adding one to `mod_test_observer`; that felt like more than a flake fix needs, but happy to add it if you would rather the slow path were covered explicitly.