### PR TITLE
fix(av-moderation): whitelist moderators whose affiliation was set before joining

### DIFF
--- a/resources/prosody-plugins/mod_av_moderation_component.lua
+++ b/resources/prosody-plugins/mod_av_moderation_component.lua
@@ -373,10 +373,15 @@ function occupant_joined(event)
         -- NOTE for some reason event.occupant.role is not reflecting the actual occupant role (when changed
         -- from allowners module) but iterating over room occupants returns the correct role
         for _, room_occupant in room:each_occupant() do
-            -- if it is a moderator, send the whitelist to every moderator
+            -- if it is a moderator, make sure it is whitelisted and send the whitelist to every moderator
             if room_occupant.nick == occupant.nick and room_occupant.role == 'moderator' then
+                local moderator_jid = internal_room_jid_match_rewrite(room_occupant.nick);
                 for _,mediaType in pairs({'audio', 'video', 'desktop'}) do
-                    if room.av_moderation[mediaType] then
+                    local whitelist = room.av_moderation[mediaType];
+                    if whitelist then
+                        if not get_index_in_table(whitelist, moderator_jid) then
+                            whitelist:push(moderator_jid);
+                        end
                         notify_whitelist_change(nil, true, room, mediaType);
                     end
                 end


### PR DESCRIPTION
A moderator whose owner affiliation exists before the join never gets into the A/V moderation whitelist: `muc-set-affiliation` fires while the occupant is not in the room yet (affiliation granted in `muc-occupant-pre-join`), or not at all
(affiliation persisted from an earlier session, non-anonymous auth). `occupant_joined` only sends the whitelist, it does not add the joining moderator.

Jicofo lets such a moderator unmute by role, but takes the bridge force-mute state from the whitelist alone, so after `Will unmute … for AUDIO` it sends `force-mute audio="true"` and nobody hears them. Hit this on a 100+ webinar:
the host who enabled moderation dropped, the co-hosts who joined later unmuted, and the room went silent.

Fix: `occupant_joined` adds a joining moderator to every enabled whitelist before sending it out. The `get_index_in_table` check avoids duplicates when `occupant_affiliation_changed` already ran (`mod_muc_allowners`).

Verify: A enables audio moderation, B with a pre-existing owner affiliation joins muted and unmutes.
Before: `force-mute audio="true"` in the bridge.
After: `Setting whitelist for AUDIO: […, B]` in jicofo on B's join, B is heard.