### PR TITLE
Default advancedAudioSettings to enabled

### DIFF
--- a/config.js
+++ b/config.js
@@ -226,10 +226,14 @@ var config = {
     // Beware, by doing so, you are disabling echo cancellation, noise suppression and AGC.
     // Specify enableOpusDtx to enable support for opus-dtx where
     // audio packets won’t be transmitted while participant is silent or muted.
+    // Specify enableAdvancedAudioSettings to show advanced audio settings (custom mic
+    // constraints) in the device selection dialog. Enabled by default; not available on
+    // WebKit-based browsers.
     // audioQuality: {
     //     stereo: false,
     //     opusMaxAverageBitrate: null, // Value to fit the 6000 to 510000 range.
     //     enableOpusDtx: false,
+    //     enableAdvancedAudioSettings: true,
     // },
 
     // Audio translation feature (requires bridge backend support).

--- a/react/features/base/config/functions.any.ts
+++ b/react/features/base/config/functions.any.ts
@@ -294,7 +294,7 @@ export function isDisplayNameVisible(state: IReduxState): boolean {
  */
 export function isAdvancedAudioSettingsEnabled(state: IReduxState): boolean {
 
-    return !browser.isWebKitBased() && Boolean(state['features/base/config']?.audioQuality?.enableAdvancedAudioSettings);
+    return !browser.isWebKitBased() && state['features/base/config']?.audioQuality?.enableAdvancedAudioSettings !== false;
 }
 
 /**


### PR DESCRIPTION
Changes isAdvancedAudioSettingsEnabled to default to enabled: it now returns true unless config.audioQuality.enableAdvancedAudioSettings is explicitly set to false, instead of requiring it to be explicitly true.

Deployments that want to keep advanced audio settings off need to actively set enableAdvancedAudioSettings: false. Checked infra: both the ansible config.js template and the nomad web-pack template already always render an explicit true/false for this key, so no deployment silently relied on the key being omitted.
