### PR TITLE
fix(chat): prefer the tracked participant's display name over the message's visitor flag

### DIFF
--- a/react/features/chat/middleware.ts
+++ b/react/features/chat/middleware.ts
@@ -935,12 +935,14 @@ function _handleReceivedMessage({ dispatch, getState }: IStore,
 
     if (lobbyChat) {
         _displayName = getLobbyChatDisplayName(state, participantId);
-    } else if (isFromVisitor) {
-        _displayName = getDisplayName(state, displayName);
-    } else if (!participant) {
-        _displayName = getDisplayName(state, displayName);
-    } else {
+    } else if (participant) {
+        // A resolvable, tracked participant always takes priority over the per-message isFromVisitor flag: a real
+        // visitor is never tracked as a participant (no MUC presence), so this doesn't affect genuine visitor
+        // messages, but it makes sure the sender's own known display name is always used once they're a tracked
+        // participant, regardless of what the message itself claims.
         _displayName = getParticipantDisplayName(state, participantId);
+    } else {
+        _displayName = getDisplayName(state, displayName);
     }
 
     const hasRead = participant?.local || isChatOpen;


### PR DESCRIPTION
## Summary
- In `_handleReceivedMessage`, a message's `isFromVisitor` flag was checked before checking whether the sender is a known, tracked participant, so the flag could override the display name of an already-tracked participant.
- Reorder the checks so a resolvable, tracked participant's own display name always takes priority. A genuine visitor is never tracked as a participant (no MUC presence), so this doesn't change behavior for real visitor messages.
- Companion fix to jitsi/lib-jitsi-meet#3101, which addresses the underlying issue of when the visitor flag can be set in the first place.
