### PR TITLE
fix(keyboard-shortcuts): add Ctrl+Alt reaction aliases for Firefox

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1294,6 +1294,7 @@
         "desktopShareHighFpsWarning": "A higher frame rate for desktop sharing might affect your bandwidth. You need to restart the screen share for the new settings to take effect.",
         "desktopShareWarning": "You need to restart the screen share for the new settings to take effect.",
         "devices": "Devices",
+        "enableCtrlAltReactionShortcuts": "Enable Ctrl+Alt alternatives for reaction shortcuts",
         "followMe": "Everyone follows me",
         "followMeRecorder": "Recorder follows me",
         "framesPerSecond": "frames-per-second",

--- a/react/features/keyboard-shortcuts/actionTypes.ts
+++ b/react/features/keyboard-shortcuts/actionTypes.ts
@@ -22,3 +22,8 @@ export const ENABLE_KEYBOARD_SHORTCUTS = 'ENABLE_KEYBOARD_SHORTCUTS';
  * The type of the action which signals that a keyboard shortcut should be disabled.
  */
 export const DISABLE_KEYBOARD_SHORTCUTS = 'DISABLE_KEYBOARD_SHORTCUTS';
+
+/**
+ * The type of the action which sets whether Ctrl+Alt reaction shortcut aliases are enabled.
+ */
+export const SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED = 'SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED';

--- a/react/features/keyboard-shortcuts/actions.ts
+++ b/react/features/keyboard-shortcuts/actions.ts
@@ -13,6 +13,7 @@ import {
     DISABLE_KEYBOARD_SHORTCUTS,
     ENABLE_KEYBOARD_SHORTCUTS,
     REGISTER_KEYBOARD_SHORTCUT,
+    SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED,
     UNREGISTER_KEYBOARD_SHORTCUT
 } from './actionTypes';
 import { areKeyboardShortcutsEnabled, getKeyboardShortcuts } from './functions';
@@ -38,13 +39,28 @@ export const registerShortcut = (shortcut: IKeyboardShortcut): AnyAction => {
 *
 * @param {string} character - The character of the shortcut to unregister.
 * @param {boolean} altKey - Whether the shortcut used altKey.
+* @param {boolean} ctrlKey - Whether the shortcut used ctrlKey.
 * @returns {AnyAction}
 */
-export const unregisterShortcut = (character: string, altKey = false): AnyAction => {
+export const unregisterShortcut = (character: string, altKey = false, ctrlKey = false): AnyAction => {
     return {
         alt: altKey,
+        ctrl: ctrlKey,
         type: UNREGISTER_KEYBOARD_SHORTCUT,
         character
+    };
+};
+
+/**
+ * Sets whether Ctrl+Alt aliases for reaction shortcuts are enabled.
+ *
+ * @param {boolean} enabled - Whether the aliases should be enabled.
+ * @returns {AnyAction}
+ */
+export const setCtrlAltReactionShortcutsEnabled = (enabled: boolean): AnyAction => {
+    return {
+        type: SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED,
+        enabled
     };
 };
 

--- a/react/features/keyboard-shortcuts/functions.ts
+++ b/react/features/keyboard-shortcuts/functions.ts
@@ -1,4 +1,19 @@
 import { IReduxState } from '../app/types';
+import { browser } from '../base/lib-jitsi-meet';
+
+/**
+ * Returns whether or not Ctrl+Alt aliases for reaction shortcuts are enabled.
+ *
+ * The setting is Firefox-only and defaults to enabled for existing users whose
+ * persisted state does not contain it yet.
+ *
+ * @param {Object} state - The redux state.
+ * @returns {boolean} - Whether or not the aliases are enabled.
+ */
+export function areCtrlAltReactionShortcutsEnabled(state: IReduxState) {
+    return browser.isFirefox()
+        && state['features/keyboard-shortcuts'].ctrlAltReactionShortcutsEnabled !== false;
+}
 
 /**
  * Returns whether or not the keyboard shortcuts are enabled.

--- a/react/features/keyboard-shortcuts/reducer.ts
+++ b/react/features/keyboard-shortcuts/reducer.ts
@@ -5,6 +5,7 @@ import {
     DISABLE_KEYBOARD_SHORTCUTS,
     ENABLE_KEYBOARD_SHORTCUTS,
     REGISTER_KEYBOARD_SHORTCUT,
+    SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED,
     UNREGISTER_KEYBOARD_SHORTCUT
 } from './actionTypes';
 import { IKeyboardShortcutsState } from './types';
@@ -15,12 +16,14 @@ import { IKeyboardShortcutsState } from './types';
 const STORE_NAME = 'features/keyboard-shortcuts';
 
 const defaultState = {
+    ctrlAltReactionShortcutsEnabled: true,
     enabled: true,
     shortcuts: new Map(),
     shortcutsHelp: new Map()
 };
 
 PersistenceRegistry.register(STORE_NAME, {
+    ctrlAltReactionShortcutsEnabled: true,
     enabled: true
 });
 
@@ -36,6 +39,11 @@ ReducerRegistry.register<IKeyboardShortcutsState>(STORE_NAME,
         return {
             ...state,
             enabled: false
+        };
+    case SET_CTRL_ALT_REACTION_SHORTCUTS_ENABLED:
+        return {
+            ...state,
+            ctrlAltReactionShortcutsEnabled: action.enabled
         };
     case REGISTER_KEYBOARD_SHORTCUT: {
         const { alt, character, ctrl } = action.shortcut;

--- a/react/features/keyboard-shortcuts/types.ts
+++ b/react/features/keyboard-shortcuts/types.ts
@@ -20,6 +20,7 @@ export interface IKeyboardShortcut {
 }
 
 export interface IKeyboardShortcutsState {
+    ctrlAltReactionShortcutsEnabled: boolean;
     enabled: boolean;
     shortcuts: Map<string, IKeyboardShortcut>;
     shortcutsHelp: Map<string, string>;

--- a/react/features/settings/actions.web.ts
+++ b/react/features/settings/actions.web.ts
@@ -19,7 +19,11 @@ import { IAudioSettings } from '../base/settings/reducer';
 import { getLocalVideoTrack } from '../base/tracks/functions.web';
 import { appendURLHashParam } from '../base/util/uri';
 import { setFollowMe, setFollowMeRecorder } from '../follow-me/actions';
-import { disableKeyboardShortcuts, enableKeyboardShortcuts } from '../keyboard-shortcuts/actions';
+import {
+    disableKeyboardShortcuts,
+    enableKeyboardShortcuts,
+    setCtrlAltReactionShortcutsEnabled
+} from '../keyboard-shortcuts/actions';
 import { toggleBackgroundEffect } from '../virtual-background/actions';
 import virtualBackgroundLogger from '../virtual-background/logger';
 
@@ -328,6 +332,11 @@ export function submitShortcutsTab(newState: any) {
             } else {
                 dispatch(disableKeyboardShortcuts());
             }
+        }
+
+        if (currentState.showCtrlAltReactionShortcuts
+                && newState.ctrlAltReactionShortcutsEnabled !== currentState.ctrlAltReactionShortcutsEnabled) {
+            dispatch(setCtrlAltReactionShortcutsEnabled(newState.ctrlAltReactionShortcutsEnabled));
         }
     };
 }

--- a/react/features/settings/components/web/SettingsDialog.tsx
+++ b/react/features/settings/components/web/SettingsDialog.tsx
@@ -306,6 +306,7 @@ function _mapStateToProps(state: IReduxState, ownProps: any) {
 
                 return {
                     ...newProps,
+                    ctrlAltReactionShortcutsEnabled: tabState?.ctrlAltReactionShortcutsEnabled,
                     keyboardShortcutsEnabled: tabState?.keyboardShortcutsEnabled
                 };
             },

--- a/react/features/settings/components/web/ShortcutsTab.tsx
+++ b/react/features/settings/components/web/ShortcutsTab.tsx
@@ -19,6 +19,11 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
     classes?: Partial<Record<keyof ReturnType<typeof styles>, string>>;
 
     /**
+     * Whether Ctrl+Alt aliases for reaction shortcuts are enabled or not.
+     */
+    ctrlAltReactionShortcutsEnabled: boolean;
+
+    /**
      * Whether to display the shortcuts or not.
      */
     displayShortcuts: boolean;
@@ -32,6 +37,11 @@ export interface IProps extends AbstractDialogTabProps, WithTranslation {
      * The keyboard shortcuts descriptions.
      */
     keyboardShortcutsHelpDescriptions: Map<string, string>;
+
+    /**
+     * Whether the Ctrl+Alt reaction shortcut setting should be displayed.
+     */
+    showCtrlAltReactionShortcuts: boolean;
 }
 
 const styles = (theme: Theme) => {
@@ -66,7 +76,15 @@ const styles = (theme: Theme) => {
             backgroundColor: theme.palette.settingsShortcutKey,
             ...theme.typography.labelBold,
             padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
-            borderRadius: `${Number(theme.shape.borderRadius) / 2}px`
+            borderRadius: `${Number(theme.shape.borderRadius) / 2}px`,
+            whiteSpace: 'nowrap' as const
+        },
+
+        listItemKeys: {
+            display: 'flex',
+            flexWrap: 'wrap' as const,
+            gap: theme.spacing(1),
+            justifyContent: 'flex-end'
         }
     };
 };
@@ -87,8 +105,20 @@ class ShortcutsTab extends AbstractDialogTab<IProps, any> {
         super(props);
 
         // Bind event handler so it is only bound once for every instance.
+        this._onCtrlAltReactionShortcutsEnableChanged
+            = this._onCtrlAltReactionShortcutsEnableChanged.bind(this);
         this._onKeyboardShortcutEnableChanged = this._onKeyboardShortcutEnableChanged.bind(this);
         this._renderShortcutsListItem = this._renderShortcutsListItem.bind(this);
+    }
+
+    /**
+     * Callback invoked to select if Ctrl+Alt reaction shortcut aliases should be enabled.
+     *
+     * @param {Object} e - The change event to handle.
+     * @returns {void}
+     */
+    _onCtrlAltReactionShortcutsEnableChanged({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) {
+        super._onChange({ ctrlAltReactionShortcutsEnabled: checked });
     }
 
     /**
@@ -106,11 +136,11 @@ class ShortcutsTab extends AbstractDialogTab<IProps, any> {
     /**
      * Render a keyboard shortcut with key and description.
      *
-     * @param {string} keyboardKey - The keyboard key for the shortcut.
+     * @param {string[]} keyboardKeys - The keyboard keys for the shortcut.
      * @param {string} translationKey - The translation key for the shortcut description.
      * @returns {JSX}
      */
-    _renderShortcutsListItem(keyboardKey: string, translationKey: string) {
+    _renderShortcutsListItem(keyboardKeys: string[], translationKey: string) {
         const { t } = this.props;
         const classes = withStyles.getClasses(this.props);
         let modifierKey = 'Alt';
@@ -124,15 +154,31 @@ class ShortcutsTab extends AbstractDialogTab<IProps, any> {
         return (
             <li
                 className = { classes.listItem }
-                key = { keyboardKey }>
+                key = { translationKey }>
                 <span
                     aria-label = { t(translationKey) }>
                     {t(translationKey)}
                 </span>
-                <span className = { classes.listItemKey }>
-                    {keyboardKey.startsWith(':')
-                        ? `${modifierKey} + ${keyboardKey.slice(1)}`
-                        : keyboardKey}
+                <span className = { classes.listItemKeys }>
+                    {keyboardKeys.map(keyboardKey => {
+                        let formattedKey = keyboardKey;
+
+                        if (keyboardKey.startsWith('-:')) {
+                            formattedKey = `Ctrl + ${modifierKey} + ${keyboardKey.slice(2)}`;
+                        } else if (keyboardKey.startsWith(':')) {
+                            formattedKey = `${modifierKey} + ${keyboardKey.slice(1)}`;
+                        } else if (keyboardKey.startsWith('-')) {
+                            formattedKey = `Ctrl + ${keyboardKey.slice(1)}`;
+                        }
+
+                        return (
+                            <span
+                                className = { classes.listItemKey }
+                                key = { keyboardKey }>
+                                {formattedKey}
+                            </span>
+                        );
+                    })}
                 </span>
             </li>
         );
@@ -146,15 +192,39 @@ class ShortcutsTab extends AbstractDialogTab<IProps, any> {
      */
     override render() {
         const {
+            ctrlAltReactionShortcutsEnabled,
             displayShortcuts,
             keyboardShortcutsHelpDescriptions,
             keyboardShortcutsEnabled,
+            showCtrlAltReactionShortcuts,
             t
         } = this.props;
         const classes = withStyles.getClasses(this.props);
         const shortcutDescriptions: Map<string, string> = displayShortcuts
             ? keyboardShortcutsHelpDescriptions
             : new Map();
+        const shortcutsByDescription = new Map<string, string[]>();
+
+        shortcutDescriptions.forEach((description, keyboardKey) => {
+            const keyboardKeys = shortcutsByDescription.get(description) ?? [];
+            const isReactionShortcut = description.startsWith('toolbar.reaction');
+
+            if (!isReactionShortcut || !keyboardKey.startsWith('-:') || ctrlAltReactionShortcutsEnabled) {
+                if (!keyboardKeys.includes(keyboardKey)) {
+                    keyboardKeys.push(keyboardKey);
+                }
+
+                if (isReactionShortcut && keyboardKey.startsWith(':') && ctrlAltReactionShortcutsEnabled) {
+                    const ctrlAltKeyboardKey = `-:${keyboardKey.slice(1)}`;
+
+                    if (!keyboardKeys.includes(ctrlAltKeyboardKey)) {
+                        keyboardKeys.push(ctrlAltKeyboardKey);
+                    }
+                }
+
+                shortcutsByDescription.set(description, keyboardKeys);
+            }
+        });
 
         return (
             <div className = { classes.container }>
@@ -164,10 +234,20 @@ class ShortcutsTab extends AbstractDialogTab<IProps, any> {
                     label = { t('prejoin.keyboardShortcuts') }
                     name = 'enable-keyboard-shortcuts'
                     onChange = { this._onKeyboardShortcutEnableChanged } />
+                {showCtrlAltReactionShortcuts && (
+                    <Checkbox
+                        checked = { ctrlAltReactionShortcutsEnabled }
+                        className = { classes.checkbox }
+                        disabled = { !keyboardShortcutsEnabled }
+                        label = { t('settings.enableCtrlAltReactionShortcuts') }
+                        name = 'enable-ctrl-alt-reaction-shortcuts'
+                        onChange = { this._onCtrlAltReactionShortcutsEnableChanged } />
+                )}
                 {displayShortcuts && (
                     <ul className = { classes.listContainer }>
-                        {Array.from(shortcutDescriptions)
-                            .map(description => this._renderShortcutsListItem(...description))}
+                        {Array.from(shortcutsByDescription)
+                            .map(([ description, keyboardKeys ]) =>
+                                this._renderShortcutsListItem(keyboardKeys, description))}
                     </ul>
                 )}
             </div>

--- a/react/features/settings/functions.web.ts
+++ b/react/features/settings/functions.web.ts
@@ -1,9 +1,14 @@
 import { IStateful } from '../base/app/types';
+import { browser } from '../base/lib-jitsi-meet';
 import { createLocalTrack } from '../base/lib-jitsi-meet/functions';
 import { isLocalParticipantModerator } from '../base/participants/functions';
 import { toState } from '../base/redux/functions';
 import { getUserSelectedCameraDeviceId } from '../base/settings/functions.web';
-import { areKeyboardShortcutsEnabled, getKeyboardShortcutsHelpDescriptions } from '../keyboard-shortcuts/functions';
+import {
+    areCtrlAltReactionShortcutsEnabled,
+    areKeyboardShortcutsEnabled,
+    getKeyboardShortcutsHelpDescriptions
+} from '../keyboard-shortcuts/functions';
 import { getParticipantsPaneConfig } from '../participants-pane/functions';
 import { isPrejoinPageVisible } from '../prejoin/functions';
 
@@ -85,9 +90,11 @@ export function getShortcutsTabProps(stateful: IStateful, isDisplayedOnWelcomePa
     const state = toState(stateful);
 
     return {
+        ctrlAltReactionShortcutsEnabled: areCtrlAltReactionShortcutsEnabled(state),
         displayShortcuts: !isDisplayedOnWelcomePage && !isPrejoinPageVisible(state),
         keyboardShortcutsEnabled: areKeyboardShortcutsEnabled(state),
-        keyboardShortcutsHelpDescriptions: getKeyboardShortcutsHelpDescriptions(state)
+        keyboardShortcutsHelpDescriptions: getKeyboardShortcutsHelpDescriptions(state),
+        showCtrlAltReactionShortcuts: browser.isFirefox()
     };
 }
 

--- a/react/features/toolbox/hooks.web.ts
+++ b/react/features/toolbox/hooks.web.ts
@@ -26,6 +26,7 @@ import { setGifMenuVisibility } from '../gifs/actions';
 import { isGifEnabled } from '../gifs/function.any';
 import InviteButton from '../invite/components/add-people-dialog/web/InviteButton';
 import { registerShortcut, unregisterShortcut } from '../keyboard-shortcuts/actions';
+import { areCtrlAltReactionShortcutsEnabled } from '../keyboard-shortcuts/functions';
 import { useKeyboardShortcutsButton } from '../keyboard-shortcuts/hooks';
 import NoiseSuppressionButton from '../noise-suppression/components/NoiseSuppressionButton';
 import {
@@ -380,6 +381,7 @@ export function useToolboxButtons(
 
 export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
     const dispatch = useDispatch();
+    const _ctrlAltReactionShortcutsEnabled = useSelector(areCtrlAltReactionShortcutsEnabled);
     const _isSpeakerStatsDisabled = useSelector(isSpeakerStatsDisabled);
     const _isParticipantsPaneEnabled = useSelector(isParticipantsPaneEnabled);
     const _shouldDisplayReactionsButtons = useSelector(shouldDisplayReactionsButtons);
@@ -631,6 +633,16 @@ export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
                     handler: shortcut.exec,
                     helpDescription: shortcut.helpDescription
                 }));
+
+                if (_ctrlAltReactionShortcutsEnabled) {
+                    dispatch(registerShortcut({
+                        alt: true,
+                        character: shortcut.character,
+                        ctrl: true,
+                        handler: shortcut.exec,
+                        helpDescription: shortcut.helpDescription
+                    }));
+                }
             });
 
             if (gifsEnabled) {
@@ -655,11 +667,17 @@ export const useKeyboardShortcuts = (toolbarButtons: Array<string>) => {
 
             if (_shouldDisplayReactionsButtons) {
                 Object.keys(REACTIONS).map(key => REACTIONS[key].shortcutChar)
-                    .forEach(letter =>
-                        dispatch(unregisterShortcut(letter, true)));
+                    .forEach(letter => {
+                        dispatch(unregisterShortcut(letter, true));
+
+                        if (_ctrlAltReactionShortcutsEnabled) {
+                            dispatch(unregisterShortcut(letter, true, true));
+                        }
+                    });
             }
         };
     }, [
+        _ctrlAltReactionShortcutsEnabled,
         _shouldDisplayReactionsButtons,
         chatOpen,
         desktopSharingButtonDisabled,

--- a/tests/pageobjects/SettingsDialog.ts
+++ b/tests/pageobjects/SettingsDialog.ts
@@ -1,6 +1,7 @@
 import BaseDialog from './BaseDialog';
 
 const EMAIL_FIELD = '#setEmail';
+const CTRL_ALT_REACTION_SHORTCUTS_CHECKBOX = '//input[@name="enable-ctrl-alt-reaction-shortcuts"]';
 const FOLLOW_ME_CHECKBOX = '//input[@name="follow-me"]';
 const HIDE_SELF_VIEW_CHECKBOX = '//input[@name="hide-self-view"]';
 const SETTINGS_DIALOG_CONTENT = '.settings-pane';
@@ -9,6 +10,7 @@ const START_VIDEO_MUTED_CHECKBOX = '//input[@name="start-video-muted"]';
 const X_PATH_MODERATOR_TAB = '//div[contains(@class, "settings-dialog")]//*[text()="Moderator"]';
 const X_PATH_MORE_TAB = '//div[contains(@class, "settings-dialog")]//*[text()="General"]';
 const X_PATH_PROFILE_TAB = '//div[contains(@class, "settings-dialog")]//*[text()="Profile"]';
+const X_PATH_SHORTCUTS_TAB = '//div[contains(@class, "settings-dialog")]//*[text()="Shortcuts"]';
 
 /**
  * The settings dialog.
@@ -52,6 +54,45 @@ export default class SettingsDialog extends BaseDialog {
      */
     openModeratorTab() {
         return this.openTab(X_PATH_MODERATOR_TAB);
+    }
+
+    /**
+     * Selects the Shortcuts tab to be displayed.
+     */
+    openShortcutsTab() {
+        return this.openTab(X_PATH_SHORTCUTS_TAB);
+    }
+
+    /**
+     * Returns whether the Firefox-only Ctrl+Alt reaction shortcut setting exists.
+     */
+    hasCtrlAltReactionShortcutsSetting() {
+        return this.participant.driver.$(CTRL_ALT_REACTION_SHORTCUTS_CHECKBOX).isExisting();
+    }
+
+    /**
+     * Returns whether Ctrl+Alt reaction shortcut aliases are enabled.
+     */
+    isCtrlAltReactionShortcutsEnabled() {
+        return this.participant.driver.$(CTRL_ALT_REACTION_SHORTCUTS_CHECKBOX).isSelected();
+    }
+
+    /**
+     * Enables or disables Ctrl+Alt reaction shortcut aliases.
+     *
+     * @param enable - Whether the aliases should be enabled.
+     */
+    setCtrlAltReactionShortcutsEnabled(enable: boolean) {
+        return this.setCheckbox(CTRL_ALT_REACTION_SHORTCUTS_CHECKBOX, enable);
+    }
+
+    /**
+     * Returns the shortcut key labels currently displayed on the Shortcuts tab.
+     */
+    async getShortcutKeyLabels() {
+        const elements = await this.participant.driver.$$('//ul/li/span[last()]/span');
+
+        return elements.map(element => element.getText());
     }
 
     /**

--- a/tests/specs/misc/reactionShortcuts.spec.ts
+++ b/tests/specs/misc/reactionShortcuts.spec.ts
@@ -1,0 +1,143 @@
+import { setTestProperties } from '../../helpers/TestProperties';
+import { ensureOneParticipant } from '../../helpers/participants';
+
+setTestProperties(__filename, {
+    usesBrowsers: [ 'p1' ]
+});
+
+const REACTION_SHORTCUT_CHARACTERS = [ 'T', 'C', 'L', 'O', 'B', 'S', 'H' ];
+
+/**
+ * Returns the currently registered keyboard shortcut keys.
+ */
+function getRegisteredShortcutKeys() {
+    return ctx.p1.execute(() =>
+        Array.from(APP.store.getState()['features/keyboard-shortcuts'].shortcuts.keys()));
+}
+
+/**
+ * Returns the persisted Ctrl+Alt reaction shortcut preference.
+ */
+function getPersistedCtrlAltReactionShortcutsPreference() {
+    return ctx.p1.execute(() => {
+        const persistedState = localStorage.getItem('features/keyboard-shortcuts');
+
+        return persistedState
+            ? JSON.parse(persistedState).ctrlAltReactionShortcutsEnabled
+            : undefined;
+    });
+}
+
+/**
+ * Dispatches a Ctrl+Alt+T key event and returns the reactions it adds to the buffer.
+ */
+function sendCtrlAltT() {
+    return ctx.p1.execute(() => {
+        const activeElement = document.activeElement as HTMLElement;
+
+        activeElement?.blur();
+
+        const buffer = APP.store.getState()['features/reactions'].buffer;
+        const originalLength = buffer.length;
+
+        window.dispatchEvent(new KeyboardEvent('keyup', {
+            altKey: true,
+            code: 'KeyT',
+            ctrlKey: true,
+            key: 't'
+        }));
+
+        return APP.store.getState()['features/reactions'].buffer.slice(originalLength);
+    });
+}
+
+describe('Reaction keyboard shortcut aliases', () => {
+    it('joins the meeting', async () => {
+        await ensureOneParticipant();
+    });
+
+    it('registers Ctrl+Alt aliases only on Firefox', async () => {
+        const isFirefox = await ctx.p1.execute(() => navigator.userAgent.includes('Firefox/'));
+        const shortcuts = await getRegisteredShortcutKeys();
+
+        REACTION_SHORTCUT_CHARACTERS.forEach(character => {
+            expect(shortcuts).toContain(`:${character}`);
+
+            if (isFirefox) {
+                expect(shortcuts).toContain(`-:${character}`);
+            } else {
+                expect(shortcuts).not.toContain(`-:${character}`);
+            }
+        });
+
+        if (isFirefox) {
+            expect(await sendCtrlAltT()).toEqual([ 'like' ]);
+        }
+    });
+
+    it('shows and saves the Firefox-only setting', async () => {
+        const { p1 } = ctx;
+        const isFirefox = await p1.execute(() => navigator.userAgent.includes('Firefox/'));
+
+        await p1.getToolbar().clickSettingsButton();
+
+        const settings = p1.getSettingsDialog();
+
+        await settings.waitForDisplay();
+        await settings.openShortcutsTab();
+        expect(await settings.hasCtrlAltReactionShortcutsSetting()).toBe(isFirefox);
+
+        if (!isFirefox) {
+            await settings.clickCloseButton();
+
+            return;
+        }
+
+        expect(await settings.isCtrlAltReactionShortcutsEnabled()).toBe(true);
+
+        const shortcutLabels = await settings.getShortcutKeyLabels();
+
+        REACTION_SHORTCUT_CHARACTERS.forEach(character => {
+            expect(shortcutLabels).toContain(`Alt + ${character}`);
+            expect(shortcutLabels).toContain(`Ctrl + Alt + ${character}`);
+        });
+
+        await settings.setCtrlAltReactionShortcutsEnabled(false);
+
+        const disabledShortcutLabels = await settings.getShortcutKeyLabels();
+
+        REACTION_SHORTCUT_CHARACTERS.forEach(character => {
+            expect(disabledShortcutLabels).toContain(`Alt + ${character}`);
+            expect(disabledShortcutLabels).not.toContain(`Ctrl + Alt + ${character}`);
+        });
+
+        await settings.submit();
+
+        await p1.driver.waitUntil(async () => {
+            const shortcuts = await getRegisteredShortcutKeys();
+
+            return REACTION_SHORTCUT_CHARACTERS.every(character =>
+                shortcuts.includes(`:${character}`) && !shortcuts.includes(`-:${character}`));
+        });
+        await p1.driver.waitUntil(async () =>
+            await getPersistedCtrlAltReactionShortcutsPreference() === false);
+
+        expect(await sendCtrlAltT()).toEqual([]);
+
+        await p1.getToolbar().clickSettingsButton();
+        await settings.waitForDisplay();
+        await settings.openShortcutsTab();
+        expect(await settings.isCtrlAltReactionShortcutsEnabled()).toBe(false);
+
+        await settings.setCtrlAltReactionShortcutsEnabled(true);
+        await settings.submit();
+
+        await p1.driver.waitUntil(async () => {
+            const shortcuts = await getRegisteredShortcutKeys();
+
+            return REACTION_SHORTCUT_CHARACTERS.every(character => shortcuts.includes(`-:${character}`));
+        });
+        await p1.driver.waitUntil(async () =>
+            await getPersistedCtrlAltReactionShortcutsPreference() === true);
+    });
+});


### PR DESCRIPTION
## Summary

Firefox on Ubuntu intercepts some Alt-based reaction shortcuts, particularly Alt+T, Alt+B, and Alt+S, before Jitsi can handle them.

This change keeps all existing Alt reaction shortcuts unchanged and adds Ctrl+Alt alternatives for Firefox users.

Fixes #15066

## Changes

- Add Ctrl+Alt aliases for all reaction shortcuts: T, C, L, O, B, S, and H.
- Keep the existing Alt shortcuts as the default shortcuts.
- Add a Firefox-only setting under Settings > Shortcuts.
- Enable the Ctrl+Alt alternatives by default on Firefox.
- Save the preference locally for the individual browser.
- Display both Alt and Ctrl+Alt labels when the alternatives are enabled.
- Keep the setting hidden on non-Firefox browsers.
- Add focused end-to-end coverage for registration, UI visibility, execution, and persistence.

## Testing

- [x] `npm run lint:ci`
- [x] `npm run tsc:ci`
- [x] `npm run lint:lang`
- [x] `npm run lint:i18n`
- [x] Firefox end-to-end test
- [x] Chrome end-to-end test
- [x] Manually verified all seven reaction shortcuts in Firefox on Ubuntu

## Screenshots

<img width="650" height="546" alt="image" src="https://github.com/user-attachments/assets/839557a1-1f08-44c0-9ee7-73c5c3d24a94" />
<img width="647" height="533" alt="image" src="https://github.com/user-attachments/assets/cdb8b9a7-7f40-47d0-84df-fbaae8df9204" />
