### PR TITLE
fix(tests): resolve fileSharing.spec's upload path relative to itself, not the CWD

### DIFF
--- a/tests/specs/jaas/fileSharing.spec.ts
+++ b/tests/specs/jaas/fileSharing.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import type { Participant } from '../../helpers/Participant';
 import { setTestProperties } from '../../helpers/TestProperties';
 import { expectations } from '../../helpers/expectations';
@@ -8,7 +10,10 @@ setTestProperties(__filename, {
     usesBrowsers: [ 'p1', 'p2' ]
 });
 
-const TEST_FILE_PATH = 'tests/resources/test-upload.txt';
+// __dirname-based (not CWD-relative) - this is a local path read on the machine running the
+// tests (uploaded to the remote grid session via wdio's own uploadFile), so it needs to resolve
+// correctly regardless of whether the process's CWD is the repo root or tests/ itself.
+const TEST_FILE_PATH = path.join(__dirname, '..', '..', 'resources', 'test-upload.txt');
 const TEST_FILE_NAME = 'test-upload.txt';
 
 describe('File sharing', () => {


### PR DESCRIPTION
## Summary
Follow-up to #17800 (already merged) - same class of bug as the `wdio.conf.ts` fixture paths fixed there, just in a spec file that search didn't cover.

`TEST_FILE_PATH = 'tests/resources/test-upload.txt'` assumed the repo root as CWD. Confirmed via a real `validate-shard.sh` run against `alpha-canary`: both file-sharing delete/download tests failed with:
```
Error: ENOENT: no such file or directory, open 'tests/resources/test-upload.txt'
```
(really looking for `tests/tests/resources/...` once tests started running from `tests/` itself, per #17800). Fixed via `path.join(__dirname, ...)`, matching the `wdio.conf.ts` fix.

Also did a full sweep of every `tests/**/*.ts` file (specs, pageobjects, helpers - not just the two directories checked before) for any other hardcoded file-extension string literal that could have the same issue; this was the only other instance.

## Test plan
- [x] Confirmed the failure directly from a real `alpha-canary` shard-validation test report
- [x] Verified the corrected path resolves to the real file (`path.join(__dirname, '..', '..', 'resources', 'test-upload.txt')`)
- [x] Full repo-wide sweep for any other hardcoded `tests/`-relative path