### PR TITLE
fix(notifications): keep a notification that is re-added while unmounting

### DIFF
--- a/react/features/notifications/components/NotificationsTransition.tsx
+++ b/react/features/notifications/components/NotificationsTransition.tsx
@@ -1,67 +1,92 @@
-import React, { ReactElement, useEffect, useState } from 'react';
-
-export const NotificationsTransitionContext = React.createContext({
-    unmounting: new Map<string, TimeoutType | null>()
-});
+import React, { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type TimeoutType = ReturnType<typeof setTimeout>;
 
+export const NotificationsTransitionContext = React.createContext({
+    unmounting: new Map<string, TimeoutType>()
+});
+
+/**
+ * How long a removed notification is kept mounted so that its exit animation can play.
+ */
+const UNMOUNT_ANIMATION_TIMEOUT = 250;
+
 const NotificationsTransition = ({ children }: { children: ReactElement[]; }) => {
     const [ childrenToRender, setChildrenToRender ] = useState(children);
-    const [ timeoutIds, setTimeoutIds ] = useState(new Map<string, TimeoutType | null>());
+
+    /**
+     * The pending removals, by uid. Held in a ref so that the timeout callbacks always act on the current
+     * timers instead of the ones captured when they were scheduled, and mirrored into state so that a render
+     * is triggered and the notifications which are animating out can be marked as such.
+     */
+    const timers = useRef(new Map<string, TimeoutType>());
+    const [ unmounting, setUnmounting ] = useState(timers.current);
+
+    const removeChild = useCallback((uid: string) => {
+        timers.current.delete(uid);
+        setUnmounting(new Map(timers.current));
+        setChildrenToRender(current => current.filter(child => child.props.uid !== uid));
+    }, []);
 
     useEffect(() => {
-        const toUnmount = childrenToRender.filter(child =>
-            children.findIndex(c => c.props.uid === child.props.uid) === -1) ?? [];
-        const toMount = children?.filter(child =>
-            childrenToRender.findIndex(c => c.props.uid === child.props.uid) === -1) ?? [];
+        const uids = new Set(children.map(child => child.props.uid));
+        let timersChanged = false;
 
-        /**
-         * Update current notifications.
-         * In some cases the UID is the same but the other props change.
-         * This way we make sure the notification displays the latest info.
-         */
-        children.forEach(child => {
-            const index = childrenToRender.findIndex(c => c.props.uid === child.props.uid);
-
-            if (index !== -1) {
-                childrenToRender[index] = child;
+        // A notification that was re-added while it was animating out is displayed again, so its pending
+        // removal has to be cancelled. Notifications are keyed by uid and are reused (the lobby one, for
+        // example), so without this the removal would fire and drop a notification that is still current.
+        timers.current.forEach((timeoutId, uid) => {
+            if (uids.has(uid)) {
+                clearTimeout(timeoutId);
+                timers.current.delete(uid);
+                timersChanged = true;
             }
         });
 
-        if (toUnmount.length > 0) {
-            const ids = new Map(timeoutIds);
+        childrenToRender.forEach(child => {
+            const { uid } = child.props;
 
-            toUnmount.forEach(child => {
-                const timeoutId = setTimeout(() => {
-                    timeoutIds.set(child.props.uid, null);
-                    setTimeoutIds(timeoutIds);
-                }, 250);
+            if (!uids.has(uid) && !timers.current.has(uid)) {
+                timers.current.set(uid, setTimeout(() => removeChild(uid), UNMOUNT_ANIMATION_TIMEOUT));
+                timersChanged = true;
+            }
+        });
 
-                ids.set(child.props.uid, timeoutId);
-            });
-            setTimeoutIds(ids);
+        if (timersChanged) {
+            setUnmounting(new Map(timers.current));
         }
 
-        setChildrenToRender(toMount.concat(childrenToRender));
+        setChildrenToRender(current => {
+            const toMount = children.filter(child =>
+                current.findIndex(c => c.props.uid === child.props.uid) === -1);
+
+            /**
+             * Update current notifications.
+             * In some cases the UID is the same but the other props change.
+             * This way we make sure the notification displays the latest info.
+             */
+            const updated = current.map(child =>
+                children.find(c => c.props.uid === child.props.uid) ?? child);
+
+            return toMount.concat(updated);
+        });
     }, [ children ]);
 
     useEffect(() => {
-        const toRemove: string[] = [];
+        const pending = timers.current;
 
-        timeoutIds.forEach((value, key) => {
-            if (value === null) {
-                toRemove.push(key);
-                timeoutIds.delete(key);
-            }
-        });
+        return () => {
+            pending.forEach(timeoutId => clearTimeout(timeoutId));
+            pending.clear();
+        };
+    }, []);
 
-        toRemove.length > 0 && setChildrenToRender(childrenToRender.filter(child =>
-            toRemove.findIndex(id => child.props.uid === id) === -1));
-    }, [ timeoutIds ]);
+    const context = useMemo(() => {
+        return { unmounting };
+    }, [ unmounting ]);
 
     return (
-        <NotificationsTransitionContext.Provider value = {{ unmounting: timeoutIds }}>
+        <NotificationsTransitionContext.Provider value = { context }>
             {childrenToRender}
         </NotificationsTransitionContext.Provider>
     );


### PR DESCRIPTION
A removed notification is kept mounted for 250ms so its exit animation can play, and is then dropped by a timeout. That timeout was not cancelled when a notification with the same uid was shown again in the meantime, so the removal fired and filtered the new notification out of the rendered list. It never came back, because the list is only recomputed when the notifications in the store change, and the store already held the new notification.

Notifications are keyed by uid and some of them reuse a constant one, so this is reachable whenever the same notification is hidden and shown again in quick succession. The lobby notification is the clearest case: with two participants knocking one after the other, the moderator can stop seeing the second knock entirely — the notification is in the store, but `#notifications-container` stays empty.

This is the suspected cause of the `Lobby.lobby persistence` torture failure on the Firefox job, which fails on the sixth knock of the spec with `Knocking participant notification not displayed`. In the archived runs the moderator receives the knocking participant's lobby presence and registers the occupant, but no notification is ever rendered. That knock is uniquely preceded by a show/hide of the same notification about 150ms apart, where every knock that passes had one displayed for 500-900ms.

Changes:

- cancel the pending removal when the uid reappears in the notifications to render;
- keep the timers in a ref, so the timeout callbacks act on the current timers instead of the ones captured when they were scheduled. Mutating the captured map and setting it back could be a no-op when it was still the current state, which deferred a removal to the next unrelated change, where it could take out a live notification;
- use functional updates instead of stale closures, and stop mutating the rendered list in place;
- clear the pending timeouts when the component unmounts.

Behaviour is otherwise unchanged: removed notifications stay mounted for 250ms with the `unmount` marker, new ones are prepended, and same-uid prop updates still refresh in place.
