### PR TITLE
feat(config): document testing.disableAV1DecodeForFF

### DIFF
--- a/config.js
+++ b/config.js
@@ -89,6 +89,12 @@ var config = {
         // Enables use of getDisplayMedia in electron
         // electronUseGetDisplayMedia: false,
 
+        // Removes AV1 from the codec list on Firefox so that it is not advertised and other endpoints do not send
+        // it. Firefox stalls on AV1 streams that carry spatial layers, see
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=2071030. Note: enableAV1ForFF only changes what Firefox
+        // encodes, this also stops it being sent to Firefox.
+        // disableAV1DecodeForFF: false,
+
         // Enables AV1 codec for FF. Note: By default it is disabled.
         // enableAV1ForFF: false,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "js-md5": "0.6.1",
         "js-sha512": "0.8.0",
         "jwt-decode": "2.2.0",
-        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2204.0.0+39743ab2/lib-jitsi-meet.tgz",
+        "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2205.0.0+7d14f385/lib-jitsi-meet.tgz",
         "lodash-es": "4.18.1",
         "null-loader": "4.0.1",
         "optional-require": "1.0.3",
@@ -14374,8 +14374,8 @@
     },
     "node_modules/lib-jitsi-meet": {
       "version": "0.0.0",
-      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2204.0.0+39743ab2/lib-jitsi-meet.tgz",
-      "integrity": "sha512-BCxye+JbwBtzW5kDploAGU6T882hmVRr+tGLeD89ybifqrOL80GNeDB0jKhlfhEOEwfIKwZyzIkJFkJHrGbOWg==",
+      "resolved": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2205.0.0+7d14f385/lib-jitsi-meet.tgz",
+      "integrity": "sha512-cYQhdb0rHWQeEpxEa/uI0Le3JtWfOL4ja2uHMA+xGv3GhlLLe5QlSuBzIINO6gTSrAePCAYYzdzyifnGkULuOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jitsi/js-utils": "6.3.2",
@@ -31644,8 +31644,8 @@
       }
     },
     "lib-jitsi-meet": {
-      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2204.0.0+39743ab2/lib-jitsi-meet.tgz",
-      "integrity": "sha512-BCxye+JbwBtzW5kDploAGU6T882hmVRr+tGLeD89ybifqrOL80GNeDB0jKhlfhEOEwfIKwZyzIkJFkJHrGbOWg==",
+      "version": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2205.0.0+7d14f385/lib-jitsi-meet.tgz",
+      "integrity": "sha512-cYQhdb0rHWQeEpxEa/uI0Le3JtWfOL4ja2uHMA+xGv3GhlLLe5QlSuBzIINO6gTSrAePCAYYzdzyifnGkULuOQ==",
       "requires": {
         "@jitsi/js-utils": "6.3.2",
         "@jitsi/logger": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "js-md5": "0.6.1",
     "js-sha512": "0.8.0",
     "jwt-decode": "2.2.0",
-    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2204.0.0+39743ab2/lib-jitsi-meet.tgz",
+    "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v2205.0.0+7d14f385/lib-jitsi-meet.tgz",
     "lodash-es": "4.18.1",
     "null-loader": "4.0.1",
     "optional-require": "1.0.3",

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -729,6 +729,7 @@ export interface IConfig {
     testing?: {
         assumeBandwidth?: boolean;
         debugAudioLevels?: boolean;
+        disableAV1DecodeForFF?: boolean;
         dumpTranscript?: boolean;
         failICE?: boolean;
         noAutoPlayVideo?: boolean;


### PR DESCRIPTION
Documents and types the new flag added in jitsi/lib-jitsi-meet#3108 (same branch name).

Removes AV1 from the codec list on Firefox so that it is neither advertised nor sent to it. Firefox stalls on AV1 streams that carry spatial layers: https://bugzilla.mozilla.org/show_bug.cgi?id=2071030

Off by default. Config only, no behaviour change without the lib-jitsi-meet change.