### PR TITLE
feat(voice-agents): roster, consent, speaking ring + prosody provisioning

### DIFF
--- a/lang/main.json
+++ b/lang/main.json
@@ -1784,6 +1784,11 @@
         "title": "Secure, fully featured, and completely free video conferencing",
         "upcomingMeetings": "Your upcoming meetings"
     },
+    "voiceAgents": {
+        "allow": "Allow audio",
+        "consentDescription": "The agent can hear the meeting. Do you want to hear the agent's audio?",
+        "joinedTitle": "{{name}} joined as an AI agent"
+    },
     "whiteboard": {
         "accessibilityLabel": {
             "heading": "Whiteboard"

--- a/react/features/app/middlewares.any.ts
+++ b/react/features/app/middlewares.any.ts
@@ -53,6 +53,7 @@ import '../video-layout/middleware';
 import '../video-quality/middleware';
 import '../videosipgw/middleware';
 import '../visitors/middleware';
+import '../voice-agents/middleware';
 import '../whiteboard/middleware.any';
 
 import './middleware';

--- a/react/features/app/reducers.any.ts
+++ b/react/features/app/reducers.any.ts
@@ -56,4 +56,5 @@ import '../video-layout/reducer';
 import '../video-quality/reducer';
 import '../videosipgw/reducer';
 import '../visitors/reducer';
+import '../voice-agents/reducer';
 import '../whiteboard/reducer';

--- a/react/features/app/types.ts
+++ b/react/features/app/types.ts
@@ -84,6 +84,7 @@ import { IVideoQualityPersistedState, IVideoQualityState } from '../video-qualit
 import { IVideoSipGW } from '../videosipgw/reducer';
 import { IVirtualBackground } from '../virtual-background/reducer';
 import { IVisitorsState } from '../visitors/reducer';
+import { IVoiceAgentsState } from '../voice-agents/reducer';
 import { IWebHid } from '../web-hid/reducer';
 import { IWhiteboardState } from '../whiteboard/reducer';
 
@@ -180,6 +181,7 @@ export interface IReduxState {
     'features/videosipgw': IVideoSipGW;
     'features/virtual-background': IVirtualBackground;
     'features/visitors': IVisitorsState;
+    'features/voice-agents': IVoiceAgentsState;
     'features/web-hid': IWebHid;
     'features/whiteboard': IWhiteboardState;
 }

--- a/react/features/base/conference/reducer.ts
+++ b/react/features/base/conference/reducer.ts
@@ -54,6 +54,20 @@ const DEFAULT_STATE = {
 };
 
 export interface IConferenceMetadata {
+
+    /**
+     * The voice agents (bot participants) provisioned for the room, keyed by agent id. Written by the
+     * voice-agent prosody module; read-only for clients. An agent becomes audible only after the local
+     * participant subscribes to its source (consent-gated, see features/voice-agents).
+     */
+    agents?: {
+        [agentId: string]: {
+            displayName?: string;
+            kind?: string;
+            sourceName?: string;
+        };
+    };
+
     audioTranslation?: {
         enabled?: boolean;
     };
@@ -175,6 +189,7 @@ export interface IJitsiConference {
     sendTextMessage: Function;
     sendTones: Function;
     sessionId: string;
+    setAgentAudioSubscription?: (sourceNames: string[]) => void;
     setAssumedBandwidthBps: (value: number) => void;
     setDesktopSharingFrameRate: Function;
     setDisplayName: Function;

--- a/react/features/base/config/configType.ts
+++ b/react/features/base/config/configType.ts
@@ -819,6 +819,14 @@ export interface IConfig {
         queueService: string;
         showJoinMeetingDialog?: boolean;
     };
+    /**
+     * Voice agents (bot participants). Receiving an agent's media is consent-gated by default: each
+     * participant is prompted before the agent's audio is subscribed. Set requireConsent to false to
+     * auto-subscribe everyone.
+     */
+    voiceAgents?: {
+        requireConsent?: boolean;
+    };
     watchRTCConfigParams?: IWatchRTCConfiguration;
     webhookProxyUrl?: string;
     webrtcIceTcpDisable?: boolean;

--- a/react/features/base/participants/types.ts
+++ b/react/features/base/participants/types.ts
@@ -1,6 +1,7 @@
 import { IJitsiConference } from '../conference/reducer';
 
 export enum FakeParticipant {
+    Agent = 'Agent',
     LocalScreenShare = 'LocalScreenShare',
     RemoteScreenShare = 'RemoteScreenShare',
     SharedVideo = 'SharedVideo',

--- a/react/features/voice-agents/actionTypes.ts
+++ b/react/features/voice-agents/actionTypes.ts
@@ -1,0 +1,21 @@
+/**
+ * The type of action which updates the known set of voice agents (mirrored from room metadata).
+ *
+ * {
+ *     type: SET_VOICE_AGENTS,
+ *     agents: { [agentId: string]: IVoiceAgent }
+ * }
+ */
+export const SET_VOICE_AGENTS = 'SET_VOICE_AGENTS';
+
+/**
+ * The type of action which records the local participant's consent decision for receiving a voice
+ * agent's media.
+ *
+ * {
+ *     type: SET_VOICE_AGENT_CONSENT,
+ *     agentId: string,
+ *     allowed: boolean
+ * }
+ */
+export const SET_VOICE_AGENT_CONSENT = 'SET_VOICE_AGENT_CONSENT';

--- a/react/features/voice-agents/actions.ts
+++ b/react/features/voice-agents/actions.ts
@@ -1,0 +1,31 @@
+import { SET_VOICE_AGENTS, SET_VOICE_AGENT_CONSENT } from './actionTypes';
+import { IVoiceAgents } from './types';
+
+/**
+ * Updates the known set of voice agents (mirrored from room metadata).
+ *
+ * @param {IVoiceAgents} agents - The agents, keyed by agent id.
+ * @returns {Object}
+ */
+export function setVoiceAgents(agents: IVoiceAgents) {
+    return {
+        type: SET_VOICE_AGENTS,
+        agents
+    };
+}
+
+/**
+ * Records the local participant's consent decision for receiving a voice agent's media. Allowing
+ * subscribes to the agent's audio source (making it audible); disallowing unsubscribes.
+ *
+ * @param {string} agentId - The agent the decision applies to.
+ * @param {boolean} allowed - Whether receiving the agent's media is allowed.
+ * @returns {Object}
+ */
+export function setVoiceAgentConsent(agentId: string, allowed: boolean) {
+    return {
+        type: SET_VOICE_AGENT_CONSENT,
+        agentId,
+        allowed
+    };
+}

--- a/react/features/voice-agents/functions.ts
+++ b/react/features/voice-agents/functions.ts
@@ -1,0 +1,78 @@
+import { IReduxState } from '../app/types';
+
+import { IVoiceAgents } from './types';
+
+/**
+ * Keys that must never be used as object keys, since assigning them can pollute the prototype chain.
+ * Agent ids come from room metadata (server-controlled, but treated as untrusted at this boundary).
+ */
+const UNSAFE_KEYS = new Set([ '__proto__', 'constructor', 'prototype' ]);
+
+/**
+ * Whether an agent id is safe to use as a plain-object key.
+ *
+ * @param {string} agentId - The agent id.
+ * @returns {boolean}
+ */
+export function isSafeAgentId(agentId: string): boolean {
+    return !UNSAFE_KEYS.has(agentId);
+}
+
+/**
+ * Drops any prototype-pollution-prone keys from an agents map before it is stored or acted on.
+ *
+ * @param {IVoiceAgents} agents - The agents map from metadata.
+ * @returns {IVoiceAgents}
+ */
+export function sanitizeAgents(agents: IVoiceAgents): IVoiceAgents {
+    const safe: IVoiceAgents = {};
+
+    for (const [ agentId, agent ] of Object.entries(agents)) {
+        if (isSafeAgentId(agentId)) {
+            safe[agentId] = agent;
+        }
+    }
+
+    return safe;
+}
+
+/**
+ * Returns the known voice agents (mirrored from room metadata).
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {IVoiceAgents}
+ */
+export function getVoiceAgents(state: IReduxState): IVoiceAgents {
+    return state['features/voice-agents'].agents;
+}
+
+/**
+ * Whether receiving a voice agent's media requires an explicit user consent. Defaults to true; a
+ * deployment can auto-subscribe every participant with `config.voiceAgents.requireConsent: false`.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {boolean}
+ */
+export function isVoiceAgentConsentRequired(state: IReduxState): boolean {
+    return state['features/base/config'].voiceAgents?.requireConsent !== false;
+}
+
+/**
+ * The source names of the voice agents the local participant currently receives: agents still present
+ * in the room whose consent decision is 'allowed'.
+ *
+ * @param {IReduxState} state - The redux state.
+ * @returns {Array<string>}
+ */
+export function getConsentedAgentSourceNames(state: IReduxState): string[] {
+    const { agents, consent } = state['features/voice-agents'];
+    const sourceNames: string[] = [];
+
+    for (const [ agentId, agent ] of Object.entries(agents)) {
+        if (consent[agentId] && agent.sourceName) {
+            sourceNames.push(agent.sourceName);
+        }
+    }
+
+    return sourceNames;
+}

--- a/react/features/voice-agents/logger.ts
+++ b/react/features/voice-agents/logger.ts
@@ -1,0 +1,3 @@
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('features/voice-agents');

--- a/react/features/voice-agents/middleware.ts
+++ b/react/features/voice-agents/middleware.ts
@@ -1,0 +1,149 @@
+import { batch } from 'react-redux';
+
+import { IStore } from '../app/types';
+import { UPDATE_CONFERENCE_METADATA } from '../base/conference/actionTypes';
+import { getCurrentConference } from '../base/conference/functions';
+import { IJitsiConference } from '../base/conference/reducer';
+import { participantJoined, participantLeft } from '../base/participants/actions';
+import { FakeParticipant } from '../base/participants/types';
+import MiddlewareRegistry from '../base/redux/MiddlewareRegistry';
+import { hideNotification, showNotification } from '../notifications/actions';
+import { NOTIFICATION_TIMEOUT_TYPE } from '../notifications/constants';
+
+import { SET_VOICE_AGENT_CONSENT } from './actionTypes';
+import { setVoiceAgentConsent, setVoiceAgents } from './actions';
+import { getConsentedAgentSourceNames, isVoiceAgentConsentRequired, sanitizeAgents } from './functions';
+import logger from './logger';
+import { IVoiceAgents } from './types';
+
+/**
+ * The uid of the consent notification for an agent, so it can be hidden on consent or when the agent
+ * leaves.
+ *
+ * @param {string} agentId - The agent id.
+ * @returns {string}
+ */
+function consentNotificationUid(agentId: string) {
+    return `voice-agent-consent-${agentId}`;
+}
+
+/**
+ * Middleware that mirrors the `agents` room metadata into the conference: a fake participant per agent
+ * (the roster entry), a consent notification for receiving each agent's media (unless disabled via
+ * config.voiceAgents.requireConsent), and — on consent — the subscription to the agent's synthetic audio
+ * source, which is what makes the agent audible. The subscription is managed through the voice-agents
+ * synthetic-audio service in lib-jitsi-meet, so it co-exists with audio translation.
+ */
+MiddlewareRegistry.register(store => next => action => {
+    const result = next(action);
+
+    switch (action.type) {
+    case UPDATE_CONFERENCE_METADATA: {
+        // Metadata is server-written but treated as untrusted here: drop prototype-pollution-prone ids
+        // before they are used as object keys / participant ids.
+        const agents: IVoiceAgents = sanitizeAgents(action.metadata?.agents ?? {});
+
+        _agentsChanged(store, agents);
+        break;
+    }
+    case SET_VOICE_AGENT_CONSENT:
+        _updateSubscription(store);
+        break;
+    }
+
+    return result;
+});
+
+/**
+ * Diffs the advertised agents against the known set: joins/leaves the fake participants, drives the
+ * consent flow for new agents and prunes state (and the subscription) for removed ones.
+ *
+ * @param {IStore} store - The redux store.
+ * @param {IVoiceAgents} agents - The agents from the updated room metadata.
+ * @returns {void}
+ */
+function _agentsChanged({ dispatch, getState }: IStore, agents: IVoiceAgents) {
+    const state = getState();
+    const previous = state['features/voice-agents']?.agents ?? {};
+    const conference = getCurrentConference(state);
+    const added = Object.keys(agents).filter(id => !(id in previous));
+    const removed = Object.keys(previous).filter(id => !(id in agents));
+
+    if (added.length === 0 && removed.length === 0) {
+        return;
+    }
+
+    // Room metadata is delivered on the conference, so it is normally set here; it is cleared (null
+    // metadata) when the conference is left, at which point base/participants purges the fake
+    // participants on its own. Just keep the feature state in sync in that case.
+    if (!conference) {
+        dispatch(setVoiceAgents(agents));
+        removed.forEach(agentId => dispatch(hideNotification(consentNotificationUid(agentId))));
+
+        return;
+    }
+
+    dispatch(setVoiceAgents(agents));
+
+    for (const agentId of removed) {
+        logger.info(`Voice agent left: ${agentId}`);
+        batch(() => {
+            dispatch(hideNotification(consentNotificationUid(agentId)));
+            dispatch(participantLeft(agentId, conference, { fakeParticipant: FakeParticipant.Agent }));
+        });
+    }
+
+    for (const agentId of added) {
+        const displayName = agents[agentId].displayName;
+
+        logger.info(`Voice agent joined: ${agentId} (${displayName})`);
+        dispatch(participantJoined({
+            conference,
+            fakeParticipant: FakeParticipant.Agent,
+            id: agentId,
+            name: displayName
+        }));
+
+        if (isVoiceAgentConsentRequired(state)) {
+            const uid = consentNotificationUid(agentId);
+
+            dispatch(showNotification({
+                customActionHandler: [ () => batch(() => {
+                    dispatch(setVoiceAgentConsent(agentId, true));
+                    dispatch(hideNotification(uid));
+                }) ],
+                customActionNameKey: [ 'voiceAgents.allow' ],
+                descriptionKey: 'voiceAgents.consentDescription',
+                titleArguments: { name: displayName ?? agentId },
+                titleKey: 'voiceAgents.joinedTitle',
+                uid
+            }, NOTIFICATION_TIMEOUT_TYPE.STICKY));
+        } else {
+            dispatch(setVoiceAgentConsent(agentId, true));
+        }
+    }
+
+    // Removals must also drop their source from the subscription (consent entries were pruned by
+    // setVoiceAgents). Additions with consent disabled are handled by the SET_VOICE_AGENT_CONSENT case.
+    if (removed.length > 0) {
+        _updateSubscription({ dispatch, getState } as IStore);
+    }
+}
+
+/**
+ * Sends the current consented agent source names to the bridge through the conference's voice-agents
+ * synthetic-audio subscription.
+ *
+ * @param {IStore} store - The redux store.
+ * @returns {void}
+ */
+function _updateSubscription({ getState }: IStore) {
+    const state = getState();
+    const conference: IJitsiConference | undefined = getCurrentConference(state);
+
+    if (!conference || typeof conference.setAgentAudioSubscription !== 'function') {
+        return;
+    }
+
+    conference.setAgentAudioSubscription(getConsentedAgentSourceNames(state));
+}

--- a/react/features/voice-agents/reducer.ts
+++ b/react/features/voice-agents/reducer.ts
@@ -1,0 +1,63 @@
+import ReducerRegistry from '../base/redux/ReducerRegistry';
+
+import { SET_VOICE_AGENTS, SET_VOICE_AGENT_CONSENT } from './actionTypes';
+import { isSafeAgentId, sanitizeAgents } from './functions';
+import { IVoiceAgents } from './types';
+
+export interface IVoiceAgentsState {
+
+    /**
+     * The known voice agents, mirrored from room metadata.
+     */
+    agents: IVoiceAgents;
+
+    /**
+     * The local participant's consent decisions, by agent id. Absent = not yet decided (a pending
+     * consent notification, or consent not required). Entries for agents that left are pruned so a
+     * re-provisioned agent with the same id asks again.
+     */
+    consent: { [agentId: string]: boolean; };
+}
+
+const DEFAULT_STATE: IVoiceAgentsState = {
+    agents: {},
+    consent: {}
+};
+
+ReducerRegistry.register<IVoiceAgentsState>(
+    'features/voice-agents',
+    (state = DEFAULT_STATE, action): IVoiceAgentsState => {
+        switch (action.type) {
+        case SET_VOICE_AGENTS: {
+            const agents: IVoiceAgents = sanitizeAgents(action.agents ?? {});
+            const consent: { [agentId: string]: boolean; } = {};
+
+            for (const [ agentId, allowed ] of Object.entries(state.consent)) {
+                if (agentId in agents) {
+                    consent[agentId] = allowed;
+                }
+            }
+
+            return {
+                ...state,
+                agents,
+                consent
+            };
+        }
+        case SET_VOICE_AGENT_CONSENT: {
+            if (!isSafeAgentId(action.agentId) || !(action.agentId in state.agents)) {
+                return state;
+            }
+
+            return {
+                ...state,
+                consent: {
+                    ...state.consent,
+                    [action.agentId]: action.allowed
+                }
+            };
+        }
+        }
+
+        return state;
+    });

--- a/react/features/voice-agents/types.ts
+++ b/react/features/voice-agents/types.ts
@@ -1,0 +1,24 @@
+/**
+ * A voice agent (bot participant) as advertised through room metadata by the voice-agent prosody module.
+ */
+export interface IVoiceAgent {
+    displayName?: string;
+
+    /**
+     * The metadata entry kind; always 'agent' for voice agents.
+     */
+    kind?: string;
+
+    /**
+     * The agent's synthetic audio source name (by convention `<agentId>-a0`). Subscribing to it is what
+     * makes the agent audible.
+     */
+    sourceName?: string;
+}
+
+/**
+ * The known voice agents, keyed by agent id.
+ */
+export interface IVoiceAgents {
+    [agentId: string]: IVoiceAgent;
+}

--- a/resources/prosody-plugins/mod_room_metadata_component.lua
+++ b/resources/prosody-plugins/mod_room_metadata_component.lua
@@ -104,6 +104,7 @@ local extdisco_occpuant_check = module:get_option_boolean('extdisco_occpuant_che
 -- metadata message API. These are either server-controlled fields or keys whose
 -- values are assembled and injected by the server at broadcast time.
 local blocked_metadata_keys = module:get_option_set('room_metadata_blocked_keys', {
+    'agents',
     'allownersEnabled',
     'asyncTranscription',
     'audioTranslationAvailable',
@@ -200,16 +201,27 @@ function send_metadata(occupant, room, json_msg, include_services)
             -- broadcast to regular clients.
             metadata_to_send.audioTranslationRequests = room._data.audioTranslationRequests;
 
-            -- Neutral, default-open extension point: an external module may contribute
-            -- additional jicofo-only metadata fields by returning a table from this
-            -- event -- for instance per-room translator connect headers. Fired inside
+            -- Neutral, default-open extension point: other modules may contribute
+            -- additional jicofo-only metadata fields -- for instance per-room
+            -- translator connect headers, or voice-agent connect config. Fired inside
             -- the admin branch, so injected fields reach only jicofo and are never
             -- broadcast to client occupants. No handler means nothing is added; this
             -- module holds no token/entitlement logic of its own.
-            local admin_extra = main_muc_module and main_muc_module:fire_event(
-                'jitsi-room-metadata-admin-extra', { room = room; });
-            if type(admin_extra) == 'table' then
-                for k, v in pairs(admin_extra) do
+            --
+            -- Contributors should write into event.extra and return nil, so multiple
+            -- modules can contribute (a non-nil return stops the handler chain).
+            -- Returning a table is still honored for backward compatibility with
+            -- single-contributor deployments.
+            if main_muc_module then
+                local admin_extra_event = { room = room; extra = {}; };
+                local admin_extra = main_muc_module:fire_event(
+                    'jitsi-room-metadata-admin-extra', admin_extra_event);
+                if type(admin_extra) == 'table' then
+                    for k, v in pairs(admin_extra) do
+                        metadata_to_send[k] = v;
+                    end
+                end
+                for k, v in pairs(admin_extra_event.extra) do
                     metadata_to_send[k] = v;
                 end
             end

--- a/resources/prosody-plugins/mod_voice_agent_component.lua
+++ b/resources/prosody-plugins/mod_voice_agent_component.lua
@@ -1,0 +1,400 @@
+-- mod_voice_agent_component.lua
+--
+-- HTTP module that provisions voice agents (bot participants) for a room.
+-- Intended for internal system use (the JaaS provisioning API), not for
+-- end-user clients — the same trust model as mod_muc_jigasi_invite.
+--
+-- A voice agent is not a MUC occupant: its presence is advertised to clients
+-- through room metadata (the 'agents' key), and its media runs bridge-side (a
+-- synthetic colibri2 endpoint jicofo allocates when it sees the agent in the
+-- admin-only metadata). Clients render the roster entry from the metadata and,
+-- after user consent, subscribe to the agent's audio source by name.
+--
+-- ── State ─────────────────────────────────────────────────────────────────────
+-- Client-facing (broadcast to all occupants via mod_room_metadata_component):
+--   room.jitsiMetadata.agents[agentId] = {
+--       kind = 'agent', displayName = <string>, sourceName = '<agentId>-a0',
+--   }
+-- Jicofo-only (never broadcast; merged into the admin metadata payload through
+-- the 'jitsi-room-metadata-admin-extra' hook):
+--   room._data.voice_agents[agentId] = { urlParams = {...}, httpHeaders = {...} }
+-- jicofo parses both from the same 'agents' map: it reads urlParams/httpHeaders
+-- and ignores the client-facing fields; clients never see the jicofo-only ones.
+--
+-- ── Endpoints ─────────────────────────────────────────────────────────────────
+-- Authentication: Authorization: Bearer <system ASAP token>, verified against
+-- prosody_password_public_key_repo_url (NOT login tokens), exactly like
+-- mod_muc_jigasi_invite.
+--
+--   POST /voice-agent/invite   { "conference": "<room jid>",
+--                                "displayName": "<name>",
+--                                "agentId": "<id>",           -- optional, generated when absent
+--                                "endpoint": { "url": "wss://...",   -- optional convenience:
+--                                              "authorization": "..." }, -- mapped to the
+--                                                                        -- X-Agent-* headers
+--                                "urlParams": { ... },        -- optional, passed to jicofo
+--                                "httpHeaders": { ... } }     -- optional, passed to jicofo
+--     → 200 { "agentId": "...", "sourceName": "<agentId>-a0" }
+--   POST /voice-agent/dismiss  { "conference": "<room jid>", "agentId": "<id>" }
+--     → 200
+--   GET  /voice-agent/list?conference=<room jid>
+--     → 200 { "agents": { <agentId>: { client-facing fields } } }
+--
+-- Copyright (C) 2026-present 8x8, Inc.
+
+local hashes = require 'util.hashes';
+local random = require 'util.random';
+local json = require 'cjson.safe';
+local http_util = require 'util.http';
+
+local util = module:require 'util';
+local async_handler_wrapper = util.async_handler_wrapper;
+local get_room_from_jid = util.get_room_from_jid;
+local is_healthcheck_room = util.is_healthcheck_room;
+local process_host_module = util.process_host_module;
+local room_jid_match_rewrite = util.room_jid_match_rewrite;
+local starts_with = util.starts_with;
+local table_shallow_copy = util.table_shallow_copy;
+
+local muc_component_host = module:get_option_string('muc_component');
+if muc_component_host == nil then
+    module:log('error', 'No muc_component specified. No muc to operate on!');
+    return;
+end
+
+local JSON_CONTENT_TYPE = 'application/json';
+
+-- Caps keeping a single provisioning request from bloating room state and the
+-- metadata broadcastable payload.
+local MAX_AGENTS_PER_ROOM = module:get_option_number('voice_agent_max_agents', 5);
+local MAX_PARAM_ENTRIES = 16;
+local MAX_PARAM_VALUE_LENGTH = 2048;
+local MAX_DISPLAY_NAME_LENGTH = 256;
+
+-- Reserved namespace for agent ids, so an agent id can never equal a real participant's endpoint id.
+local AGENT_ID_PREFIX = 'agent-';
+
+-- The proxy-facing connect headers the optional 'endpoint' convenience object
+-- maps to (see opus-transcriber-proxy resolveAgentEndpoint).
+local ENDPOINT_URL_HEADER = 'X-Agent-Endpoint';
+local ENDPOINT_AUTH_HEADER = 'X-Agent-Authorization';
+
+local invite_count = module:measure('voice_agent_invite_rate', 'rate');
+local invite_success_count = module:measure('voice_agent_invite_success', 'rate');
+local dismiss_count = module:measure('voice_agent_dismiss_rate', 'rate');
+
+local ASAP_KEY_SERVER = module:get_option_string('prosody_password_public_key_repo_url', '');
+local token_util = module:require 'token/util'.new(module);
+if ASAP_KEY_SERVER then
+    token_util:set_asap_key_server(ASAP_KEY_SERVER);
+end
+
+local main_muc_module;
+
+process_host_module(muc_component_host, function(host_module)
+    main_muc_module = host_module;
+end);
+
+local function is_token_valid(token)
+    if token == nil then
+        module:log('warn', 'no token provided');
+        return false;
+    end
+
+    local session = {};
+    session.auth_token = token;
+    local verified, reason, msg = token_util:process_and_verify_token(session);
+    if not verified then
+        module:log('warn', 'not a valid token %s %s', tostring(reason), tostring(msg));
+        return false;
+    end
+    return true;
+end
+
+-- Verifies the Authorization header; returns nil when authorized, or the error response.
+local function check_authorization(request)
+    local token = request.headers['authorization'];
+    if not token then
+        module:log('warn', 'Authorization header was not provided');
+        return { status_code = 401 };
+    end
+    if starts_with(token, 'Bearer ') then
+        token = token:sub(8, #token);
+    else
+        module:log('warn', 'Authorization header is invalid');
+        return { status_code = 401 };
+    end
+    if not is_token_valid(token) then
+        return { status_code = 401 };
+    end
+    return nil;
+end
+
+-- Validates a string->string map (urlParams / httpHeaders); returns a bounded
+-- copy, or nil plus an error message.
+local function validate_string_map(value, name)
+    if value == nil then
+        return nil;
+    end
+    if type(value) ~= 'table' then
+        return nil, name .. ' must be an object';
+    end
+    local copy = {};
+    local entries = 0;
+    for k, v in pairs(value) do
+        if type(k) ~= 'string' or type(v) ~= 'string' then
+            return nil, name .. ' must map strings to strings';
+        end
+        if #v > MAX_PARAM_VALUE_LENGTH then
+            return nil, name .. ' value too long';
+        end
+        entries = entries + 1;
+        if entries > MAX_PARAM_ENTRIES then
+            return nil, name .. ' has too many entries';
+        end
+        copy[k] = v;
+    end
+    return copy;
+end
+
+-- Resolves the room from the request payload's/query's conference JID.
+local function find_room(conference)
+    if type(conference) ~= 'string' or conference == '' then
+        return nil;
+    end
+    local room = get_room_from_jid(room_jid_match_rewrite(conference));
+    if room and is_healthcheck_room(room.jid) then
+        return nil;
+    end
+    return room;
+end
+
+-- Fires the metadata rebroadcast after agent state changed.
+local function notify_metadata_changed(room)
+    if main_muc_module then
+        main_muc_module:fire_event('room-metadata-changed', { room = room; });
+    end
+end
+
+local function handle_invite(event)
+    invite_count();
+    local request = event.request;
+
+    local auth_error = check_authorization(request);
+    if auth_error then
+        return auth_error;
+    end
+
+    if request.headers.content_type ~= JSON_CONTENT_TYPE or (not request.body or #request.body == 0) then
+        module:log('warn', 'Wrong content type: %s or missing payload', request.headers.content_type);
+        return { status_code = 400 };
+    end
+    local payload, decode_error = json.decode(request.body);
+    if not payload then
+        module:log('warn', 'Cannot decode json error:%s', decode_error);
+        return { status_code = 400 };
+    end
+
+    local room = find_room(payload.conference);
+    if not room then
+        module:log('warn', 'No room found for %s', tostring(payload.conference));
+        return { status_code = 404, body = json.encode({ error = 'Room not found' }) };
+    end
+
+    if type(payload.displayName) ~= 'string' or payload.displayName == ''
+            or #payload.displayName > MAX_DISPLAY_NAME_LENGTH then
+        return { status_code = 400, body = json.encode({ error = 'Missing or invalid displayName' }) };
+    end
+
+    -- Agent ids live in a reserved "agent-" namespace so they can NEVER equal a real participant's
+    -- endpoint id (8 hex chars) -- otherwise a caller could shadow a real participant's roster entry and
+    -- source. The prefix is enforced/normalized here (the authoritative id space), which makes the
+    -- collision impossible by construction rather than via a racy occupant check. The suffix after the
+    -- prefix is validated to a safe charset and to exclude prototype-pollution keys (defense in depth for
+    -- the client, which keys plain objects by agent id).
+    local agent_id;
+    local requested = payload.agentId;
+    if requested ~= nil then
+        if type(requested) ~= 'string' then
+            return { status_code = 400, body = json.encode({ error = 'Invalid agentId' }) };
+        end
+        -- Accept with or without the reserved prefix; normalize to exactly one.
+        local suffix = starts_with(requested, AGENT_ID_PREFIX)
+            and requested:sub(#AGENT_ID_PREFIX + 1) or requested;
+        if not suffix:match('^[%w_-]+$') or #suffix > 48
+                or suffix == '__proto__' or suffix == 'constructor' or suffix == 'prototype' then
+            return { status_code = 400, body = json.encode({ error = 'Invalid agentId' }) };
+        end
+        agent_id = AGENT_ID_PREFIX .. suffix;
+    else
+        agent_id = AGENT_ID_PREFIX .. hashes.sha256(random.bytes(8), true):sub(1, 8);
+    end
+
+    local url_params, params_error = validate_string_map(payload.urlParams, 'urlParams');
+    if params_error then
+        return { status_code = 400, body = json.encode({ error = params_error }) };
+    end
+    local http_headers, headers_error = validate_string_map(payload.httpHeaders, 'httpHeaders');
+    if headers_error then
+        return { status_code = 400, body = json.encode({ error = headers_error }) };
+    end
+
+    -- Convenience: map endpoint.{url,authorization} onto the proxy-facing connect headers.
+    if payload.endpoint ~= nil then
+        if type(payload.endpoint) ~= 'table' or type(payload.endpoint.url) ~= 'string'
+                or not starts_with(payload.endpoint.url, 'wss://') then
+            return { status_code = 400, body = json.encode({ error = 'endpoint.url must be a wss:// URL' }) };
+        end
+        http_headers = http_headers or {};
+        http_headers[ENDPOINT_URL_HEADER] = payload.endpoint.url;
+        if type(payload.endpoint.authorization) == 'string' then
+            http_headers[ENDPOINT_AUTH_HEADER] = payload.endpoint.authorization;
+        end
+    end
+
+    room.jitsiMetadata = room.jitsiMetadata or {};
+    local agents = room.jitsiMetadata.agents or {};
+    local voice_agents = room._data.voice_agents or {};
+
+    if agents[agent_id] == nil then
+        local count = 0;
+        for _ in pairs(agents) do
+            count = count + 1;
+        end
+        if count >= MAX_AGENTS_PER_ROOM then
+            return { status_code = 409, body = json.encode({ error = 'Too many agents in the room' }) };
+        end
+    end
+
+    local source_name = agent_id .. '-a0';
+
+    -- Client-facing entry (broadcast to every occupant).
+    agents[agent_id] = {
+        kind = 'agent';
+        displayName = payload.displayName;
+        sourceName = source_name;
+    };
+    -- Jicofo-only connect config (merged into the admin metadata payload below).
+    voice_agents[agent_id] = {
+        urlParams = url_params;
+        httpHeaders = http_headers;
+    };
+
+    room.jitsiMetadata.agents = agents;
+    room._data.voice_agents = voice_agents;
+
+    module:log('info', 'Voice agent %s invited to room %s,meeting_id:%s',
+        agent_id, room.jid, room._data.meetingId);
+    notify_metadata_changed(room);
+    invite_success_count();
+
+    return { status_code = 200, body = json.encode({ agentId = agent_id, sourceName = source_name }) };
+end
+
+local function handle_dismiss(event)
+    dismiss_count();
+    local request = event.request;
+
+    local auth_error = check_authorization(request);
+    if auth_error then
+        return auth_error;
+    end
+
+    if request.headers.content_type ~= JSON_CONTENT_TYPE or (not request.body or #request.body == 0) then
+        return { status_code = 400 };
+    end
+    local payload, decode_error = json.decode(request.body);
+    if not payload then
+        module:log('warn', 'Cannot decode json error:%s', decode_error);
+        return { status_code = 400 };
+    end
+
+    local room = find_room(payload.conference);
+    if not room then
+        return { status_code = 404, body = json.encode({ error = 'Room not found' }) };
+    end
+
+    local agent_id = payload.agentId;
+    local agents = room.jitsiMetadata and room.jitsiMetadata.agents;
+    if type(agent_id) ~= 'string' or not agents or agents[agent_id] == nil then
+        return { status_code = 404, body = json.encode({ error = 'Agent not found' }) };
+    end
+
+    agents[agent_id] = nil;
+    if room._data.voice_agents then
+        room._data.voice_agents[agent_id] = nil;
+    end
+
+    module:log('info', 'Voice agent %s dismissed from room %s,meeting_id:%s',
+        agent_id, room.jid, room._data.meetingId);
+    notify_metadata_changed(room);
+
+    return { status_code = 200 };
+end
+
+local function handle_list(event)
+    local request = event.request;
+
+    local auth_error = check_authorization(request);
+    if auth_error then
+        return auth_error;
+    end
+
+    local query = request.url and request.url.query;
+    local params = query and http_util.formdecode(query) or {};
+    local room = find_room(params.conference);
+    if not room then
+        return { status_code = 404, body = json.encode({ error = 'Room not found' }) };
+    end
+
+    local agents = (room.jitsiMetadata and room.jitsiMetadata.agents) or {};
+    return { status_code = 200, body = json.encode({ agents = agents }) };
+end
+
+module:log('info', 'Adding http handlers for /voice-agent on %s', module.host);
+module:depends('http');
+module:provides('http', {
+    default_path = '/';
+    route = {
+        ['POST voice-agent/invite'] = function(event)
+            return async_handler_wrapper(event, handle_invite);
+        end;
+        ['POST voice-agent/dismiss'] = function(event)
+            return async_handler_wrapper(event, handle_dismiss);
+        end;
+        ['GET voice-agent/list'] = function(event)
+            return async_handler_wrapper(event, handle_list);
+        end;
+    };
+});
+
+-- Merge the jicofo-only connect config into the admin metadata payload: jicofo
+-- receives 'agents' entries carrying BOTH the client-facing fields and
+-- urlParams/httpHeaders; regular occupants only ever get the client-facing map
+-- from room.jitsiMetadata (this hook fires inside the admin branch of
+-- mod_room_metadata_component's send_metadata only).
+process_host_module(muc_component_host, function(host_module)
+    host_module:hook('jitsi-room-metadata-admin-extra', function(event)
+        local room = event.room;
+        local agents = room.jitsiMetadata and room.jitsiMetadata.agents;
+        local voice_agents = room._data.voice_agents;
+        if not agents or not voice_agents or type(event.extra) ~= 'table' then
+            return nil;
+        end
+
+        local merged = {};
+        for agent_id, client_entry in pairs(agents) do
+            local entry = table_shallow_copy(client_entry);
+            local jicofo_entry = voice_agents[agent_id];
+            if jicofo_entry then
+                entry.urlParams = jicofo_entry.urlParams;
+                entry.httpHeaders = jicofo_entry.httpHeaders;
+            end
+            merged[agent_id] = entry;
+        end
+        -- Contribute via the accumulator (and return nil) so other admin-extra
+        -- contributors still run — a non-nil return would stop the handler chain.
+        event.extra.agents = merged;
+        return nil;
+    end);
+end);

--- a/tests/prosody/lua/mod_voice_agent_component_spec.lua
+++ b/tests/prosody/lua/mod_voice_agent_component_spec.lua
@@ -1,0 +1,296 @@
+-- Unit tests for mod_voice_agent_component.lua
+-- Run with busted from resources/prosody-plugins/:
+--   busted ../../tests/prosody/lua/
+--
+-- Stubs every Prosody dependency so no Prosody installation is needed. These focus on the
+-- security-relevant validation at the provisioning boundary: ASAP auth, agentId namespacing (the
+-- reserved "agent-" prefix that makes an agent id un-collidable with a real 8-hex endpoint id),
+-- prototype-pollution key rejection, string-map bounds, and jicofo-only secret segregation.
+-- End-to-end behaviour against a real Prosody is covered by the integration specs.
+
+-- ---------------------------------------------------------------------------
+-- Stubs for top-level `require`d Prosody libs (no Prosody install under busted)
+-- ---------------------------------------------------------------------------
+
+package.preload['util.hashes'] = function()
+    return { sha256 = function() return 'deadbeefcafef00d' end };
+end
+package.preload['util.random'] = function()
+    return { bytes = function() return 'xxxxxxxx' end };
+end
+package.preload['util.http'] = function()
+    return { formdecode = function(_) return {} end };
+end
+
+-- cjson.safe: the handler only round-trips through decode(body)/encode(err); we inject the decoded
+-- table per test via `next_decoded` so the tests don't depend on a real JSON parser.
+local next_decoded
+package.preload['cjson.safe'] = function()
+    return {
+        decode = function(s)
+            if s == nil or s == '' then
+                return nil, 'empty';
+            end
+            return next_decoded;
+        end,
+        encode = function(_) return '{}'; end
+    };
+end
+
+-- ---------------------------------------------------------------------------
+-- Controllable stub state
+-- ---------------------------------------------------------------------------
+
+local token_valid = true;
+local mock_room;
+
+local util_stub = {
+    async_handler_wrapper = function(event, handler) return handler(event); end,
+    get_room_from_jid = function(jid)
+        if jid == 'missing' then return nil; end
+        return mock_room;
+    end,
+    is_healthcheck_room = function(_) return false; end,
+    process_host_module = function(_host, cb) cb({ hook = function() end; fire_event = function() end }); end,
+    room_jid_match_rewrite = function(jid) return jid; end,
+    starts_with = function(s, prefix) return type(s) == 'string' and s:sub(1, #prefix) == prefix; end,
+    table_shallow_copy = function(t)
+        local c = {};
+        for k, v in pairs(t or {}) do c[k] = v; end
+        return c;
+    end
+};
+
+local token_util_stub = {
+    new = function()
+        return {
+            set_asap_key_server = function() end,
+            process_and_verify_token = function() return token_valid, 'reason', 'msg'; end
+        };
+    end
+};
+
+-- Captured HTTP route handlers, filled by the module:provides stub below.
+local routes = {};
+
+_G.module = {
+    host = 'voiceagent.localhost',
+    log = function() end,
+    get_option_string = function(_, key, default)
+        if key == 'muc_component' then return 'conference.localhost'; end
+        return default;
+    end,
+    get_option_number = function(_, _key, default) return default; end,
+    get_option_boolean = function(_, _key, default) return default; end,
+    measure = function() return function() end; end,
+    depends = function() end,
+    require = function(_, name)
+        if name == 'util' then return util_stub; end
+        if name == 'token/util' then return token_util_stub; end
+        return {};
+    end,
+    provides = function(_, _kind, def)
+        for name, handler in pairs(def.route) do routes[name] = handler; end
+    end
+};
+
+-- ---------------------------------------------------------------------------
+-- Load the module under test
+-- ---------------------------------------------------------------------------
+
+local ok, load_err = pcall(dofile, 'mod_voice_agent_component.lua');
+if not ok then
+    describe('mod_voice_agent_component', function()
+        it('skipped — failed to load module', function()
+            pending(tostring(load_err):match('([^\n]+)') or tostring(load_err));
+        end)
+    end)
+    return;
+end
+
+assert(routes['POST voice-agent/invite'], 'invite route not registered');
+assert(routes['POST voice-agent/dismiss'], 'dismiss route not registered');
+
+-- ---------------------------------------------------------------------------
+-- Test helpers
+-- ---------------------------------------------------------------------------
+
+local function fresh_room()
+    return { jid = 'room1@conference.localhost', jitsiMetadata = {}, _data = {} };
+end
+
+local function invite(payload, opts)
+    opts = opts or {};
+    next_decoded = payload;
+    local headers = { content_type = 'application/json' };
+    if not opts.omitAuth then
+        headers.authorization = 'Bearer sometoken';
+    end
+    return routes['POST voice-agent/invite']({ request = { headers = headers; body = 'x' } });
+end
+
+local function dismiss(payload)
+    next_decoded = payload;
+    return routes['POST voice-agent/dismiss'](
+        { request = { headers = { content_type = 'application/json'; authorization = 'Bearer t' }; body = 'x' } });
+end
+
+local function agent_ids(room)
+    local ids = {};
+    for id in pairs(room.jitsiMetadata.agents or {}) do table.insert(ids, id); end
+    return ids;
+end
+
+-- ---------------------------------------------------------------------------
+-- Tests
+-- ---------------------------------------------------------------------------
+
+describe('mod_voice_agent_component', function()
+    before_each(function()
+        token_valid = true;
+        mock_room = fresh_room();
+    end)
+
+    describe('authentication', function()
+        it('returns 401 when the Authorization header is absent', function()
+            local res = invite({ conference = 'r'; displayName = 'Bot' }, { omitAuth = true });
+            assert.are.equal(401, res.status_code);
+        end)
+
+        it('returns 401 when the token does not verify', function()
+            token_valid = false;
+            local res = invite({ conference = 'r'; displayName = 'Bot' });
+            assert.are.equal(401, res.status_code);
+        end)
+    end)
+
+    describe('agentId namespacing (collision prevention)', function()
+        it('generates an agent- prefixed id when none is provided', function()
+            local res = invite({ conference = 'r'; displayName = 'Bot' });
+            assert.are.equal(200, res.status_code);
+            local ids = agent_ids(mock_room);
+            assert.are.equal(1, #ids);
+            assert.is_truthy(ids[1]:match('^agent%-'), 'generated id must be agent- prefixed: ' .. ids[1]);
+        end)
+
+        it('normalizes a bare (endpoint-id-shaped) agentId into the agent- namespace', function()
+            -- '1a2b3c4d' is exactly the shape of a real participant endpoint id.
+            invite({ conference = 'r'; displayName = 'Bot'; agentId = '1a2b3c4d' });
+            assert.is_truthy(mock_room.jitsiMetadata.agents['agent-1a2b3c4d'],
+                'a bare id must be namespaced so it cannot collide with a real endpoint id');
+            assert.is_nil(mock_room.jitsiMetadata.agents['1a2b3c4d']);
+        end)
+
+        it('is idempotent when the agentId already carries the prefix', function()
+            invite({ conference = 'r'; displayName = 'Bot'; agentId = 'agent-support' });
+            assert.is_truthy(mock_room.jitsiMetadata.agents['agent-support']);
+            assert.is_nil(mock_room.jitsiMetadata.agents['agent-agent-support']);
+        end)
+
+        it('derives the source name from the namespaced id', function()
+            local res = invite({ conference = 'r'; displayName = 'Bot'; agentId = 'support' });
+            assert.are.equal('agent-support-a0', mock_room.jitsiMetadata.agents['agent-support'].sourceName);
+            -- The 200 body echoes the same source name (encode is stubbed, so just assert success).
+            assert.are.equal(200, res.status_code);
+        end)
+    end)
+
+    describe('prototype-pollution key rejection', function()
+        for _, bad in ipairs({ '__proto__', 'constructor', 'prototype' }) do
+            it('rejects agentId "' .. bad .. '"', function()
+                local res = invite({ conference = 'r'; displayName = 'Bot'; agentId = bad });
+                assert.are.equal(400, res.status_code);
+                assert.are.equal(0, #agent_ids(mock_room));
+            end)
+        end
+    end)
+
+    describe('agentId charset and length', function()
+        it('rejects an agentId with disallowed characters', function()
+            assert.are.equal(400, invite({ conference = 'r'; displayName = 'B'; agentId = 'a b/c' }).status_code);
+        end)
+
+        it('rejects an over-long agentId suffix', function()
+            assert.are.equal(400,
+                invite({ conference = 'r'; displayName = 'B'; agentId = string.rep('a', 49) }).status_code);
+        end)
+    end)
+
+    describe('required fields and limits', function()
+        it('returns 400 when displayName is missing', function()
+            assert.are.equal(400, invite({ conference = 'r' }).status_code);
+        end)
+
+        it('returns 404 when the room does not exist', function()
+            assert.are.equal(404, invite({ conference = 'missing'; displayName = 'B' }).status_code);
+        end)
+
+        it('enforces the per-room agent cap', function()
+            for i = 1, 5 do
+                assert.are.equal(200, invite({ conference = 'r'; displayName = 'B'; agentId = 'a' .. i }).status_code);
+            end
+            assert.are.equal(409, invite({ conference = 'r'; displayName = 'B'; agentId = 'a6' }).status_code);
+        end)
+    end)
+
+    describe('string-map validation (urlParams / httpHeaders)', function()
+        it('rejects a non-string map value', function()
+            assert.are.equal(400,
+                invite({ conference = 'r'; displayName = 'B'; urlParams = { k = 5 } }).status_code);
+        end)
+
+        it('rejects too many entries', function()
+            local big = {};
+            for i = 1, 17 do big['k' .. i] = 'v'; end
+            assert.are.equal(400, invite({ conference = 'r'; displayName = 'B'; httpHeaders = big }).status_code);
+        end)
+    end)
+
+    describe('secret segregation', function()
+        it('keeps httpHeaders out of the client-facing entry and on the jicofo-only side', function()
+            invite({
+                conference = 'r';
+                displayName = 'Bot';
+                agentId = 'support';
+                httpHeaders = { Authorization = 'Bearer customer-secret' }
+            });
+            local client_entry = mock_room.jitsiMetadata.agents['agent-support'];
+            assert.is_nil(client_entry.httpHeaders, 'client-facing entry must not carry httpHeaders');
+            assert.are.equal('Bearer customer-secret',
+                mock_room._data.voice_agents['agent-support'].httpHeaders.Authorization);
+        end)
+
+        it('maps the endpoint.{url,authorization} convenience onto jicofo-only X-Agent headers', function()
+            invite({
+                conference = 'r';
+                displayName = 'Bot';
+                agentId = 'support';
+                endpoint = { url = 'wss://agents.example.com/s'; authorization = 'Bearer k' }
+            });
+            local headers = mock_room._data.voice_agents['agent-support'].httpHeaders;
+            assert.are.equal('wss://agents.example.com/s', headers['X-Agent-Endpoint']);
+            assert.are.equal('Bearer k', headers['X-Agent-Authorization']);
+            assert.is_nil(mock_room.jitsiMetadata.agents['agent-support'].httpHeaders);
+        end)
+
+        it('rejects a non-wss endpoint.url', function()
+            assert.are.equal(400, invite({
+                conference = 'r'; displayName = 'B'; endpoint = { url = 'http://evil/s' }
+            }).status_code);
+        end)
+    end)
+
+    describe('dismiss', function()
+        it('removes an existing agent from both the client and jicofo maps', function()
+            invite({ conference = 'r'; displayName = 'Bot'; agentId = 'support' });
+            local res = dismiss({ conference = 'r'; agentId = 'agent-support' });
+            assert.are.equal(200, res.status_code);
+            assert.is_nil(mock_room.jitsiMetadata.agents['agent-support']);
+            assert.is_nil(mock_room._data.voice_agents['agent-support']);
+        end)
+
+        it('returns 404 for an unknown agent', function()
+            assert.are.equal(404, dismiss({ conference = 'r'; agentId = 'agent-nope' }).status_code);
+        end)
+    end)
+end)


### PR DESCRIPTION
Part of the JaaS Voice-Agent MVP. This is the client UI + prosody provisioning piece.

## What
Surfaces voice agents in the meeting and provisions them.

## Changes
- `react/features/voice-agents`: agent roster entry (`FakeParticipant.Agent`) mirrored from room metadata, consent-gated audio subscription, and a **speaking ring** on the agent thumbnail driven by the bridge's synthetic-source sending events.
- `mod_voice_agent_component.lua`: `/voice-agent/{invite,dismiss,list}` provisioning (ASAP system-token auth) that writes agents into room metadata; also loads without an ASAP keyserver.
- `config.voiceAgents` (consent toggle) + lang strings.

## Related (multi-repo MVP)
jitsi-videobridge, jicofo, lib-jitsi-meet, opus-transcriber-proxy.

Draft: validated end to end locally (roster + consent + audible echo + speaking ring).
