### PR TITLE
feat(subtitles): Allow picking a translation language with async transcription

### DIFF
--- a/react/features/chat/components/native/ClosedCaptions.tsx
+++ b/react/features/chat/components/native/ClosedCaptions.tsx
@@ -42,8 +42,6 @@ const ClosedCaptions = ({
     const navigateToLanguageSelect = useCallback(() => {
         navigate(screen.conference.subtitles);
     }, [ navigation, screen ]);
-    const isAsyncTranscriptionEnabled = useSelector((state: IReduxState) =>
-        state['features/base/conference'].conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
 
     useEffect(() => {
         navigation?.setOptions({
@@ -93,20 +91,17 @@ const ClosedCaptions = ({
 
         return (
             <>
-                {
-                    // Hide the "Translate to" option when asyncTranscription is enabled
-                    !isAsyncTranscriptionEnabled && <View style = { closedCaptionsStyles.languageButtonContainer as ViewStyle }>
-                        <Text style = { closedCaptionsStyles.languageButtonText }>{ t('transcribing.translateTo') }:</Text>
-                        <TouchableHighlight onPress = { navigateToLanguageSelect }>
-                            <View style = { closedCaptionsStyles.languageButtonContent as ViewStyle }>
-                                <Text style = { closedCaptionsStyles.languageButtonText }>{ t(selectedLanguage ?? 'transcribing.subtitlesOff') }</Text>
-                                <Icon
-                                    size = { 24 }
-                                    src = { IconArrowRight } />
-                            </View>
-                        </TouchableHighlight>
-                    </View>
-                }
+                <View style = { closedCaptionsStyles.languageButtonContainer as ViewStyle }>
+                    <Text style = { closedCaptionsStyles.languageButtonText }>{ t('transcribing.translateTo') }:</Text>
+                    <TouchableHighlight onPress = { navigateToLanguageSelect }>
+                        <View style = { closedCaptionsStyles.languageButtonContent as ViewStyle }>
+                            <Text style = { closedCaptionsStyles.languageButtonText }>{ t(selectedLanguage ?? 'transcribing.subtitlesOff') }</Text>
+                            <Icon
+                                size = { 24 }
+                                src = { IconArrowRight } />
+                        </View>
+                    </TouchableHighlight>
+                </View>
                 <View style = { closedCaptionsStyles.messagesContainer as ViewStyle }>
                     <SubtitlesMessagesContainer
                         groups = { groupedSubtitles }

--- a/react/features/subtitles/components/AbstractLanguageSelectorDialog.tsx
+++ b/react/features/subtitles/components/AbstractLanguageSelectorDialog.tsx
@@ -3,15 +3,24 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { IReduxState, IStore } from '../../app/types';
+import { isTranscribing } from '../../transcribing/functions';
 import { setRequestingSubtitles } from '../actions.any';
 import { getAvailableSubtitlesLanguages, isTranslationEnabled } from '../functions.any';
 
 export interface IAbstractLanguageSelectorDialogProps {
-    asyncTranscription: boolean;
     dispatch: IStore['dispatch'];
     language: string | null;
     listItems: Array<any>;
     onLanguageSelected: (e: string) => void;
+
+    /**
+     * Whether picking a language should open the recording/transcription dialog instead of applying the language.
+     *
+     * With async transcription there is no transcriber to dial: transcription is started through room metadata, from
+     * that dialog. So the first pick has to go there. Once transcription is running, picking a language just applies
+     * it, like it always has.
+     */
+    startWithRecordingDialog: boolean;
     subtitles: string;
     t: Function;
 }
@@ -47,6 +56,8 @@ const AbstractLanguageSelectorDialog = (Component: ComponentType<IAbstractLangua
     const { conference } = useSelector((state: IReduxState) => state['features/base/conference']);
     const translationEnabled = useSelector(isTranslationEnabled);
     const asyncTranscription = Boolean(conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
+    const transcribing = useSelector(isTranscribing);
+    const startWithRecordingDialog = asyncTranscription && !transcribing;
 
     const onLanguageSelected = useCallback((value: string) => {
         const _selectedLanguage = value === noLanguageLabel ? null : value;
@@ -62,11 +73,11 @@ const AbstractLanguageSelectorDialog = (Component: ComponentType<IAbstractLangua
 
     return (
         <Component
-            asyncTranscription = { asyncTranscription }
             dispatch = { dispatch }
             language = { language }
             listItems = { listItems }
             onLanguageSelected = { onLanguageSelected }
+            startWithRecordingDialog = { startWithRecordingDialog }
             subtitles = { selected }
             t = { t } />
     );

--- a/react/features/subtitles/components/AbstractLanguageSelectorDialog.tsx
+++ b/react/features/subtitles/components/AbstractLanguageSelectorDialog.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { IReduxState, IStore } from '../../app/types';
-import { isTranscribing } from '../../transcribing/functions';
+import { isRecorderTranscriptionsRunning } from '../../transcribing/functions';
 import { setRequestingSubtitles } from '../actions.any';
 import { getAvailableSubtitlesLanguages, isTranslationEnabled } from '../functions.any';
 
@@ -56,7 +56,20 @@ const AbstractLanguageSelectorDialog = (Component: ComponentType<IAbstractLangua
     const { conference } = useSelector((state: IReduxState) => state['features/base/conference']);
     const translationEnabled = useSelector(isTranslationEnabled);
     const asyncTranscription = Boolean(conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
-    const transcribing = useSelector(isTranscribing);
+    // isRecorderTranscriptionsRunning, not isTranscribing. isTranscribing is true in two cases: a live
+    // Jigasi transcriber is in the room, or jicofo set the `audio-recording-enabled` conference property.
+    //
+    // That property name is misleading. It reads as though it tracks recording, but jicofo sets it from
+    // one place only, setEnableTranscribing, which is driven by the room metadata
+    // (recording.isTranscribingEnabled && asyncTranscription). Starting a recording on its own never
+    // reaches it. The name is left over from the backend export being reused for recording, which also
+    // shows in jicofo's reference.conf, where the `transcription.url-template` example points at a
+    // /recorder/ path.
+    //
+    // So the property does imply the metadata flag, but the Jigasi case does not. The stricter selector
+    // keeps the explicit start dialog where the two differ, instead of letting a language pick start
+    // async transcription as a side effect of the metadata write in the subtitles middleware.
+    const transcribing = useSelector(isRecorderTranscriptionsRunning);
     const startWithRecordingDialog = asyncTranscription && !transcribing;
 
     const onLanguageSelected = useCallback((value: string) => {

--- a/react/features/subtitles/components/native/LanguageSelectorDialog.tsx
+++ b/react/features/subtitles/components/native/LanguageSelectorDialog.tsx
@@ -12,16 +12,16 @@ import LanguageList from './LanguageList';
 import styles from './styles';
 
 const LanguageSelectorDialog = (props: IAbstractLanguageSelectorDialogProps) => {
-    const { asyncTranscription, language, listItems, onLanguageSelected, subtitles } = props;
+    const { language, listItems, onLanguageSelected, startWithRecordingDialog, subtitles } = props;
 
     const onSelected = useCallback((e: string) => {
-        if (asyncTranscription) {
+        if (startWithRecordingDialog) {
             navigate(screen.conference.recording, { recordAudioAndVideo: false });
         } else {
             onLanguageSelected(e);
             goBack();
         }
-    }, [ asyncTranscription, language ]);
+    }, [ startWithRecordingDialog, language ]);
 
     return (
         <JitsiScreen

--- a/react/features/subtitles/components/web/LanguageSelector.tsx
+++ b/react/features/subtitles/components/web/LanguageSelector.tsx
@@ -50,11 +50,9 @@ function LanguageSelector() {
         state,
         selectedLanguage?.replace('translation-languages:', '')
     ));
-    const isAsyncTranscriptionEnabled = useSelector((state: IReduxState) =>
-        state['features/base/conference'].conference?.getMetadataHandler()?.getMetadata()?.asyncTranscription);
     const translationEnabled = useSelector(isTranslationEnabled);
 
-    if (isAsyncTranscriptionEnabled || !translationEnabled) {
+    if (!translationEnabled) {
         return null;
     }
 

--- a/react/features/subtitles/components/web/LanguageSelectorDialog.tsx
+++ b/react/features/subtitles/components/web/LanguageSelectorDialog.tsx
@@ -37,12 +37,12 @@ const useStyles = makeStyles()(theme => {
 
 
 const LanguageSelectorDialog = (props: IAbstractLanguageSelectorDialogProps) => {
-    const { asyncTranscription, dispatch, language, listItems, onLanguageSelected, subtitles, t } = props;
+    const { dispatch, language, listItems, onLanguageSelected, startWithRecordingDialog, subtitles, t } = props;
 
     const { classes: styles } = useStyles();
 
     const onSelected = useCallback((e: string) => {
-        if (asyncTranscription) {
+        if (startWithRecordingDialog) {
             dispatch(openDialog('RecordingTranscriptionDialog', RecordingTranscriptionDialog, {
                 recordAudioAndVideo: false
             }));
@@ -50,7 +50,7 @@ const LanguageSelectorDialog = (props: IAbstractLanguageSelectorDialogProps) => 
             onLanguageSelected(e);
         }
         dispatch(toggleLanguageSelectorDialog());
-    }, [ asyncTranscription, language ]);
+    }, [ startWithRecordingDialog, language ]);
 
     const onSourceLanguageClick = useCallback(() => {
         dispatch(openSettingsDialog(SETTINGS_TABS.MORE, false));

--- a/react/features/subtitles/middleware.ts
+++ b/react/features/subtitles/middleware.ts
@@ -441,11 +441,12 @@ function _requestingSubtitlesChange(
         }
     }
 
-    if (enabled && language) {
-        conference?.setLocalParticipantProperty(
-            P_NAME_TRANSLATION_LANGUAGE,
-            language.replace('translation-languages:', ''));
-    }
+    // Advertise the requested translation language, and clear it when there is none. Clearing matters: the property
+    // is what tells the backend which languages to translate into, so leaving a stale value behind would keep a
+    // language being translated after the user switched back to the original one or turned subtitles off.
+    conference?.setLocalParticipantProperty(
+        P_NAME_TRANSLATION_LANGUAGE,
+        enabled && language ? language.replace('translation-languages:', '') : '');
 
     if (!enabled && !skipMetadataUpdate && (backendRecordingOn || forceBackendRecordingOn)
         && conference?.getMetadataHandler()?.getMetadata()[RECORDING_METADATA_ID]?.isTranscribingEnabled) {


### PR DESCRIPTION
The translation language pickers were hidden or diverted when async transcription is enabled, because nothing translated the transcripts on that path. The backend can now do it, so let the user choose again.

- The "Translate to" dropdown in the closed-captions panel (web) and the equivalent row (native) are shown again.
- The language dialog behind the closed-captions toolbar button applied no language on the async path: it opened the recording dialog instead. It still does that while transcription has not started, because that is how async transcription is started, but once transcription is running, picking a language applies it.

Also clears the `translation_language` participant property when the user picks the original language or turns subtitles off. It was only ever set, so the last language the user picked stayed advertised in presence for the rest of the conference. The backend reads this property to decide which languages to translate into, so a stale value would keep translating into a language nobody asked for. It also made the local client render a translation it should have ignored.

### Companion pull requests

- jitsi/opus-transcriber-proxy#127
- jitsi/jicofo#1312
