### PR TITLE
fix(prosody): propagate room metadata to visitor nodes, forward visit…

### DIFF
--- a/resources/prosody-plugins/mod_fmuc.lua
+++ b/resources/prosody-plugins/mod_fmuc.lua
@@ -95,6 +95,34 @@ local function send_transcriptions_update(room)
       }):up());
 end
 
+-- Forwards this vnode's local 'recording' metadata (isTranscribingEnabled, set by a visitor allowed via
+-- the transcription JWT feature -- see mod_filter_iq_rayo's 'jitsi-metadata-allow-moderation' hook) up to
+-- the main room, the same way send_transcriptions_update() forwards transcription-languages: as a
+-- 'visitors' IQ to the main prosody's visitors component, which applies it to the real room metadata.
+local function send_recording_metadata_update(room)
+    local recording_metadata = room.jitsiMetadata and room.jitsiMetadata.recording;
+    if not recording_metadata then
+        return;
+    end
+
+    local json_data, encode_error = json.encode(recording_metadata);
+    if not json_data then
+        module:log('error', 'Error encoding recording metadata for room:%s error:%s', room.jid, encode_error);
+        return;
+    end
+
+    local iq_id = new_id();
+    sent_iq_cache:set(iq_id, socket.gettime());
+    module:send(st.iq({
+        type = 'set',
+        to = 'visitors.'..main_domain,
+        from = local_domain,
+        id = iq_id })
+      :tag('visitors', { xmlns = 'jitsi:visitors',
+                         room = jid.join(jid.node(room.jid), muc_domain_prefix..'.'..main_domain) })
+      :tag('recording-metadata', { xmlns = 'jitsi:visitors' }):text(json_data):up());
+end
+
 local function remove_transcription(room, occupant)
     local send_update = false;
     if room._transcription_languages then
@@ -778,6 +806,22 @@ local function iq_from_main_handler(event)
         room._main_room_lobby_enabled = false;
     end
 
+    -- Mirror the main room's metadata (e.g. asyncTranscription) onto this vnode's room, so visitor
+    -- clients connected here see the same metadata main-room clients do. Fired as 'room-metadata-changed'
+    -- so a room_metadata_component enabled on this host (muc_component pointing at this muc) rebroadcasts
+    -- it to visitor occupants, exactly like it does for the main room.
+    local metadataEl = node:get_child('metadata', 'jitsi:visitors');
+    if metadataEl then
+        local metadataText = metadataEl:get_text();
+        local metadata, metadata_error = json.decode(metadataText);
+        if metadata then
+            room.jitsiMetadata = metadata;
+            module:fire_event('room-metadata-changed', { room = room; });
+        else
+            module:log('error', 'Failed to decode metadata for room:%s error:%s', room.jid, metadata_error);
+        end
+    end
+
     -- read the moderators list
     room.moderators_list = room.moderators_list or set.new();
     local moderators = node:get_child('moderators');
@@ -838,6 +882,15 @@ local function iq_from_main_handler(event)
     return true;
 end
 module:hook('iq/host', iq_from_main_handler, 10);
+
+-- Fired locally (by the room_metadata_component enabled on this vnode) after a client successfully
+-- writes a metadata key on this vnode's mirrored room. When it's the 'recording' key (isTranscribingEnabled,
+-- set by a visitor via the transcription JWT feature), forward it up to the main room.
+module:hook('jitsi-metadata-updated', function(event)
+    if event.key == 'recording' then
+        send_recording_metadata_update(event.room);
+    end
+end);
 
 -- Filters presences (if detected) that are with destination the main prosody
 function filter_stanza(stanza, session)

--- a/resources/prosody-plugins/mod_visitors.lua
+++ b/resources/prosody-plugins/mod_visitors.lua
@@ -50,6 +50,11 @@ local sent_iq_cache = require 'util.cache'.new(200);
 --}
 local visitors_nodes = {};
 
+-- forward declaration; assigned below. Referenced by a closure registered on the main muc's
+-- 'room-metadata-changed' event (see process_host_module(main_muc_component_config, ...) below) so vnodes
+-- are refreshed whenever the main room's metadata (e.g. asyncTranscription) changes.
+local update_vnodes_for_room;
+
 -- sends connect or update iq
 -- @parameter type - Type of iq to send 'connect' or 'update'
 local function send_visitors_iq(conference_service, room, type)
@@ -116,6 +121,17 @@ local function send_visitors_iq(conference_service, room, type)
             end
 
             visitors_iq:tag('polls'):text(json_msg_str):up();
+        end
+    end
+
+    -- Forward the main room's metadata (e.g. asyncTranscription) so visitor nodes/clients can make the
+    -- same decisions main-room clients do (sent on both 'connect' and 'update', not just 'update').
+    if room.jitsiMetadata then
+        local json_metadata, metadata_error = json.encode(room.jitsiMetadata);
+        if json_metadata then
+            visitors_iq:tag('metadata', { xmlns = 'jitsi:visitors' }):text(json_metadata):up();
+        else
+            module:log('error', 'Error encoding metadata for room:%s error:%s', room.jid, metadata_error);
         end
     end
 
@@ -261,6 +277,14 @@ module:hook('presence/full', function(event)
 end, 900);
 
 process_host_module(main_muc_component_config, function(host_module, host)
+    -- room metadata changed (e.g. asyncTranscription) -- refresh all connected vnodes so their
+    -- mirrored room and visitor clients stay in sync with the main room. Called via a wrapper closure
+    -- (rather than passing update_vnodes_for_room directly) since it is only assigned further down in
+    -- this file, after this hook is registered.
+    host_module:hook('room-metadata-changed', function(event)
+        update_vnodes_for_room(event);
+    end);
+
     -- detects presence change in a main participant and propagate it to the used visitor nodes
     host_module:hook('muc-occupant-pre-change', function (event)
         local room, stanzaEv, occupant = event.room, event.stanza, event.dest_occupant;
@@ -560,7 +584,7 @@ process_host_module(main_muc_component_config, function(host_module, host)
     end);
 end);
 
-local function update_vnodes_for_room(event)
+function update_vnodes_for_room(event)
     local room = event.room;
         if visitors_nodes[room.jid] then
             -- we need to update all vnodes

--- a/resources/prosody-plugins/mod_visitors_component.lua
+++ b/resources/prosody-plugins/mod_visitors_component.lua
@@ -366,6 +366,33 @@ local function stanza_handler(event)
         end
     end
 
+    -- A visitor (allowed via the transcription JWT feature, see mod_filter_iq_rayo's
+    -- 'jitsi-metadata-allow-moderation' hook) set 'recording' metadata (isTranscribingEnabled) on their
+    -- vnode's local mirrored room. Apply it to the real room here so jicofo (which only watches the main
+    -- room's metadata) sees it and starts async transcription.
+    local recording_metadata_el = visitors_iq:get_child('recording-metadata');
+    if recording_metadata_el then
+        if not from_vnode then
+            module:log('warn', 'Received forged recording_metadata message: %s %s',
+                stanza, inspect(room._connected_vnodes));
+            return true; -- stop processing
+        end
+
+        local data, decode_error = json.decode(recording_metadata_el:get_text());
+        if data then
+            if not room.jitsiMetadata then
+                room.jitsiMetadata = {};
+            end
+            room.jitsiMetadata.recording = data;
+            processed = true;
+
+            module:context(muc_domain_prefix..'.'..muc_domain_base)
+                :fire_event('room-metadata-changed', { room = room; });
+        else
+            module:log('error', 'Failed to decode recording metadata for room:%s error:%s', room.jid, decode_error);
+        end
+    end
+
     if not processed then
         module:log('warn', 'Unknown iq received for %s: %s', module.host, stanza);
     end


### PR DESCRIPTION
…or-initiated recording metadata to main room

Visitor clients previously never received the main room's metadata (e.g. asyncTranscription), because it was never forwarded across the FMUC link to the vnode's mirrored room. This made a visitor's client always fall back to dialing a live Jigasi transcriber regardless of the room's real async-transcription configuration.

- mod_visitors.lua: include the main room's jitsiMetadata (as JSON) in the 'connect'/'update' visitors IQ sent to vnodes, and re-send it whenever the main room's metadata changes.
- mod_fmuc.lua: apply that metadata to the vnode's local mirrored room and fire 'room-metadata-changed' so a room_metadata_component enabled on the vnode rebroadcasts it to visitor occupants, same as the main room does for main participants. Also forward a visitor-initiated 'recording' metadata write (isTranscribingEnabled, permitted via the transcription JWT feature per mod_filter_iq_rayo's jitsi-metadata-allow-moderation hook) back up to the main room, the same way transcription-languages are already forwarded.
- mod_visitors_component.lua: apply a forwarded 'recording' metadata update to the real room and fire 'room-metadata-changed' on the main muc, so jicofo (which only watches the main room) picks it up and starts async transcription.

Requires enabling a room_metadata_component on each visitor prosody, pointed at its local muc component, mirroring the main prosody's setup.

<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
