### PR TITLE
fix(conference): remove the window hook for the legacy Electron picker

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -139,7 +139,6 @@ import { getLocalJitsiAudioTrackSettings } from './react/features/base/tracks/fu
 import { downloadJSON } from './react/features/base/util/downloadJSON';
 import { getJitsiMeetGlobalNSConnectionTimes } from './react/features/base/util/helpers';
 import { openLeaveReasonDialog } from './react/features/conference/actions.web';
-import { showDesktopPicker } from './react/features/desktop-picker/actions';
 import { appendSuffix } from './react/features/display-name/functions';
 import { maybeOpenFeedbackDialog, submitFeedback } from './react/features/feedback/actions';
 import { maybeSetLobbyChatMessageListener } from './react/features/lobby/actions.any';
@@ -169,18 +168,6 @@ import { muteLocal } from './react/features/video-menu/actions.any';
 
 const logger = Logger.getLogger('app:conference-web');
 let room;
-
-/*
- * Logic to open a desktop picker put on the window global for
- * lib-jitsi-meet to detect and invoke.
- *
- * TODO: remove once the Electron SDK supporting gDM has been out for a while.
- */
-window.JitsiMeetScreenObtainer = {
-    openDesktopPicker(options, onSourceChoose) {
-        APP.store.dispatch(showDesktopPicker(options, onSourceChoose));
-    }
-};
 
 /**
  * Known custom conference commands.


### PR DESCRIPTION
Follow-up to lib-jitsi-meet#3096, which removed the legacy Electron path. lib-jitsi-meet was the only caller of `window.JitsiMeetScreenObtainer`, so the hook can no longer fire.

The picker itself stays: `@jitsi/electron-sdk` (checked at v10.0.4, `screensharing/renderer.js`) opens it over the iframe API during getDisplayMedia, so `react/features/desktop-picker`, the `open-desktop-picker` command and `_openDesktopPicker()` are all still in use.