### PR TITLE
fix(conference): do not commit a local track the conference rejected

### DIFF
--- a/react/features/base/conference/actions.any.ts
+++ b/react/features/base/conference/actions.any.ts
@@ -547,7 +547,8 @@ export function _conferenceWillJoin(conference: IJitsiConference) {
                 .map(t => t.jitsiTrack);
 
         if (localTracks.length && !iAmVisitor(state)) {
-            _addLocalTracksToConference(conference, localTracks);
+            _addLocalTracksToConference(conference, localTracks)
+                .catch((err: Error) => logger.error('Failed to add local tracks on conference join', err));
         }
 
         dispatch(conferenceWillJoin(conference));

--- a/react/features/base/conference/functions.ts
+++ b/react/features/base/conference/functions.ts
@@ -66,12 +66,8 @@ export function _addLocalTracksToConference(
         // XXX The library lib-jitsi-meet may be draconian, for example, when
         // adding one and the same video track multiple times.
         if (conferenceLocalTracks.indexOf(track) === -1) {
-            promises.push(
-                conference.addTrack(track).catch((err: Error) => {
-                    _reportError(
-                        'Failed to add local track to conference',
-                        err);
-                }));
+            // Rejections propagate so that callers can refuse to commit a track the conference rejected.
+            promises.push(conference.addTrack(track));
         }
     }
 

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -44,6 +44,7 @@ import {
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import StateListenerRegistry from '../redux/StateListenerRegistry';
 import { TRACK_ADDED, TRACK_CREATE_CANCELED, TRACK_REMOVED } from '../tracks/actionTypes';
+import { getLocalTrack } from '../tracks/functions.any';
 import { parseURIString } from '../util/uri';
 
 import {
@@ -806,16 +807,17 @@ async function _trackAddedOrRemoved(store: IStore, next: Function, action: AnyAc
                             await _addLocalTracksToConference(conference, [ jitsiTrack ]);
                         } catch (error) {
                             logger.error(
-                                `Conference refused local ${track.mediaType} track, discarding it: ${error}`);
+                                `Conference refused local ${track.mediaType} track, discarding it`, error);
 
                             jitsiTrack.dispose?.().catch(() => { /* may already be disposed */ });
 
-                            // Clears the pending TRACK_WILL_CREATE stub, which would otherwise block future
-                            // creation via getLocalTrack(..., includePending).
-                            store.dispatch({
-                                type: TRACK_CREATE_CANCELED,
-                                trackType: track.mediaType
-                            });
+                            // Clears a pending TRACK_WILL_CREATE stub when no ready track of this type remains.
+                            if (!getLocalTrack(getState()['features/base/tracks'], track.mediaType)) {
+                                store.dispatch({
+                                    type: TRACK_CREATE_CANCELED,
+                                    trackType: track.mediaType
+                                });
+                            }
 
                             return;
                         }

--- a/react/features/base/conference/middleware.any.ts
+++ b/react/features/base/conference/middleware.any.ts
@@ -43,7 +43,7 @@ import {
 } from '../participants/functions';
 import MiddlewareRegistry from '../redux/MiddlewareRegistry';
 import StateListenerRegistry from '../redux/StateListenerRegistry';
-import { TRACK_ADDED, TRACK_REMOVED } from '../tracks/actionTypes';
+import { TRACK_ADDED, TRACK_CREATE_CANCELED, TRACK_REMOVED } from '../tracks/actionTypes';
 import { parseURIString } from '../util/uri';
 
 import {
@@ -802,7 +802,23 @@ async function _trackAddedOrRemoved(store: IStore, next: Function, action: AnyAc
                             await conference.replaceTrack(null, jitsiTrack);
                         }
                     } else {
-                        await _addLocalTracksToConference(conference, [ jitsiTrack ]);
+                        try {
+                            await _addLocalTracksToConference(conference, [ jitsiTrack ]);
+                        } catch (error) {
+                            logger.error(
+                                `Conference refused local ${track.mediaType} track, discarding it: ${error}`);
+
+                            jitsiTrack.dispose?.().catch(() => { /* may already be disposed */ });
+
+                            // Clears the pending TRACK_WILL_CREATE stub, which would otherwise block future
+                            // creation via getLocalTrack(..., includePending).
+                            store.dispatch({
+                                type: TRACK_CREATE_CANCELED,
+                                trackType: track.mediaType
+                            });
+
+                            return;
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
A local track that `JitsiConference.addTrack()` rejects still becomes the authoritative track in redux: `_addLocalTracksToConference` swallowed the rejection, the middleware called `next(action)` regardless, and the reducer evicted the previous local track unconditionally. Redux then pointed at a track that was never attached to the `RTCRtpSender`, so self-view and the mute button followed the orphan while nothing was sent — with no path back.

Observed on a call where a camera switch and an unmute overlapped: outbound video stayed at 0 kbps for over an hour while the sender held an earlier, muted track and the client had signalled `videoType: none`.

## Change

- `functions.ts` — `_addLocalTracksToConference` propagates `addTrack` rejections instead of swallowing them.
- `middleware.any.ts` — on rejection, log, dispose the track, dispatch `TRACK_CREATE_CANCELED`, and return without `next(action)` so redux never commits it.
- `actions.any.ts` — the fire-and-forget call site in `_conferenceWillJoin` now catches, since the callee can reject.

## Notes

`base/conference` middleware is registered before `base/media` and `base/tracks` (`app/middlewares.any.ts`), and `applyMiddleware(...this._elements)` makes the first registered outermost — so skipping `next(action)` does prevent the reducer from committing.

The `TRACK_CREATE_CANCELED` dispatch is required, not defensive: `TRACK_REMOVED` filters by `jitsiTrack` identity and pending stubs have none, so without it the `TRACK_WILL_CREATE` stub would leak and `getLocalTrack(..., includePending)` would block all future track creation for that media type.

This stops the desync, not the duplicate `getUserMedia` that triggers it. `TRACK_WILL_CREATE` is dispatched only by `createLocalTracksA`, while `createLocalTracksF` — used by `onVideoDeviceChanged` — reserves nothing, so an in-flight device-switch gUM is invisible to a concurrent unmute. Follow-up.

`tsc:web` and `eslint` clean. Not covered by the e2e suite; worth a manual pass on visitor → participant promotion with tracks present.