### PR TITLE
fix(polls): respect notify flag when incrementing unreadPollsCount

### DIFF
--- a/react/features/polls/reducer.ts
+++ b/react/features/polls/reducer.ts
@@ -64,7 +64,9 @@ ReducerRegistry.register<IPollsState>(STORE_NAME, (state = INITIAL_STATE, action
                 ...state.polls,
                 [action.poll.pollId]: action.poll
             },
-            unreadPollsCount: state.unreadPollsCount + 1
+            unreadPollsCount: action.notify
+                ? state.unreadPollsCount + 1
+                : state.unreadPollsCount
         };
     }
 


### PR DESCRIPTION
Fixes #17794

## Summary
Fixed the unread polls counter to respect the `notify` flag, preventing historical polls from incorrectly incrementing the badge count when participants join late.

## Changes
Modified `react/features/polls/reducer.ts` in the `RECEIVE_POLL` case to only increment `unreadPollsCount` when `action.notify` is true.

## Details
When a participant joins a conference with existing polls, the server replays those polls as history (with `notify = false`). The middleware already respects this flag for sound notifications, but the reducer was unconditionally incrementing the unread counter for all polls, including historical ones. This caused late-joiners to see an inflated unread badge.

The fix ensures consistency: only polls with `notify = true` (genuinely new polls) increment the counter, while historical polls (replayed on join with `notify = false`) do not affect the badge count.

## Testing
- Verified the `notify` flag is properly set in the action creator (`actions.ts`)
- Confirmed the middleware already uses this flag correctly for notifications
- Code change aligns reducer behavior with existing middleware logic

