### PR TITLE
test(virtual-background): give the first real effect-enable a cold-start timeout

### DIFF
--- a/tests/specs/misc/virtualBackground.spec.ts
+++ b/tests/specs/misc/virtualBackground.spec.ts
@@ -104,7 +104,12 @@ describe('Virtual backgrounds', () => {
         expect(await vbDialog.isBlurChecked()).toBe(false);
 
         await vbDialog.confirm();
-        await waitForEffectEnabled(true);
+
+        // This is the first real (non-preview) effect enable in the suite, so — like
+        // "select full blur" below — it pays the cold-start cost of spinning up the
+        // segmentation worker on the actual conference track. The default 8s timeout is
+        // tuned for a warm worker and flakes on this one.
+        await waitForEffectEnabled(true, 15000);
 
         const state = await getVBState();
 


### PR DESCRIPTION
## Summary
- The "select slight blur" test in `virtualBackground.spec.ts` is the first test in the file that enables the effect on the real conference track (not just the dialog preview), so it pays the same segmentation worker/model cold-start cost that "select full blur" already budgets 15s for.
- Left on the default 8s timeout, it flaked under CI load: a torture run (`chrome-chrome`) showed the confirm's effect construction starting ~9s after the preview's effect construction, past the 8s window — timing out with `backgroundEffectEnabled did not settle to true within 8000ms`.
- Bumped its `waitForEffectEnabled` call to 15000ms, matching "select full blur", with a comment explaining why.

## Test plan
- [x] `npx eslint tests/specs/misc/virtualBackground.spec.ts` passes
- [ ] Torture run of `misc/virtualBackground.spec.ts` (chrome-chrome grid) passes consistently