### PR TITLE
fix(prosody): Restore the features of a session when owner is revoked

### DIFF
--- a/resources/prosody-plugins/mod_jitsi_permissions.lua
+++ b/resources/prosody-plugins/mod_jitsi_permissions.lua
@@ -28,6 +28,7 @@ local is_healthcheck_room = util.is_healthcheck_room;
 local room_jid_match_rewrite = util.room_jid_match_rewrite;
 local is_focus = util.is_focus;
 local presence_check_status = util.presence_check_status;
+local get_occupant_by_real_jid = util.get_occupant_by_real_jid;
 
 local MUC_NS = 'http://jabber.org/protocol/muc';
 
@@ -88,10 +89,11 @@ function process_set_affiliation(event)
         return;
     end
 
-    -- An affiliation belongs to a bare JID. Resolve the live sessions of that JID
-    -- directly, and not through the occupants of this room: a session that is in a
-    -- breakout room at this time is not an occupant here, but its affiliation in
-    -- this room still decides its role there.
+    -- An affiliation belongs to a bare JID, and a bare JID can have more than one
+    -- live session (multiple devices/tabs). Resolve them all, but only touch a
+    -- session that is actually an occupant of this room or one of its own breakout
+    -- rooms: an affiliation set on this room must not reach a session that happens
+    -- to share the same bare JID while sitting in an unrelated conference.
     local bare_session = prosody.bare_sessions[jid];
     if not bare_session then
         return;
@@ -104,39 +106,41 @@ function process_set_affiliation(event)
     local revoking = previous_affiliation == 'owner' and affiliation ~= 'owner';
 
     for _, occupant_session in pairs(bare_session.sessions) do
-        if granting then
-            -- Keep the features the session had before the grant, so that a later revoke
-            -- can put them back. The value false marks a session that had no features,
-            -- which is not the same as a session that had an empty table.
-            if occupant_session.pre_grant_jitsi_meet_context_features == nil then
-                occupant_session.pre_grant_jitsi_meet_context_features
-                    = occupant_session.jitsi_meet_context_features or false;
-            end
+        if get_occupant_by_real_jid(room, occupant_session.full_jid) then
+            if granting then
+                -- Keep the features the session had before the grant, so that a later
+                -- revoke can put them back. The value false marks a session that had no
+                -- features, which is not the same as a session that had an empty table.
+                if occupant_session.pre_grant_jitsi_meet_context_features == nil then
+                    occupant_session.pre_grant_jitsi_meet_context_features
+                        = occupant_session.jitsi_meet_context_features or false;
+                end
 
-            occupant_session.jitsi_meet_context_features
-                = copy_features(actor_session.jitsi_meet_context_features);
-            if actor_session.jitsi_meet_context_user then
-                occupant_session.granted_jitsi_meet_context_user_id = actor_session.jitsi_meet_context_user['id']
-                    or actor_session.granted_jitsi_meet_context_user_id;
-            end
-            occupant_session.granted_jitsi_meet_context_group_id = actor_session.jitsi_meet_context_group
-                or actor_session.granted_jitsi_meet_context_group_id;
-            -- even if token and features are set we may want to re-send permissions
-            occupant_session.force_permissions_update = true;
-        elseif revoking then
-            occupant_session.granted_jitsi_meet_context_user_id = nil;
-            occupant_session.granted_jitsi_meet_context_group_id = nil;
+                occupant_session.jitsi_meet_context_features
+                    = copy_features(actor_session.jitsi_meet_context_features);
+                if actor_session.jitsi_meet_context_user then
+                    occupant_session.granted_jitsi_meet_context_user_id = actor_session.jitsi_meet_context_user['id']
+                        or actor_session.granted_jitsi_meet_context_user_id;
+                end
+                occupant_session.granted_jitsi_meet_context_group_id = actor_session.jitsi_meet_context_group
+                    or actor_session.granted_jitsi_meet_context_group_id;
+                -- even if token and features are set we may want to re-send permissions
+                occupant_session.force_permissions_update = true;
+            elseif revoking then
+                occupant_session.granted_jitsi_meet_context_user_id = nil;
+                occupant_session.granted_jitsi_meet_context_group_id = nil;
 
-            local pre_grant = occupant_session.pre_grant_jitsi_meet_context_features;
+                local pre_grant = occupant_session.pre_grant_jitsi_meet_context_features;
 
-            if pre_grant ~= nil then
-                -- The session received a grant before. Put back the features it had then.
-                -- A token session gets its token features again, and any other session
-                -- gets no features and falls back to a check of its current role.
-                occupant_session.jitsi_meet_context_features = pre_grant or nil;
-                occupant_session.pre_grant_jitsi_meet_context_features = nil;
-            elseif not occupant_session.auth_token then
-                occupant_session.jitsi_meet_context_features = nil;
+                if pre_grant ~= nil then
+                    -- The session received a grant before. Put back the features it had
+                    -- then. A token session gets its token features again, and any other
+                    -- session gets no features and falls back to a check of its current role.
+                    occupant_session.jitsi_meet_context_features = pre_grant or nil;
+                    occupant_session.pre_grant_jitsi_meet_context_features = nil;
+                elseif not occupant_session.auth_token then
+                    occupant_session.jitsi_meet_context_features = nil;
+                end
             end
         end
     end

--- a/resources/prosody-plugins/mod_jitsi_permissions.lua
+++ b/resources/prosody-plugins/mod_jitsi_permissions.lua
@@ -50,6 +50,19 @@ end
 local sessions = prosody.full_sessions;
 local default_permissions;
 
+-- Returns a copy of a feature table. Sessions must not share one table, because
+-- a change to the features of one session must not change the features of
+-- another session.
+local function copy_features(features)
+    local res = {};
+
+    for k, v in pairs(features) do
+        res[k] = v;
+    end
+
+    return res;
+end
+
 local function load_config()
     default_permissions = module:get_option('jitsi_default_permissions', {
         livestreaming = true;
@@ -75,39 +88,56 @@ function process_set_affiliation(event)
         return;
     end
 
-    local occupant;
-    for _, o in room:each_occupant() do
-        if o.bare_jid == jid then
-            occupant = o;
-        end
-    end
-
-    if not occupant then
+    -- An affiliation belongs to a bare JID. Resolve the live sessions of that JID
+    -- directly, and not through the occupants of this room: a session that is in a
+    -- breakout room at this time is not an occupant here, but its affiliation in
+    -- this room still decides its role there.
+    local bare_session = prosody.bare_sessions[jid];
+    if not bare_session then
         return;
     end
 
-    local occupant_session = sessions[occupant.jid];
-    if not occupant_session then
-        return;
-    end
+    -- Any transition into owner is a grant. Any transition out of owner is a revoke.
+    -- This also covers the admin and outcast affiliations, which the client does not
+    -- use but which a raw stanza can set.
+    local granting = affiliation == 'owner' and previous_affiliation ~= 'owner';
+    local revoking = previous_affiliation == 'owner' and affiliation ~= 'owner';
 
-    if (previous_affiliation == 'none' or previous_affiliation == 'member') and affiliation == 'owner' then
-        occupant_session.jitsi_meet_context_features = actor_session.jitsi_meet_context_features;
-        if actor_session.jitsi_meet_context_user then
-            occupant_session.granted_jitsi_meet_context_user_id = actor_session.jitsi_meet_context_user['id']
-                or actor_session.granted_jitsi_meet_context_user_id;
-        end
-        occupant_session.granted_jitsi_meet_context_group_id = actor_session.jitsi_meet_context_group
-            or actor_session.granted_jitsi_meet_context_group_id;
-        -- even if token and features are set we may want to re-send permissions
-        occupant_session.force_permissions_update = true;
-    elseif previous_affiliation == 'owner' and ( affiliation == 'member' or affiliation == 'none' ) then
-        occupant_session.granted_jitsi_meet_context_user_id = nil;
-        occupant_session.granted_jitsi_meet_context_group_id = nil;
+    for _, occupant_session in pairs(bare_session.sessions) do
+        if granting then
+            -- Keep the features the session had before the grant, so that a later revoke
+            -- can put them back. The value false marks a session that had no features,
+            -- which is not the same as a session that had an empty table.
+            if occupant_session.pre_grant_jitsi_meet_context_features == nil then
+                occupant_session.pre_grant_jitsi_meet_context_features
+                    = occupant_session.jitsi_meet_context_features or false;
+            end
 
-        -- on revoke
-        if not occupant_session.auth_token then
-            occupant_session.jitsi_meet_context_features = nil;
+            occupant_session.jitsi_meet_context_features
+                = copy_features(actor_session.jitsi_meet_context_features);
+            if actor_session.jitsi_meet_context_user then
+                occupant_session.granted_jitsi_meet_context_user_id = actor_session.jitsi_meet_context_user['id']
+                    or actor_session.granted_jitsi_meet_context_user_id;
+            end
+            occupant_session.granted_jitsi_meet_context_group_id = actor_session.jitsi_meet_context_group
+                or actor_session.granted_jitsi_meet_context_group_id;
+            -- even if token and features are set we may want to re-send permissions
+            occupant_session.force_permissions_update = true;
+        elseif revoking then
+            occupant_session.granted_jitsi_meet_context_user_id = nil;
+            occupant_session.granted_jitsi_meet_context_group_id = nil;
+
+            local pre_grant = occupant_session.pre_grant_jitsi_meet_context_features;
+
+            if pre_grant ~= nil then
+                -- The session received a grant before. Put back the features it had then.
+                -- A token session gets its token features again, and any other session
+                -- gets no features and falls back to a check of its current role.
+                occupant_session.jitsi_meet_context_features = pre_grant or nil;
+                occupant_session.pre_grant_jitsi_meet_context_features = nil;
+            elseif not occupant_session.auth_token then
+                occupant_session.jitsi_meet_context_features = nil;
+            end
         end
     end
 end
@@ -177,7 +207,7 @@ function filter_stanza(stanza, session)
     session.force_permissions_update = false;
 
     if not session.jitsi_meet_context_features then
-        session.jitsi_meet_context_features = default_permissions;
+        session.jitsi_meet_context_features = copy_features(default_permissions);
     end
 
     room.send_default_permissions_to[bare_to] = nil;

--- a/tests/prosody/mod_jitsi_permissions_spec.js
+++ b/tests/prosody/mod_jitsi_permissions_spec.js
@@ -610,6 +610,46 @@ describe('mod_jitsi_permissions', () => {
             assert.strictEqual(restored.recording, false);
         });
 
+        it('does not touch the features of a session that is not in this room', async () => {
+            const roomA = nextRoom();
+            const roomB = nextRoom();
+
+            clients.push(await joinWithFocus(roomA));
+            clients.push(await joinWithFocus(roomB));
+
+            const granter = await joinAsGranter(connect, roomA);
+
+            const token = mintAsapToken({
+                room: roomB.split('@')[0],
+                context: {
+                    user: { id: 'user-other-room' },
+                    features: { recording: false }
+                }
+            });
+            const other = await connect({ params: { token } });
+
+            await other.joinRoom(roomB);
+
+            const bare = other.jid.split('/')[0];
+
+            // The granter is only a moderator of room A, and the recipient is only
+            // ever an occupant of room B. An affiliation change on room A must not
+            // reach a session that shares the same bare JID in an unrelated room.
+            const reply = await granter.sendMucAdmin(roomA, { jid: bare,
+                affiliation: 'owner' });
+
+            assert.strictEqual(reply.attrs.type, 'result');
+
+            const features = await getSessionFeatures(other.jid);
+
+            assert.ok(features !== null, 'the token features must be unchanged');
+            assert.strictEqual(features.recording, false);
+            assert.strictEqual(
+                await jibriStartErrorCondition(other, roomB),
+                'forbidden',
+                'a cross-room grant must not authorize this session in its own room');
+        });
+
     });
 
     // ── session features via HTTP ─────────────────────────────────────────────

--- a/tests/prosody/mod_jitsi_permissions_spec.js
+++ b/tests/prosody/mod_jitsi_permissions_spec.js
@@ -201,6 +201,417 @@ describe('mod_jitsi_permissions', () => {
 
     });
 
+
+    // ── affiliation grant and revoke ──────────────────────────────────────────
+    //
+    // When a moderator grants owner affiliation to another participant,
+    // process_set_affiliation copies the granting session's feature table onto
+    // the recipient's session.  When the affiliation is revoked, the recipient
+    // must go back to the features that its own token supplied, or to no
+    // features at all when the token supplied none.  A session that keeps the
+    // granted table stays allowed by is_feature_allowed(), which does not look
+    // at the current role once a feature table is present.
+
+    describe('affiliation grant and revoke', () => {
+
+        /**
+         * Joins a room as a moderator that holds every default feature.
+         * Use it as the actor that grants and revokes owner affiliation.
+         *
+         * @param {Function} connectFn  the spec-local connect helper.
+         * @param {string} roomJid      e.g. 'room@conference.localhost'
+         * @returns {Promise<object>}
+         */
+        async function joinAsGranter(connectFn, roomJid, extraParams = {}) {
+            const features = {};
+
+            for (const key of DEFAULT_PERMISSION_KEYS) {
+                features[key] = true;
+            }
+
+            const token = mintAsapToken({
+                room: roomJid.split('@')[0],
+                context: {
+                    user: { id: 'granter',
+                        moderator: true },
+                    features
+                }
+            });
+            const c = await connectFn({ params: { token,
+                ...extraParams } });
+
+            await c.joinRoom(roomJid);
+
+            return c;
+        }
+
+        /**
+         * Sends a Jibri start IQ and returns the name of the error condition
+         * that comes back. mod_filter_iq_jibri answers 'forbidden' when it
+         * blocks the request. Anything else means the IQ was routed on to the
+         * focus occupant, which has no Jibri handler in these tests.
+         *
+         * @param {object} client   the sender.
+         * @param {string} roomJid  e.g. 'room@conference.localhost'
+         * @returns {Promise<string|null>}
+         */
+        async function jibriStartErrorCondition(client, roomJid) {
+            const wait = client.waitForIq(iq => iq.attrs.type === 'error', 5000);
+
+            client.sendJibriIq(roomJid, 'start', 'file');
+
+            const error = (await wait).getChild('error');
+
+            return error ? error.children[0].name : null;
+        }
+
+        /**
+         * Sends a Rayo dial IQ and returns the name of the error condition that
+         * comes back. mod_filter_iq_rayo answers 'forbidden' when it blocks the
+         * request. Anything else means the IQ was routed on to the focus
+         * occupant, which has no Rayo handler in these tests.
+         *
+         * @param {object} client   the sender.
+         * @param {string} roomJid  e.g. 'room@conference.localhost'
+         * @returns {Promise<string|null>}
+         */
+        async function rayoDialErrorCondition(client, roomJid) {
+            const reply = await client.sendRayoIqAndWait(roomJid);
+            const error = reply.getChild('error');
+
+            return error ? error.children[0].name : null;
+        }
+
+        it('restores the token features of the recipient when owner is revoked', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+
+            const token = mintAsapToken({
+                room: r.split('@')[0],
+                context: {
+                    user: { id: 'user1' },
+                    features: {
+                        recording: false,
+                        livestreaming: false,
+                        transcription: false,
+                        'outbound-call': false
+                    }
+                }
+            });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            const granted = await getSessionFeatures(c.jid);
+
+            assert.strictEqual(granted.recording, true, 'grant should hand over the actor features');
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            const restored = await getSessionFeatures(c.jid);
+
+            assert.ok(restored !== null, 'the token features should come back');
+            assert.strictEqual(restored.recording, false);
+            assert.strictEqual(restored.livestreaming, false);
+            assert.strictEqual(restored.transcription, false);
+            assert.strictEqual(restored['outbound-call'], false);
+        });
+
+        it('clears granted features when the token of the recipient has none', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+
+            const token = mintAsapToken({ room: r.split('@')[0],
+                context: { user: { id: 'user2' } } });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            assert.ok(await getSessionFeatures(c.jid) !== null, 'grant should set features');
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            assert.strictEqual(await getSessionFeatures(c.jid), null,
+                'the session must hold no features again');
+        });
+
+        it('clears granted features for a participant without a token', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+            const c = await connect();
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            assert.ok(await getSessionFeatures(c.jid) !== null, 'grant should set features');
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            assert.strictEqual(await getSessionFeatures(c.jid), null,
+                'the session must hold no features again');
+        });
+
+        it('restores the token features when owner is revoked twice in a row', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+
+            const token = mintAsapToken({
+                room: r.split('@')[0],
+                context: {
+                    user: { id: 'user3' },
+                    features: { recording: false }
+                }
+            });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            for (let i = 0; i < 2; i++) {
+                await granter.sendMucAdmin(r, { jid: bare,
+                    affiliation: 'owner' });
+                await granter.sendMucAdmin(r, { jid: bare,
+                    affiliation: 'member' });
+            }
+
+            const restored = await getSessionFeatures(c.jid);
+
+            assert.ok(restored !== null, 'the token features should come back');
+            assert.strictEqual(restored.recording, false);
+        });
+
+        it('blocks Jibri and Rayo requests from a recipient whose owner affiliation was revoked', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+
+            const token = mintAsapToken({
+                room: r.split('@')[0],
+                context: {
+                    user: { id: 'user4' },
+                    features: { recording: false,
+                        'outbound-call': false }
+                }
+            });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            assert.strictEqual(
+                await jibriStartErrorCondition(c, r),
+                'forbidden',
+                'a member with recording=false must not reach Jibri');
+            assert.strictEqual(
+                await rayoDialErrorCondition(c, r),
+                'forbidden',
+                'a member with outbound-call=false must not reach Jigasi');
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            assert.notStrictEqual(
+                await jibriStartErrorCondition(c, r),
+                'forbidden',
+                'an owner with a granted recording feature must reach Jibri');
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            assert.strictEqual(
+                await jibriStartErrorCondition(c, r),
+                'forbidden',
+                'the recipient must not keep the granted recording feature');
+            assert.strictEqual(
+                await rayoDialErrorCondition(c, r),
+                'forbidden',
+                'the recipient must not keep the granted outbound-call feature');
+        });
+
+        it('restores the token features when the recipient revokes its own owner affiliation', async () => {
+            const r = nextRoom();
+
+            clients.push(await joinWithFocus(r));
+
+            const granter = await joinAsGranter(connect, r);
+
+            const token = mintAsapToken({
+                room: r.split('@')[0],
+                context: {
+                    user: { id: 'user5' },
+                    features: { recording: false }
+                }
+            });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            // As an owner, the recipient can set its own affiliation.
+            const reply = await c.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            assert.strictEqual(reply.attrs.type, 'result');
+
+            const restored = await getSessionFeatures(c.jid);
+
+            assert.ok(restored !== null, 'the token features should come back');
+            assert.strictEqual(restored.recording, false);
+            assert.strictEqual(
+                await jibriStartErrorCondition(c, r),
+                'forbidden',
+                'the recipient must not keep the granted recording feature');
+        });
+
+        for (const target of [ 'admin', 'outcast' ]) {
+            it(`restores the token features when owner changes to ${target}`, async () => {
+                const r = nextRoom();
+
+                clients.push(await joinWithFocus(r));
+
+                const granter = await joinAsGranter(connect, r);
+
+                const token = mintAsapToken({
+                    room: r.split('@')[0],
+                    context: {
+                        user: { id: `user-${target}` },
+                        features: { recording: false }
+                    }
+                });
+                const c = await connect({ params: { token } });
+
+                await c.joinRoom(r);
+
+                const bare = c.jid.split('/')[0];
+
+                await granter.sendMucAdmin(r, { jid: bare,
+                    affiliation: 'owner' });
+
+                assert.strictEqual((await getSessionFeatures(c.jid)).recording, true);
+
+                const reply = await granter.sendMucAdmin(r, { jid: bare,
+                    affiliation: target });
+
+                assert.strictEqual(reply.attrs.type, 'result');
+
+                const restored = await getSessionFeatures(c.jid);
+
+                assert.ok(restored !== null, 'the token features should come back');
+                assert.strictEqual(restored.recording, false);
+            });
+        }
+
+        it('restores the token features of a recipient that is in a breakout room', async () => {
+            const BREAKOUT_MUC = 'breakout.conference.localhost';
+            const r = nextRoom();
+            const name = r.split('@')[0];
+            const focus = await joinWithFocus(r);
+
+            clients.push(focus);
+
+            // mod_muc_breakout_rooms finds the main room of the moderator through
+            // the ?room= query parameter.
+            const granter = await joinAsGranter(connect, r, { room: name });
+
+            const token = mintAsapToken({
+                room: name,
+                context: {
+                    user: { id: 'user-breakout' },
+                    features: { recording: false }
+                }
+            });
+            const c = await connect({ params: { token } });
+
+            await c.joinRoom(r);
+
+            const bare = c.jid.split('/')[0];
+
+            await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'owner' });
+
+            assert.strictEqual((await getSessionFeatures(c.jid)).recording, true);
+
+            // Create a breakout room and move the recipient into it.
+            const parseJsonMessage = s => {
+                try {
+                    return JSON.parse(s.getChild('json-message', PERMISSIONS_NS)?.getText());
+                } catch {
+                    return null;
+                }
+            };
+            const update = granter.waitForMessage(s => {
+                const payload = parseJsonMessage(s);
+
+                return payload?.type === 'breakout_rooms'
+                    && payload?.event === 'features/breakout-rooms/update';
+            }, 6000);
+
+            await granter.sendBreakoutRoomsMessage(BREAKOUT_MUC, 'features/breakout-rooms/add', { subject: 'Group 1' });
+
+            const payload = parseJsonMessage(await update);
+            const breakoutJid = Object.values(payload.rooms).find(room => !room.isMainRoom)?.jid;
+
+            assert.ok(breakoutJid, 'the update must list the new breakout room');
+
+            // focus creates the breakout room, then the recipient moves into it.
+            await focus.joinRoom(breakoutJid, 'focus');
+            const breakoutPresence = await c.joinRoom(breakoutJid);
+
+            assert.notStrictEqual(breakoutPresence.attrs.type, 'error');
+            await c.leaveRoom(r);
+
+            // The recipient is no longer an occupant of the main room, but its
+            // affiliation there still decides its role in the breakout room.
+            const reply = await granter.sendMucAdmin(r, { jid: bare,
+                affiliation: 'member' });
+
+            assert.strictEqual(reply.attrs.type, 'result');
+
+            const restored = await getSessionFeatures(c.jid);
+
+            assert.ok(restored !== null, 'the token features should come back');
+            assert.strictEqual(restored.recording, false);
+        });
+
+    });
+
     // ── session features via HTTP ─────────────────────────────────────────────
     //
     // Verify that jitsi_meet_context_features is set correctly on the Prosody


### PR DESCRIPTION
`mod_jitsi_permissions` copies the feature table of the granting session onto a
participant when it receives owner affiliation. On revoke it only cleared that
table for sessions without a token. A token-authenticated participant kept the
granted table, so its own token features never came back after the demotion.

This restores the participant's own features on revoke:
- Save the features a session had before a grant, restore them when the grant
  ends, instead of deciding restoration from the presence of a token.
- Give each session its own copy of a feature table so sessions never alias
  one another's mutable table.
- Treat every transition into owner as a grant and every transition out of
  owner as a revoke, so the `admin` and `outcast` affiliations are covered.
- Resolve the sessions of the affected bare JID directly instead of through
  the occupants of the room, so a revoke reaches a participant that is in a
  breakout room at that time.

Added integration tests covering grant/revoke cycles, self-demotion, the
`admin`/`outcast` affiliations, and a participant in a breakout room.
